### PR TITLE
Removing compilation warnings

### DIFF
--- a/include/Planner/grasp_coordinates.h
+++ b/include/Planner/grasp_coordinates.h
@@ -66,6 +66,7 @@ public:
   coordinates(coordinates* c);
   coordinates(vec3 v);
   coordinates();
+  virtual ~coordinates(){};
   
   virtual coord_system_type    get_coord_system_type();
   virtual void                 set_coord_system_type(coord_system_type);

--- a/include/Planner/grasp_planner.h
+++ b/include/Planner/grasp_planner.h
@@ -231,7 +231,7 @@ private:
  * private methods
  */
 
-  SoPathList searchPrimitives(GraspableBody*);
+  SoPathList searchPrimitives();
 
     /* Takes prasp list with local cartesian coordinates
        and changes these to global. */

--- a/include/dynJoint.h
+++ b/include/dynJoint.h
@@ -125,6 +125,8 @@ public:
 
   //! Computes the 6x6 Jacobian of this joint wrt to a point 
   void jacobian(transf toTarget, Matrix *J, bool worldCoords);
+
+  virtual ~DynJoint(){};
 };
 
 //! A fixed joint constrains all translations and rotations.

--- a/include/humanHand.h
+++ b/include/humanHand.h
@@ -475,9 +475,7 @@ public:
   //! Solves for contact forces that balance given joint torques. Does not care about tendons.
   //! Contact forces are allowed in all directions (not just normal)
   int contactForcesFromJointTorques(std::list<Contact*> contacts,
-				    std::vector<vec3> &contactForces,
-				    const std::vector<double> &jointTorques,
-				    bool convert_to_world_frame);
+                    const std::vector<double> &jointTorques);
 
   //! Returns the joint torques created by the given tendon forces. Does not care about contacts.
   int tendonTorques(const std::set<size_t> &activeTendons,

--- a/include/maxdet.h
+++ b/include/maxdet.h
@@ -67,8 +67,8 @@
 
 void mydlascl(double from,double to,int m,int n,double *A);
 
-void disp_imat(FILE* fp, int* ip, int r, int c, int att);
-void disp_mat(FILE* fp, double* dp,int r, int c, int att);
+void disp_imat(FILE* fp, int* ip, int r, int c);
+void disp_mat(FILE* fp, double* dp,int r, int c);
 /* double inprd(double *X, double *Z, int L, int* blck_szs); */
 double eig_val(double*sig, double* ap, int L, int* blck_szs, int Npd, double* work);
 

--- a/include/worldElementFactory.h
+++ b/include/worldElementFactory.h
@@ -38,6 +38,7 @@ class WorldElementCreator
 {
 public:
   virtual WorldElement* operator() (World* parent, const char* name) = 0;
+  virtual ~WorldElementCreator(){};
 };
 
 //! Templated implementation

--- a/ply/ply.c
+++ b/ply/ply.c
@@ -1429,7 +1429,7 @@ void ascii_get_element(PlyFile *plyfile, char *elem_ptr)
   char **words;
   int nwords;
   int which_word;
-  char *elem_data,*item;
+  char *elem_data,*item=NULL;
   char *item_ptr;
   int item_size;
   int int_val;
@@ -1439,7 +1439,7 @@ void ascii_get_element(PlyFile *plyfile, char *elem_ptr)
   int store_it;
   char **store_array;
   char *orig_line;
-  char *other_data;
+  char *other_data=NULL;
   int other_flag;
 
   /* the kind of element we're reading currently */
@@ -1562,7 +1562,7 @@ void binary_get_element(PlyFile *plyfile, char *elem_ptr)
   PlyProperty *prop;
   FILE *fp = plyfile->fp;
   char *elem_data;
-  char *item;
+  char *item=NULL;
   char *item_ptr;
   int item_size;
   int int_val;
@@ -1571,7 +1571,7 @@ void binary_get_element(PlyFile *plyfile, char *elem_ptr)
   int list_count;
   int store_it;
   char **store_array;
-  char *other_data;
+  char *other_data=NULL;
   int other_flag;
 
   /* the kind of element we're reading currently */

--- a/ply/ply.c
+++ b/ply/ply.c
@@ -626,7 +626,6 @@ PlyFile *ply_read(FILE *fp, int *nelems, char ***elem_names)
   PlyFile *plyfile;
   int nwords;
   char **words;
-  int found_format = 0;
   char **elist;
   PlyElement *elem;
   char *orig_line;
@@ -672,7 +671,6 @@ PlyFile *ply_read(FILE *fp, int *nelems, char ***elem_names)
       else
         return (NULL);
       plyfile->version = (float)atof (words[2]);
-      found_format = 1;
     }
     else if (equal_strings (words[0], "element"))
       add_element (plyfile, words, nwords);

--- a/src/Collision/Graspit/collisionAlgorithms_inl.h
+++ b/src/Collision/Graspit/collisionAlgorithms_inl.h
@@ -187,7 +187,7 @@ void DistanceCallback::leafTest(const Leaf *l1, const Leaf *l2)
 		const std::list<Triangle>*	list2 = l2->getTriangles();
 		for (it2 = list2->begin(); it2!=list2->end() && mMinDistSq >= 0.0; it2++) {
 			mNumTriangleTests++;
-            position p1=NULL,p2=NULL;
+            position p1(0,0,0),p2(0,0,0);
 			//both points get computed in the coordinate system of leaf 2
 			double distSq = triangleTriangleDistanceSq(t1, *it2, p1, p2);
 			if (distSq < mMinDistSq) {

--- a/src/Collision/Graspit/collisionAlgorithms_inl.h
+++ b/src/Collision/Graspit/collisionAlgorithms_inl.h
@@ -187,7 +187,7 @@ void DistanceCallback::leafTest(const Leaf *l1, const Leaf *l2)
 		const std::list<Triangle>*	list2 = l2->getTriangles();
 		for (it2 = list2->begin(); it2!=list2->end() && mMinDistSq >= 0.0; it2++) {
 			mNumTriangleTests++;
-            position p1(0,0,0),p2(0,0,0);
+			position p1(0,0,0),p2(0,0,0);
 			//both points get computed in the coordinate system of leaf 2
 			double distSq = triangleTriangleDistanceSq(t1, *it2, p1, p2);
 			if (distSq < mMinDistSq) {

--- a/src/Collision/Graspit/collisionAlgorithms_inl.h
+++ b/src/Collision/Graspit/collisionAlgorithms_inl.h
@@ -187,7 +187,7 @@ void DistanceCallback::leafTest(const Leaf *l1, const Leaf *l2)
 		const std::list<Triangle>*	list2 = l2->getTriangles();
 		for (it2 = list2->begin(); it2!=list2->end() && mMinDistSq >= 0.0; it2++) {
 			mNumTriangleTests++;
-			position p1,p2;
+            position p1=NULL,p2=NULL;
 			//both points get computed in the coordinate system of leaf 2
 			double distSq = triangleTriangleDistanceSq(t1, *it2, p1, p2);
 			if (distSq < mMinDistSq) {

--- a/src/Collision/Graspit/collisionModel.cpp
+++ b/src/Collision/Graspit/collisionModel.cpp
@@ -26,6 +26,7 @@
 #include "collisionModel.h"
 
 #include <algorithm>
+#include <limits>
 
 //#define GRASPITDBG
 #include "debug.h"
@@ -594,7 +595,8 @@ void SymSchur2(double a[3][3], int p, int q, double &c, double &s)
 void Jacobi(double a[3][3], double v[3][3])
 {
     int i, j, n, p, q;
-    double prevoff, c, s;
+    double prevoff = std::numeric_limits<double>::max();
+    double c, s;
     double J[3][3], tmp1[3][3], tmp2[3][3];
 
     // Initialize v to identity matrix

--- a/src/Collision/collisionInterface.cpp
+++ b/src/Collision/collisionInterface.cpp
@@ -164,7 +164,7 @@ CollisionInterface::replaceContactSetWithPerimeter(ContactReport &contactSet)
 
 	coordT *array = new coordT[contactSet.size()*2];
 	coordT *ptr = &array[0];
-	int ptCount = 0;
+    volatile int ptCount = 0;
 	for (cp=contactSet.begin(); cp!=contactSet.end(); cp++) {    
 		*ptr++ = (cp->b1_pos - position::ORIGIN) % axis1;
 		*ptr++ = (cp->b1_pos - position::ORIGIN) % axis2;

--- a/src/Collision/collisionInterface.cpp
+++ b/src/Collision/collisionInterface.cpp
@@ -164,7 +164,7 @@ CollisionInterface::replaceContactSetWithPerimeter(ContactReport &contactSet)
 
 	coordT *array = new coordT[contactSet.size()*2];
 	coordT *ptr = &array[0];
-    volatile int ptCount = 0;
+	volatile int ptCount = 0;
 	for (cp=contactSet.begin(); cp!=contactSet.end(); cp++) {    
 		*ptr++ = (cp->b1_pos - position::ORIGIN) % axis1;
 		*ptr++ = (cp->b1_pos - position::ORIGIN) % axis2;

--- a/src/EGPlanner/searchEnergy.cpp
+++ b/src/EGPlanner/searchEnergy.cpp
@@ -356,6 +356,7 @@ SearchEnergy::potentialQualityEnergy(bool verbose) const
 	}
 
 	double gq = -1 ,gv = -1;
+    Q_UNUSED(gv)
 	//to make computations more efficient, we only use a 3D approximation
 	//of the 6D wrench space
 	std::vector<int> forceDimensions(6,0);
@@ -584,7 +585,7 @@ SearchEnergy::dynamicAutograspEnergy() const
 	PRINT_STAT(mOut, "Autograsp done");
 
 	//disable contacts on pedestal
-	Body *obstacle;
+    Body *obstacle=NULL;
 	for (int b=0; b<mHand->getWorld()->getNumBodies(); b++) {
 		Body *bod = mHand->getWorld()->getBody(b);
 		if (bod->isDynamic()) continue;

--- a/src/EGPlanner/searchEnergy.cpp
+++ b/src/EGPlanner/searchEnergy.cpp
@@ -355,22 +355,20 @@ SearchEnergy::potentialQualityEnergy(bool verbose) const
 		} else contact->mark(false);
 	}
 
-	double gq = -1 ,gv = -1;
-    Q_UNUSED(gv)
+	double gq = -1;
 	//to make computations more efficient, we only use a 3D approximation
 	//of the 6D wrench space
 	std::vector<int> forceDimensions(6,0);
 	forceDimensions[0] = forceDimensions[1] = forceDimensions[2] = 1;
 	if (count >= 3) {
 		mHand->getGrasp()->updateWrenchSpaces(forceDimensions);
-		gq = mEpsQual->evaluate();
-		gv = mVolQual->evaluate();
+		gq = mEpsQual->evaluate();		
 	}
 	if (verbose) {
 		fprintf(stderr,"Quality: %f\n\n",gq);
 	}
 	if (count) {
-		DBGP("Count: " << count << "; Gq: " << gq << "; Gv: " << gv);
+	  DBGP("Count: " << count << "; Gq: " << gq << ";");
 	}
 	return -gq;
 }

--- a/src/EGPlanner/searchEnergy.cpp
+++ b/src/EGPlanner/searchEnergy.cpp
@@ -583,7 +583,7 @@ SearchEnergy::dynamicAutograspEnergy() const
 	PRINT_STAT(mOut, "Autograsp done");
 
 	//disable contacts on pedestal
-    Body *obstacle=NULL;
+	Body *obstacle=NULL;
 	for (int b=0; b<mHand->getWorld()->getNumBodies(); b++) {
 		Body *bod = mHand->getWorld()->getBody(b);
 		if (bod->isDynamic()) continue;

--- a/src/EGPlanner/searchEnergy.cpp
+++ b/src/EGPlanner/searchEnergy.cpp
@@ -368,7 +368,7 @@ SearchEnergy::potentialQualityEnergy(bool verbose) const
 		fprintf(stderr,"Quality: %f\n\n",gq);
 	}
 	if (count) {
-	  DBGP("Count: " << count << "; Gq: " << gq << ";");
+	        DBGP("Count: " << count << "; Gq: " << gq << ";");
 	}
 	return -gq;
 }

--- a/src/EGPlanner/simAnn.cpp
+++ b/src/EGPlanner/simAnn.cpp
@@ -240,7 +240,7 @@ void
 SimAnn::variableNeighbor(VariableSet *set, double T, VariableSet *target)
 {
 	SearchVariable *var;
-    double v,tv,conf=0;
+    double v,tv=0,conf=0;
 	for (int i=0; i<set->getNumVariables(); i++) {
 		var = set->getVariable(i);
 		if ( var->isFixed() ) continue;

--- a/src/EGPlanner/simAnn.cpp
+++ b/src/EGPlanner/simAnn.cpp
@@ -240,7 +240,7 @@ void
 SimAnn::variableNeighbor(VariableSet *set, double T, VariableSet *target)
 {
 	SearchVariable *var;
-    double v,tv=0,conf=0;
+	double v,tv=0,conf=0;
 	for (int i=0; i<set->getNumVariables(); i++) {
 		var = set->getVariable(i);
 		if ( var->isFixed() ) continue;

--- a/src/EGPlanner/simAnn.cpp
+++ b/src/EGPlanner/simAnn.cpp
@@ -240,7 +240,7 @@ void
 SimAnn::variableNeighbor(VariableSet *set, double T, VariableSet *target)
 {
 	SearchVariable *var;
-	double v,tv,conf;
+    double v,tv,conf=0;
 	for (int i=0; i<set->getNumVariables(); i++) {
 		var = set->getVariable(i);
 		if ( var->isFixed() ) continue;

--- a/src/Planner/grasp_planner.cpp
+++ b/src/Planner/grasp_planner.cpp
@@ -159,7 +159,7 @@ grasp_planner::planIt(GraspableBody* gb,SoGroup *IVPrimitives)
 #endif
     
     /* Search graspable primitive objects in object tree. */
-    SoPathList pl = searchPrimitives(my_body);
+    SoPathList pl = searchPrimitives();
     
     int length = pl.getLength();
 #ifdef GRASPITDBG
@@ -583,9 +583,8 @@ grasp_planner::get_planningParameters(int& nr_of_360_deg_steps_in,
   that node in a path list.  The final list of paths is returned at the end.
 */
 SoPathList 
-grasp_planner::searchPrimitives(GraspableBody* bg)
+grasp_planner::searchPrimitives()
 {	
-  Q_UNUSED(bg)
   SoPathList pl_ret;
   SoPathList pl;
   SoSearchAction *saction = new SoSearchAction;

--- a/src/Planner/grasp_planner.cpp
+++ b/src/Planner/grasp_planner.cpp
@@ -585,13 +585,13 @@ grasp_planner::get_planningParameters(int& nr_of_360_deg_steps_in,
 SoPathList 
 grasp_planner::searchPrimitives(GraspableBody* bg)
 {	
+  Q_UNUSED(bg)
   SoPathList pl_ret;
   SoPathList pl;
   SoSearchAction *saction = new SoSearchAction;
   SoGroup *primGeomRoot;
   int j;
   
-  bg = NULL;  // bg is not needed but gives an unused parameter warning
   primGeomRoot = IVGeomPrimitives;
   
   /* Search for cylinders */

--- a/src/contact.cpp
+++ b/src/contact.cpp
@@ -1004,7 +1004,6 @@ SoSeparator* SoftContact::getVisualIndicator()
 	zaxisMat->diffuseColor = SbColor(0,0,0);
 	zaxisMat->ambientColor = SbColor(0,0,0);
 
-    //radius = Body::CONE_HEIGHT / 5;
 	height = Body::CONE_HEIGHT;
 
 	tran = new SoTransform;  

--- a/src/contact.cpp
+++ b/src/contact.cpp
@@ -973,8 +973,7 @@ double SoftContact::CalcContact_Mattress( double nForce )
 */
 SoSeparator* SoftContact::getVisualIndicator()
 {
-    double height;
-    //double radius;
+        double height;
 	SoSeparator *cne;
 	SoTransform *tran;
 	SoCoordinate3 *coords;

--- a/src/contact.cpp
+++ b/src/contact.cpp
@@ -973,7 +973,8 @@ double SoftContact::CalcContact_Mattress( double nForce )
 */
 SoSeparator* SoftContact::getVisualIndicator()
 {
-	double height,radius;
+    double height;
+    //double radius;
 	SoSeparator *cne;
 	SoTransform *tran;
 	SoCoordinate3 *coords;
@@ -1003,7 +1004,7 @@ SoSeparator* SoftContact::getVisualIndicator()
 	zaxisMat->diffuseColor = SbColor(0,0,0);
 	zaxisMat->ambientColor = SbColor(0,0,0);
 
-	radius = Body::CONE_HEIGHT / 5;
+    //radius = Body::CONE_HEIGHT / 5;
 	height = Body::CONE_HEIGHT;
 
 	tran = new SoTransform;  

--- a/src/dynamics.cpp
+++ b/src/dynamics.cpp
@@ -379,11 +379,11 @@ iterateDynamics(std::vector<Robot *> robotVec,
   double *v2=NULL;
 
   // intermediate matrices for case of both joint and contact constraints
-  double *NutM_i,*NutM_iNu,*INVNutM_iNu,*INVNutM_iNuNut;
-  double *INVNutM_iNuNutM_i,*INVNutM_iNuNutM_iH;
+  double *NutM_i=NULL,*NutM_iNu=NULL,*INVNutM_iNu=NULL,*INVNutM_iNuNut=NULL;
+  double *INVNutM_iNuNutM_i=NULL,*INVNutM_iNuNutM_iH=NULL;
 
   // intermediate vectors for case of both joint and contact constraints
-  double *NutM_ikminuseps,*INVNutM_iNuNutM_ikminuseps;
+  double *NutM_ikminuseps=NULL,*INVNutM_iNuNutM_ikminuseps=NULL;
 
   double *currq,*currM;
 

--- a/src/dynamics.cpp
+++ b/src/dynamics.cpp
@@ -336,7 +336,7 @@ iterateDynamics(std::vector<Robot *> robotVec,
   int numJoints=0;
   int numDOF=0;
   int bn,cn,i,j;
-  int Mrows,Dcols,Arows,Hrows,Hcols,Nurows,Nucols;
+  int Mrows,Dcols,Arows=0,Hrows=0,Hcols=0,Nurows=0,Nucols=0;
   int numDOFLimits=0;
 
   std::list<Contact *> contactList;
@@ -354,29 +354,29 @@ iterateDynamics(std::vector<Robot *> robotVec,
   double *fext = new double[6*numBodies];
 
   // LCP matrix
-  double *A;
+  double *A=NULL;
 
   // LCP vectors
-  double *g,*lambda;
+  double *g=NULL,*lambda=NULL;
   double *predLambda = NULL; //used for debugging the prediction of LCP basis
 
   // main matrices for contact constraints
-  double *H;
+  double *H=NULL;
 
   // main matrices for joint constraints
-  double *Nu;
+  double *Nu=NULL;
 
   // main vector for contact constraints
-  double *k;
+  double *k=NULL;
   
   // main vectors for joint constraints
-  double *eps;
+  double *eps=NULL;
 
   // intermediate matrices for contact constraints
-  double *HtM_i,*v1;
+  double *HtM_i=NULL,*v1=NULL;
 
   // intermediate matrices for contact constraints
-  double *v2;
+  double *v2=NULL;
 
   // intermediate matrices for case of both joint and contact constraints
   double *NutM_i,*NutM_iNu,*INVNutM_iNu,*INVNutM_iNuNut;

--- a/src/eigenGrasp.cpp
+++ b/src/eigenGrasp.cpp
@@ -592,7 +592,7 @@ EigenGraspInterface::setMinMax()
 
 	for (int e = 0; e < eSize; e++)
 	{
-		int mind, maxd;
+        //int mind, maxd;
 		//fprintf(stderr,"\n------\nEG %d\n",e);
 #ifdef EIGENGRASP_LOOSE
 		mmin = +1.0e5;
@@ -608,11 +608,15 @@ EigenGraspInterface::setMinMax()
 			M = ( mRobot->getDOF(d)->getMax() - currentDOF[d] ) / ( eg[d] * mNorm->getAxisValue(d) );
 			if ( m > M) {std::swap(m,M);} //swap m and M if needed
 #ifdef EIGENGRASP_LOOSE
-			if ( m < mmin ) {mmin = m; mind = d;}
-			if ( M > mmax ) {mmax = M; maxd = d;}
+            //if ( m < mmin ) {mmin = m; mind = d;}
+            //if ( M > mmax ) {mmax = M; maxd = d;}
+            if ( m < mmin ) {mmin = m;}
+            if ( M > mmax ) {mmax = M;}
 #else
-			if ( m > mmin ) {mmin = m; mind = d;}
-			if ( M < mmax ) {mmax = M; maxd = d;}
+            //if ( m > mmin ) {mmin = m; mind = d;}
+            //if ( M < mmax ) {mmax = M; maxd = d;}
+            if ( m > mmin ) {mmin = m;}
+            if ( M < mmax ) {mmax = M;}
 #endif
 		}
 		if(!mGrasps[e]->mPredefinedLimits){

--- a/src/eigenGrasp.cpp
+++ b/src/eigenGrasp.cpp
@@ -592,7 +592,6 @@ EigenGraspInterface::setMinMax()
 
 	for (int e = 0; e < eSize; e++)
 	{
-        //int mind, maxd;
 		//fprintf(stderr,"\n------\nEG %d\n",e);
 #ifdef EIGENGRASP_LOOSE
 		mmin = +1.0e5;

--- a/src/gloveInterface.cpp
+++ b/src/gloveInterface.cpp
@@ -244,7 +244,7 @@ void writePoseListToFile(std::list<CalibrationPose*> *list, const char *filename
 		fprintf(stderr,"Unable to open calibration file!\n");
 		return;
 	}
-	fprintf(fp,"%d\n",list->size());
+    fprintf(fp,"%lu\n",list->size());
 	std::list<CalibrationPose*>::iterator it;
 	for (it = list->begin(); it!=list->end(); it++) {
 		(*it)->writeToFile(fp);
@@ -1026,8 +1026,8 @@ double GloveInterface::getPoseError(vec3* error, position* thumbLocation)
 	Body *thumbTip = mRobot->getChain(4)->getLink(2);
 	Body *indexTip = mRobot->getChain(0)->getLink(2);
 	position p1, p2;
-	double rawDistance;
-	rawDistance = mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
+    //double rawDistance;
+    //rawDistance = mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
 
 	if (thumbLocation != NULL) {
 		*thumbLocation = p1;

--- a/src/gloveInterface.cpp
+++ b/src/gloveInterface.cpp
@@ -1026,8 +1026,7 @@ double GloveInterface::getPoseError(vec3* error, position* thumbLocation)
 	Body *thumbTip = mRobot->getChain(4)->getLink(2);
 	Body *indexTip = mRobot->getChain(0)->getLink(2);
 	position p1, p2;
-    //double rawDistance;
-    //rawDistance = mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
+    mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
 
 	if (thumbLocation != NULL) {
 		*thumbLocation = p1;

--- a/src/gloveInterface.cpp
+++ b/src/gloveInterface.cpp
@@ -244,7 +244,7 @@ void writePoseListToFile(std::list<CalibrationPose*> *list, const char *filename
 		fprintf(stderr,"Unable to open calibration file!\n");
 		return;
 	}
-    fprintf(fp,"%lu\n",list->size());
+	fprintf(fp,"%lu\n",list->size());
 	std::list<CalibrationPose*>::iterator it;
 	for (it = list->begin(); it!=list->end(); it++) {
 		(*it)->writeToFile(fp);
@@ -1026,7 +1026,7 @@ double GloveInterface::getPoseError(vec3* error, position* thumbLocation)
 	Body *thumbTip = mRobot->getChain(4)->getLink(2);
 	Body *indexTip = mRobot->getChain(0)->getLink(2);
 	position p1, p2;
-    mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
+	mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
 
 	if (thumbLocation != NULL) {
 		*thumbLocation = p1;

--- a/src/gws.cpp
+++ b/src/gws.cpp
@@ -114,7 +114,8 @@ int
 GWS::projectTo3D(double *projCoords, std::set<int> fixedCoordSet,
 				 std::vector<position> &hullCoords, std::vector<int> &hullIndices)
 {
-  int i,j,k,validPlanes,numCoords,numInLoop;
+  int i,j,k,numCoords,numInLoop;
+  volatile int validPlanes;
   double **planes;
   int freeCoord[3],fixedCoord[3];
 
@@ -448,11 +449,6 @@ GWS::buildHyperplanesFromWrenches(void *wr, int numWrenches,
 {
   DBGP("Qhull init on " << numWrenches << " wrenches"); 
 
-  int dimensions = 0;
-  for (int d=0; d<6; d++) {
-    if (useDimensions[d]) dimensions++;
-  }
-
   // qhull variables
   coordT *wrenches = (coordT*)wr;
   boolT ismalloc;
@@ -472,7 +468,7 @@ GWS::buildHyperplanesFromWrenches(void *wr, int numWrenches,
 
 
   if ((exitcode = setjmp(qh errexit))) {
-    DBGP("QUALITY: 0 volume in " << dimensions <<"D, quick exit");
+    DBGP("QUALITY: 0 volume, quick exit");
 	qh NOerrexit= True;
 	qh_freeqhull(!qh_ALL);
 	qh_memfreeshort (&curlong, &totlong);
@@ -481,6 +477,11 @@ GWS::buildHyperplanesFromWrenches(void *wr, int numWrenches,
 		  totlong, curlong);
 	if (qhfp) fclose(qhfp);
     return FAILURE;
+  }
+
+  int dimensions = 0;
+  for (int d=0; d<6; d++) {
+    if (useDimensions[d]) dimensions++;
   }
   
   sprintf(options, "qhull Pp n Qx C-0.0001");

--- a/src/humanHand.cpp
+++ b/src/humanHand.cpp
@@ -1389,13 +1389,8 @@ int HumanHand::tendonEquilibrium(const std::set<size_t> &activeTendons,
   overdetermined.
 */
 int HumanHand::contactForcesFromJointTorques(std::list<Contact*> contacts,
-					     std::vector<vec3> &contactForces,
-					     const std::vector<double> &jointTorques,
-					     bool convert_to_world_frame)
+                         const std::vector<double> &jointTorques)
 {
-  Q_UNUSED(contactForces);
-  Q_UNUSED(convert_to_world_frame);
-
   std::list<Joint*> joints;
   for(int c=0; c<getNumChains(); c++) 
   {

--- a/src/humanHand.cpp
+++ b/src/humanHand.cpp
@@ -705,7 +705,7 @@ PROF_DECLARE(TENDON_UPDATE_INSERTION_FORCES);
 void Tendon::updateInsertionForces()
 {
   PROF_TIMER_FUNC(TENDON_UPDATE_INSERTION_FORCES);
-  SbVec3f pPrev=NULL,pCur=NULL,pNext=NULL;
+  SbVec3f pPrev(0,0,0),pCur(0,0,0),pNext(0,0,0);
   position tmpPos;
   vec3 dPrev,dNext,dRes,c;
   

--- a/src/humanHand.cpp
+++ b/src/humanHand.cpp
@@ -303,8 +303,8 @@ inline bool wrapperIntersection(TendonWrapper *wrapper, QString tendonName,
   tmpPos = position (P4.toSbVec3f()) * ( link->getTran());
   P4 = vec3 ( tmpPos.toSbVec3f() );
   
-  vec3 Pa, Pb;
-  double mua, mub;
+  vec3 Pa=NULL, Pb=NULL;
+  double mua=0, mub=0;
   LineLineIntersect( pPrev , pNext , P3,P4 , &Pa, &Pb, &mua, &mub);
 
   // if closest point is not between wrapper edges we are done
@@ -705,7 +705,7 @@ PROF_DECLARE(TENDON_UPDATE_INSERTION_FORCES);
 void Tendon::updateInsertionForces()
 {
   PROF_TIMER_FUNC(TENDON_UPDATE_INSERTION_FORCES);
-  SbVec3f pPrev,pCur,pNext;
+  SbVec3f pPrev=NULL,pCur=NULL,pNext=NULL;
   position tmpPos;
   vec3 dPrev,dNext,dRes,c;
   
@@ -1393,6 +1393,9 @@ int HumanHand::contactForcesFromJointTorques(std::list<Contact*> contacts,
 					     const std::vector<double> &jointTorques,
 					     bool convert_to_world_frame)
 {
+  Q_UNUSED(contactForces);
+  Q_UNUSED(convert_to_world_frame);
+
   std::list<Joint*> joints;
   for(int c=0; c<getNumChains(); c++) 
   {

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -652,7 +652,7 @@ IVmgr::transRot(DraggerInfo *dInfo)
 
 	// save the desired position or orientation and set what percent of the 
 	// desired moved will be accomplished in each step
-	SbVec3f temp = dInfo->lastTran;
+    //SbVec3f temp = dInfo->lastTran;
 	if (translating) {
 		if ((myHandleBox->translation.getValue() - dInfo->lastTran).length()<0.00001) {
 			myHandleBox->translation.setValue(dInfo->lastTran); 
@@ -1553,16 +1553,9 @@ IVmgr::saveImage(QString filename)
   
   myRenderer->render(renderRoot);
   
-  SbBool result;
-  result = myRenderer->writeToFile(SbString(filename.latin1()),
-				   SbName(filename.section('.',-1)));
 
-#ifdef GRASPITDBG
-  if (result)
-    fprintf(stderr,"saved\n");
-  else
-    fprintf(stderr,"not saved\n");
-#endif
+  myRenderer->writeToFile(SbString(filename.latin1()),
+                          SbName(filename.section('.',-1)));
   
   renderRoot->unref();
   delete myRenderer;

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -652,7 +652,6 @@ IVmgr::transRot(DraggerInfo *dInfo)
 
 	// save the desired position or orientation and set what percent of the 
 	// desired moved will be accomplished in each step
-    //SbVec3f temp = dInfo->lastTran;
 	if (translating) {
 		if ((myHandleBox->translation.getValue() - dInfo->lastTran).length()<0.00001) {
 			myHandleBox->translation.setValue(dInfo->lastTran); 

--- a/src/lmiOptimizer.cpp
+++ b/src/lmiOptimizer.cpp
@@ -1215,7 +1215,7 @@ LMIOptimizer::findOptimalGraspForce()
     optmXHistory = xzHistoryTransfrom(extendOptmZHistory, optmNTiters+1);
     
     printf("OPTIMAL CONTACT FORCES:\n");
-    disp_mat(stdout,optmx0,1,numWrenches,0);
+    disp_mat(stdout,optmx0,1,numWrenches);
 
     //    double *testOut = new double[6];
     //    dgemv("N",6,numWrenches,1.0,graspMap,6,optmx0,1,0.0,testOut,1);
@@ -1233,7 +1233,7 @@ LMIOptimizer::findOptimalGraspForce()
 	  optmx0, 1,1.0, optTorques, 1);
 
     printf("OPTIMAL TORQUES:\n");
-    disp_mat(stdout,optTorques,1,numDOF,0);
+    disp_mat(stdout,optTorques,1,numDOF);
 
     int offset = 0;
     for (i=0;i<mGrasp->numContacts;i++) {

--- a/src/lmiOptimizer.cpp
+++ b/src/lmiOptimizer.cpp
@@ -695,6 +695,7 @@ double * maxdet_wrap(int m, int L, double *F, int *F_blkszs,
 
 
 {
+  Q_UNUSED(pRstFile);
   register int i;
   int    n, l, max_n, max_l, F_sz, G_sz;  
   int    ptr_size;

--- a/src/lmiOptimizer.cpp
+++ b/src/lmiOptimizer.cpp
@@ -708,11 +708,6 @@ double * maxdet_wrap(int m, int L, double *F, int *F_blkszs,
   
   //  struct tms before,after;
   
-  // Gets rid of compiler warning
-#ifndef GRASPDBG
-  pRstFile = NULL;
-#endif
-  
   for (i=0; i<L; i++) {
     if (F_blkszs[i] <= 0) {
       pr_error("Elements of F_blkszs must be positive.\n");

--- a/src/math/matrix.cpp
+++ b/src/math/matrix.cpp
@@ -598,7 +598,7 @@ void Matrix::print(FILE *fp, std::string name) const
 {
   if (!name.empty()) fprintf(fp,"%s:\n",name.c_str());
   std::auto_ptr<double> data = getDataCopy();
-  disp_mat(fp, data.get(), mRows, mCols, 0);
+  disp_mat(fp, data.get(), mRows, mCols);
 }
 
 void

--- a/src/maxdet_src.cpp
+++ b/src/maxdet_src.cpp
@@ -46,7 +46,7 @@ void mydlascl(double from,double to,int m,int n,double *A)
 
 /* from sdpsol, for debugging */
 /* print an integer matrix to a stream */
-void disp_imat(FILE *fp,int *ip,int  r, int c,int att)
+void disp_imat(FILE *fp,int *ip,int  r, int c)
 {
     register int i,j;
     register int *rip;
@@ -58,12 +58,10 @@ void disp_imat(FILE *fp,int *ip,int  r, int c,int att)
         fprintf(fp,"|\n");
     }
     fprintf(fp,"\n");
-
-    att = 0;  /* get rid of unused parameter warning */
 }
 
 /* print a double matrix to a stream */
-void disp_mat(FILE *fp, double *dp,int r,int c,int att)
+void disp_mat(FILE *fp, double *dp,int r,int c)
 {
     register int    i,j;
     register double *rdp,dtmp,maxmag=0;
@@ -100,8 +98,6 @@ void disp_mat(FILE *fp, double *dp,int r,int c,int att)
         }
         fprintf(fp,"  \n\n");
     }
-
-    att = 0; /* get rid of unused parameter warning */
 }
 
 
@@ -343,7 +339,7 @@ int maxdet(
     int    iters, minlwork, lwkspc, maxNTiters; /* itmp */
     int    dual_equ_feas=YES, dual_PD_feas=NO;
     int    n, F_sz, F_upsz, max_n, l, G_sz, G_upsz, max_l, sz, M_sz, M_upsz;
-    double t, sqrtt, t_old, y, gap, mu, lambda, alpha[2], beta, psi_ub;
+    double t, sqrtt, t_old, y=0, gap, mu, lambda, alpha[2], beta=0, psi_ub;
     double grad1, grad2, hess1, hess2;
     double *rhs, *GaF, *ZWtmp, *Fsc, *Gsc, *XF, *XG, *dXF, *dXG, *dW, *dZ;
     double *LF, *LG, *LFinv, *LGinv;

--- a/src/quality.cpp
+++ b/src/quality.cpp
@@ -162,7 +162,7 @@ QualEpsilon::~QualEpsilon()
 double
 QualEpsilon::evaluate()
 {
-  double minOffset;
+  double minOffset=std::numeric_limits<double>::max();
 
   if (!gws->hyperPlanes) {
 #ifdef GRASPITDBG

--- a/src/quality.cpp
+++ b/src/quality.cpp
@@ -42,6 +42,8 @@
 #include "grasp.h"
 #include "gws.h"
 
+#include <limits>
+
 #ifdef USE_DMALLOC
 #include "dmalloc.h"
 #endif

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -508,10 +508,10 @@ World::loadFromXml(const TiXmlElement* root,QString rootPath)
 	QString buf, elementType, matStr, elementPath, elementName,mountFilename;
 	Link *mountPiece;
 	QString line;
-    WorldElement *element=NULL;
+	WorldElement *element=NULL;
 	transf tr;
 	int prevRobNum,chainNum,nextRobNum;
-    bool cameraFound;
+	bool cameraFound;
 	while(child!=NULL){
 		elementType = child->Value();
 		if(elementType.isNull()){
@@ -1984,7 +1984,7 @@ World::computeNewVelocities(double timeStep)
 	std::vector<DynamicBody *> robotLinks;
 	std::vector<DynamicBody *> dynIsland;
 	std::vector<Robot *> islandRobots;
-    int i,j,numLinks,numDynBodies,lemkeErrCode;
+	int i,j,numLinks,numDynBodies,lemkeErrCode;
 
 #ifdef GRASPITDBG
 	int islandCount = 0;
@@ -2048,7 +2048,7 @@ World::computeNewVelocities(double timeStep)
 				std::cout << dynIsland[i]->getName() <<" ";
 			std::cout << std::endl;
 			std::cout << "Island Robots"<< islandCount<<" Robots: ";
-            for (i=0;i<islandRobots.size();;i++)
+			for (i=0;i<islandRobots.size();;i++)
 				std::cout << islandRobots[i]->getName() <<" ";
 			std::cout << std::endl << std::endl;
 #endif  

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -508,7 +508,7 @@ World::loadFromXml(const TiXmlElement* root,QString rootPath)
 	QString buf, elementType, matStr, elementPath, elementName,mountFilename;
 	Link *mountPiece;
 	QString line;
-	WorldElement *element;
+    WorldElement *element=NULL;
 	transf tr;
 	int prevRobNum,chainNum,nextRobNum;
     bool cameraFound;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -511,7 +511,7 @@ World::loadFromXml(const TiXmlElement* root,QString rootPath)
 	WorldElement *element;
 	transf tr;
 	int prevRobNum,chainNum,nextRobNum;
-	bool badFile,cameraFound;
+    bool cameraFound;
 	while(child!=NULL){
 		elementType = child->Value();
 		if(elementType.isNull()){
@@ -647,12 +647,11 @@ World::loadFromXml(const TiXmlElement* root,QString rootPath)
 			if (prevRobNum < 0 || prevRobNum >= numRobots || nextRobNum < 0 ||
 				nextRobNum >= numRobots || chainNum < 0 || 
 				chainNum >= robotVec[prevRobNum]->getNumChains()) {
-					badFile = true; break;
+                    QTWARNING("Error reading connection transform"); break;
 			}
 			xmlElement = findXmlElement( child, "transform");
 			if(xmlElement){
 				if (!getTransform(xmlElement,tr)) {
-					badFile = true;
 					QTWARNING("Error reading connection transform"); break;
 				}
 			}
@@ -1985,7 +1984,7 @@ World::computeNewVelocities(double timeStep)
 	std::vector<DynamicBody *> robotLinks;
 	std::vector<DynamicBody *> dynIsland;
 	std::vector<Robot *> islandRobots;
-	int i,j,numLinks,numDynBodies,numIslandRobots,lemkeErrCode;
+    int i,j,numLinks,numDynBodies,lemkeErrCode;
 
 #ifdef GRASPITDBG
 	int islandCount = 0;
@@ -2043,15 +2042,13 @@ World::computeNewVelocities(double timeStep)
 				}
 			}
 
-			numIslandRobots = islandRobots.size();
-
 #ifdef GRASPITDBG
 			std::cout << "Island "<< ++islandCount<<" Bodies: ";
 			for (i=0;i<numDynBodies;i++)
 				std::cout << dynIsland[i]->getName() <<" ";
 			std::cout << std::endl;
 			std::cout << "Island Robots"<< islandCount<<" Robots: ";
-			for (i=0;i<numIslandRobots;i++)
+            for (i=0;i<islandRobots.size();;i++)
 				std::cout << islandRobots[i]->getName() <<" ";
 			std::cout << std::endl << std::endl;
 #endif  

--- a/ui/EGPlanner/compliantPlannerDlg.cpp
+++ b/ui/EGPlanner/compliantPlannerDlg.cpp
@@ -350,10 +350,9 @@ CompliantPlannerDlg::showResult()
 {
 	int d = mPlanner->getListSize();
 	int rank, size, iteration; double energy;
-	bool render = true;
 
 	if (d==0) {
-		mBestGraspNum = rank = size = iteration = energy = 0; render = false;
+        mBestGraspNum = rank = size = iteration = energy = 0;
 	} else if (mBestGraspNum < 0){
 		mBestGraspNum = 0;
 	} else if ( mBestGraspNum >= d) {


### PR DESCRIPTION
I started to fix compilation warnings.  Mostly removed unused variables and unitialized variables:

Two alternatives to some of these changes would be:

1)  to add:
-Wno-uninitialized
-Wno-unused

to the QMAKE_CXXFLAGS in graspit-core.pro

2) wrapping them with:
Q_UNUSED
