### PR TITLE
Removed all warnings from cgdb

### DIFF
--- a/src/DBase/DBPlanner/db_manager.h
+++ b/src/DBase/DBPlanner/db_manager.h
@@ -180,6 +180,8 @@ class DatabaseManager {
   virtual bool LoadModelGeometry(Model*) const = 0;
   //! Loads the graspit relative path for a hand
   virtual QString getHandGraspitPath(QString handDBName) const = 0;
+
+  virtual ~DatabaseManager(){}
   
 };
 

--- a/src/DBase/DBPlanner/grasp.h
+++ b/src/DBase/DBPlanner/grasp.h
@@ -139,6 +139,7 @@ class Grasp {
 class GraspAllocator {
 public:
 	virtual Grasp* Get() const = 0;
+    virtual ~GraspAllocator(){}
 };
 
 }

--- a/src/DBase/DBPlanner/sql_database_manager.cpp
+++ b/src/DBase/DBPlanner/sql_database_manager.cpp
@@ -86,7 +86,14 @@ class LoadModelFunctor {
   bool initialized_;
  public:
    LoadModelFunctor(const Table& table, const string& model_root) 
-       : table_(table), model_root_(model_root) {
+       : table_(table), model_root_(model_root),
+         model_name_column_(-1),
+         thumbnail_path_column_(-1),
+         scale_column_(-1),
+         tags_column_(-1),
+         grasping_rescale_column_(-1),
+         geometry_path_column_(-1)
+   {
      initialized_ = 
          table_.GetColumnIndex("model_name", &model_name_column_) &&
          table_.GetColumnIndex("thumbnail_path", &thumbnail_path_column_) &&

--- a/src/DBase/DBPlanner/sql_database_manager.h
+++ b/src/DBase/DBPlanner/sql_database_manager.h
@@ -129,12 +129,12 @@ class SqlDatabaseManager : public DatabaseManager {
   virtual bool DeleteGrasp(Grasp* /*grasp*/) const  {return false;}
   virtual bool AcquireNextTask(TaskRecord* /*rec*/, std::vector<std::string> /*accepted_types*/){return false;}
   virtual bool SetTaskStatus(int /*task_id*/, const string& /*status*/){return false;}
-  virtual bool GetPlanningTaskRecord(int task_id, PlanningTaskRecord* /*rec*/){return false;}
+  virtual bool GetPlanningTaskRecord(int /*task_id*/, PlanningTaskRecord* /*rec*/){return false;}
   virtual bool SetGraspClusterRep(Grasp* /*grasp*/, bool /*rep*/) const {return false;}
   virtual bool InsertGraspPair(const Grasp* /*grasp1*/, const Grasp* /*grasp2*/) const {return false;}
   virtual bool SetGraspTableClearance(Grasp* /*grasp*/, double /*clearance*/) const { return false;}
   virtual bool LoadModelGeometry(Model*) const {return false;}
-  virtual bool ScaledModel(Model* &model, int scaled_model_id) const {return false;}
+  virtual bool ScaledModel(Model*& /*model*/, int /*scaled_model_id*/ ) const { return false;}
 
   // Translate hand database name into a graspit xml path
   virtual QString getHandGraspitPath(QString handDBName) const;

--- a/src/DBase/dbaseDlg.cpp
+++ b/src/DBase/dbaseDlg.cpp
@@ -532,8 +532,15 @@ void DBaseDlg::nextGrasp() {
 //go to see the previous grasp and show the corresponding image
 void DBaseDlg::previousGrasp() {
 	if (mGraspList.empty()) return;
-	mCurrentFrame --;
-	if (mCurrentFrame < 0) mCurrentFrame = mGraspList.size() - 1;
+
+    if (mCurrentFrame == 0)
+    {
+        mCurrentFrame = mGraspList.size() - 1;
+    }
+    else
+    {
+        mCurrentFrame --;
+    }
 	showGrasp(mCurrentFrame);
 }
 

--- a/src/DBase/dbaseDlg.h
+++ b/src/DBase/dbaseDlg.h
@@ -95,9 +95,9 @@ private:
 	void initializeGraspInfo();
 
 public:
-	DBaseDlg(QWidget *parent = 0) : QDialog(parent), mCurrentLoadedModel(NULL), mDBMgr(NULL), 
-									mModelScene(NULL), mCurrentFrame(0), 
-									inModelConstruction(false) {
+    DBaseDlg(QWidget *parent = 0) : QDialog(parent), mCurrentLoadedModel(NULL),mModelScene(NULL),
+        mDBMgr(NULL), mCurrentFrame(0), inModelConstruction(false)
+    {
 		setupUi(this);
 		QObject::connect(exitButton, SIGNAL(clicked()), this, SLOT(exitButton_clicked()));
 		QObject::connect(connectButton, SIGNAL(clicked()), this, SLOT(connectButton_clicked()));

--- a/src/DBase/dbaseDlg.h
+++ b/src/DBase/dbaseDlg.h
@@ -66,7 +66,7 @@ private:
 	//! A list of grasps for a dbase model, retrieved from the DBMgr
 	std::vector<db_planner::Grasp*> mGraspList;
 	//! An index for the current grasp shown on the screen
-	int mCurrentFrame;
+    unsigned int mCurrentFrame;
 	//! Helper variable to disable the modelChanged trigger
 	bool inModelConstruction;
 

--- a/src/DBase/dbasePlannerDlg.cpp
+++ b/src/DBase/dbasePlannerDlg.cpp
@@ -176,7 +176,7 @@ void DBasePlannerDlg::rankGraspsButton_clicked(){
 	setGroupBoxEnabled(true, true, true, true, true);
 	//show the first grasp of the retrieved list
 	mCurrentOriginalGrasp = 0;
-	if(mCurrentOriginalGrasp < (int)mOriginalGrasps.size())
+    if(mCurrentOriginalGrasp < mOriginalGrasps.size())
 		showGrasp(mOriginalGrasps[mCurrentOriginalGrasp]);
 	updateOriginalGraspInfo();
 }
@@ -254,15 +254,22 @@ void DBasePlannerDlg::updateTestedGraspInfo(){
 }
 
 // given a grasp list and a current position index i, show the previous grasp before i
-void DBasePlannerDlg::previousGrasp(int& i, std::vector<db_planner::Grasp*> graspList) {
+void DBasePlannerDlg::previousGrasp(unsigned int& i, std::vector<db_planner::Grasp*> graspList) {
 	if (graspList.empty()) return;
-	i --;
-	if (i < 0) i = graspList.size() - 1;
+
+    if (i == 0)
+    {
+        i = graspList.size() - 1;
+    }
+    else
+    {
+        i --;
+    }
 	showGrasp(graspList[i]);
 }
 
 // given a grasp list and a current position index i, show the next grasp after i
-void DBasePlannerDlg::nextGrasp(int& i, std::vector<db_planner::Grasp*> graspList){
+void DBasePlannerDlg::nextGrasp(unsigned int& i, std::vector<db_planner::Grasp*> graspList){
 	if (graspList.empty()) return;
 	i ++;
 	if (i == graspList.size()) i = 0;
@@ -333,14 +340,14 @@ void DBasePlannerDlg::neighborCheckBoxChanged(){
 
 // trigger when we choose to show the original grasp
 void DBasePlannerDlg::originalGraspRadioButton_clicked(){
-	if(mCurrentOriginalGrasp < (int)mOriginalGrasps.size())
+    if(mCurrentOriginalGrasp < mOriginalGrasps.size())
 		showGrasp(mOriginalGrasps[mCurrentOriginalGrasp]);
 	updateOriginalGraspInfo();
 }
 
 // trigger when we choose to show the tested grasp
 void DBasePlannerDlg::testedGraspRadioButton_clicked(){
-	if(mCurrentTestedGrasp < (int) mTestedGrasps.size())
+    if(mCurrentTestedGrasp < mTestedGrasps.size())
 		showGrasp(mTestedGrasps[mCurrentTestedGrasp]);
 	updateTestedGraspInfo();
 }

--- a/src/DBase/dbasePlannerDlg.h
+++ b/src/DBase/dbasePlannerDlg.h
@@ -79,9 +79,9 @@ private:
 	//! A pointer to the hand involved in the current grasps
 	Hand* mHand;
 	//! Index of the current grasp in mOriginalGrasps
-	int mCurrentOriginalGrasp;
+    unsigned int mCurrentOriginalGrasp;
 	//! Index of the current grasp in mTestedGrasps
-	int mCurrentTestedGrasp;
+    unsigned int mCurrentTestedGrasp;
 	//! Widget for displaying thumbnails
 	QGraphicsScene * mModelScene;
 	//! Helper variable that indicates whether the neighbor combo box is in reconstruction
@@ -99,17 +99,17 @@ private:
 	template <class vectorType, class treatAsType>
 	void deleteVectorElements(std::vector<vectorType>& v);
 
-	void previousGrasp(int& i, std::vector<db_planner::Grasp*> graspList);
-	void nextGrasp(int& i, std::vector<db_planner::Grasp*> graspList);
+    void previousGrasp(unsigned int& i, std::vector<db_planner::Grasp*> graspList);
+    void nextGrasp(unsigned int& i, std::vector<db_planner::Grasp*> graspList);
 	void showGrasp(db_planner::Grasp* grasp);
 	void setGroupBoxEnabled(bool nbrGen, bool alignment, bool ranking, bool grasp, bool execute);
 
 public:
 	DBasePlannerDlg(QWidget *parent = 0, db_planner::DatabaseManager* dbm = NULL, 
 				    db_planner::Model* m = NULL, Hand* h = NULL) :
-					QDialog(parent), mDBMgr(dbm), mPlanningModel(m), mModelShown(m), 
-					mHand(h), mModelScene(NULL), mCurrentOriginalGrasp(0), 
-					mCurrentTestedGrasp(0), neighborComboBoxInReconstruction(false), mAligner(NULL) {
+                    QDialog(parent), mDBMgr(dbm),mAligner(NULL), mPlanningModel(m), mModelShown(m),
+                    mHand(h), mCurrentOriginalGrasp(0), mCurrentTestedGrasp(0),
+                    mModelScene(NULL), neighborComboBoxInReconstruction(false) {
 		setupUi(this);
 		QObject::connect(exitButton, SIGNAL(clicked()), this, SLOT(exitButton_clicked()));
 		QObject::connect(getNeighborButton, SIGNAL(clicked()), this, SLOT(getNeighborButton_clicked()));

--- a/src/DBase/graspTransferCheckTask.cpp
+++ b/src/DBase/graspTransferCheckTask.cpp
@@ -131,8 +131,8 @@ void GraspTransferCheckTask::start()
 
   //do the actual work
   bool success = true;
-  for (int g1=0; g1<graspList1.size(); g1++) {
-    for (int g2=g1; g2<graspList2.size(); g2++) {
+  for (unsigned int g1=0; g1<graspList1.size(); g1++) {
+    for (unsigned int g2=g1; g2<graspList2.size(); g2++) {
       if (g1==g2) continue;
       DBGA("Checking combo " << g1 << " -- " << g2);      
       if (checkGraspCombo(graspList1[g1], graspList2[g2])) {

--- a/src/DBase/taskDispatcher.cpp
+++ b/src/DBase/taskDispatcher.cpp
@@ -88,6 +88,10 @@ int TaskDispatcher::connect(std::string host, int port, std::string username,
 	return 0;
 #else
 	DBGA("Task dispatcher only tested using the ROS database manager, which is not available");
+    Q_UNUSED(host);
+    Q_UNUSED(username);
+    Q_UNUSED(password);
+    Q_UNUSED(database);
 	return -1;
 #endif
 }


### PR DESCRIPTION
When compiling with 
CONFIG += cgdb
There are no longer any warnings.  The only warning that I fixed that may have been causing issues was adding virtual destructors to DatabaseManager and GraspAllocator.  Without doing this, then deleting their subclasses has undefined behaviour.

Compiles and runs on my linux machine.  I was not able to fully test all the cgdb code as I don't have a version of the cgdb that works with this version of graspit.  

The current copy of cgdb does work with this branch of graspit:
https://github.com/jvarley/graspit/commit/c696caa87a364acbd2adba68fef98712f0567992

I have a PR coming for this as well. 