### PR TITLE
Fix string duplication bug in plugin initialization

### DIFF
--- a/src/graspitGUI.cpp
+++ b/src/graspitGUI.cpp
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: graspitGUI.cpp,v 1.19 2010/08/11 02:45:37 cmatei Exp $
 //
@@ -85,7 +85,7 @@ GraspItGUI *graspItGUI = 0;
 GraspItGUI::GraspItGUI(int argc,char **argv) : mDispatch(NULL)
 {
   if (!initialized) {
-    mainWindow = new MainWindow; 
+    mainWindow = new MainWindow;
     SoQt::init(mainWindow->mWindow);
 
     // initialize my Inventor additions
@@ -94,10 +94,10 @@ GraspItGUI::GraspItGUI(int argc,char **argv) : mDispatch(NULL)
     SoTorquePointer::initClass();
 
     ivmgr = new IVmgr((QWidget *)mainWindow->mUI->viewerHolder,"myivmgr");
-	
+
 //	mainWindow->viewerHolder->setFocusProxy(ivmgr->getViewer()->getWidget());
 //	mainWindow->viewerHolder->setFocusPolicy(QWidget::StrongFocus);
-    
+
     ivmgr->getViewer()->getWidget()->setFocusPolicy(Qt::StrongFocus);
 
     initialized = true;
@@ -175,7 +175,7 @@ GraspItGUI::processArgs(int argc, char** argv)
 
     //start any plugins with auto start enabled
     mPluginSensor = new SoIdleSensor(GraspItGUI::sensorCB, (void*)this);
-    for (size_t i=0; i<mPluginCreators.size(); i++)
+    for (size_t i = 0; i < mPluginCreators.size(); i++)
     {
         std::cout << "plugin creator autostart " << mPluginCreators[i]->autoStart() << std::endl;
         if (mPluginCreators[i]->autoStart())
@@ -206,7 +206,7 @@ GraspItGUI::processArgs(int argc, char** argv)
       }
 #endif
   }
- 
+
 #ifdef Q_WS_X11
 
   if (args->exist("world"))
@@ -274,12 +274,12 @@ GraspItGUI::processArgs(int argc, char** argv)
 */
 void
 GraspItGUI::startMainLoop()
-{	
+{
   SoQt::show(mainWindow->mWindow);
   mainWindow->setMainWorld(ivmgr->getWorld());
-  mainWindow->mWindow->resize(QSize(1070,937));  
+  mainWindow->mWindow->resize(QSize(1070,937));
   SoQt::mainLoop();
-}  
+}
 
 /*!
   Exits the Qt event loop.
@@ -302,14 +302,14 @@ GraspItGUI::sensorCB(void*, SoSensor*)
   graspItGUI->processPlugins();
 }
 
-void 
+void
 GraspItGUI::startPlugin(PluginCreator* creator, int argc, char** argv)
 {
   Plugin *plugin = creator->createPlugin(argc,argv);
   if (plugin) mActivePlugins.push_back( std::pair<Plugin*, std::string>(plugin, creator->type()) );
   if (!mActivePlugins.empty()) {
     mPluginSensor->schedule();
-  }  
+  }
 }
 
 void GraspItGUI::processPlugins()

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -38,6 +38,9 @@ extern "C"{
 #include "plugin.h"
 #include "mytools.h"
 #include "debug.h"
+#include "string.h"
+
+
 
 PluginCreator::~PluginCreator()
 {
@@ -47,7 +50,7 @@ PluginCreator::~PluginCreator()
 
 Plugin* PluginCreator::createPlugin(int argc, char** argv)
 {
-  Plugin* plugin = (*mCreatePluginFctn)(); 
+  Plugin* plugin = (*mCreatePluginFctn)();
   if (!plugin)
   {
       return NULL;
@@ -57,9 +60,7 @@ Plugin* PluginCreator::createPlugin(int argc, char** argv)
   char ** argv_copy = new char*[argc+1];
   for(int i=0; i < argc; i++)
   {
-      int len = strlen(argv[i] + 1);
-      argv_copy[i] = new char[len];
-      strcpy(argv_copy[i], argv[i]);
+      argv_copy[i] = strdup(argv[i]);
   }
   argv_copy[argc] = NULL;
 
@@ -107,10 +108,10 @@ PluginCreator* PluginCreator::loadFromLibrary(std::string libName)
       }
     }
     if (!found) {
-      DBGA("Could not find relative plugin file " << filename.latin1() << 
+      DBGA("Could not find relative plugin file " << filename.latin1() <<
            " in any directory specified in GRASPIT_PLUGIN_DIR");
       return NULL;
-    }    
+    }
   }
 
   //look for the library file and load it


### PR DESCRIPTION
Replacing hand-rolled strdup with call to strdup.

Mysteriously fixes plugin init issues... but it does work :)

More concretely: when loading a world file and a plugin, GraspIt! would crash with a memory bound check error in malloc(). Now, GraspIt! does not crash in this case.

@mateiciocarlie @jvarley 