### PR TITLE
Fixing include subdirectories to work with plugins.

### DIFF
--- a/include/EGPlanner/searchEnergy.h
+++ b/include/EGPlanner/searchEnergy.h
@@ -31,7 +31,7 @@
 #include <QObject>
 
 #include "search.h"
-#include "matvec3D.h"
+#include "include/matvec3D.h"
 
 class Hand;
 class Body;

--- a/include/EGPlanner/searchState.h
+++ b/include/EGPlanner/searchState.h
@@ -31,7 +31,7 @@
 #include <QString>
 
 #include "search.h"
-#include "matvec3D.h"
+#include "include/matvec3D.h"
 
 class Hand;
 class Body;

--- a/include/EGPlanner/simAnn.h
+++ b/include/EGPlanner/simAnn.h
@@ -35,7 +35,7 @@ class Body;
 class SoSensor;
 
 #include <stdio.h>
-#include <matvec3D.h>
+#include "include/matvec3D.h"
 #include <vector>
 
 /*!	This class performs simulated annealing on a collection of variables 

--- a/include/Planner/grasp_coordinates.h
+++ b/include/Planner/grasp_coordinates.h
@@ -37,7 +37,7 @@
 #ifndef __GRASP_COORDINATES_H__
 #define __GRASP_COORDINATES_H__
 
-#include "matvec3D.h"
+#include "include/matvec3D.h"
 class coordinates;
 class cartesian_coordinates;
 class cylindrical_coordinates;

--- a/include/Planner/grasp_planner.h
+++ b/include/Planner/grasp_planner.h
@@ -158,7 +158,7 @@ class GraspDirection;
 class SoPath;
 class SoSeparator;
 
-#include "matvec3D.h"
+#include "include/matvec3D.h"
 #include <Inventor/SoLists.h>
 #include <vector>
 typedef std::pair<Body *,Body *> BodyPair;

--- a/include/Planner/grasp_tester.h
+++ b/include/Planner/grasp_tester.h
@@ -57,7 +57,7 @@
 
 #include <vector>
 
-#include "matvec3D.h"
+#include "include/matvec3D.h"
 #include "collisionStructures.h"
 #include "grasp_directions.h"
 #include "grasp_preshape.h"


### PR DESCRIPTION
The original line works fine for graspit, but if a plugin uses a header file from a subdirectory such as EGPlanner, then the include for header files in the main include directory will fail from within the subdirectory header.  

Ex:
include/
      A.h
      EGPlanner/B.h  

If a plugin uses B.h which has the line "include 'A.h'"  FAIL
If a plugin uses B.h which has the line "include 'include/A.h'"  SUCCESS

Either will work for graspit without any plugins.