### PR TITLE
Fixing tests using q mutex

### DIFF
--- a/graspit-lib-LINUX.pro
+++ b/graspit-lib-LINUX.pro
@@ -39,7 +39,6 @@ graspit_test{
     SOURCES += test/simple_test.cpp
     LIBS += -L/usr/lib/ -lgtest
     TARGET = graspit-test
-    QMAKE_CXXFLAGS += -std=c++0x
 }
 
 cgdb {

--- a/graspit.pro
+++ b/graspit.pro
@@ -8,7 +8,7 @@ LANGUAGE	= C++
 #-------------------------options--------------------------
 
 #uncomment this line for compiling graspit tests.
-CONFIG += graspit_test
+#CONFIG += graspit_test
 
 #comment out this line for compiling in Release mode
 #usually, compiling in Release mode delivers a significant gain in performance

--- a/graspit.pro
+++ b/graspit.pro
@@ -8,7 +8,7 @@ LANGUAGE	= C++
 #-------------------------options--------------------------
 
 #uncomment this line for compiling graspit tests.
-#CONFIG += graspit_test
+CONFIG += graspit_test
 
 #comment out this line for compiling in Release mode
 #usually, compiling in Release mode delivers a significant gain in performance

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <QString>
 #include <pthread.h>
-#include <mutex>
+#include <QMutex>
 #include <Inventor/Qt/SoQt.h>
 
 #include "graspitGUI.h"
@@ -16,7 +16,7 @@
 #include "qmDlg.h"
 #include "grasp.h"
 
-std::mutex mtx_;
+QMutex mtx_;
 
 void *exit_graspit( void *ptr );
 void *run_test(void *ptr );
@@ -27,7 +27,7 @@ void *exit_graspit(void *ptr )
   sleep(3);
 
   //hang here until tests are finished and mtx is released.
-  std::lock_guard<std::mutex> guard(mtx_);
+  QMutexLocker guard(&mtx_);
 
   GraspItGUI *gui;
   gui = (GraspItGUI *) ptr;
@@ -40,7 +40,7 @@ void *exit_graspit(void *ptr )
 
 void *run_test(void *ptr )
 {
-  std::lock_guard<std::mutex> guard(mtx_);
+  QMutexLocker guard(&mtx_);
 
   PlannerDlg *dlg;
   dlg = (PlannerDlg *) ptr;


### PR DESCRIPTION
No longer requires c++0x to run tests.  I used the QMutex and QMutexLocker classes instead. 
