### PR TITLE
minor UI improvements to EGPLannerDlg

### DIFF
--- a/ui/EGPlanner/egPlannerDlg.cpp
+++ b/ui/EGPlanner/egPlannerDlg.cpp
@@ -68,7 +68,7 @@ void EigenGraspPlannerDlg::init()
  energyBox->insertItem("Contacts AND Quality");
  energyBox->insertItem("Autograsp Quality");
  energyBox->insertItem("Guided Autograsp");
- energyBox->setCurrentItem(0);
+ energyBox->setCurrentItem(2);
 
  plannerTypeBox->insertItem("Sim. Ann.");
  plannerTypeBox->insertItem("Loop");
@@ -384,8 +384,8 @@ void EigenGraspPlannerDlg::updateResults(bool render)
  nStr.setNum(mPlanner->getCurrentStep());
  currentStepLabel->setText(QString("Current step: ") + nStr);
 
- nStr.setNum(mPlanner->getRunningTime(),'f',0);
- timeLabel->setText(QString("Time used: ") + nStr + QString(" sec."));
+ nStr.setNum(mPlanner->getRunningTime(),'f',3);
+ timeLabel->setText(QString("Time used: ") + nStr + QString(" sec"));
 
  int d = mPlanner->getListSize();
  int rank, size, iteration; double energy;

--- a/ui/EGPlanner/egPlannerDlg.ui
+++ b/ui/EGPlanner/egPlannerDlg.ui
@@ -1,22 +1,20 @@
-<ui version="4.0" >
- <author></author>
- <comment></comment>
- <exportmacro></exportmacro>
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>EigenGraspPlannerDlgUI</class>
- <widget class="QDialog" name="EigenGraspPlannerDlgUI" >
-  <property name="geometry" >
+ <widget class="QDialog" name="EigenGraspPlannerDlgUI">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>561</width>
-    <height>552</height>
+    <width>652</width>
+    <height>559</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>EigenGrasp Planners</string>
   </property>
-  <widget class="QPushButton" name="exitButton" >
-   <property name="geometry" >
+  <widget class="QPushButton" name="exitButton">
+   <property name="geometry">
     <rect>
      <x>10</x>
      <y>514</y>
@@ -24,391 +22,391 @@
      <height>31</height>
     </rect>
    </property>
-   <property name="text" >
+   <property name="text">
     <string>Exit</string>
    </property>
   </widget>
-  <widget class="Q3GroupBox" name="groupBox3" >
-   <property name="geometry" >
+  <widget class="Q3GroupBox" name="groupBox3">
+   <property name="geometry">
     <rect>
-     <x>270</x>
-     <y>220</y>
+     <x>300</x>
+     <y>210</y>
      <width>280</width>
      <height>90</height>
     </rect>
    </property>
-   <property name="title" >
+   <property name="title">
     <string>Planner</string>
    </property>
-   <property name="orientation" >
+   <property name="orientation">
     <enum>Qt::Vertical</enum>
    </property>
-   <widget class="QLabel" name="textLabel1" >
-    <property name="geometry" >
+   <widget class="QLabel" name="textLabel1">
+    <property name="geometry">
      <rect>
       <x>16</x>
-      <y>21</y>
-      <width>30</width>
+      <y>25</y>
+      <width>41</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Type:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QPushButton" name="plannerResetButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="plannerResetButton">
+    <property name="geometry">
      <rect>
       <x>60</x>
-      <y>50</y>
-      <width>40</width>
+      <y>60</y>
+      <width>51</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Reset</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="plannerInitButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="plannerInitButton">
+    <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>50</y>
+      <x>16</x>
+      <y>60</y>
       <width>40</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Init</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="plannerStartButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="plannerStartButton">
+    <property name="geometry">
      <rect>
-      <x>110</x>
-      <y>50</y>
-      <width>30</width>
+      <x>115</x>
+      <y>60</y>
+      <width>51</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
-     <string>></string>
+    <property name="text">
+     <string>Start</string>
     </property>
    </widget>
-   <widget class="QComboBox" name="plannerTypeBox" >
-    <property name="geometry" >
+   <widget class="QComboBox" name="plannerTypeBox">
+    <property name="geometry">
      <rect>
-      <x>50</x>
+      <x>70</x>
       <y>20</y>
-      <width>140</width>
-      <height>20</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="instantEnergyButton" >
-    <property name="geometry" >
-     <rect>
-      <x>200</x>
-      <y>50</y>
-      <width>20</width>
+      <width>171</width>
       <height>31</height>
      </rect>
     </property>
-    <property name="text" >
+   </widget>
+   <widget class="QPushButton" name="instantEnergyButton">
+    <property name="geometry">
+     <rect>
+      <x>200</x>
+      <y>60</y>
+      <width>41</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="text">
      <string>e</string>
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="groupBox8" >
-   <property name="geometry" >
+  <widget class="Q3GroupBox" name="groupBox8">
+   <property name="geometry">
     <rect>
-     <x>270</x>
+     <x>300</x>
      <y>10</y>
-     <width>280</width>
+     <width>361</width>
      <height>200</height>
     </rect>
    </property>
-   <property name="title" >
+   <property name="title">
     <string>Settings and results</string>
    </property>
-   <property name="orientation" >
+   <property name="orientation">
     <enum>Qt::Vertical</enum>
    </property>
-   <widget class="QPushButton" name="nextGraspButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="nextGraspButton">
+    <property name="geometry">
      <rect>
-      <x>80</x>
+      <x>105</x>
       <y>151</y>
       <width>30</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
-     <string>></string>
+    <property name="text">
+     <string>&gt;</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="bestGraspButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="bestGraspButton">
+    <property name="geometry">
      <rect>
-      <x>40</x>
+      <x>50</x>
       <y>151</y>
-      <width>41</width>
+      <width>51</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Best</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="prevGraspButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="prevGraspButton">
+    <property name="geometry">
      <rect>
-      <x>10</x>
+      <x>15</x>
       <y>151</y>
       <width>30</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>&lt;</string>
     </property>
    </widget>
-   <widget class="QLabel" name="textLabel2_3" >
-    <property name="geometry" >
+   <widget class="QLabel" name="textLabel2_3">
+    <property name="geometry">
      <rect>
       <x>27</x>
       <y>129</y>
-      <width>63</width>
+      <width>101</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Show results:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QComboBox" name="energyBox" >
-    <property name="geometry" >
+   <widget class="QComboBox" name="energyBox">
+    <property name="geometry">
      <rect>
-      <x>140</x>
-      <y>20</y>
-      <width>111</width>
-      <height>21</height>
+      <x>150</x>
+      <y>15</y>
+      <width>191</width>
+      <height>31</height>
      </rect>
     </property>
    </widget>
-   <widget class="QLabel" name="textLabel1_2" >
-    <property name="geometry" >
+   <widget class="QLabel" name="textLabel1_2">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>20</y>
-      <width>122</width>
+      <width>141</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Energy formulation:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QCheckBox" name="setContactsBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="setContactsBox">
+    <property name="geometry">
      <rect>
-      <x>140</x>
-      <y>48</y>
-      <width>16</width>
+      <x>150</x>
+      <y>50</y>
+      <width>21</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string/>
     </property>
    </widget>
-   <widget class="QLabel" name="textLabel1_5" >
-    <property name="geometry" >
+   <widget class="QLabel" name="textLabel1_5">
+    <property name="geometry">
      <rect>
       <x>22</x>
       <y>48</y>
-      <width>99</width>
+      <width>121</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Preset contacts:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="textLabel1_4" >
-    <property name="geometry" >
+   <widget class="QLabel" name="textLabel1_4">
+    <property name="geometry">
      <rect>
-      <x>147</x>
+      <x>170</x>
       <y>77</y>
       <width>30</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Max:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="currentStepLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="currentStepLabel">
+    <property name="geometry">
      <rect>
       <x>13</x>
       <y>78</y>
-      <width>120</width>
+      <width>151</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Current step: 0</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="timeLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="timeLabel">
+    <property name="geometry">
      <rect>
       <x>13</x>
       <y>99</y>
-      <width>150</width>
+      <width>201</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Time used: 0 sec.</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="Line" name="line1_2" >
-    <property name="geometry" >
+   <widget class="Line" name="line1_2">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>113</y>
-      <width>260</width>
+      <width>321</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="frameShape" >
+    <property name="frameShape">
      <enum>QFrame::HLine</enum>
     </property>
-    <property name="frameShadow" >
+    <property name="frameShadow">
      <enum>QFrame::Sunken</enum>
     </property>
-    <property name="orientation" >
+    <property name="orientation">
      <enum>Qt::Horizontal</enum>
     </property>
    </widget>
-   <widget class="Line" name="line1_2_2_2" >
-    <property name="geometry" >
+   <widget class="Line" name="line1_2_2_2">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>62</y>
-      <width>260</width>
+      <width>321</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="frameShape" >
+    <property name="frameShape">
      <enum>QFrame::HLine</enum>
     </property>
-    <property name="frameShadow" >
+    <property name="frameShadow">
      <enum>QFrame::Sunken</enum>
     </property>
-    <property name="orientation" >
+    <property name="orientation">
      <enum>Qt::Horizontal</enum>
     </property>
    </widget>
-   <widget class="QLabel" name="rankLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="rankLabel">
+    <property name="geometry">
      <rect>
-      <x>142</x>
+      <x>170</x>
       <y>135</y>
       <width>120</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Rank: 0/0</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="energyLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="energyLabel">
+    <property name="geometry">
      <rect>
-      <x>135</x>
+      <x>170</x>
       <y>152</y>
       <width>130</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Energy: 0</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="iterationLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="iterationLabel">
+    <property name="geometry">
      <rect>
-      <x>131</x>
+      <x>170</x>
       <y>169</y>
       <width>140</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Iteration: 0</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLineEdit" name="annStepsEdit" >
-    <property name="geometry" >
+   <widget class="QLineEdit" name="annStepsEdit">
+    <property name="geometry">
      <rect>
-      <x>180</x>
-      <y>76</y>
-      <width>60</width>
-      <height>21</height>
+      <x>210</x>
+      <y>77</y>
+      <width>91</width>
+      <height>20</height>
      </rect>
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="onlineDetailsGroup" >
-   <property name="geometry" >
+  <widget class="Q3GroupBox" name="onlineDetailsGroup">
+   <property name="geometry">
     <rect>
-     <x>270</x>
-     <y>320</y>
-     <width>280</width>
+     <x>300</x>
+     <y>330</y>
+     <width>351</width>
      <height>220</height>
     </rect>
    </property>
-   <property name="title" >
+   <property name="title">
     <string>OnLine Planning Details</string>
    </property>
-   <property name="orientation" >
+   <property name="orientation">
     <enum>Qt::Vertical</enum>
    </property>
-   <widget class="QLabel" name="objDistLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="objDistLabel">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>20</y>
@@ -416,15 +414,15 @@
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Object distance:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="solDistLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="solDistLabel">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>40</y>
@@ -432,15 +430,15 @@
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Solution distance:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="onlineStatusLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="onlineStatusLabel">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>60</y>
@@ -448,15 +446,15 @@
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Status:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="fcBufferLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="fcBufferLabel">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>98</y>
@@ -464,15 +462,15 @@
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>FC Thread buffer:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QLabel" name="saBufferLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="saBufferLabel">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>79</y>
@@ -480,112 +478,112 @@
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>SimAnn buffer:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
-   <widget class="QPushButton" name="onlineGraspButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="onlineGraspButton">
+    <property name="geometry">
      <rect>
-      <x>211</x>
-      <y>10</y>
-      <width>40</width>
+      <x>230</x>
+      <y>25</y>
+      <width>51</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Grasp</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="autoGraspBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="autoGraspBox">
+    <property name="geometry">
      <rect>
-      <x>208</x>
-      <y>119</y>
-      <width>50</width>
+      <x>235</x>
+      <y>140</y>
+      <width>61</width>
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Auto</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="onlineReleaseButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="onlineReleaseButton">
+    <property name="geometry">
      <rect>
-      <x>210</x>
-      <y>43</y>
-      <width>40</width>
+      <x>230</x>
+      <y>60</y>
+      <width>51</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Open</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="onlinePlanButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="onlinePlanButton">
+    <property name="geometry">
      <rect>
-      <x>210</x>
-      <y>76</y>
-      <width>40</width>
+      <x>230</x>
+      <y>95</y>
+      <width>51</width>
       <height>30</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Plan</string>
     </property>
    </widget>
-   <widget class="Line" name="line3" >
-    <property name="geometry" >
+   <widget class="Line" name="line3">
+    <property name="geometry">
      <rect>
-      <x>180</x>
-      <y>14</y>
+      <x>210</x>
+      <y>23</y>
       <width>20</width>
-      <height>190</height>
+      <height>181</height>
      </rect>
     </property>
-    <property name="frameShape" >
+    <property name="frameShape">
      <enum>QFrame::VLine</enum>
     </property>
-    <property name="frameShadow" >
+    <property name="frameShadow">
      <enum>QFrame::Sunken</enum>
     </property>
-    <property name="orientation" >
+    <property name="orientation">
      <enum>Qt::Vertical</enum>
     </property>
    </widget>
-   <widget class="QCheckBox" name="showCloneBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="showCloneBox">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>120</y>
-      <width>170</width>
+      <width>181</width>
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Show pre-grasp search</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="showSolutionBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="showSolutionBox">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>140</y>
-      <width>160</width>
+      <width>181</width>
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Show current solution</string>
     </property>
    </widget>
-   <widget class="Line" name="line4" >
-    <property name="geometry" >
+   <widget class="Line" name="line4">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>155</y>
@@ -593,45 +591,45 @@
       <height>20</height>
      </rect>
     </property>
-    <property name="frameShape" >
+    <property name="frameShape">
      <enum>QFrame::HLine</enum>
     </property>
-    <property name="frameShadow" >
+    <property name="frameShadow">
      <enum>QFrame::Sunken</enum>
     </property>
-    <property name="orientation" >
+    <property name="orientation">
      <enum>Qt::Horizontal</enum>
     </property>
    </widget>
-   <widget class="QCheckBox" name="useVirtualHandBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="useVirtualHandBox">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>170</y>
-      <width>140</width>
+      <width>201</width>
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Shape virtual hand model</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="useRealBarrettBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="useRealBarrettBox">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>190</y>
-      <width>170</width>
+      <width>191</width>
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Shape real Barrett Hand</string>
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="inputBox" >
-   <property name="geometry" >
+  <widget class="Q3GroupBox" name="inputBox">
+   <property name="geometry">
     <rect>
      <x>10</x>
      <y>420</y>
@@ -639,83 +637,83 @@
      <height>80</height>
     </rect>
    </property>
-   <property name="title" >
+   <property name="title">
     <string>Input</string>
    </property>
-   <property name="orientation" >
+   <property name="orientation">
     <enum>Qt::Vertical</enum>
    </property>
-   <widget class="QPushButton" name="inputLoadButton" >
-    <property name="geometry" >
+   <widget class="QPushButton" name="inputLoadButton">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>50</y>
-      <width>100</width>
-      <height>20</height>
+      <width>131</width>
+      <height>31</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Load from File...</string>
     </property>
    </widget>
-   <widget class="QCheckBox" name="inputGloveBox" >
-    <property name="geometry" >
+   <widget class="QCheckBox" name="inputGloveBox">
+    <property name="geometry">
      <rect>
       <x>10</x>
       <y>20</y>
-      <width>121</width>
+      <width>161</width>
       <height>21</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Use CyberGlove</string>
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="variableBox" >
-   <property name="geometry" >
+  <widget class="Q3GroupBox" name="variableBox">
+   <property name="geometry">
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>250</width>
+     <width>281</width>
      <height>400</height>
     </rect>
    </property>
-   <property name="title" >
+   <property name="title">
     <string>Space Search</string>
    </property>
-   <property name="orientation" >
+   <property name="orientation">
     <enum>Qt::Vertical</enum>
    </property>
-   <widget class="QComboBox" name="spaceSearchBox" >
-    <property name="geometry" >
+   <widget class="QComboBox" name="spaceSearchBox">
+    <property name="geometry">
      <rect>
       <x>60</x>
       <y>20</y>
       <width>180</width>
-      <height>21</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
-   <widget class="QLabel" name="spaceSearchLabel" >
-    <property name="geometry" >
+   <widget class="QLabel" name="spaceSearchLabel">
+    <property name="geometry">
      <rect>
       <x>10</x>
-      <y>20</y>
+      <y>25</y>
       <width>35</width>
       <height>20</height>
      </rect>
     </property>
-    <property name="text" >
+    <property name="text">
      <string>Type:</string>
     </property>
-    <property name="wordWrap" >
+    <property name="wordWrap">
      <bool>false</bool>
     </property>
    </widget>
   </widget>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
@@ -723,11 +721,10 @@
    <extends>QGroupBox</extends>
    <header>Qt3Support/Q3GroupBox</header>
    <container>1</container>
-   <pixmap></pixmap>
   </customwidget>
  </customwidgets>
  <includes>
-  <include location="global" >vector</include>
+  <include location="global">vector</include>
  </includes>
  <resources/>
  <connections>
@@ -737,11 +734,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>exitButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -753,11 +750,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>prevGraspButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -769,11 +766,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>bestGraspButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -785,11 +782,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>nextGraspButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -801,11 +798,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>setContactsBox_toggled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -817,11 +814,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>spaceSearchBox_activated(QString)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -833,11 +830,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>energyBox_activated(QString)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -849,11 +846,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>plannerTypeBox_activated(QString)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -865,11 +862,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>plannerReset_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -881,11 +878,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>plannerInit_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -897,11 +894,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>plannerStart_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -913,11 +910,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>onlineGraspButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -929,11 +926,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>autoGraspBox_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -945,11 +942,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>onlineReleaseButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -961,11 +958,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>onlinePlanButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -977,11 +974,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>instantEnergyButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -993,11 +990,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>showCloneBox_toggled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -1009,11 +1006,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>showSolutionBox_toggled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -1025,11 +1022,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>useRealBarrettBox_toggled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -1041,11 +1038,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>inputGloveBox_toggled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -1057,11 +1054,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>inputLoadButton_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>
@@ -1073,11 +1070,11 @@
    <receiver>EigenGraspPlannerDlgUI</receiver>
    <slot>useVirtualHandBox_clicked()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
     </hint>


### PR DESCRIPTION
1)Fixed so text is no longer cutoff
2) Made planner runtime display 3 addional decimal places, as just seconds is not very precise.
3) made default energy formulation Contacts and Quality. No one uses just Contact Quality

Old Dlg:
![old_eg_planner_dlg](https://cloud.githubusercontent.com/assets/1675542/12686226/851ccd7e-c696-11e5-84e7-d965148748f9.jpg)

New dialogue, it has no new features, but you can read all the text. 
![new_egplannerdlg](https://cloud.githubusercontent.com/assets/1675542/12686128/139f1c9c-c696-11e5-8a38-18aa2ac012af.jpg)
