### PR TITLE
another take at reformating

### DIFF
--- a/include/FitParabola.h
+++ b/include/FitParabola.h
@@ -1,155 +1,155 @@
 /*********************************************
-FitParabola
-Claire Lackner
-August 16, 2006
+    FitParabola
+    Claire Lackner
+    August 16, 2006
 
-Fits a second order curve to a set points
-used in soft contacts to calculate the analytic curve in 
-the neighborhood of a contact
-The curve is of the form z = Ax^2 +By^2 +Cxy
-RotateParaboloid takes the fit and rotates it such that the mixed term
-goes to zero, leaving z = R1x^2 + R2y^2 
-where R1 and R2 are the radii of curvature
+    Fits a second order curve to a set points
+    used in soft contacts to calculate the analytic curve in
+    the neighborhood of a contact
+    The curve is of the form z = Ax^2 +By^2 +Cxy
+    RotateParaboloid takes the fit and rotates it such that the mixed term
+    goes to zero, leaving z = R1x^2 + R2y^2
+    where R1 and R2 are the radii of curvature
 *********************************************/
 
 #include "matvec3D.h"
 
-inline void FitParaboloid( vec3 *points, int numpts, double *coeffs );
-inline void RotateParaboloid( double *coeff, double *R1, double *R2, mat3 *Rot, double *rotAngle );
+inline void FitParaboloid(vec3 *points, int numpts, double *coeffs);
+inline void RotateParaboloid(double *coeff, double *R1, double *R2, mat3 *Rot, double *rotAngle);
 
 #define FIT_TINY 1.0e-6
 #define CONCAVE_WARNING 1.0e-3
 
-void FitParaboloid( vec3 *points, int numpts, double *coeffs )
-{
-	//std::cerr << "Numpts: " << numpts;
-	//trying to solve Ax=z for x where x is the vector of the coefficients
-	//x_1=coeff x^2, x_2=coeff y^2, x_3=coeff xy
+void FitParaboloid(vec3 *points, int numpts, double *coeffs) {
+    //std::cerr << "Numpts: " << numpts;
+    //trying to solve Ax=z for x where x is the vector of the coefficients
+    //x_1=coeff x^2, x_2=coeff y^2, x_3=coeff xy
 
-	mat3 A, A_add, A_inverse;
-	vec3 z, z_add, x;
+    mat3 A, A_add, A_inverse;
+    vec3 z, z_add, x;
 
-		z.set(0, 0, 0);
-	A=mat3::ZERO;
-	
-	for( int i = 0; i < numpts; i++ )
-	{
-		z_add.set(points[i].x()*points[i].x()*points[i].z(), 
-				points[i].y()*points[i].y()*points[i].z(),
-				points[i].x()*points[i].y()*points[i].z());
-		z+=z_add;
+    z.set(0, 0, 0);
+    A = mat3::ZERO;
 
-		double M [9]={points[i].x()*points[i].x()*points[i].x()*points[i].x(),	//0,0
-					points[i].x()*points[i].x()*points[i].y()*points[i].y(), //1,0
-					points[i].x()*points[i].x()*points[i].x()*points[i].y(), //2,0
-					points[i].x()*points[i].x()*points[i].y()*points[i].y(), //0,1
-					points[i].y()*points[i].y()*points[i].y()*points[i].y(), //1,1
-					points[i].x()*points[i].y()*points[i].y()*points[i].y(), //2,1
-					points[i].x()*points[i].x()*points[i].x()*points[i].y(), //0,2
-					points[i].x()*points[i].y()*points[i].y()*points[i].y(), //1,2
-					points[i].x()*points[i].x()*points[i].y()*points[i].y()}; //2,2
-		
-		A_add.set(M);
+    for (int i = 0; i < numpts; i++) {
+        z_add.set(points[i].x()*points[i].x()*points[i].z(),
+                  points[i].y()*points[i].y()*points[i].z(),
+                  points[i].x()*points[i].y()*points[i].z());
+        z += z_add;
 
-		A+=A_add;
-	}
+        double M [9] = {points[i].x() *points[i].x() *points[i].x() *points[i].x(), //0,0
+                        points[i].x() *points[i].x() *points[i].y() *points[i].y(), //1,0
+                        points[i].x() *points[i].x() *points[i].x() *points[i].y(), //2,0
+                        points[i].x() *points[i].x() *points[i].y() *points[i].y(), //0,1
+                        points[i].y() *points[i].y() *points[i].y() *points[i].y(), //1,1
+                        points[i].x() *points[i].y() *points[i].y() *points[i].y(), //2,1
+                        points[i].x() *points[i].x() *points[i].x() *points[i].y(), //0,2
+                        points[i].x() *points[i].y() *points[i].y() *points[i].y(), //1,2
+                        points[i].x() *points[i].x() *points[i].y() *points[i].y()
+                       }; //2,2
 
-	A_inverse = A.inverse();
-	
-	x=A_inverse*z;
+        A_add.set(M);
 
-	coeffs[0] = x.x();
-	coeffs[1] = x.y();
-	coeffs[2] = x.z();
-	for (int i=0; i<3; i++) {
-		//almost planar
-		if ( fabs(coeffs[i]) < FIT_TINY ) {
-			coeffs[i] = 0.0;
-		} 
-		/*
-		else if ( coeffs[i] < 0) {
-			//concave
-			if ( fabs(coeffs[i]) > CONCAVE_WARNING ) {
-				//if really concave, display warning
-				std::cerr << "Warning: concave fit at soft contact: " << coeffs[i] << std::endl;
-			}
-			coeffs[i] = 0;
-		}
-		*/
-	       
-	}
-	//std::cerr<<"\nRadii of curvature: "<<coeffs[0]<<"\t"<<coeffs[1]<<"\t"<<coeffs[2]<<std::endl;
+        A += A_add;
+    }
+
+    A_inverse = A.inverse();
+
+    x = A_inverse * z;
+
+    coeffs[0] = x.x();
+    coeffs[1] = x.y();
+    coeffs[2] = x.z();
+    for (int i = 0; i < 3; i++) {
+        //almost planar
+        if (fabs(coeffs[i]) < FIT_TINY) {
+            coeffs[i] = 0.0;
+        }
+        /*
+            else if ( coeffs[i] < 0) {
+            //concave
+            if ( fabs(coeffs[i]) > CONCAVE_WARNING ) {
+                //if really concave, display warning
+                std::cerr << "Warning: concave fit at soft contact: " << coeffs[i] << std::endl;
+            }
+            coeffs[i] = 0;
+            }
+        */
+
+    }
+    //std::cerr<<"\nRadii of curvature: "<<coeffs[0]<<"\t"<<coeffs[1]<<"\t"<<coeffs[2]<<std::endl;
 
 }
 
-void RotateParaboloid( double *coeff, double *R1, double *R2, mat3 *Rot, double *rotAngle )
-{
-	//rotate a given parabola so that the xy coefficient is zero
-	//fill out the rads (radii of curvature) and the rotation that
-	//takes you from the first (contact) frame into the rotated frame
+void RotateParaboloid(double *coeff, double *R1, double *R2, mat3 *Rot, double *rotAngle) {
+    //rotate a given parabola so that the xy coefficient is zero
+    //fill out the rads (radii of curvature) and the rotation that
+    //takes you from the first (contact) frame into the rotated frame
 
-	//tan(2theta) = C/(B-A)
+    //tan(2theta) = C/(B-A)
 
-	//R^t*[[A C/2][C/2 B]]*R = [[rads[0] 0][0 rads[1]]
-	//where R is the rotation matrix [[cos(theta) -sin(theta)][sin(theta) cos(theta)]]
+    //R^t*[[A C/2][C/2 B]]*R = [[rads[0] 0][0 rads[1]]
+    //where R is the rotation matrix [[cos(theta) -sin(theta)][sin(theta) cos(theta)]]
 
 
-	double theta, sintheta, costheta;
-	vec3 col1, col2, col3;
+    double theta, sintheta, costheta;
+    vec3 col1, col2, col3;
 
-	if( fabs(coeff[2]) > FIT_TINY )
-	{
-		if( coeff[0] != coeff[1] )
-			theta = atan( coeff[2]/(coeff[1] - coeff[0])  )/2.0;
-		else
-			theta = M_PI/2;
+    if (fabs(coeff[2]) > FIT_TINY) {
+        if (coeff[0] != coeff[1])
+            theta = atan(coeff[2] / (coeff[1] - coeff[0])) / 2.0;
+        else
+            theta = M_PI / 2;
 
-		*rotAngle = theta;
-		sintheta = sin(theta);
-		costheta = cos(theta);
-	
-		col1.set( costheta, sintheta, 0.0 );
-		col2.set( -1.0*sintheta, costheta, 0.0 );
-		col3.set( 0.0, 0.0, 1.0 );
-		Rot->set( col1, col2, col3 );
+        *rotAngle = theta;
+        sintheta = sin(theta);
+        costheta = cos(theta);
 
-		double temp1 = (coeff[0]*costheta*costheta + coeff[1]*sintheta*sintheta 
-					- coeff[2] * sintheta*costheta)*2;
-		double temp2 = (coeff[0]*sintheta*sintheta + coeff[1]*costheta*costheta 
-					+ coeff[2] * sintheta*costheta)*2;
-		if( fabs(temp1) > FIT_TINY ) {
-			*R1 = 1/temp1;
-		} else { 
-			*R1 = -1.0;
-		}
-		if( fabs(temp2) > FIT_TINY ) {
-			*R2 = 1/temp2;
-		} else {
-			*R2 = -1.0;
-		}
-		//the else's take care of flat case, which will be addressed
-		//in finding the relative radii of curvature
-	}
-	else
-	{
-		if( fabs(coeff[0]) > FIT_TINY ) {
-			*R1 = 1/(2*coeff[0]);
-		} else { 
-			*R1 = -1.0;
-		}
-		if( fabs(coeff[1]) > FIT_TINY ) {
-			*R2 = 1/(2*coeff[1]);
-		} else {
-			*R2 = -1.0;
-		}
+        col1.set(costheta, sintheta, 0.0);
+        col2.set(-1.0 * sintheta, costheta, 0.0);
+        col3.set(0.0, 0.0, 1.0);
+        Rot->set(col1, col2, col3);
 
-		*rotAngle = 0;
-		*Rot = mat3::IDENTITY;
+        double temp1 = (coeff[0] * costheta * costheta + coeff[1] * sintheta * sintheta
+                        - coeff[2] * sintheta * costheta) * 2;
+        double temp2 = (coeff[0] * sintheta * sintheta + coeff[1] * costheta * costheta
+                        + coeff[2] * sintheta * costheta) * 2;
+        if (fabs(temp1) > FIT_TINY) {
+            *R1 = 1 / temp1;
+        }
+        else {
+            *R1 = -1.0;
+        }
+        if (fabs(temp2) > FIT_TINY) {
+            *R2 = 1 / temp2;
+        }
+        else {
+            *R2 = -1.0;
+        }
+        //the else's take care of flat case, which will be addressed
+        //in finding the relative radii of curvature
+    }
+    else {
+        if (fabs(coeff[0]) > FIT_TINY) {
+            *R1 = 1 / (2 * coeff[0]);
+        }
+        else {
+            *R1 = -1.0;
+        }
+        if (fabs(coeff[1]) > FIT_TINY) {
+            *R2 = 1 / (2 * coeff[1]);
+        }
+        else {
+            *R2 = -1.0;
+        }
 
-	}
+        *rotAngle = 0;
+        *Rot = mat3::IDENTITY;
 
-	//std::cerr<<"Coeffs on entry: " << coeff[0] << " " << coeff[1] << " " << coeff[2] << std::endl;
-	//std::cerr<<"Radii of curvature: "<<*R1<<"\t"<<*R2<<std::endl;
+    }
 
-	//final form of eqn z = 1/2r1*x^2 +1/2r2*y^2
+    //std::cerr<<"Coeffs on entry: " << coeff[0] << " " << coeff[1] << " " << coeff[2] << std::endl;
+    //std::cerr<<"Radii of curvature: "<<*R1<<"\t"<<*R2<<std::endl;
+
+    //final form of eqn z = 1/2r1*x^2 +1/2r2*y^2
 }

--- a/include/SoArrow.h
+++ b/include/SoArrow.h
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: SoArrow.h,v 1.2 2009/03/25 22:10:23 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Defines an arrow node for Inventor/Coin.
+    \brief Defines an arrow node for Inventor/Coin.
 */
 
 #include <Inventor/engines/SoCalculator.h>
@@ -35,58 +35,58 @@
 
 //! A ComplexShape node for Inventor/Coin that defines an arrow or pointer.
 /*!
-  This class combines a cylinder with 0,1, or 2 cones that serve as arrow
-  heads.  This makes it easy to add arrows to an Inventor scene without
-  defining the pieces separately.  The lengths and radii of the various
-  pieces can all be customized.
+    This class combines a cylinder with 0,1, or 2 cones that serve as arrow
+    heads.  This makes it easy to add arrows to an Inventor scene without
+    defining the pieces separately.  The lengths and radii of the various
+    pieces can all be customized.
 */
 class SoArrow : public SoComplexShape {
 
-   SO_NODE_HEADER(SoArrow);
+        SO_NODE_HEADER(SoArrow);
 
- public:
+    public:
 
-   //! Bitflags controlling which arrowheads are visible (NONE, BEGIN, END, or BOTH)
-   enum Part {
-     NONE   = 0x00, 
-     BEGIN  = 0x01,             // Arrow at the beginning of the cylinder
-     END    = 0x02,             // at the end
-     BOTH   = 0x03              // at both ends
-   };
+        //! Bitflags controlling which arrowheads are visible (NONE, BEGIN, END, or BOTH)
+        enum Part {
+            NONE   = 0x00,
+            BEGIN  = 0x01,             // Arrow at the beginning of the cylinder
+            END    = 0x02,             // at the end
+            BOTH   = 0x03              // at both ends
+        };
 
-   // Fields
-   //! Defines which arrow heads should be shown.
-   SoSFBitMask   arrowHeads;
+        // Fields
+        //! Defines which arrow heads should be shown.
+        SoSFBitMask   arrowHeads;
 
-   //! Width of arrow shaft
-   SoSFFloat     cylRadius;     
+        //! Width of arrow shaft
+        SoSFFloat     cylRadius;
 
-   //! Height of the entire arrow
-   SoSFFloat     height;
+        //! Height of the entire arrow
+        SoSFFloat     height;
 
-   //! Height of the arrow head
-   SoSFFloat     coneHeight;
-    
-   //! Radius of the arrow head
-   SoSFFloat     coneRadius;    
+        //! Height of the arrow head
+        SoSFFloat     coneHeight;
 
-   static void   initClass();
-   SoArrow();
+        //! Radius of the arrow head
+        SoSFFloat     coneRadius;
 
-   void          addPart(Part part);
-   void          removePart(Part part);
-   SbBool        hasPart(Part part) const;
+        static void   initClass();
+        SoArrow();
 
- private:
+        void          addPart(Part part);
+        void          removePart(Part part);
+        SbBool        hasPart(Part part) const;
 
-   //! A pointer to the calculator engine that computes the cylinder height
-   SoCalculator *calEngine;
+    private:
 
-   //! Pointer to switch node that controls the visibility of an arrowhead
-   SoSwitch     *beginSw,*endSw;
+        //! A pointer to the calculator engine that computes the cylinder height
+        SoCalculator *calEngine;
 
-   virtual ~SoArrow();
+        //! Pointer to switch node that controls the visibility of an arrowhead
+        SoSwitch     *beginSw, *endSw;
 
-   void generateChildren();
+        virtual ~SoArrow();
+
+        void generateChildren();
 
 };

--- a/include/SoComplexShape.h
+++ b/include/SoComplexShape.h
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: SoComplexShape.h,v 1.2 2009/03/25 22:10:23 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Defines a new abstract shape class for Inventor/Coin.
+    \brief Defines a new abstract shape class for Inventor/Coin.
 */
 
 #ifndef _SO_COMPLEX_SHAPE_H
@@ -43,43 +43,43 @@ class SoChildList;
 */
 class SoComplexShape : public SoNode {
 
-   SO_NODE_ABSTRACT_HEADER(SoComplexShape);
+        SO_NODE_ABSTRACT_HEADER(SoComplexShape);
 
- public:
-  
-   static void    initClass();
+    public:
 
-   virtual SoChildList *getChildren() const;
+        static void    initClass();
 
-   virtual void copyContents(const SoFieldContainer *FC, 
-			     SbBool copyConnection);
+        virtual SoChildList *getChildren() const;
 
- protected:
+        virtual void copyContents(const SoFieldContainer *FC,
+                                  SbBool copyConnection);
 
-   // These are the methods that are used to apply the action
-   // to various node classes. The third method is registered
-   // for all relevant non-shape nodes. The calling sequence for
-   // these methods is that used for all methods in the global
-   // action table.
+    protected:
 
-   SoComplexShape();
+        // These are the methods that are used to apply the action
+        // to various node classes. The third method is registered
+        // for all relevant non-shape nodes. The calling sequence for
+        // these methods is that used for all methods in the global
+        // action table.
 
-   virtual ~SoComplexShape();
+        SoComplexShape();
 
-   /*! Empty stub. */
-   virtual void generateChildren() { }
+        virtual ~SoComplexShape();
+
+        /*! Empty stub. */
+        virtual void generateChildren() { }
 
 
-   virtual void  doAction(SoAction *action);
-   virtual void  getBoundingBox(SoGetBoundingBoxAction *action);
-   virtual void  GLRender(SoGLRenderAction *action);
-   virtual void  handleEvent(SoHandleEventAction *action);
-   virtual void  pick(SoPickAction *action);
-   virtual void  callback(SoCallbackAction *action);
-   virtual void  getMatrix(SoGetMatrixAction *action);
+        virtual void  doAction(SoAction *action);
+        virtual void  getBoundingBox(SoGetBoundingBoxAction *action);
+        virtual void  GLRender(SoGLRenderAction *action);
+        virtual void  handleEvent(SoHandleEventAction *action);
+        virtual void  pick(SoPickAction *action);
+        virtual void  callback(SoCallbackAction *action);
+        virtual void  getMatrix(SoGetMatrixAction *action);
 
-   //! A pointer to a list of the nodes that make up this complex shape.
-   SoChildList *children;
+        //! A pointer to a list of the nodes that make up this complex shape.
+        SoChildList *children;
 
 
 };

--- a/include/SoTorquePointer.h
+++ b/include/SoTorquePointer.h
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: SoTorquePointer.h,v 1.2 2009/03/25 22:10:23 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Defines a torque pointer node for Inventor/Coin.
+    \brief Defines a torque pointer node for Inventor/Coin.
 */
 
 #include <Inventor/fields/SoSFFloat.h>
@@ -33,35 +33,35 @@
 
 //! A ComplexShape node for Inventor/Coin that defines an torque pointer.
 /*!
-  This class combines a cylinder with a circular arrow that points in a
-  counter clockwise direction at the end of the cylinder.  This indicates
-  a torque axis and the direction of the torque.  The length of the axis
-  indiciates the magnitude of the torque.  This node makes it easy to add
-  these pointers to an Inventor scene without defining the pieces separately.
-  The geometry for the circular arrow has been precomputed and the binary
-  Inventor data is included directly as a header file.
+    This class combines a cylinder with a circular arrow that points in a
+    counter clockwise direction at the end of the cylinder.  This indicates
+    a torque axis and the direction of the torque.  The length of the axis
+    indiciates the magnitude of the torque.  This node makes it easy to add
+    these pointers to an Inventor scene without defining the pieces separately.
+    The geometry for the circular arrow has been precomputed and the binary
+    Inventor data is included directly as a header file.
 */
 class SoTorquePointer : public SoComplexShape {
 
-   SO_NODE_HEADER(SoTorquePointer);
+        SO_NODE_HEADER(SoTorquePointer);
 
- public:
+    public:
 
-   // Fields
-   //! Defines the width of the shaft
-   SoSFFloat     cylRadius;
+        // Fields
+        //! Defines the width of the shaft
+        SoSFFloat     cylRadius;
 
-   //! Defines the height of the shaft
-   SoSFFloat     height;
+        //! Defines the height of the shaft
+        SoSFFloat     height;
 
-   static void   initClass();
-   SoTorquePointer();
+        static void   initClass();
+        SoTorquePointer();
 
- private:
-   //! A pointer to the geometry of the curved arrow
-   static SoSeparator *curvedArrow;
-   
-   virtual ~SoTorquePointer();
+    private:
+        //! A pointer to the geometry of the curved arrow
+        static SoSeparator *curvedArrow;
 
-   void generateChildren();
+        virtual ~SoTorquePointer();
+
+        void generateChildren();
 };

--- a/include/arch.h
+++ b/include/arch.h
@@ -19,18 +19,18 @@
 //
 // Author(s): Matei T. Ciocarlie
 //
-// $Id: 
+// $Id:
 //
 //######################################################################
 
-/*! \file 
-	This function creates an arch of blocks. The original reason was a project
-	that did not continue. However, it is a useful test of the dynamics engine
-	so it was left in. It is also a good test of the body cloning mechanism.
-	This can be called from the Misc. menu of the main window.
+/*! \file
+    This function creates an arch of blocks. The original reason was a project
+    that did not continue. However, it is a useful test of the dynamics engine
+    so it was left in. It is also a good test of the body cloning mechanism.
+    This can be called from the Misc. menu of the main window.
 */
 
 class World;
 
-void create_arch(World *world, double inner_radius, double outer_radius, 
-				double thickness, int n_blocks, bool add_supports);
+void create_arch(World *world, double inner_radius, double outer_radius,
+                 double thickness, int n_blocks, bool add_supports);

--- a/include/bBox.h
+++ b/include/bBox.h
@@ -31,43 +31,46 @@
 
 #include <iostream>
 
-/*! A bounding box. Transform holds the translation to the center of the box and 
-	the rotation to make the box axes align with coordinate axes. HalfSize is the extents
-	of half of the box along each axis.
+/*! A bounding box. Transform holds the translation to the center of the box and
+    the rotation to make the box axes align with coordinate axes. HalfSize is the extents
+    of half of the box along each axis.
 */
-class BoundingBox
-{
-private:
-	transf mTran;
-	transf mTranInv;
-public:
-	vec3 halfSize;
-	//for debugging purposes
-	mutable bool mMark;
-	BoundingBox(const transf &t, const vec3 &v) : mTran(t), mTranInv(t.inverse()), 
-												  halfSize(v), mMark(false) {}
-	BoundingBox(const BoundingBox &b) : mTran(b.getTran()), mTranInv(b.getTranInv()), 
-										halfSize(b.halfSize), mMark(b.mMark) {}
-	BoundingBox() : mTran(), mTranInv(), halfSize(), mMark(false){}
-	INLINE_RELEASE void applyTransform(const transf &t);
-	void setTran(const transf &t) {
-		mTran = t;
-		mTranInv = mTran.inverse();
-	}
-	const transf& getTran() const {return mTran;}
-	const transf& getTranInv() const {return mTranInv;}
+class BoundingBox {
+    private:
+        transf mTran;
+        transf mTranInv;
+    public:
+        vec3 halfSize;
+        //for debugging purposes
+        mutable bool mMark;
+        BoundingBox(const transf &t, const vec3 &v) : mTran(t), mTranInv(t.inverse()),
+            halfSize(v), mMark(false) {}
+        BoundingBox(const BoundingBox &b) : mTran(b.getTran()), mTranInv(b.getTranInv()),
+            halfSize(b.halfSize), mMark(b.mMark) {}
+        BoundingBox() : mTran(), mTranInv(), halfSize(), mMark(false) {}
+        INLINE_RELEASE void applyTransform(const transf &t);
+        void setTran(const transf &t) {
+            mTran = t;
+            mTranInv = mTran.inverse();
+        }
+        const transf &getTran() const {
+            return mTran;
+        }
+        const transf &getTranInv() const {
+            return mTranInv;
+        }
 };
 
-INLINE_RELEASE bool 
+INLINE_RELEASE bool
 bboxOverlap(const BoundingBox &bb1, const BoundingBox &bb2, const transf &tran2To1);
 
-INLINE_RELEASE double 
+INLINE_RELEASE double
 bboxDistanceSq(const BoundingBox &bb1, const BoundingBox &bb2, const transf &tran2To1);
 
-INLINE_RELEASE double 
+INLINE_RELEASE double
 bboxDistanceApp(const BoundingBox &bb1, const BoundingBox &bb2);
 
-INLINE_RELEASE double 
+INLINE_RELEASE double
 pointBoxDistanceSq(const BoundingBox &bbox, const position &p);
 
 INLINE_RELEASE

--- a/include/bbox_inl.h
+++ b/include/bbox_inl.h
@@ -24,388 +24,415 @@
 //######################################################################
 
 /*! \file
-	Bounding box functions to be inlined during release compilation.
-	Do not put any of the necessary includes here, put them in both
-	bbox.h and bbox.cpp instead.
+    Bounding box functions to be inlined during release compilation.
+    Do not put any of the necessary includes here, put them in both
+    bbox.h and bbox.cpp instead.
 */
 
-double 
-pointBoxDistanceSq(const BoundingBox &box, const position &p)
-{
-	vec3 v = (p - position::ORIGIN) - box.getTran().translation();
-	const mat3 &RMat(box.getTran().affine());
+double
+pointBoxDistanceSq(const BoundingBox &box, const position &p) {
+    vec3 v = (p - position::ORIGIN) - box.getTran().translation();
+    const mat3 &RMat(box.getTran().affine());
 
 
     double sqDist = 0.0;
-    for (int i=0; i<3; i++) {
-		double d = v % RMat.row(i);
-		double excess = 0.0;
+    for (int i = 0; i < 3; i++) {
+        double d = v % RMat.row(i);
+        double excess = 0.0;
         // Project vector from box center to p on each axis, getting the distance
         // of p along that axis, and count any excess distance outside box extents
-		if (d < -box.halfSize[i])
-			excess = d + box.halfSize[i];
-		else if (d > box.halfSize[i])
-			excess = d - box.halfSize[i];
-		sqDist += excess * excess;
+        if (d < -box.halfSize[i])
+            excess = d + box.halfSize[i];
+        else if (d > box.halfSize[i])
+            excess = d - box.halfSize[i];
+        sqDist += excess * excess;
     }
     return sqDist;
 }
 
-/*! Code from REAL-TIME COLLISION DETECTION by Christer Ericson, 
-	published by Elsevier.
+/*! Code from REAL-TIME COLLISION DETECTION by Christer Ericson,
+    published by Elsevier.
 */
-position 
-closestPtBbox(const BoundingBox &bbox, const position &p)
-{
-	vec3 d = (p - position::ORIGIN) - bbox.getTran().translation();
-	const mat3 & RMat(bbox.getTran().affine());
+position
+closestPtBbox(const BoundingBox &bbox, const position &p) {
+    vec3 d = (p - position::ORIGIN) - bbox.getTran().translation();
+    const mat3 &RMat(bbox.getTran().affine());
 
     // Start result at center of box; make steps from there
-	vec3 q = bbox.getTran().translation();
+    vec3 q = bbox.getTran().translation();
     // For each OBB axis...
-    for (int i=0; i<3; i++) {
+    for (int i = 0; i < 3; i++) {
         // project d onto that axis to get the distance
         // along the axis of d from the box center
-		double dist = d % RMat.row(i);
+        double dist = d % RMat.row(i);
         // If distance farther than the box extents, clamp to the box
-		if (dist > bbox.halfSize[i]) dist = bbox.halfSize[i];
-		if (dist < -bbox.halfSize[i]) dist = -bbox.halfSize[i];
+        if (dist > bbox.halfSize[i]) dist = bbox.halfSize[i];
+        if (dist < -bbox.halfSize[i]) dist = -bbox.halfSize[i];
         // Step that distance along the axis to get world coordinate
-		q += dist * RMat.row(i);
+        q += dist * RMat.row(i);
     }
-	return position( q.x(), q.y(), q.z() );
+    return position(q.x(), q.y(), q.z());
 }
 
-void 
-BoundingBox::applyTransform(const transf &t)
-{
-	mTran = mTran * t;
-	mTranInv = mTran.inverse();
+void
+BoundingBox::applyTransform(const transf &t) {
+    mTran = mTran * t;
+    mTranInv = mTran.inverse();
 }
 
 bool
-bboxOverlap(const BoundingBox &bb1, const BoundingBox &bb2, const transf &tran2To1)
-{
-	int i, k;
+bboxOverlap(const BoundingBox &bb1, const BoundingBox &bb2, const transf &tran2To1) {
+    int i, k;
 
-	transf BtoA = bb2.getTran() * tran2To1 * bb1.getTranInv();
-	const mat3 &RMat(BtoA.affine());
+    transf BtoA = bb2.getTran() * tran2To1 * bb1.getTranInv();
+    const mat3 &RMat(BtoA.affine());
 
-	double B[3][3];
-	for( i=0; i<3 ; i++ ) {
-		for( k=0; k<3 ; k++ ) {
-			B[i][k] = RMat.element(k,i);
-		}
-	}
+    double B[3][3];
+    for (i = 0; i < 3 ; i++) {
+        for (k = 0; k < 3 ; k++) {
+            B[i][k] = RMat.element(k, i);
+        }
+    }
 
-	//translation between box centers
-	vec3 T = BtoA.translation();
+    //translation between box centers
+    vec3 T = BtoA.translation();
 
-	vec3 a = bb1.halfSize;
-	vec3 b = bb2.halfSize;
+    vec3 a = bb1.halfSize;
+    vec3 b = bb2.halfSize;
 
-  double t, s;
-  register int r;
-  double Bf[3][3];
-  const double reps = 1e-6;
-  
-  // Bf = fabs(B)
-  Bf[0][0] = fabs(B[0][0]);  Bf[0][0] += reps;
-  Bf[0][1] = fabs(B[0][1]);  Bf[0][1] += reps;
-  Bf[0][2] = fabs(B[0][2]);  Bf[0][2] += reps;
-  Bf[1][0] = fabs(B[1][0]);  Bf[1][0] += reps;
-  Bf[1][1] = fabs(B[1][1]);  Bf[1][1] += reps;
-  Bf[1][2] = fabs(B[1][2]);  Bf[1][2] += reps;
-  Bf[2][0] = fabs(B[2][0]);  Bf[2][0] += reps;
-  Bf[2][1] = fabs(B[2][1]);  Bf[2][1] += reps;
-  Bf[2][2] = fabs(B[2][2]);  Bf[2][2] += reps;
+    double t, s;
+    register int r;
+    double Bf[3][3];
+    const double reps = 1e-6;
 
-  // if any of these tests are one-sided, then the polyhedra are disjoint
-  r = 1;
+    // Bf = fabs(B)
+    Bf[0][0] = fabs(B[0][0]);
+    Bf[0][0] += reps;
+    Bf[0][1] = fabs(B[0][1]);
+    Bf[0][1] += reps;
+    Bf[0][2] = fabs(B[0][2]);
+    Bf[0][2] += reps;
+    Bf[1][0] = fabs(B[1][0]);
+    Bf[1][0] += reps;
+    Bf[1][1] = fabs(B[1][1]);
+    Bf[1][1] += reps;
+    Bf[1][2] = fabs(B[1][2]);
+    Bf[1][2] += reps;
+    Bf[2][0] = fabs(B[2][0]);
+    Bf[2][0] += reps;
+    Bf[2][1] = fabs(B[2][1]);
+    Bf[2][1] += reps;
+    Bf[2][2] = fabs(B[2][2]);
+    Bf[2][2] += reps;
 
-  // A1 x A2 = A0
-  t = fabs(T[0]);
-  
-  r &= (t <= 
-	  (a[0] + b[0] * Bf[0][0] + b[1] * Bf[0][1] + b[2] * Bf[0][2]));
-  if (!r) return false;
-  
-  // B1 x B2 = B0
-  s = T[0]*B[0][0] + T[1]*B[1][0] + T[2]*B[2][0];
-  t = fabs(s);
+    // if any of these tests are one-sided, then the polyhedra are disjoint
+    r = 1;
 
-  r &= ( t <=
-	  (b[0] + a[0] * Bf[0][0] + a[1] * Bf[1][0] + a[2] * Bf[2][0]));
-  if (!r) return false;
-    
-  // A2 x A0 = A1
-  t = fabs(T[1]);
-  
-  r &= ( t <= 
-	  (a[1] + b[0] * Bf[1][0] + b[1] * Bf[1][1] + b[2] * Bf[1][2]));
-  if (!r) return false;
+    // A1 x A2 = A0
+    t = fabs(T[0]);
 
-  // A0 x A1 = A2
-  t = fabs(T[2]);
+    r &= (t <=
+          (a[0] + b[0] * Bf[0][0] + b[1] * Bf[0][1] + b[2] * Bf[0][2]));
+    if (!r) return false;
 
-  r &= ( t <= 
-	  (a[2] + b[0] * Bf[2][0] + b[1] * Bf[2][1] + b[2] * Bf[2][2]));
-  if (!r) return false;
+    // B1 x B2 = B0
+    s = T[0] * B[0][0] + T[1] * B[1][0] + T[2] * B[2][0];
+    t = fabs(s);
 
-  // B2 x B0 = B1
-  s = T[0]*B[0][1] + T[1]*B[1][1] + T[2]*B[2][1];
-  t = fabs(s);
+    r &= (t <=
+          (b[0] + a[0] * Bf[0][0] + a[1] * Bf[1][0] + a[2] * Bf[2][0]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (b[1] + a[0] * Bf[0][1] + a[1] * Bf[1][1] + a[2] * Bf[2][1]));
-  if (!r) return false;
+    // A2 x A0 = A1
+    t = fabs(T[1]);
 
-  // B0 x B1 = B2
-  s = T[0]*B[0][2] + T[1]*B[1][2] + T[2]*B[2][2];
-  t = fabs(s);
+    r &= (t <=
+          (a[1] + b[0] * Bf[1][0] + b[1] * Bf[1][1] + b[2] * Bf[1][2]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (b[2] + a[0] * Bf[0][2] + a[1] * Bf[1][2] + a[2] * Bf[2][2]));
-  if (!r) return false;
+    // A0 x A1 = A2
+    t = fabs(T[2]);
 
-  // A0 x B0
-  s = T[2] * B[1][0] - T[1] * B[2][0];
-  t = fabs(s);
-  
-  r &= ( t <= 
-	(a[1] * Bf[2][0] + a[2] * Bf[1][0] +
-	 b[1] * Bf[0][2] + b[2] * Bf[0][1]));
-  if (!r) return false;
-  
-  // A0 x B1
-  s = T[2] * B[1][1] - T[1] * B[2][1];
-  t = fabs(s);
+    r &= (t <=
+          (a[2] + b[0] * Bf[2][0] + b[1] * Bf[2][1] + b[2] * Bf[2][2]));
+    if (!r) return false;
 
-  r &= ( t <=
-	(a[1] * Bf[2][1] + a[2] * Bf[1][1] +
-	 b[0] * Bf[0][2] + b[2] * Bf[0][0]));
-  if (!r) return false;
+    // B2 x B0 = B1
+    s = T[0] * B[0][1] + T[1] * B[1][1] + T[2] * B[2][1];
+    t = fabs(s);
 
-  // A0 x B2
-  s = T[2] * B[1][2] - T[1] * B[2][2];
-  t = fabs(s);
+    r &= (t <=
+          (b[1] + a[0] * Bf[0][1] + a[1] * Bf[1][1] + a[2] * Bf[2][1]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (a[1] * Bf[2][2] + a[2] * Bf[1][2] +
-	   b[0] * Bf[0][1] + b[1] * Bf[0][0]));
-  if (!r) return false;
+    // B0 x B1 = B2
+    s = T[0] * B[0][2] + T[1] * B[1][2] + T[2] * B[2][2];
+    t = fabs(s);
 
-  // A1 x B0
-  s = T[0] * B[2][0] - T[2] * B[0][0];
-  t = fabs(s);
+    r &= (t <=
+          (b[2] + a[0] * Bf[0][2] + a[1] * Bf[1][2] + a[2] * Bf[2][2]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (a[0] * Bf[2][0] + a[2] * Bf[0][0] +
-	   b[1] * Bf[1][2] + b[2] * Bf[1][1]));
-  if (!r) return false;
+    // A0 x B0
+    s = T[2] * B[1][0] - T[1] * B[2][0];
+    t = fabs(s);
 
-  // A1 x B1
-  s = T[0] * B[2][1] - T[2] * B[0][1];
-  t = fabs(s);
+    r &= (t <=
+          (a[1] * Bf[2][0] + a[2] * Bf[1][0] +
+           b[1] * Bf[0][2] + b[2] * Bf[0][1]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (a[0] * Bf[2][1] + a[2] * Bf[0][1] +
-	   b[0] * Bf[1][2] + b[2] * Bf[1][0]));
-  if (!r) return false;
+    // A0 x B1
+    s = T[2] * B[1][1] - T[1] * B[2][1];
+    t = fabs(s);
 
-  // A1 x B2
-  s = T[0] * B[2][2] - T[2] * B[0][2];
-  t = fabs(s);
+    r &= (t <=
+          (a[1] * Bf[2][1] + a[2] * Bf[1][1] +
+           b[0] * Bf[0][2] + b[2] * Bf[0][0]));
+    if (!r) return false;
 
-  r &= (t <=
-	  (a[0] * Bf[2][2] + a[2] * Bf[0][2] +
-	   b[0] * Bf[1][1] + b[1] * Bf[1][0]));
-  if (!r) return false;
+    // A0 x B2
+    s = T[2] * B[1][2] - T[1] * B[2][2];
+    t = fabs(s);
 
-  // A2 x B0
-  s = T[1] * B[0][0] - T[0] * B[1][0];
-  t = fabs(s);
+    r &= (t <=
+          (a[1] * Bf[2][2] + a[2] * Bf[1][2] +
+           b[0] * Bf[0][1] + b[1] * Bf[0][0]));
+    if (!r) return false;
 
-  r &= (t <=
-	  (a[0] * Bf[1][0] + a[1] * Bf[0][0] +
-	   b[1] * Bf[2][2] + b[2] * Bf[2][1]));
-  if (!r) return false;
+    // A1 x B0
+    s = T[0] * B[2][0] - T[2] * B[0][0];
+    t = fabs(s);
 
-  // A2 x B1
-  s = T[1] * B[0][1] - T[0] * B[1][1];
-  t = fabs(s);
+    r &= (t <=
+          (a[0] * Bf[2][0] + a[2] * Bf[0][0] +
+           b[1] * Bf[1][2] + b[2] * Bf[1][1]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (a[0] * Bf[1][1] + a[1] * Bf[0][1] +
-	   b[0] * Bf[2][2] + b[2] * Bf[2][0]));
-  if (!r) return false;
+    // A1 x B1
+    s = T[0] * B[2][1] - T[2] * B[0][1];
+    t = fabs(s);
 
-  // A2 x B2
-  s = T[1] * B[0][2] - T[0] * B[1][2];
-  t = fabs(s);
+    r &= (t <=
+          (a[0] * Bf[2][1] + a[2] * Bf[0][1] +
+           b[0] * Bf[1][2] + b[2] * Bf[1][0]));
+    if (!r) return false;
 
-  r &= ( t <=
-	  (a[0] * Bf[1][2] + a[1] * Bf[0][2] +
-	   b[0] * Bf[2][1] + b[1] * Bf[2][0]));
-  if (!r) return false;
+    // A1 x B2
+    s = T[0] * B[2][2] - T[2] * B[0][2];
+    t = fabs(s);
 
-  return true;  // should equal 0
+    r &= (t <=
+          (a[0] * Bf[2][2] + a[2] * Bf[0][2] +
+           b[0] * Bf[1][1] + b[1] * Bf[1][0]));
+    if (!r) return false;
+
+    // A2 x B0
+    s = T[1] * B[0][0] - T[0] * B[1][0];
+    t = fabs(s);
+
+    r &= (t <=
+          (a[0] * Bf[1][0] + a[1] * Bf[0][0] +
+           b[1] * Bf[2][2] + b[2] * Bf[2][1]));
+    if (!r) return false;
+
+    // A2 x B1
+    s = T[1] * B[0][1] - T[0] * B[1][1];
+    t = fabs(s);
+
+    r &= (t <=
+          (a[0] * Bf[1][1] + a[1] * Bf[0][1] +
+           b[0] * Bf[2][2] + b[2] * Bf[2][0]));
+    if (!r) return false;
+
+    // A2 x B2
+    s = T[1] * B[0][2] - T[0] * B[1][2];
+    t = fabs(s);
+
+    r &= (t <=
+          (a[0] * Bf[1][2] + a[1] * Bf[0][2] +
+           b[0] * Bf[2][1] + b[1] * Bf[2][0]));
+    if (!r) return false;
+
+    return true;  // should equal 0
 }
 
-double bboxDistanceApp(const BoundingBox &bb1, const BoundingBox &bb2)
-{
-	//for now a placeholder: return the distance as if they were bounding spheres
-	//uses three sqrt's, maybe could use less
+double bboxDistanceApp(const BoundingBox &bb1, const BoundingBox &bb2) {
+    //for now a placeholder: return the distance as if they were bounding spheres
+    //uses three sqrt's, maybe could use less
 
-	vec3 t = bb1.getTran().translation() - bb2.getTran().translation();
-	double dist = t.len();
-	dist -= bb1.halfSize.len();
-	dist -= bb2.halfSize.len();
-	return dist;
+    vec3 t = bb1.getTran().translation() - bb2.getTran().translation();
+    double dist = t.len();
+    dist -= bb1.halfSize.len();
+    dist -= bb2.halfSize.len();
+    return dist;
 }
 
-double bboxDistanceSq(const BoundingBox &bb1, const BoundingBox &bb2, const transf &tran2To1)
-{
-	//trying to use the separating axis theorem to get a better distance bound
-	int i, k;
+double bboxDistanceSq(const BoundingBox &bb1, const BoundingBox &bb2, const transf &tran2To1) {
+    //trying to use the separating axis theorem to get a better distance bound
+    int i, k;
 
-	transf BtoA = bb2.getTran() * tran2To1 * bb1.getTranInv();
-	const mat3 &RMat(BtoA.affine());
+    transf BtoA = bb2.getTran() * tran2To1 * bb1.getTranInv();
+    const mat3 &RMat(BtoA.affine());
 
-	double B[3][3];
-	for( i=0; i<3 ; i++ ) {
-		for( k=0; k<3 ; k++ ) {
-			B[i][k] = RMat.element(k,i);
-		}
-	}
+    double B[3][3];
+    for (i = 0; i < 3 ; i++) {
+        for (k = 0; k < 3 ; k++) {
+            B[i][k] = RMat.element(k, i);
+        }
+    }
 
-	//translation between box centers
-	vec3 T = BtoA.translation();
+    //translation between box centers
+    vec3 T = BtoA.translation();
 
-	vec3 a = bb1.halfSize;
-	vec3 b = bb2.halfSize;
+    vec3 a = bb1.halfSize;
+    vec3 b = bb2.halfSize;
 
-	double Bf[3][3];
-	const double reps = 1e-6;
-  
-	// Bf = fabs(B)
-	Bf[0][0] = fabs(B[0][0]);  Bf[0][0] += reps;
-	Bf[0][1] = fabs(B[0][1]);  Bf[0][1] += reps;
-	Bf[0][2] = fabs(B[0][2]);  Bf[0][2] += reps;
-	Bf[1][0] = fabs(B[1][0]);  Bf[1][0] += reps;
-	Bf[1][1] = fabs(B[1][1]);  Bf[1][1] += reps;
-	Bf[1][2] = fabs(B[1][2]);  Bf[1][2] += reps;
-	Bf[2][0] = fabs(B[2][0]);  Bf[2][0] += reps;
-	Bf[2][1] = fabs(B[2][1]);  Bf[2][1] += reps;
-	Bf[2][2] = fabs(B[2][2]);  Bf[2][2] += reps;
+    double Bf[3][3];
+    const double reps = 1e-6;
 
-	double d, maxD = -1.0e10;
-	double t, s;
-	double a0,a1,a2,b0,b1,b2;
+    // Bf = fabs(B)
+    Bf[0][0] = fabs(B[0][0]);
+    Bf[0][0] += reps;
+    Bf[0][1] = fabs(B[0][1]);
+    Bf[0][1] += reps;
+    Bf[0][2] = fabs(B[0][2]);
+    Bf[0][2] += reps;
+    Bf[1][0] = fabs(B[1][0]);
+    Bf[1][0] += reps;
+    Bf[1][1] = fabs(B[1][1]);
+    Bf[1][1] += reps;
+    Bf[1][2] = fabs(B[1][2]);
+    Bf[1][2] += reps;
+    Bf[2][0] = fabs(B[2][0]);
+    Bf[2][0] += reps;
+    Bf[2][1] = fabs(B[2][1]);
+    Bf[2][1] += reps;
+    Bf[2][2] = fabs(B[2][2]);
+    Bf[2][2] += reps;
+
+    double d, maxD = -1.0e10;
+    double t, s;
+    double a0, a1, a2, b0, b1, b2;
 
 
-	// A1 x A2 = A0
-	t = fabs(T[0]);  
-	d = t - (a[0] + b[0] * Bf[0][0] + b[1] * Bf[0][1] + b[2] * Bf[0][2]);
-	a0 = std::max(0.0, d); a0*=a0;
-     
-	// A2 x A0 = A1
-	t = fabs(T[1]);
-	d = t - (a[1] + b[0] * Bf[1][0] + b[1] * Bf[1][1] + b[2] * Bf[1][2]);
-	a1 = std::max(0.0, d); a1*=a1;
+    // A1 x A2 = A0
+    t = fabs(T[0]);
+    d = t - (a[0] + b[0] * Bf[0][0] + b[1] * Bf[0][1] + b[2] * Bf[0][2]);
+    a0 = std::max(0.0, d);
+    a0 *= a0;
 
-	// A0 x A1 = A2
-	t = fabs(T[2]);
-	d = t - (a[2] + b[0] * Bf[2][0] + b[1] * Bf[2][1] + b[2] * Bf[2][2]);
-	a2 = std::max(0.0, d); a2*=a2;
+    // A2 x A0 = A1
+    t = fabs(T[1]);
+    d = t - (a[1] + b[0] * Bf[1][0] + b[1] * Bf[1][1] + b[2] * Bf[1][2]);
+    a1 = std::max(0.0, d);
+    a1 *= a1;
 
-	// B1 x B2 = B0
-	s = T[0]*B[0][0] + T[1]*B[1][0] + T[2]*B[2][0];
-	t = fabs(s);
-	d = t - (b[0] + a[0] * Bf[0][0] + a[1] * Bf[1][0] + a[2] * Bf[2][0]);
-	b0 = std::max(0.0, d); b0*=b0;
+    // A0 x A1 = A2
+    t = fabs(T[2]);
+    d = t - (a[2] + b[0] * Bf[2][0] + b[1] * Bf[2][1] + b[2] * Bf[2][2]);
+    a2 = std::max(0.0, d);
+    a2 *= a2;
 
-	// B2 x B0 = B1
-	s = T[0]*B[0][1] + T[1]*B[1][1] + T[2]*B[2][1];
-	t = fabs(s);
-	d = t - (b[1] + a[0] * Bf[0][1] + a[1] * Bf[1][1] + a[2] * Bf[2][1]);
-	b1 = std::max(0.0, d); b1*=b1;
+    // B1 x B2 = B0
+    s = T[0] * B[0][0] + T[1] * B[1][0] + T[2] * B[2][0];
+    t = fabs(s);
+    d = t - (b[0] + a[0] * Bf[0][0] + a[1] * Bf[1][0] + a[2] * Bf[2][0]);
+    b0 = std::max(0.0, d);
+    b0 *= b0;
 
-	// B0 x B1 = B2
-	s = T[0]*B[0][2] + T[1]*B[1][2] + T[2]*B[2][2];
-	t = fabs(s);
-	d = t - (b[2] + a[0] * Bf[0][2] + a[1] * Bf[1][2] + a[2] * Bf[2][2]);
-	b2 = std::max(0.0, d); b2*=b2;
+    // B2 x B0 = B1
+    s = T[0] * B[0][1] + T[1] * B[1][1] + T[2] * B[2][1];
+    t = fabs(s);
+    d = t - (b[1] + a[0] * Bf[0][1] + a[1] * Bf[1][1] + a[2] * Bf[2][1]);
+    b1 = std::max(0.0, d);
+    b1 *= b1;
 
-	maxD = std::max(a0+a1+a2, b0+b1+b2);
-//	if (maxD == 0.0) return -1;
-//	return maxD;
+    // B0 x B1 = B2
+    s = T[0] * B[0][2] + T[1] * B[1][2] + T[2] * B[2][2];
+    t = fabs(s);
+    d = t - (b[2] + a[0] * Bf[0][2] + a[1] * Bf[1][2] + a[2] * Bf[2][2]);
+    b2 = std::max(0.0, d);
+    b2 *= b2;
 
-	//---- edge cross product tests
+    maxD = std::max(a0 + a1 + a2, b0 + b1 + b2);
+    //  if (maxD == 0.0) return -1;
+    //  return maxD;
 
-	// A0 x B0
-	s = T[2] * B[1][0] - T[1] * B[2][0];
-	t = fabs(s);
+    //---- edge cross product tests
+
+    // A0 x B0
+    s = T[2] * B[1][0] - T[1] * B[2][0];
+    t = fabs(s);
     d = t - (a[1] * Bf[2][0] + a[2] * Bf[1][0] + b[1] * Bf[0][2] + b[2] * Bf[0][1]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a0+d, b0+d));
-  
-	// A0 x B1
-	s = T[2] * B[1][1] - T[1] * B[2][1];
-	t = fabs(s);
-	d = t - (a[1] * Bf[2][1] + a[2] * Bf[1][1] + b[0] * Bf[0][2] + b[2] * Bf[0][0]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a0+d, b1+d));
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a0 + d, b0 + d));
 
-	// A0 x B2
-	s = T[2] * B[1][2] - T[1] * B[2][2];
-	t = fabs(s);
-	d = t - (a[1] * Bf[2][2] + a[2] * Bf[1][2] + b[0] * Bf[0][1] + b[1] * Bf[0][0]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a0+d, b2+d));
+    // A0 x B1
+    s = T[2] * B[1][1] - T[1] * B[2][1];
+    t = fabs(s);
+    d = t - (a[1] * Bf[2][1] + a[2] * Bf[1][1] + b[0] * Bf[0][2] + b[2] * Bf[0][0]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a0 + d, b1 + d));
 
-	// A1 x B0
-	s = T[0] * B[2][0] - T[2] * B[0][0];
-	t = fabs(s);
-	d = t - (a[0] * Bf[2][0] + a[2] * Bf[0][0] + b[1] * Bf[1][2] + b[2] * Bf[1][1]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a1+d, b0+d));
+    // A0 x B2
+    s = T[2] * B[1][2] - T[1] * B[2][2];
+    t = fabs(s);
+    d = t - (a[1] * Bf[2][2] + a[2] * Bf[1][2] + b[0] * Bf[0][1] + b[1] * Bf[0][0]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a0 + d, b2 + d));
 
-	// A1 x B1
-	s = T[0] * B[2][1] - T[2] * B[0][1];
-	t = fabs(s);
-	d = t - (a[0] * Bf[2][1] + a[2] * Bf[0][1] + b[0] * Bf[1][2] + b[2] * Bf[1][0]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a1+d, b1+d));
+    // A1 x B0
+    s = T[0] * B[2][0] - T[2] * B[0][0];
+    t = fabs(s);
+    d = t - (a[0] * Bf[2][0] + a[2] * Bf[0][0] + b[1] * Bf[1][2] + b[2] * Bf[1][1]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a1 + d, b0 + d));
 
-	// A1 x B2
-	s = T[0] * B[2][2] - T[2] * B[0][2];
-	t = fabs(s);
-	d = t - (a[0] * Bf[2][2] + a[2] * Bf[0][2] + b[0] * Bf[1][1] + b[1] * Bf[1][0]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a1+d, b2+d));
+    // A1 x B1
+    s = T[0] * B[2][1] - T[2] * B[0][1];
+    t = fabs(s);
+    d = t - (a[0] * Bf[2][1] + a[2] * Bf[0][1] + b[0] * Bf[1][2] + b[2] * Bf[1][0]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a1 + d, b1 + d));
 
-	// A2 x B0
-	s = T[1] * B[0][0] - T[0] * B[1][0];
-	t = fabs(s);
-	d = t - (a[0] * Bf[1][0] + a[1] * Bf[0][0] + b[1] * Bf[2][2] + b[2] * Bf[2][1]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a2+d, b0+d));
+    // A1 x B2
+    s = T[0] * B[2][2] - T[2] * B[0][2];
+    t = fabs(s);
+    d = t - (a[0] * Bf[2][2] + a[2] * Bf[0][2] + b[0] * Bf[1][1] + b[1] * Bf[1][0]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a1 + d, b2 + d));
 
-	// A2 x B1
-	s = T[1] * B[0][1] - T[0] * B[1][1];
-	t = fabs(s);
-	d = t - (a[0] * Bf[1][1] + a[1] * Bf[0][1] + b[0] * Bf[2][2] + b[2] * Bf[2][0]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a2+d, b1+d));
+    // A2 x B0
+    s = T[1] * B[0][0] - T[0] * B[1][0];
+    t = fabs(s);
+    d = t - (a[0] * Bf[1][0] + a[1] * Bf[0][0] + b[1] * Bf[2][2] + b[2] * Bf[2][1]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a2 + d, b0 + d));
 
-	// A2 x B2
-	s = T[1] * B[0][2] - T[0] * B[1][2];
-	t = fabs(s);
-	d = t - (a[0] * Bf[1][2] + a[1] * Bf[0][2] + b[0] * Bf[2][1] + b[1] * Bf[2][0]);
-	d = std::max(0.0, d); d*=d;
-	maxD = std::max(maxD, std::max(a2+d, b2+d));
+    // A2 x B1
+    s = T[1] * B[0][1] - T[0] * B[1][1];
+    t = fabs(s);
+    d = t - (a[0] * Bf[1][1] + a[1] * Bf[0][1] + b[0] * Bf[2][2] + b[2] * Bf[2][0]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a2 + d, b1 + d));
 
-	if (maxD == 0.0) return -1;
-	return maxD;
+    // A2 x B2
+    s = T[1] * B[0][2] - T[0] * B[1][2];
+    t = fabs(s);
+    d = t - (a[0] * Bf[1][2] + a[1] * Bf[0][2] + b[0] * Bf[2][1] + b[1] * Bf[2][0]);
+    d = std::max(0.0, d);
+    d *= d;
+    maxD = std::max(maxD, std::max(a2 + d, b2 + d));
+
+    if (maxD == 0.0) return -1;
+    return maxD;
 }

--- a/include/body.h
+++ b/include/body.h
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller and Matei T. Ciocarlie 
+// Author(s):  Andrew T. Miller and Matei T. Ciocarlie
 //
 // $Id: body.h,v 1.46 2010/08/10 17:23:59 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the body class hierarchy.
- */
+/*! \file
+    \brief Defines the body class hierarchy.
+*/
 #ifndef BODY_HXX
 
 #include <QTextStream>
@@ -60,12 +60,12 @@ class TiXmlElement;
 
 //! A triangular body face used in computing mass properties.
 /*!
-  For use with Mirtich's mass property code
+    For use with Mirtich's mass property code
 */
 typedef struct {
-  double norm[3];
-  double w;
-  double *verts[3];
+    double norm[3];
+    double w;
+    double *verts[3];
 } FACE;
 
 //! A generic simulation body.
@@ -74,288 +74,328 @@ typedef struct {
     objects but are not part of of the dynamics system.
 */
 class Body : public WorldElement {
-  Q_OBJECT
-public:
-  //! Parameter to control the height of friction cones
-  static const float CONE_HEIGHT;
+        Q_OBJECT
+    public:
+        //! Parameter to control the height of friction cones
+        static const float CONE_HEIGHT;
 
-protected:
-  //! The surface material of the body specified as an index to the world material list
-  int material; 
+    protected:
+        //! The surface material of the body specified as an index to the world material list
+        int material;
 
-  //! Tells us whether this is a rigid body or not (affects friction models)
-  bool mIsElastic;
-	
-  //! The Young's Modulus of the material, it describes its elasticity
-  double youngMod;
+        //! Tells us whether this is a rigid body or not (affects friction models)
+        bool mIsElastic;
 
-  //! The file that geometry was loaded from, if any
-  QString mGeometryFilename;
-	
-  //! Type of geometry file, for now either "Inventor" or "off"
-  QString mGeometryFileType;
+        //! The Young's Modulus of the material, it describes its elasticity
+        double youngMod;
 
-  //! The body's world position (translations are in mm)
-  transf Tran;  
+        //! The file that geometry was loaded from, if any
+        QString mGeometryFilename;
 
-  //! When this is un-checked, changing the transform of this body will not trigger a redraw
-  bool mRenderGeometry;
+        //! Type of geometry file, for now either "Inventor" or "off"
+        QString mGeometryFileType;
 
-  //! The number of contacts on the body
-  int numContacts;
+        //! The body's world position (translations are in mm)
+        transf Tran;
 
-  //! The current contacts on the body
-  std::list<Contact *> contactList;
+        //! When this is un-checked, changing the transform of this body will not trigger a redraw
+        bool mRenderGeometry;
 
-  //! The contacts on the body at the previous time step
-  std::list<Contact *> prevContactList;
+        //! The number of contacts on the body
+        int numContacts;
 
-  //! Virtual Contacts on this body. See the Virtual Contact class for explanation
-  std::list<Contact *> virtualContactList;
+        //! The current contacts on the body
+        std::list<Contact *> contactList;
 
-  //! This flag determines whether the body's friction cones should be shown
-  bool showFC;
+        //! The contacts on the body at the previous time step
+        std::list<Contact *> prevContactList;
 
-  //! This flag determines whether the body's virtual contacts should be shown
-  bool showVC;
+        //! Virtual Contacts on this body. See the Virtual Contact class for explanation
+        std::list<Contact *> virtualContactList;
 
-  //! A pointer to the root node of the geometry of this model
-  SoSeparator *IVGeomRoot;
+        //! This flag determines whether the body's friction cones should be shown
+        bool showFC;
 
-  //! A pointer to a node that scales the geometry of this model
-  SoTransform* IVScaleTran;
-  
-  //! A pointer to a node that offsets the geometry of this model
-  SoTransform *IVOffsetTran;
+        //! This flag determines whether the body's virtual contacts should be shown
+        bool showVC;
 
-  //! A pointer to a node that can hold the geometry of the bounding volume struture
-  SoSeparator *IVBVRoot;
+        //! A pointer to the root node of the geometry of this model
+        SoSeparator *IVGeomRoot;
 
-#ifdef GEOMETRY_LIB
-  //! If we are using the geometry library, here we will show the primitives that approximate this body
-  SoSeparator *IVPrimitiveRoot;
-#endif
+        //! A pointer to a node that scales the geometry of this model
+        SoTransform *IVScaleTran;
 
-  //! A pointer to the Inventor transform for the body
-  SoTransform *IVTran;  
+        //! A pointer to a node that offsets the geometry of this model
+        SoTransform *IVOffsetTran;
 
-  //! A pointer to the material node that controls this body's transparency
-  SoMaterial *IVMat;
+        //! A pointer to a node that can hold the geometry of the bounding volume struture
+        SoSeparator *IVBVRoot;
 
-  //! A pointer to the root of the friction cones on this body
-  SoSeparator *IVContactIndicators;
+        #ifdef GEOMETRY_LIB
+        //! If we are using the geometry library, here we will show the primitives that approximate this body
+        SoSeparator *IVPrimitiveRoot;
+        #endif
 
-  //! This flag tells us if this body follows the Flock of Birds tracker
-  bool mUsesFlock;
+        //! A pointer to the Inventor transform for the body
+        SoTransform *IVTran;
 
-  //! This tells us which bird in the flock the object is using
-  int mBirdNumber;
+        //! A pointer to the material node that controls this body's transparency
+        SoMaterial *IVMat;
 
-  //! The relative tranform used for the Flock of Birds
-  FlockTransf mFlockTran;
+        //! A pointer to the root of the friction cones on this body
+        SoSeparator *IVContactIndicators;
 
-  //! Inventor root of the axes in the body subtree
-  SoSwitch *IVAxes;
+        //! This flag tells us if this body follows the Flock of Birds tracker
+        bool mUsesFlock;
 
-  //! Inventor root of the worst case disturbance wrench indicator
-  SoSeparator *IVWorstCase;
+        //! This tells us which bird in the flock the object is using
+        int mBirdNumber;
 
-  //! Inventor transform from body frame to center of gravity
-  SoTranslation *axesTranToCOG;
+        //! The relative tranform used for the Flock of Birds
+        FlockTransf mFlockTran;
 
-  //! Inventor scale for axes so that they extend outside the body
-  SoScale *axesScale;
+        //! Inventor root of the axes in the body subtree
+        SoSwitch *IVAxes;
 
-  //! Copy constructor
-  Body (const Body &b);
+        //! Inventor root of the worst case disturbance wrench indicator
+        SoSeparator *IVWorstCase;
 
-  //! Creates the axes for display
-  void createAxesGeometry();
+        //! Inventor transform from body frame to center of gravity
+        SoTranslation *axesTranToCOG;
 
-  //! Initialize an empty scene graph structure with just the needed roots 
-  void initializeIV();
+        //! Inventor scale for axes so that they extend outside the body
+        SoScale *axesScale;
 
-  //! Adds itself to the given vector of Bodies
-  virtual void getBodyList(std::vector<Body*> *bodies) {bodies->push_back(this);}
+        //! Copy constructor
+        Body(const Body &b);
 
-  /////////////////////////////// PUBLIC /////////////////////////////////
-public:
-  //! Empty body with invalid material and no geometry
-  Body(World *w,const char *name=0);
+        //! Creates the axes for display
+        void createAxesGeometry();
 
-  //! Breaks all contacts; does not remove body from collision detection or scene graph
-  virtual ~Body();
+        //! Initialize an empty scene graph structure with just the needed roots
+        void initializeIV();
 
-  //! Load the body information from a file
-  virtual int load(const QString &filename);
-  
-  //! Convert the body information to xml and link the xml to the given geometry file
-  int convert2xml(QString filename);
-  
-  //! Loads the body information from an XML structure
-  virtual int loadFromXml(const TiXmlElement *root, QString rootPath);
+        //! Adds itself to the given vector of Bodies
+        virtual void getBodyList(std::vector<Body *> *bodies) {
+            bodies->push_back(this);
+        }
 
-  //! Loads the geometry of the body from an Inventor file that can be read by Coin (IV or VRML)
-  int loadGeometryIV(const QString &filename);
+        /////////////////////////////// PUBLIC /////////////////////////////////
+    public:
+        //! Empty body with invalid material and no geometry
+        Body(World *w, const char *name = 0);
 
-  //! Loads the geometry of the body from an .off file
-  int loadGeometryOFF(const QString &filename);
+        //! Breaks all contacts; does not remove body from collision detection or scene graph
+        virtual ~Body();
 
-  //! Loads the geometry of the body from a .ply file
-  int loadGeometryPLY(const QString &filename);
+        //! Load the body information from a file
+        virtual int load(const QString &filename);
 
-  //! Loads the geometry from a vector of vertices and one of triangles
-  int loadGeometryMemory(const std::vector<position> &vertices, const std::vector<int> &triangles);
+        //! Convert the body information to xml and link the xml to the given geometry file
+        int convert2xml(QString filename);
 
- //! Saves the body information to an XML structure
- virtual int saveToXml(QTextStream& xml);
+        //! Loads the body information from an XML structure
+        virtual int loadFromXml(const TiXmlElement *root, QString rootPath);
 
-  //! Make this body a clone of another body
-  virtual void cloneFrom(const Body* original);
+        //! Loads the geometry of the body from an Inventor file that can be read by Coin (IV or VRML)
+        int loadGeometryIV(const QString &filename);
 
-  //! Adds additional material nodes so we can control the transparency of the body
-  void addIVMat(bool clone = false);
+        //! Loads the geometry of the body from an .off file
+        int loadGeometryOFF(const QString &filename);
 
-  //! Adds this body to the collision detection system
-  virtual void addToIvc(bool ExpectEmpty = false);
+        //! Loads the geometry of the body from a .ply file
+        int loadGeometryPLY(const QString &filename);
 
-  //! Adds this body to the collision detection system as a clone of another body
-  virtual void cloneToIvc(const Body* original);
-
-  //! Changes the scale of the geometry. Collision geometry gets updated as well (might be slow)
-  virtual void setGeometryScaling(double x, double y, double z);
-
-  //! Changes the offset of the geometry. Collision geometry gets updates as well (might be slow)
-  virtual void setGeometryOffset(transf tr);
-
-  //! Sets the body to another location in the world. Collisions are not checked.
-  virtual int setTran(transf const& newTr);
-
-  //! Default parameters for transparency, show friction cones, etc.
-  virtual void setDefaultViewingParameters();
-
-  //! Enables / disabled automatic render requests when this body is moved
-  void setRenderGeometry(bool s);
-
-  //! Gets the current rendering requests state
-  bool getRenderGeometry() const {return mRenderGeometry;}
-
-  //! Tells us if this body's position is controlled by the Flock of Birds
-  bool usesFlock(){return mUsesFlock;}
-
-  //! Which bird in the flock controlls this body
-  int getBirdNumber(){return mBirdNumber;}
-
-  //! Where on the body the Flock of Birds sensor is mounted
-  FlockTransf *getFlockTran(){return &mFlockTran;}
-
-  //! Individual bodies belong to themselves.  Links override this and return their robot.
-  virtual WorldElement *getOwner() {return (WorldElement *)this;}
-
-  //! Determines whether instance is dynamic (overridden in DynamicBody)
-  virtual bool isDynamic() const {return false;}
-
-  //! Returns whether this body is soft (elastic) or not. Affect contact models.
-  bool isElastic(){return mIsElastic;}
-
-  /*! Returns the current material of the body. 
-   * \sa setMaterial()
-   */
-  int getMaterial() const {return material;}
-  //! Sets the material of this body
-  void setMaterial(int mat);
-
-  /*! Returns the Inventor material for the body. */
-  SoMaterial *getIVMat() const {return IVMat;}
-
-  //! Returns the Young's modulus for this body
-  double getYoungs() { return youngMod; }
-
-  /*! Returns a pointer to the root of the Inventor geometry that was loaded.*/
-  SoSeparator *getIVGeomRoot() const {return IVGeomRoot;}
-
-  /*! Returns a pointer ot the scaling transform of this body */
-  SoTransform* getIVScaleTran() {return IVScaleTran;}
-
-#ifdef GEOMETRY_LIB
-  //! The root of the scene graph where we can put primitive geometry
-  SoSeparator *getIVPrimitiveRoot() const {return IVPrimitiveRoot;}
-#endif
-
-  /*! Returns a pointer to the Inventor transform node for the body. */
-  SoTransform *getIVTran() const {return IVTran;}
-
-  /*! Returns a pointer to the root of the Inventor subtree containing the 
-    friction cones.
-  */
-  SoSeparator *getIVContactIndicators() const {return IVContactIndicators;}
-
-  /*! Asks the body to display a number of bounding boxes as part of its
-	  collision detection bbox hierarchy. Used only for debugging purposes.
-  */
-  void setBVGeometry(const std::vector<BoundingBox> &bvs);
-
-  /*! Returns the current pose of the body. */
-  transf const& getTran() const {return Tran;}
-
-  /*! Returns the number of contacts on the body, against another given body. */
-  int getNumContacts(Body *b = NULL) const;
-
-  /*! Returns the number of virtual contacts on the body. */
-  int getNumVirtualContacts() const {return (int)virtualContactList.size();}
-
-  /*! Returns a copy of the body's contact list against a given body. */
-  std::list<Contact *>getContacts(Body *b = NULL) const;
-
-  /*! Returns a copy of the body's virtual contact list. */
-  std::list<Contact *>getVirtualContacts() const {return virtualContactList;}
-
-  /*! Returns the value of the flag determining whether friction cones are
-    shown on this body
-  */
-  bool frictionConesShown() const {return showFC;}
-
-  //! Returns the transparency of this body for rendering
-  float getTransparency() const;
-  //! Sets the transparency of this body for rendering
-  void setTransparency(float t);
-
-  //! Shows or hides the friction cones for this body
-  void showFrictionCones(bool on, int vc=0);
-  //! Asks all contacts to recompute their friction cones
-  virtual void redrawFrictionCones();
-
-  //! Adds a contact to this body
-  virtual void addContact(Contact *c);
-  //! Adds a virtual contact to this body
-  virtual void addVirtualContact(Contact *c);
-  //! Removed a contact from this body
-  virtual void removeContact(Contact *c);
-  //! Removes a contact from the list of contacts at the previous time step
-  virtual void removePrevContact(Contact *c);
-  //! Removes all the cotacts on this body (usually after a move)
-  virtual void breakContacts();
-  //! Removes all virtual contacts on this body
-  virtual void breakVirtualContacts();
-  //! Load in virtual contacts specified in file fn
-  virtual int loadContactData(QString fn);
-
-  //! Moves all current contacts to the list of previous contacts
-  virtual void resetContactList();
-  //! Checks if a current contact is the same as a contact from the previous time step
-  Contact* checkContactInheritance(Contact *c);
-
-  //! Returns true if current contacts prevent motion in the given direction
-  virtual bool contactsPreventMotion(const transf& motion) const;
-
-  //! Prints the name and material of this body to a stream
-  friend QTextStream& operator<<(QTextStream &os, const Body &b);
-
-  /*! Returns all the triangles of the scene graph geometry of this object */
-  void getGeometryTriangles(std::vector<Triangle> *triangles) const;
-
-  /*! Returns all the vertices of the scene graph geometry of this object*/
-  void getGeometryVertices(std::vector<position> *vertices) const;
+        //! Loads the geometry from a vector of vertices and one of triangles
+        int loadGeometryMemory(const std::vector<position> &vertices, const std::vector<int> &triangles);
+
+        //! Saves the body information to an XML structure
+        virtual int saveToXml(QTextStream &xml);
+
+        //! Make this body a clone of another body
+        virtual void cloneFrom(const Body *original);
+
+        //! Adds additional material nodes so we can control the transparency of the body
+        void addIVMat(bool clone = false);
+
+        //! Adds this body to the collision detection system
+        virtual void addToIvc(bool ExpectEmpty = false);
+
+        //! Adds this body to the collision detection system as a clone of another body
+        virtual void cloneToIvc(const Body *original);
+
+        //! Changes the scale of the geometry. Collision geometry gets updated as well (might be slow)
+        virtual void setGeometryScaling(double x, double y, double z);
+
+        //! Changes the offset of the geometry. Collision geometry gets updates as well (might be slow)
+        virtual void setGeometryOffset(transf tr);
+
+        //! Sets the body to another location in the world. Collisions are not checked.
+        virtual int setTran(transf const &newTr);
+
+        //! Default parameters for transparency, show friction cones, etc.
+        virtual void setDefaultViewingParameters();
+
+        //! Enables / disabled automatic render requests when this body is moved
+        void setRenderGeometry(bool s);
+
+        //! Gets the current rendering requests state
+        bool getRenderGeometry() const {
+            return mRenderGeometry;
+        }
+
+        //! Tells us if this body's position is controlled by the Flock of Birds
+        bool usesFlock() {
+            return mUsesFlock;
+        }
+
+        //! Which bird in the flock controlls this body
+        int getBirdNumber() {
+            return mBirdNumber;
+        }
+
+        //! Where on the body the Flock of Birds sensor is mounted
+        FlockTransf *getFlockTran() {
+            return &mFlockTran;
+        }
+
+        //! Individual bodies belong to themselves.  Links override this and return their robot.
+        virtual WorldElement *getOwner() {
+            return (WorldElement *)this;
+        }
+
+        //! Determines whether instance is dynamic (overridden in DynamicBody)
+        virtual bool isDynamic() const {
+            return false;
+        }
+
+        //! Returns whether this body is soft (elastic) or not. Affect contact models.
+        bool isElastic() {
+            return mIsElastic;
+        }
+
+        /*! Returns the current material of the body.
+            \sa setMaterial()
+        */
+        int getMaterial() const {
+            return material;
+        }
+        //! Sets the material of this body
+        void setMaterial(int mat);
+
+        /*! Returns the Inventor material for the body. */
+        SoMaterial *getIVMat() const {
+            return IVMat;
+        }
+
+        //! Returns the Young's modulus for this body
+        double getYoungs() {
+            return youngMod;
+        }
+
+        /*! Returns a pointer to the root of the Inventor geometry that was loaded.*/
+        SoSeparator *getIVGeomRoot() const {
+            return IVGeomRoot;
+        }
+
+        /*! Returns a pointer ot the scaling transform of this body */
+        SoTransform *getIVScaleTran() {
+            return IVScaleTran;
+        }
+
+        #ifdef GEOMETRY_LIB
+        //! The root of the scene graph where we can put primitive geometry
+        SoSeparator *getIVPrimitiveRoot() const {
+            return IVPrimitiveRoot;
+        }
+        #endif
+
+        /*! Returns a pointer to the Inventor transform node for the body. */
+        SoTransform *getIVTran() const {
+            return IVTran;
+        }
+
+        /*! Returns a pointer to the root of the Inventor subtree containing the
+            friction cones.
+        */
+        SoSeparator *getIVContactIndicators() const {
+            return IVContactIndicators;
+        }
+
+        /*! Asks the body to display a number of bounding boxes as part of its
+            collision detection bbox hierarchy. Used only for debugging purposes.
+        */
+        void setBVGeometry(const std::vector<BoundingBox> &bvs);
+
+        /*! Returns the current pose of the body. */
+        transf const &getTran() const {
+            return Tran;
+        }
+
+        /*! Returns the number of contacts on the body, against another given body. */
+        int getNumContacts(Body *b = NULL) const;
+
+        /*! Returns the number of virtual contacts on the body. */
+        int getNumVirtualContacts() const {
+            return (int)virtualContactList.size();
+        }
+
+        /*! Returns a copy of the body's contact list against a given body. */
+        std::list<Contact *>getContacts(Body *b = NULL) const;
+
+        /*! Returns a copy of the body's virtual contact list. */
+        std::list<Contact *>getVirtualContacts() const {
+            return virtualContactList;
+        }
+
+        /*! Returns the value of the flag determining whether friction cones are
+            shown on this body
+        */
+        bool frictionConesShown() const {
+            return showFC;
+        }
+
+        //! Returns the transparency of this body for rendering
+        float getTransparency() const;
+        //! Sets the transparency of this body for rendering
+        void setTransparency(float t);
+
+        //! Shows or hides the friction cones for this body
+        void showFrictionCones(bool on, int vc = 0);
+        //! Asks all contacts to recompute their friction cones
+        virtual void redrawFrictionCones();
+
+        //! Adds a contact to this body
+        virtual void addContact(Contact *c);
+        //! Adds a virtual contact to this body
+        virtual void addVirtualContact(Contact *c);
+        //! Removed a contact from this body
+        virtual void removeContact(Contact *c);
+        //! Removes a contact from the list of contacts at the previous time step
+        virtual void removePrevContact(Contact *c);
+        //! Removes all the cotacts on this body (usually after a move)
+        virtual void breakContacts();
+        //! Removes all virtual contacts on this body
+        virtual void breakVirtualContacts();
+        //! Load in virtual contacts specified in file fn
+        virtual int loadContactData(QString fn);
+
+        //! Moves all current contacts to the list of previous contacts
+        virtual void resetContactList();
+        //! Checks if a current contact is the same as a contact from the previous time step
+        Contact *checkContactInheritance(Contact *c);
+
+        //! Returns true if current contacts prevent motion in the given direction
+        virtual bool contactsPreventMotion(const transf &motion) const;
+
+        //! Prints the name and material of this body to a stream
+        friend QTextStream &operator<<(QTextStream &os, const Body &b);
+
+        /*! Returns all the triangles of the scene graph geometry of this object */
+        void getGeometryTriangles(std::vector<Triangle> *triangles) const;
+
+        /*! Returns all the vertices of the scene graph geometry of this object*/
+        void getGeometryVertices(std::vector<position> *vertices) const;
 };
 
 //! The superclass for all bodies that take part in the dynamics.
@@ -364,267 +404,313 @@ public:
     and velocity of the body at the current time step of the dynamics.
 */
 class DynamicBody : public Body {
-  Q_OBJECT
+        Q_OBJECT
 
-  //! Is this body affected by dynamics?
-  bool useDynamics;
+        //! Is this body affected by dynamics?
+        bool useDynamics;
 
-  //! projection integrals used in mass properties computations
-  double P1, Pa, Pb, Paa, Pab, Pbb, Paaa, Paab, Pabb, Pbbb;
+        //! projection integrals used in mass properties computations
+        double P1, Pa, Pb, Paa, Pab, Pbb, Paaa, Paab, Pabb, Pbbb;
 
-  //! face integrals used in mass properties computations
-  double Fa, Fb, Fc, Faa, Fbb, Fcc, Faaa, Fbbb, Fccc, Faab, Fbbc, Fcca;
+        //! face integrals used in mass properties computations
+        double Fa, Fb, Fc, Faa, Fbb, Fcc, Faaa, Fbbb, Fccc, Faab, Fbbc, Fcca;
 
- protected:
-  //! Center of gravity position (in millimeters)
-  position CoG;
+    protected:
+        //! Center of gravity position (in millimeters)
+        position CoG;
 
-  //! Maximum radius of the body from the center of gravity (in millimeters)
-  double maxRadius;
+        //! Maximum radius of the body from the center of gravity (in millimeters)
+        double maxRadius;
 
-  //! Mass of the body (in grams)
-  double mass;
+        //! Mass of the body (in grams)
+        double mass;
 
-  //! Is this body fixed in the world frame?
-  bool fixed;
+        //! Is this body fixed in the world frame?
+        bool fixed;
 
-  //! World pose a fixed body should maintain
-  transf fixedTran;
+        //! World pose a fixed body should maintain
+        transf fixedTran;
 
-  //! Points to the dynamic joint connecting this body to its parent
-  DynJoint *dynJoint;
+        //! Points to the dynamic joint connecting this body to its parent
+        DynJoint *dynJoint;
 
-  //! Corners of the box bounding the possible world positions of the object
-  vec3 bbox_max, bbox_min;
+        //! Corners of the box bounding the possible world positions of the object
+        vec3 bbox_max, bbox_min;
 
-  //! Flag determining whether axes should be shown (origin at COG)
-  bool showAx;
+        //! Flag determining whether axes should be shown (origin at COG)
+        bool showAx;
 
-  //! Flag determining whether dynamic contact forces for this body should be drawn
-  bool showDynCF;
+        //! Flag determining whether dynamic contact forces for this body should be drawn
+        bool showDynCF;
 
-  //! Dynamic acceleration, in mm/sec^2
-  double a[6];
-  //! Dynamic velocity, in mm/sec
-  double v[6];
-  //! Dynamic pose (translation in mm and quaternion)
-  double q[7];
-  //! Stack for saved velocity states
-  std::list<double*> vStack;
-  //! Stack for saved position states
-  std::list<double*> qStack;
-  //! A single saved velocity state
-  double markedV[6];
-  //! A single saved position state
-  double markedQ[7];
+        //! Dynamic acceleration, in mm/sec^2
+        double a[6];
+        //! Dynamic velocity, in mm/sec
+        double v[6];
+        //! Dynamic pose (translation in mm and quaternion)
+        double q[7];
+        //! Stack for saved velocity states
+        std::list<double *> vStack;
+        //! Stack for saved position states
+        std::list<double *> qStack;
+        //! A single saved velocity state
+        double markedV[6];
+        //! A single saved position state
+        double markedQ[7];
 
-  //! The inertia tensor of this body; remember to multiply by mass to get the actual inertia
-  double I[9];
-  
-  //! Tells us if the motion for this body has been computed at the current time step
-  bool dynamicsComputedFlag;
+        //! The inertia tensor of this body; remember to multiply by mass to get the actual inertia
+        double I[9];
 
-  //! Accumulates external wrenches in world coordinates applied to this body
-  double extWrenchAcc[6];
+        //! Tells us if the motion for this body has been computed at the current time step
+        bool dynamicsComputedFlag;
 
-  //! Used for computing mass properties if not supplied in file
-  void compProjectionIntegrals(FACE &f,int A,int B);
+        //! Accumulates external wrenches in world coordinates applied to this body
+        double extWrenchAcc[6];
 
-  //! Used for computing mass properties if not supplied in file
-  void compFaceIntegrals(FACE &f,int A,int B,int C);
+        //! Used for computing mass properties if not supplied in file
+        void compProjectionIntegrals(FACE &f, int A, int B);
 
-  //! Uses Brian Mirtich's code to compute cog and inertia matrix based on geometry
-  int computeDefaultInertiaMatrix(std::vector<Triangle> &triangles, double *defaultI);
+        //! Used for computing mass properties if not supplied in file
+        void compFaceIntegrals(FACE &f, int A, int B, int C);
 
-  //! Initializes an empty dynamic body, common to all constructors
-  void init();
+        //! Uses Brian Mirtich's code to compute cog and inertia matrix based on geometry
+        int computeDefaultInertiaMatrix(std::vector<Triangle> &triangles, double *defaultI);
 
-public:
-  //! An empty dynamic body with no meaningful properties
-  DynamicBody(World *w, const char *name=0);
+        //! Initializes an empty dynamic body, common to all constructors
+        void init();
 
-  //! Creates a dynamic body from a static one
-  DynamicBody(const Body &b, double m);
+    public:
+        //! An empty dynamic body with no meaningful properties
+        DynamicBody(World *w, const char *name = 0);
 
-  virtual ~DynamicBody();
+        //! Creates a dynamic body from a static one
+        DynamicBody(const Body &b, double m);
 
-  //! Initializes dynamic parameters after copy constructor or load method
-  void resetDynamics();
+        virtual ~DynamicBody();
 
-  //! Clones another dynamic body
-  void cloneFrom(const DynamicBody *newBody);
+        //! Initializes dynamic parameters after copy constructor or load method
+        void resetDynamics();
 
-  //! Also looks for properties specific to the dynamic body
-  virtual int loadFromXml(const TiXmlElement *root, QString rootPath);
+        //! Clones another dynamic body
+        void cloneFrom(const DynamicBody *newBody);
 
-  //! Saves the DynamicBody information to an XML structure
-  virtual int saveToXml(QTextStream& xml);
+        //! Also looks for properties specific to the dynamic body
+        virtual int loadFromXml(const TiXmlElement *root, QString rootPath);
 
-  //! Also updates the dynamic state of the body.
-  virtual int setTran(transf const& newTr);
+        //! Saves the DynamicBody information to an XML structure
+        virtual int saveToXml(QTextStream &xml);
 
-  //! Sets the center of gravity and reinitializes the state vector to match it
-  void setCoG(const position& newCoG);
-  
-  //! Sets the inertia matrix from \a newI
-  void setInertiaMatrix(const double *newI);
+        //! Also updates the dynamic state of the body.
+        virtual int setTran(transf const &newTr);
 
-  //! Computes and sets the default center of gravity and inertia matrix
-  void setDefaultDynamicParameters();
+        //! Sets the center of gravity and reinitializes the state vector to match it
+        void setCoG(const position &newCoG);
 
-  //! Sets the maximum radius of the object, used for scaling and grasp computations
-  void setMaxRadius(double maxRad);
+        //! Sets the inertia matrix from \a newI
+        void setInertiaMatrix(const double *newI);
 
-  //! Attempts to compute mass and inertia matrix based only on geometry
-  void computeDefaultMassProp(position &cog, double *I);
+        //! Computes and sets the default center of gravity and inertia matrix
+        void setDefaultDynamicParameters();
 
-  //! Attempts to compute the max radius based only on geometry
-  double computeDefaultMaxRadius();
+        //! Sets the maximum radius of the object, used for scaling and grasp computations
+        void setMaxRadius(double maxRad);
 
-  //! Hides the axes by default
-  virtual void setDefaultViewingParameters();
+        //! Attempts to compute mass and inertia matrix based only on geometry
+        void computeDefaultMassProp(position &cog, double *I);
 
-  /*! Returns the center of gravity position. */
-  position const& getCoG() const {return CoG;}
+        //! Attempts to compute the max radius based only on geometry
+        double computeDefaultMaxRadius();
 
-  /*! Returns the max radius of the body. */
-  double getMaxRadius() const {return maxRadius;}
+        //! Hides the axes by default
+        virtual void setDefaultViewingParameters();
 
-  /*! Returns the mass of the body (in grams).
-   * \sa setMass()
-   */
-  double getMass() const {return mass;}
+        /*! Returns the center of gravity position. */
+        position const &getCoG() const {
+            return CoG;
+        }
 
-  //! Returns a pointer to the body's 3x3 inertia tensor (stored as an array).
-  const double *getInertia() const {return I;} 
+        /*! Returns the max radius of the body. */
+        double getMaxRadius() const {
+            return maxRadius;
+        }
 
-  /*! Returns a pointer to the body's 6x1 velocity vector. */
-  const double *getVelocity() {return v;}
+        /*! Returns the mass of the body (in grams).
+            \sa setMass()
+        */
+        double getMass() const {
+            return mass;
+        }
 
-  /*! Returns a pointer to the body's 6x1 acceleration vector (simple first
-    order approximation).
-   */
-  const double *getAccel() {return a;}
+        //! Returns a pointer to the body's 3x3 inertia tensor (stored as an array).
+        const double *getInertia() const {
+            return I;
+        }
 
-  /*! Returns a pointer to the body's 7x1 position vector [3x1 translation , 
-     4x1 quaternion]
-   */
-  const double *getPos() {return q;} 
+        /*! Returns a pointer to the body's 6x1 velocity vector. */
+        const double *getVelocity() {
+            return v;
+        }
 
-  /*! The returns a pointer to the Inventor subgraph containing the worst case
-    indicator */
-  SoSeparator *getIVWorstCase() const {return IVWorstCase;}
+        /*! Returns a pointer to the body's 6x1 acceleration vector (simple first
+            order approximation).
+        */
+        const double *getAccel() {
+            return a;
+        }
 
-  /*! Returns whether the body is fixed within the world */
-  bool isFixed() const {return fixed;}
+        /*! Returns a pointer to the body's 7x1 position vector [3x1 translation ,
+            4x1 quaternion]
+        */
+        const double *getPos() {
+            return q;
+        }
 
-  /*! Returns whether this body is affected by dynamics
-    \sa setUseDynamics()
-   */
-  bool isDynamic() const {return useDynamics;}
+        /*! The returns a pointer to the Inventor subgraph containing the worst case
+            indicator */
+        SoSeparator *getIVWorstCase() const {
+            return IVWorstCase;
+        }
 
-  /*! Returns the world pose a fixed body should maintain */
-  const transf& getFixedTran() const {return fixedTran;}
+        /*! Returns whether the body is fixed within the world */
+        bool isFixed() const {
+            return fixed;
+        }
 
-  /*! Returns the dynamic joint connecting this body to its parent or NULL
-   * if there is none
-   */
-  virtual DynJoint *getDynJoint() {return dynJoint;}
+        /*! Returns whether this body is affected by dynamics
+            \sa setUseDynamics()
+        */
+        bool isDynamic() const {
+            return useDynamics;
+        }
 
-  /*! Returns whether axes are drawn for this body */
-  bool axesShown() const {return showAx;}
+        /*! Returns the world pose a fixed body should maintain */
+        const transf &getFixedTran() const {
+            return fixedTran;
+        }
 
-  /*! Returns whether dynamic contact forces should be drawn for this body */
-  bool dynContactForcesShown() const {return showDynCF;}
+        /*! Returns the dynamic joint connecting this body to its parent or NULL
+            if there is none
+        */
+        virtual DynJoint *getDynJoint() {
+            return dynJoint;
+        }
 
-  /*! Sets whether this body should be affected by dynamics.  Rather than
-      creating a new static body when a body is set to be static, we just set
-      this flag to false.  That way if the body is made dynamic again, many\
-      parameters won't have to be recomputed.
-  */
-  void setUseDynamics(bool dyn) {useDynamics = dyn;}
+        /*! Returns whether axes are drawn for this body */
+        bool axesShown() const {
+            return showAx;
+        }
 
-  /*! Returns whether the dynamics have been computed for this body during
-    the current dynamics iteration.
-    \sa setDynamicsFlag()
-    \sa resetDynamicsFlag()
-  */
-  bool dynamicsComputed() const {return dynamicsComputedFlag;}  
+        /*! Returns whether dynamic contact forces should be drawn for this body */
+        bool dynContactForcesShown() const {
+            return showDynCF;
+        }
 
-  /*! At the end of the dynamics iteration, this is used to reset the
-    dynamicsComputed flag
-   */
-  void resetDynamicsFlag() {dynamicsComputedFlag = false;}
-  
-  /*! This is called to set the dynamicsComputed flag after the motions for
-    this body have been computed during the current iteration of the dynamics.
-   */
-  void setDynamicsFlag() {dynamicsComputedFlag = true;}
+        /*! Sets whether this body should be affected by dynamics.  Rather than
+            creating a new static body when a body is set to be static, we just set
+            this flag to false.  That way if the body is made dynamic again, many\
+            parameters won't have to be recomputed.
+        */
+        void setUseDynamics(bool dyn) {
+            useDynamics = dyn;
+        }
 
-  /*! Sets whether axes should be drawn for this body */
-  void showAxes(bool on);
+        /*! Returns whether the dynamics have been computed for this body during
+            the current dynamics iteration.
+            \sa setDynamicsFlag()
+            \sa resetDynamicsFlag()
+        */
+        bool dynamicsComputed() const {
+            return dynamicsComputedFlag;
+        }
 
-  /*! Sets whether dynamic contact forces should be drawn for this body */
-  void showDynContactForces(bool on);
+        /*! At the end of the dynamics iteration, this is used to reset the
+            dynamicsComputed flag
+        */
+        void resetDynamicsFlag() {
+            dynamicsComputedFlag = false;
+        }
 
-  /*! Sets the current 7x1 position vector */
-  bool setPos(const double *new_q);
+        /*! This is called to set the dynamicsComputed flag after the motions for
+            this body have been computed during the current iteration of the dynamics.
+        */
+        void setDynamicsFlag() {
+            dynamicsComputedFlag = true;
+        }
 
-  /*! Sets the current 6x1 velocity vector [vx vy vz vrx vry vrz] */
-  void setVelocity(double *new_v)  {memcpy(v,new_v,6*sizeof(double));}
+        /*! Sets whether axes should be drawn for this body */
+        void showAxes(bool on);
 
-  /*! Sets the current 6x1 acceleration vector */
-  void setAccel(double *new_a)  {memcpy(a,new_a,6*sizeof(double));}
+        /*! Sets whether dynamic contact forces should be drawn for this body */
+        void showDynContactForces(bool on);
 
-  /*! Sets the world boundaries for this body.  This is so a body can't fall forever.*/
-  void setBounds(vec3 minBounds,vec3 maxBounds)
-    {bbox_min = minBounds; bbox_max = maxBounds;}
-  
-  /*! Sets the body's mass in grams to m.
-    \sa getMass()
-   */
-  void setMass(double m) {mass = m;}
+        /*! Sets the current 7x1 position vector */
+        bool setPos(const double *new_q);
 
-  /*! Returns the value of the external wrench accumulator. */
-  double *getExtWrenchAcc() {return extWrenchAcc;}
+        /*! Sets the current 6x1 velocity vector [vx vy vz vrx vry vrz] */
+        void setVelocity(double *new_v)  {
+            memcpy(v, new_v, 6 * sizeof(double));
+        }
 
-  //! Saves the current state on the stack
-  void pushState();
-  //! Pops and sets the current state from the stack
-  bool popState();
-  //! Clears the state stack
-  void clearState();
-  //! Saves the current state in a one-slot-only location
-  void markState();
-  //! Returns to previously saved state
-  void returnToMarkedState();
+        /*! Sets the current 6x1 acceleration vector */
+        void setAccel(double *new_a)  {
+            memcpy(a, new_a, 6 * sizeof(double));
+        }
 
-  //! Clears the external wrench accumulator
-  void resetExtWrenchAcc();
-  //! Adds an external wrench expressed in world coordinates
-  void addExtWrench(double *extW);
-  //! Adds a pure force expressed in world coordinates
-  void addForce(vec3 force);
-  //! Adds an external torque expressed in world coordinates
-  void addTorque(vec3 torque);
-  //! Adds a torque expressed in body coordinates
-  void addRelTorque(vec3 torque);
-  //! Adds the wrench resulting from a force applied at some location on the object in world coords
-  void addForceAtPos(vec3 force,position pos);
-  //! Adds the wrench resulting from a force applied at some location on the object in body coords
-  void addForceAtRelPos(vec3 force,position pos);
-  
-  //! Makes this body fixed for dynamic simulations
-  void fix();
-  //! Allows this body to move in dynamic simulations
-  void unfix();
-  //! Connects a dynamic joint (usually a fixed one) to this body
-  virtual void setDynJoint(DynJoint *dj);
+        /*! Sets the world boundaries for this body.  This is so a body can't fall forever.*/
+        void setBounds(vec3 minBounds, vec3 maxBounds) {
+            bbox_min = minBounds;
+            bbox_max = maxBounds;
+        }
 
-  /*! Holds a default mass in case a body file doesn't specify one.
-   *  The other mass properties can be computed assuming uniform density
-   */
-  static double defaultMass;
+        /*! Sets the body's mass in grams to m.
+            \sa getMass()
+        */
+        void setMass(double m) {
+            mass = m;
+        }
+
+        /*! Returns the value of the external wrench accumulator. */
+        double *getExtWrenchAcc() {
+            return extWrenchAcc;
+        }
+
+        //! Saves the current state on the stack
+        void pushState();
+        //! Pops and sets the current state from the stack
+        bool popState();
+        //! Clears the state stack
+        void clearState();
+        //! Saves the current state in a one-slot-only location
+        void markState();
+        //! Returns to previously saved state
+        void returnToMarkedState();
+
+        //! Clears the external wrench accumulator
+        void resetExtWrenchAcc();
+        //! Adds an external wrench expressed in world coordinates
+        void addExtWrench(double *extW);
+        //! Adds a pure force expressed in world coordinates
+        void addForce(vec3 force);
+        //! Adds an external torque expressed in world coordinates
+        void addTorque(vec3 torque);
+        //! Adds a torque expressed in body coordinates
+        void addRelTorque(vec3 torque);
+        //! Adds the wrench resulting from a force applied at some location on the object in world coords
+        void addForceAtPos(vec3 force, position pos);
+        //! Adds the wrench resulting from a force applied at some location on the object in body coords
+        void addForceAtRelPos(vec3 force, position pos);
+
+        //! Makes this body fixed for dynamic simulations
+        void fix();
+        //! Allows this body to move in dynamic simulations
+        void unfix();
+        //! Connects a dynamic joint (usually a fixed one) to this body
+        virtual void setDynJoint(DynJoint *dj);
+
+        /*! Holds a default mass in case a body file doesn't specify one.
+            The other mass properties can be computed assuming uniform density
+        */
+        static double defaultMass;
 };
 
 //! Used for bodies that are part of a robot.
@@ -632,46 +718,52 @@ public:
     changed.
 */
 class Link : public DynamicBody {
-  Q_OBJECT
+        Q_OBJECT
 
-  friend class Robot;
-  friend class KinematicChain;
+        friend class Robot;
+        friend class KinematicChain;
 
- protected:
+    protected:
 
-  //! A pointer to the robot that this link is a part of
-  Robot *owner;
+        //! A pointer to the robot that this link is a part of
+        Robot *owner;
 
-  //! Identifies what part of the robot this link is
-  int chainNum,linkNum;
+        //! Identifies what part of the robot this link is
+        int chainNum, linkNum;
 
- public:
-  Link(Robot *r,int c, int l,World *w,const char *name=0);
-  virtual ~Link();
+    public:
+        Link(Robot *r, int c, int l, World *w, const char *name = 0);
+        virtual ~Link();
 
-  /*! Returns a pointer to the robot owning this link. */
-  virtual WorldElement *getOwner() {return (WorldElement *)owner;}
+        /*! Returns a pointer to the robot owning this link. */
+        virtual WorldElement *getOwner() {
+            return (WorldElement *)owner;
+        }
 
-  /*! Returns which chain this link is a part of. */
-  int getChainNum() const {return chainNum;}
+        /*! Returns which chain this link is a part of. */
+        int getChainNum() const {
+            return chainNum;
+        }
 
-  /*! Returns which link in the chain this link is. */
-  int getLinkNum() const {return linkNum;}
-  
-  /*! Check if contact against a body not belonging to the same robot prevents motion.*/
-  bool externalContactsPreventMotion(const transf& motion);
+        /*! Returns which link in the chain this link is. */
+        int getLinkNum() const {
+            return linkNum;
+        }
 
-  //! Sets the flag that indicates that contacts have changed
-  virtual void setContactsChanged();
+        /*! Check if contact against a body not belonging to the same robot prevents motion.*/
+        bool externalContactsPreventMotion(const transf &motion);
 
-  /*! Returns the location of the distal joint in this link's coordinate system */
-  position getDistalJointLocation();
+        //! Sets the flag that indicates that contacts have changed
+        virtual void setContactsChanged();
 
-  /*! Returns the location of the proximal joint in this link's coordinate system */
-  position getProximalJointLocation();
+        /*! Returns the location of the distal joint in this link's coordinate system */
+        position getDistalJointLocation();
 
-  /*! Returns the z axis of the proximal joint in link's coordinate system */
-  vec3 getProximalJointAxis();
+        /*! Returns the location of the proximal joint in this link's coordinate system */
+        position getProximalJointLocation();
+
+        /*! Returns the z axis of the proximal joint in link's coordinate system */
+        vec3 getProximalJointAxis();
 };
 
 
@@ -685,39 +777,43 @@ class GraspitDBModel;
     locations of any contacts on its surface.
 */
 class GraspableBody : public DynamicBody {
-  Q_OBJECT
+        Q_OBJECT
 
-  //! A pointer to the Inventor root of the shape primitives for this body
-  SoSeparator *IVGeomPrimitives;
+        //! A pointer to the Inventor root of the shape primitives for this body
+        SoSeparator *IVGeomPrimitives;
 
-  //! When using the CGDB, here we store the CGDB model that this body comes from, if any
-#ifdef CGDB_ENABLED
-  GraspitDBModel* mGraspitDBModel;
-#endif
+        //! When using the CGDB, here we store the CGDB model that this body comes from, if any
+        #ifdef CGDB_ENABLED
+        GraspitDBModel *mGraspitDBModel;
+        #endif
 
- public:
-  GraspableBody(World *w, const char *name=0);
-  virtual ~GraspableBody();
+    public:
+        GraspableBody(World *w, const char *name = 0);
+        virtual ~GraspableBody();
 
-  virtual void setDefaultViewingParameters();
+        virtual void setDefaultViewingParameters();
 
-  virtual void cloneFrom(const GraspableBody *newBody);
+        virtual void cloneFrom(const GraspableBody *newBody);
 
-  /*! If the body has shape primitives defined (i.e. they were found when the
-    body was loaded), this returns a pointer to the Inventor root node of
-    that tree.  Otherwise, it returns NULL. */
-  SoSeparator *getIVGeomPrimitives() const {return IVGeomPrimitives;}
+        /*! If the body has shape primitives defined (i.e. they were found when the
+            body was loaded), this returns a pointer to the Inventor root node of
+            that tree.  Otherwise, it returns NULL. */
+        SoSeparator *getIVGeomPrimitives() const {
+            return IVGeomPrimitives;
+        }
 
-  friend QTextStream& operator<<(QTextStream &os, const GraspableBody &gb);
+        friend QTextStream &operator<<(QTextStream &os, const GraspableBody &gb);
 
-#ifdef CGDB_ENABLED
-  //! When using the CGDB, returns the database model that this body comes from, if any
-  GraspitDBModel *getDBModel(){
-    return mGraspitDBModel;
-  }
-  //! When using the CGDB, sets the database model that this body comes from, if any
-  void setDBModel(GraspitDBModel* model) {mGraspitDBModel = model;}
-#endif
+        #ifdef CGDB_ENABLED
+        //! When using the CGDB, returns the database model that this body comes from, if any
+        GraspitDBModel *getDBModel() {
+            return mGraspitDBModel;
+        }
+        //! When using the CGDB, sets the database model that this body comes from, if any
+        void setDBModel(GraspitDBModel *model) {
+            mGraspitDBModel = model;
+        }
+        #endif
 
 };
 

--- a/include/contact.h
+++ b/include/contact.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the contact class hierarchy
- */
+/*! \file
+    \brief Defines the contact class hierarchy
+*/
 #ifndef CONTACT_HXX
 
 #include <Inventor/nodes/SoSeparator.h>
@@ -46,529 +46,591 @@ class Matrix;
 
 #define DISPLAY_CONE_SCALE 20.0
 #define MAX_FRICTION_EDGES 100
-  
+
 
 //! Friction type: Frictionless, Point contact with friction, Soft finger contact with elliptic approximation, Soft finger contact with linearized elliptic approximation
-enum frictionT {FL,PCWF,SFCE,SFCL};
+enum frictionT {FL, PCWF, SFCE, SFCL};
 
 //!  A wrench is a 6-vector containing 2 3-vectors for the force and torque components
 struct Wrench {
-  vec3 force;
-  vec3 torque;
+    vec3 force;
+    vec3 torque;
 };
 
 //! A contact between 2 bodies
 /*! Contacts always come in pairs.  When two bodies touch, a contact is defined
-	for each of them.  They have the same (or very close to the same) global
-	positions, opposite inward pointing normals, and share the same coefficients
-	of friction. Any instance of this class will have as mate its reciprocal 
-	contact on the other body.
-	
-	A contact is defined in places where two bodies are separated by less then
-	the contact threshold (usually set to 0.1 mm). In GraspIt, two bodies are 
-	NEVER allowed to interpenetrate; they are considered in contact if they are
-	apart, but separated by less than the threshold.
-	
-	We always define contacts to occur precisely at a point (as opposed to a small
-	area). This makes computations much easier, as we don't have to compute 
-	deformations. The Grasp class will however consider the case of objects that
-	match geometry so that many point contacts can occur on the same patch. For
-	soft bodies, we have the SoftContact class which inherits from this one and
-	tries to approximate the frictional effects of having a contact patch (while
-	not computing such a patch explicitly).
-	
-	Contacts also define their own linearized friction models. This means that,
-	for each contact, friction is constrained to lie within some convex polyhedron.
-	The edges that define this polyhedron are different for different types of 
-	contacts, which inherit from this class. However, once the edges of the friction
-	polyhedron are defined, all contact behave identically.
-	
-	You will also find here code for two projects which are not used right now. The 
-	first one if Grasp Force Optimization (GFO). See the grasp class for that code;
-	it is finished but has never been tested. Also, the GFO code has never been updated
-	to work with the new Contact hierarchy of PointContact, SoftContact etc, and uses a 
-	parallel mechanism to keep track of friction models. The second one concerns the 
-	dynamics engine: in theory, we can try to save contact information from a time step 
-	to help the solver during the next time step. The framework is in place, but we have 
-	never used it.
- */
-class Contact
-{
-friend class VirtualContact;
-
-protected:
-  //! Pointer to the body this contact is on
-  Body *body1;
-    
-  //! Pointer to the other body involved in this contact
-  Body *body2;
-
-  //! Points to the other contact in this pair
-  Contact *mate;
-
-  //! Coefficient of static friction
-  double cof;
-
-  //! Coefficient of kinetic friction
-  double kcof;
-
-  //! The type of friction model at this contact
-  frictionT frictionType;
-
-  //! Contact dimension (num basisvecs): 1 for FL, 3 for PCWF, 4 for SFCE, 4 for SFCL
-  int contactDim;
-
-  //! LMI dimension: 1 for FL, 3 for PCWF, 4 for SFCE, 7 for SFCL
-  int lmiDim;
-
-  //! Coordinates of the contact with respect to body 1 base frame
-  position loc;
-
-  //! Contact normal with respect to body 1 base frame
-  vec3 normal; 
-
-  //! Pose of the contact frame with respect to the body1 frame. 
-  transf frame;
- 
-  //! Pose of body 1 in world space at time of contact
-  transf body1Tran;
-
-  //! Pose of body 2 in world space at time of contact
-  transf body2Tran;
-
-  //! Root Inventor node stores arrow geometry representing current contact force
-  SoSeparator *contactForcePointers;
-
-  //! The maximum normal force for this contact point due to hand torque limits
-  double normalForceLimit; 
-
-  //! A contactDim vector containing the optimal values to multiply with basisVecs. This will produce the contact forces necessary to generate the needed object wrench.
-  double *optimalCoeffs;    
-
-  //! The current dynamic force acting at this contact
-  double dynamicForce[6];
-
-  //! Dynamics LCP information from the previous time step;
-  double prevCn;
-  //! Dynamics LCP information from the previous time step;
-  double prevLambda;
-  //! Dynamics LCP information from the previous time step;
-  double *prevBetas;
-  //! Tells us wether this contact has inherited some information from the previous dynamic time step.
-  bool inheritanceInfo;
-
-  //! Based on LCP solution, this flag shows if the contact is slipping or not. Does not work well.
-  bool mSlip;
-
-  //! computes a single contact wrench from a friction edge
-  void wrenchFromFrictionEdge(double *edge, const vec3 &radius, Wrench *wr);  
-  
-  //! Sets up frictional forces at this contact using a linearized ellipsoid
-  int setUpFrictionEllipsoid(int numLatitudes,int numDirs[], double phi[],double eccen[]);
-
-public:
-
-  //! 6 x numFrictionEdges matrix of friction cone boundary wrenches used in dynmaics
-  /*! Friction edges contain "normalised" friction information: just the 
-	  frictional component, and without reference to normal force or coeff
-	  of friction (c.o.f.). They only care about the relationship between 
-	  frictional components.
-  */
-  double frictionEdges[6*MAX_FRICTION_EDGES];
-
-  //! number of friction edges defining the frictional component of contact wrenches
-  int numFrictionEdges;
-
-  //! Array of wrenches bounding the Contact Wrench Space (CWS)
-  /*! The CWS is a convex polyhedron that defines the space of wrenches that
-	  can be applied at this contact. Also encapsulates normal forces (usually
-	  normalised to 1N) and the relationship between normal and frictional 
-	  components (usually encapsulated in the coefficient of friction).
-  */
-  Wrench *wrench;
-
-  //! Number of total friction wrenches.
-  int numFCWrenches;
-
-  //! Initializes an empty contact (not really used)
-  Contact() : body1(NULL),body2(NULL),mate(NULL),cof(0.0),
-	contactForcePointers(NULL), optimalCoeffs(NULL), prevBetas(NULL), wrench(NULL) {}
-
-  //! Constructs a contact between two bodies 
-  Contact(Body *b1,Body *b2, position pos, vec3 norm);
-
-  //! Destructor
-  virtual ~Contact();
-
-  //! Converts pure friction edges into full contact wrenches by considering normal force
-  virtual void computeWrenches();
-
-  //! Main function for defining the space of friction that can be applied at this contact.
-  virtual int setUpFrictionEdges(bool dynamicsOn = false)=0;
-
-  /*! Connects the mate contact to this one */
-  void setMate(Contact *m) {mate = m;}
-
-  /*! Returns contact position wrt Body1 frame. */
-  position getPosition(){return loc;}
-
-  /*! Return contact normal wrt Body1 frame. */
-  vec3 getNormal(){return normal;}
-
-  /*! Returns a pointer to the other half of this contact pair. */
-  Contact *getMate() const {return mate;}
-
-  /*! Returns a pointer to body this contact is on. */
-  Body *getBody1() const {return body1;}
-
-  /*! Returns a pointer to the other body invovled in this contact. */
-  Body *getBody2() const {return body2;}
-
-  /*! Returns the pose of body1 when this contact was formed. */
-  transf getBody1Tran() const {return body1Tran;}
-
-  /*! Returns the pose of body2 when this contact was formed. */
-  transf getBody2Tran() const {return body2Tran;}
-
-  //! Gets the coefficient of friction for this contact
-  double getCof() const;
-
-  //! Gets the location
-  position getLocation() const {return loc;}
-
-  //! Gets the frame
-  transf getFrame() const { return frame;}
-
-  //! Updates the coefficient of friction (called when the body materials have changed)
-  void updateCof();
-
-  /*! Returns the type of friction modeled at this contact. */
-  frictionT getFrictionType() const {return frictionType;}
-
-  /*! Returns pose of the contact frame relative to the base frame of body1. */
-  transf getContactFrame() const {return frame;}
-
-  /*! Returns the current dynamic force acting at this contact. */
-  double *getDynamicContactWrench() {return dynamicForce;}
-
-  /*! Returns the Inventor root of the pointer geometry for this contact */
-  SoSeparator *getContactForcePointers() const {return contactForcePointers;}
-
-  /*! Determines whether this contact will prevent motion of body 1 as expressed in local body 1 coordinates */
-  bool preventsMotion(const transf& motion) const;
-
-  //! Called by GFO routine to set optimal contact force
-  void setContactForce(double *optmx);
-
-  /*! Returns the contact dimension (number of basis wrenches). */
-  int getContactDim() const {return contactDim;}
-  
-  /*! Returns the dimension of the LMI block for this contact. (used in GFO) */
-  int getLmiDim() const {return lmiDim;}
-
-  /*! Sets the normal force limit based on hand torque limits as computed during GFO. */
-  void setNormalForceLimit(double nfl) {normalForceLimit = nfl;}
-
-  /*! Returns the maximum normal force due to torque limits in the hand computed by GFO.  */
-  double getNormalForceLimit() const {return normalForceLimit;}
-
-  //------------------- QuasiStatic equilibrium matrices and helper functions ---------------------
-
-  //! Returns a matrix for friction constraints at this contact that can be used in an LCP
-  Matrix frictionConstraintsMatrix() const;
-  //! Returns a block matrix composed of individual constraint matrices for the contacts in the list
-  static Matrix frictionConstraintsBlockMatrix(const std::list<Contact*> &contacts);
-
-  //! Returns the matrix that relates friction edge amplitudes to normal and frictional force
-  Matrix frictionForceMatrix() const;
-  //! Returns a block matrix made up of individual force matrices from the contacts in the list
-  static Matrix frictionForceBlockMatrix(const std::list<Contact*> &contacts);
-
-  //! Returns the matrix that transforms a force on this contact into a wrench on the other body
-  Matrix localToWorldWrenchMatrix() const;
-  //! Returns a block matrix made up of individual force to world wrench conversion matrices
-  static Matrix localToWorldWrenchBlockMatrix(const std::list<Contact*> &contacts);
-
-  //! Returns a matrix that adds just the normal force components of an amplitudes vector
-  static Matrix normalForceSumMatrix(const std::list<Contact*> &contacts);
-
-  //---------------------------------
-
-  /*! Sets the dynamic force acting at this contact during the current time step. Used when drawing contact forces.*/
-  void setDynamicContactWrench(double f[6])
-    {memcpy(dynamicForce,f,6*sizeof(double));}
-
-  /*! Sets just the force part of a dynamic wrench using a vec3*/
-  void setDynamicContactForce(const vec3 &force) {
-    dynamicForce[0] = force.x(); dynamicForce[1] = force.y();dynamicForce[2] = force.z();
-	dynamicForce[3] = dynamicForce[4] = dynamicForce[5] = 0;
-  }
-
-  /*! This contact inherits some properties from a contact from a previous dynamic time step.  */
-  void inherit(Contact *c);
-
-  //! The error that shows that this contact constraints are violated during dynamic simulation
-  double getConstraintError();
-
-  //! Maximum separation distance (in mm) between two bodies that are considered to be in contact
-  static const double THRESHOLD;
-
-  //! Maximum linear distance for which two contacts at consecutive time steps are considered to be the same contact
-  static const double INHERITANCE_THRESHOLD;
-
-  //! Maximum angular distance for which two contacts at consecutive time steps are considered to be the same contact
-  static const double INHERITANCE_ANGULAR_THRESHOLD;
-
-  //! Returns the IV root of the visual markers that shows the location of this contact
-  virtual SoSeparator* getVisualIndicator(){return NULL;}
-
-  //! Get dynamic sovler LCP information from the previous time step
-  double getPrevCn(){return prevCn;}
-  //! Get dynamic sovler LCP information from the previous time step
-  double getPrevLambda(){return prevLambda;}
-  //! Get dynamic sovler LCP information from the previous time step
-  double *getPrevBetas(){return prevBetas;}
-  //! Set dynamic sovler LCP information which might be used at the next time step
-  void setLCPInfo(double cn, double l, double *betas);
-
-  //! Returns the slip flag which does not work very well.
-  bool isSlipping() const {return mSlip;}
-
-  //! Tells us if this contact has inherited some information from previous time step
-  bool inherits(){return inheritanceInfo;}
-
-  //! A debug tool to see that contact inheritance works right
-  SoMaterial *coneMat;
-  //! A debug tool to see that contact inheritance works right
-  float coneR, coneG, coneB;
+    for each of them.  They have the same (or very close to the same) global
+    positions, opposite inward pointing normals, and share the same coefficients
+    of friction. Any instance of this class will have as mate its reciprocal
+    contact on the other body.
+
+    A contact is defined in places where two bodies are separated by less then
+    the contact threshold (usually set to 0.1 mm). In GraspIt, two bodies are
+    NEVER allowed to interpenetrate; they are considered in contact if they are
+    apart, but separated by less than the threshold.
+
+    We always define contacts to occur precisely at a point (as opposed to a small
+    area). This makes computations much easier, as we don't have to compute
+    deformations. The Grasp class will however consider the case of objects that
+    match geometry so that many point contacts can occur on the same patch. For
+    soft bodies, we have the SoftContact class which inherits from this one and
+    tries to approximate the frictional effects of having a contact patch (while
+    not computing such a patch explicitly).
+
+    Contacts also define their own linearized friction models. This means that,
+    for each contact, friction is constrained to lie within some convex polyhedron.
+    The edges that define this polyhedron are different for different types of
+    contacts, which inherit from this class. However, once the edges of the friction
+    polyhedron are defined, all contact behave identically.
+
+    You will also find here code for two projects which are not used right now. The
+    first one if Grasp Force Optimization (GFO). See the grasp class for that code;
+    it is finished but has never been tested. Also, the GFO code has never been updated
+    to work with the new Contact hierarchy of PointContact, SoftContact etc, and uses a
+    parallel mechanism to keep track of friction models. The second one concerns the
+    dynamics engine: in theory, we can try to save contact information from a time step
+    to help the solver during the next time step. The framework is in place, but we have
+    never used it.
+*/
+class Contact {
+        friend class VirtualContact;
+
+    protected:
+        //! Pointer to the body this contact is on
+        Body *body1;
+
+        //! Pointer to the other body involved in this contact
+        Body *body2;
+
+        //! Points to the other contact in this pair
+        Contact *mate;
+
+        //! Coefficient of static friction
+        double cof;
+
+        //! Coefficient of kinetic friction
+        double kcof;
+
+        //! The type of friction model at this contact
+        frictionT frictionType;
+
+        //! Contact dimension (num basisvecs): 1 for FL, 3 for PCWF, 4 for SFCE, 4 for SFCL
+        int contactDim;
+
+        //! LMI dimension: 1 for FL, 3 for PCWF, 4 for SFCE, 7 for SFCL
+        int lmiDim;
+
+        //! Coordinates of the contact with respect to body 1 base frame
+        position loc;
+
+        //! Contact normal with respect to body 1 base frame
+        vec3 normal;
+
+        //! Pose of the contact frame with respect to the body1 frame.
+        transf frame;
+
+        //! Pose of body 1 in world space at time of contact
+        transf body1Tran;
+
+        //! Pose of body 2 in world space at time of contact
+        transf body2Tran;
+
+        //! Root Inventor node stores arrow geometry representing current contact force
+        SoSeparator *contactForcePointers;
+
+        //! The maximum normal force for this contact point due to hand torque limits
+        double normalForceLimit;
+
+        //! A contactDim vector containing the optimal values to multiply with basisVecs. This will produce the contact forces necessary to generate the needed object wrench.
+        double *optimalCoeffs;
+
+        //! The current dynamic force acting at this contact
+        double dynamicForce[6];
+
+        //! Dynamics LCP information from the previous time step;
+        double prevCn;
+        //! Dynamics LCP information from the previous time step;
+        double prevLambda;
+        //! Dynamics LCP information from the previous time step;
+        double *prevBetas;
+        //! Tells us wether this contact has inherited some information from the previous dynamic time step.
+        bool inheritanceInfo;
+
+        //! Based on LCP solution, this flag shows if the contact is slipping or not. Does not work well.
+        bool mSlip;
+
+        //! computes a single contact wrench from a friction edge
+        void wrenchFromFrictionEdge(double *edge, const vec3 &radius, Wrench *wr);
+
+        //! Sets up frictional forces at this contact using a linearized ellipsoid
+        int setUpFrictionEllipsoid(int numLatitudes, int numDirs[], double phi[], double eccen[]);
+
+    public:
+
+        //! 6 x numFrictionEdges matrix of friction cone boundary wrenches used in dynmaics
+        /*! Friction edges contain "normalised" friction information: just the
+            frictional component, and without reference to normal force or coeff
+            of friction (c.o.f.). They only care about the relationship between
+            frictional components.
+        */
+        double frictionEdges[6 * MAX_FRICTION_EDGES];
+
+        //! number of friction edges defining the frictional component of contact wrenches
+        int numFrictionEdges;
+
+        //! Array of wrenches bounding the Contact Wrench Space (CWS)
+        /*! The CWS is a convex polyhedron that defines the space of wrenches that
+            can be applied at this contact. Also encapsulates normal forces (usually
+            normalised to 1N) and the relationship between normal and frictional
+            components (usually encapsulated in the coefficient of friction).
+        */
+        Wrench *wrench;
+
+        //! Number of total friction wrenches.
+        int numFCWrenches;
+
+        //! Initializes an empty contact (not really used)
+        Contact() : body1(NULL), body2(NULL), mate(NULL), cof(0.0),
+            contactForcePointers(NULL), optimalCoeffs(NULL), prevBetas(NULL), wrench(NULL) {}
+
+        //! Constructs a contact between two bodies
+        Contact(Body *b1, Body *b2, position pos, vec3 norm);
+
+        //! Destructor
+        virtual ~Contact();
+
+        //! Converts pure friction edges into full contact wrenches by considering normal force
+        virtual void computeWrenches();
+
+        //! Main function for defining the space of friction that can be applied at this contact.
+        virtual int setUpFrictionEdges(bool dynamicsOn = false) = 0;
+
+        /*! Connects the mate contact to this one */
+        void setMate(Contact *m) {
+            mate = m;
+        }
+
+        /*! Returns contact position wrt Body1 frame. */
+        position getPosition() {
+            return loc;
+        }
+
+        /*! Return contact normal wrt Body1 frame. */
+        vec3 getNormal() {
+            return normal;
+        }
+
+        /*! Returns a pointer to the other half of this contact pair. */
+        Contact *getMate() const {
+            return mate;
+        }
+
+        /*! Returns a pointer to body this contact is on. */
+        Body *getBody1() const {
+            return body1;
+        }
+
+        /*! Returns a pointer to the other body invovled in this contact. */
+        Body *getBody2() const {
+            return body2;
+        }
+
+        /*! Returns the pose of body1 when this contact was formed. */
+        transf getBody1Tran() const {
+            return body1Tran;
+        }
+
+        /*! Returns the pose of body2 when this contact was formed. */
+        transf getBody2Tran() const {
+            return body2Tran;
+        }
+
+        //! Gets the coefficient of friction for this contact
+        double getCof() const;
+
+        //! Gets the location
+        position getLocation() const {
+            return loc;
+        }
+
+        //! Gets the frame
+        transf getFrame() const {
+            return frame;
+        }
+
+        //! Updates the coefficient of friction (called when the body materials have changed)
+        void updateCof();
+
+        /*! Returns the type of friction modeled at this contact. */
+        frictionT getFrictionType() const {
+            return frictionType;
+        }
+
+        /*! Returns pose of the contact frame relative to the base frame of body1. */
+        transf getContactFrame() const {
+            return frame;
+        }
+
+        /*! Returns the current dynamic force acting at this contact. */
+        double *getDynamicContactWrench() {
+            return dynamicForce;
+        }
+
+        /*! Returns the Inventor root of the pointer geometry for this contact */
+        SoSeparator *getContactForcePointers() const {
+            return contactForcePointers;
+        }
+
+        /*! Determines whether this contact will prevent motion of body 1 as expressed in local body 1 coordinates */
+        bool preventsMotion(const transf &motion) const;
+
+        //! Called by GFO routine to set optimal contact force
+        void setContactForce(double *optmx);
+
+        /*! Returns the contact dimension (number of basis wrenches). */
+        int getContactDim() const {
+            return contactDim;
+        }
+
+        /*! Returns the dimension of the LMI block for this contact. (used in GFO) */
+        int getLmiDim() const {
+            return lmiDim;
+        }
+
+        /*! Sets the normal force limit based on hand torque limits as computed during GFO. */
+        void setNormalForceLimit(double nfl) {
+            normalForceLimit = nfl;
+        }
+
+        /*! Returns the maximum normal force due to torque limits in the hand computed by GFO.  */
+        double getNormalForceLimit() const {
+            return normalForceLimit;
+        }
+
+        //------------------- QuasiStatic equilibrium matrices and helper functions ---------------------
+
+        //! Returns a matrix for friction constraints at this contact that can be used in an LCP
+        Matrix frictionConstraintsMatrix() const;
+        //! Returns a block matrix composed of individual constraint matrices for the contacts in the list
+        static Matrix frictionConstraintsBlockMatrix(const std::list<Contact *> &contacts);
+
+        //! Returns the matrix that relates friction edge amplitudes to normal and frictional force
+        Matrix frictionForceMatrix() const;
+        //! Returns a block matrix made up of individual force matrices from the contacts in the list
+        static Matrix frictionForceBlockMatrix(const std::list<Contact *> &contacts);
+
+        //! Returns the matrix that transforms a force on this contact into a wrench on the other body
+        Matrix localToWorldWrenchMatrix() const;
+        //! Returns a block matrix made up of individual force to world wrench conversion matrices
+        static Matrix localToWorldWrenchBlockMatrix(const std::list<Contact *> &contacts);
+
+        //! Returns a matrix that adds just the normal force components of an amplitudes vector
+        static Matrix normalForceSumMatrix(const std::list<Contact *> &contacts);
+
+        //---------------------------------
+
+        /*! Sets the dynamic force acting at this contact during the current time step. Used when drawing contact forces.*/
+        void setDynamicContactWrench(double f[6]) {
+            memcpy(dynamicForce, f, 6 * sizeof(double));
+        }
+
+        /*! Sets just the force part of a dynamic wrench using a vec3*/
+        void setDynamicContactForce(const vec3 &force) {
+            dynamicForce[0] = force.x();
+            dynamicForce[1] = force.y();
+            dynamicForce[2] = force.z();
+            dynamicForce[3] = dynamicForce[4] = dynamicForce[5] = 0;
+        }
+
+        /*! This contact inherits some properties from a contact from a previous dynamic time step.  */
+        void inherit(Contact *c);
+
+        //! The error that shows that this contact constraints are violated during dynamic simulation
+        double getConstraintError();
+
+        //! Maximum separation distance (in mm) between two bodies that are considered to be in contact
+        static const double THRESHOLD;
+
+        //! Maximum linear distance for which two contacts at consecutive time steps are considered to be the same contact
+        static const double INHERITANCE_THRESHOLD;
+
+        //! Maximum angular distance for which two contacts at consecutive time steps are considered to be the same contact
+        static const double INHERITANCE_ANGULAR_THRESHOLD;
+
+        //! Returns the IV root of the visual markers that shows the location of this contact
+        virtual SoSeparator *getVisualIndicator() {
+            return NULL;
+        }
+
+        //! Get dynamic sovler LCP information from the previous time step
+        double getPrevCn() {
+            return prevCn;
+        }
+        //! Get dynamic sovler LCP information from the previous time step
+        double getPrevLambda() {
+            return prevLambda;
+        }
+        //! Get dynamic sovler LCP information from the previous time step
+        double *getPrevBetas() {
+            return prevBetas;
+        }
+        //! Set dynamic sovler LCP information which might be used at the next time step
+        void setLCPInfo(double cn, double l, double *betas);
+
+        //! Returns the slip flag which does not work very well.
+        bool isSlipping() const {
+            return mSlip;
+        }
+
+        //! Tells us if this contact has inherited some information from previous time step
+        bool inherits() {
+            return inheritanceInfo;
+        }
+
+        //! A debug tool to see that contact inheritance works right
+        SoMaterial *coneMat;
+        //! A debug tool to see that contact inheritance works right
+        float coneR, coneG, coneB;
 };
 
 //! A Point Contact With Friction (PCWF) implementing a Coulomb friction model
 /*! The Point Contact simulates rigid bodies in contact. As such, its wrench
-	space is a 3D cone and its friction space is a 2D circle with just 
-	tangential friction. Its visual indicator is the cone itself. The cone's
-	angle is equal to the tangent of the friction coefficient.
+    space is a 3D cone and its friction space is a 2D circle with just
+    tangential friction. Its visual indicator is the cone itself. The cone's
+    angle is equal to the tangent of the friction coefficient.
 */
-class PointContact : public Contact
-{
-public:
-	//! Also sets up friction edges according to Coulomb model
-	PointContact(Body *b1, Body *b2, position pos, vec3 norm);
-	//! Stub destructor
-	~PointContact();
-	//! Defines a 2D friction circle with tangential friction only.
-	int setUpFrictionEdges(bool dynamicsOn = false);
-	//! Returns the visual indicator which is the wrench space cone itself
-	SoSeparator* getVisualIndicator();
+class PointContact : public Contact {
+    public:
+        //! Also sets up friction edges according to Coulomb model
+        PointContact(Body *b1, Body *b2, position pos, vec3 norm);
+        //! Stub destructor
+        ~PointContact();
+        //! Defines a 2D friction circle with tangential friction only.
+        int setUpFrictionEdges(bool dynamicsOn = false);
+        //! Returns the visual indicator which is the wrench space cone itself
+        SoSeparator *getVisualIndicator();
 };
 
 //! Soft Contact implements an SFC model for contacts between soft bodies
 /*! The SoftContact attempts to capture some of the frictional effects between
-	soft bodies without explicitly computing the deformation at the contacts.
-	It locally fits analytical surfaces to both bodies involved by computing
-	their local radii of curvature. After this, it uses analytical models
-	to compute the expected contact area and pressure distribution.
-	
-	Based on the contact area, it then tries to approximate the relationship
-	between tangential friction and frictional torque using the limit surface,
-	which becomes a 3D friction ellipsoid. The friction space is thus 3D, and
-	the wrench space becomes 4D.
-	
-	Its visual indicator shows the analytical surface that has been fit to both
-	bodies involved, as a small patch around the contact location.
+    soft bodies without explicitly computing the deformation at the contacts.
+    It locally fits analytical surfaces to both bodies involved by computing
+    their local radii of curvature. After this, it uses analytical models
+    to compute the expected contact area and pressure distribution.
+
+    Based on the contact area, it then tries to approximate the relationship
+    between tangential friction and frictional torque using the limit surface,
+    which becomes a 3D friction ellipsoid. The friction space is thus 3D, and
+    the wrench space becomes 4D.
+
+    Its visual indicator shows the analytical surface that has been fit to both
+    bodies involved, as a small patch around the contact location.
 */
-class SoftContact : public Contact
-{
-protected:
-	//! A list of points from body1 that surround the contact in the frame of body1
-	vec3 *bodyNghbd;
+class SoftContact : public Contact {
+    protected:
+        //! A list of points from body1 that surround the contact in the frame of body1
+        vec3 *bodyNghbd;
 
-	//! The number of points in the current fit for analytical surfaces
-	int numPts;
+        //! The number of points in the current fit for analytical surfaces
+        int numPts;
 
-	//! Second order fit of points from body1 in the form r1x^2 + r2y^2
-	double r1, r2;
-	//! Parameters of unrotated fit in form z= ax^2+by^2+cxy
-	double a, b, c;
+        //! Second order fit of points from body1 in the form r1x^2 + r2y^2
+        double r1, r2;
+        //! Parameters of unrotated fit in form z= ax^2+by^2+cxy
+        double a, b, c;
 
-	//! The relative angle between r1 and the mate's r1
-	double relPhi;
+        //! The relative angle between r1 and the mate's r1
+        double relPhi;
 
-	//! The rotation from the contact frame to the frame in which the fit is given by the radii of curvature, r1 and r2
-	mat3 fitRot;
+        //! The rotation from the contact frame to the frame in which the fit is given by the radii of curvature, r1 and r2
+        mat3 fitRot;
 
-	//! The angle of the fitRot rotation
-	double fitRotAngle;
+        //! The angle of the fitRot rotation
+        double fitRotAngle;
 
-	//! The major axis of the ellipse of contact
-	double majorAxis;
-	//! The minor axis of the ellipse of contact
-	double minorAxis;
+        //! The major axis of the ellipse of contact
+        double majorAxis;
+        //! The minor axis of the ellipse of contact
+        double minorAxis;
 
-	//! The relative radii of curvature of the two bodies
-	double r1prime;
-	//! The relative radii of curvature of the two bodies
-	double r2prime;
+        //! The relative radii of curvature of the two bodies
+        double r1prime;
+        //! The relative radii of curvature of the two bodies
+        double r2prime;
 
-	//calculates the relative angle between the frames with 2 radii of curvature between
-	//the contact and its mate
-	int CalcRelPhi();
+        //calculates the relative angle between the frames with 2 radii of curvature between
+        //the contact and its mate
+        int CalcRelPhi();
 
-	//! Calculate the relative curvatures of the two bodies for contact dynamics
-	int CalcRprimes();
+        //! Calculate the relative curvatures of the two bodies for contact dynamics
+        int CalcRprimes();
 
-	//! Fits an analytical surface to a local patch on body1 around the contact
-	void FitPoints( );
+        //! Fits an analytical surface to a local patch on body1 around the contact
+        void FitPoints();
 
-	//! Calculates friction characteristics using a Mattress model
-	double CalcContact_Mattress( double nForce );
+        //! Calculates friction characteristics using a Mattress model
+        double CalcContact_Mattress(double nForce);
 
-public:
-	//! Also takes a local neighborhood of points around body 1
-	SoftContact( Body *b1, Body *b2, position pos, vec3 norm, Neighborhood *bn );
+    public:
+        //! Also takes a local neighborhood of points around body 1
+        SoftContact(Body *b1, Body *b2, position pos, vec3 norm, Neighborhood *bn);
 
-	//! Deletes its local record of the body neighborhood
-	~SoftContact( );
+        //! Deletes its local record of the body neighborhood
+        ~SoftContact();
 
-	//! Friction model is a 3D friction ellipsoid also containing frictional torque
-	int setUpFrictionEdges(bool dynamicsOn = false );
+        //! Friction model is a 3D friction ellipsoid also containing frictional torque
+        int setUpFrictionEdges(bool dynamicsOn = false);
 
-	//! Visual indicator is a small patch of the fit analytical surface on the body
-	SoSeparator* getVisualIndicator();
+        //! Visual indicator is a small patch of the fit analytical surface on the body
+        SoSeparator *getVisualIndicator();
 
-	//! Also attempt to apply some torques in the contact plane; currently disabled.
-	virtual void computeWrenches();
+        //! Also attempt to apply some torques in the contact plane; currently disabled.
+        virtual void computeWrenches();
 };
 
 //! A contact that exists even when a hand is not perfectly touching another object
-/*!	This class is meant for studing grasp quality when there is really no grasp, as
-	the hand is not exactly touching an object. The high-level purpose is to convert
-	the grasp quality function to a continous function that exists in all hand
-	configurations, rather then a highly discrete function that only is non-zero
-	when the hand is touching an object in the right way. However, this line of
-	work is not completed and this class is in bad need of an overhaul.
-	
-	A virtual contact does NOT come in a pair - there is no mate. As such, any instance
-	of this will have the mate set to NULL, a distinct sign of a virtual contact. 
-	Also, virtual contacts have the normals pointing outward, instead of the usual
-	contacts whose normals point inward. This is confusing and should probably be
-	changed at some point.
-	
-	The VirtualContact does not always need a body2. In fact, most of its design can
-	work if the body2 is NULL. However, it can have a body2, in which case some
-	distance functions are computed based on the body2. This is not very well
-	implemented right now and subject to change.
-	
-	A virtual contact can be instantiated from any kind of contact as it pretty much 
-	only copies the friction edges and location. It also needs a separate 
-	computeWrenches to eliminate the need for the object.
-	
-	All computations for a virtual contact (like wrenches, etc) are performed in the
-	world coordinate system, unlike the usual contact which is in the object's 
-	coordinate system. The reason is that we can have a grasp defined my many virtual
-	contacts on the hand (rather then meny traditional contacts on an object). In this 
-	case, each link of the hand has its own coordinate frame, so in order to have a 
-	coherent frame for the grasp we use world coordinates.
+/*! This class is meant for studing grasp quality when there is really no grasp, as
+    the hand is not exactly touching an object. The high-level purpose is to convert
+    the grasp quality function to a continous function that exists in all hand
+    configurations, rather then a highly discrete function that only is non-zero
+    when the hand is touching an object in the right way. However, this line of
+    work is not completed and this class is in bad need of an overhaul.
+
+    A virtual contact does NOT come in a pair - there is no mate. As such, any instance
+    of this will have the mate set to NULL, a distinct sign of a virtual contact.
+    Also, virtual contacts have the normals pointing outward, instead of the usual
+    contacts whose normals point inward. This is confusing and should probably be
+    changed at some point.
+
+    The VirtualContact does not always need a body2. In fact, most of its design can
+    work if the body2 is NULL. However, it can have a body2, in which case some
+    distance functions are computed based on the body2. This is not very well
+    implemented right now and subject to change.
+
+    A virtual contact can be instantiated from any kind of contact as it pretty much
+    only copies the friction edges and location. It also needs a separate
+    computeWrenches to eliminate the need for the object.
+
+    All computations for a virtual contact (like wrenches, etc) are performed in the
+    world coordinate system, unlike the usual contact which is in the object's
+    coordinate system. The reason is that we can have a grasp defined my many virtual
+    contacts on the hand (rather then meny traditional contacts on an object). In this
+    case, each link of the hand has its own coordinate frame, so in order to have a
+    coherent frame for the grasp we use world coordinates.
 */
-class VirtualContact : public Contact 
-{
-private:
-	//! Meant to replace the object CoG when a virtual contact has no object
-	position mCenter;
-	//! Meant to replace the object max radius when a virtual contact has no object
-	float mMaxRadius;
-	
-	//! We can hook this up directly to the world root to see the contact; for debug purposes
-	SoSeparator *mWorldInd;
-	//! We keep a pointer so we can change this contact's appearance on the fly; for debug
-	SoMaterial *mZaxisMat;
+class VirtualContact : public Contact {
+    private:
+        //! Meant to replace the object CoG when a virtual contact has no object
+        position mCenter;
+        //! Meant to replace the object max radius when a virtual contact has no object
+        float mMaxRadius;
 
-	//! Which finger (kinematic chain) of the robot this virtual contact is on. -1 means the palm.
-	int mFingerNum;
-	//! Which link of the chain this virtual contact is on.
-	int mLinkNum;
+        //! We can hook this up directly to the world root to see the contact; for debug purposes
+        SoSeparator *mWorldInd;
+        //! We keep a pointer so we can change this contact's appearance on the fly; for debug
+        SoMaterial *mZaxisMat;
 
-	//! Empty contact initialization shared by all constructors; sets the contact as its own mate
-	void init();
-public:
-	
-	//! The constructor initializes an empty virtual contact, setting it as its own mate
-	VirtualContact();
-	//! Also flips the normal of the original contact, to make it point outward
-	VirtualContact(int f, int l, Contact *original);
-	//! Copy constructor copies friction edges and location
-	VirtualContact(const VirtualContact *original);
-	//! Destructor
-	~VirtualContact();
+        //! Which finger (kinematic chain) of the robot this virtual contact is on. -1 means the palm.
+        int mFingerNum;
+        //! Which link of the chain this virtual contact is on.
+        int mLinkNum;
 
-	//! Sets the body that this contact is on, presumably to a robot link
-	void setBody(Body *b){body1 = b;}
-	//! Sets an object that this contact is not exactly on, but we use in calculations.
-	void setObject(Body *b){body2 = b;}
+        //! Empty contact initialization shared by all constructors; sets the contact as its own mate
+        void init();
+    public:
 
-	//! Writes this contact, including friction edges, to a file
-	void writeToFile(FILE *fp);
-	//! Loads this contact, including friction edges, from a file
-	void readFromFile(FILE *fp);
+        //! The constructor initializes an empty virtual contact, setting it as its own mate
+        VirtualContact();
+        //! Also flips the normal of the original contact, to make it point outward
+        VirtualContact(int f, int l, Contact *original);
+        //! Copy constructor copies friction edges and location
+        VirtualContact(const VirtualContact *original);
+        //! Destructor
+        ~VirtualContact();
 
-	//! Wrench computation is done in world coordinates considers the fact that we have no object
-	void computeWrenches(bool useObjectData = false, bool simply = false);
-	
-	//! Scales the wrench space of this contact by a given factor
-	void scaleWrenches(double factor);
+        //! Sets the body that this contact is on, presumably to a robot link
+        void setBody(Body *b) {
+            body1 = b;
+        }
+        //! Sets an object that this contact is not exactly on, but we use in calculations.
+        void setObject(Body *b) {
+            body2 = b;
+        }
 
-	//! The virtual contact can not set up its own friction edges.
-	int setUpFrictionEdges(bool dynamicsOn = false);
+        //! Writes this contact, including friction edges, to a file
+        void writeToFile(FILE *fp);
+        //! Loads this contact, including friction edges, from a file
+        void readFromFile(FILE *fp);
 
-	//! Updates mObjectDistance and mObjectNormal based on current world locations.
-	void updateContact(Body* object);
+        //! Wrench computation is done in world coordinates considers the fact that we have no object
+        void computeWrenches(bool useObjectData = false, bool simply = false);
 
-	//! Sets the max radius that is to be used in wrench computations
-	void setRadius(float r){mMaxRadius = r;}
-	//! Sets the c.o.g that is to be used in wrench computations
-	void setCenter(position c){mCenter = c;}
-	//! Gets the max radius that is used in wrench computations
-	double getMaxRadius(){return mMaxRadius;}
-	//! Gets the center that is used in wrench computations
-	position getCenter(){return mCenter;}
+        //! Scales the wrench space of this contact by a given factor
+        void scaleWrenches(double factor);
 
-	//! The visual indicator is just a thin red cylinder
-	SoSeparator* getVisualIndicator();
-	//! Another indicator that can be atatched directly to the world root, for debug
-	void getWorldIndicator(bool useObjectData = false);
+        //! The virtual contact can not set up its own friction edges.
+        int setUpFrictionEdges(bool dynamicsOn = false);
 
-	//! The location of this contact in world coordinates
-	position getWorldLocation();
-	//! The normal of this contact (pointing outwards) in world coordinates
-	vec3 getWorldNormal();
-	//! Computes the distance to the object along the contact normal and the object surface normal at the closest point
-	void getObjectDistanceAndNormal(Body *body, vec3 *objDistance, vec3 *objNormal);
+        //! Updates mObjectDistance and mObjectNormal based on current world locations.
+        void updateContact(Body *object);
 
-	//! Changes the visual marker to show that this contact is marked; for debug purposes.
-	void mark(bool m);
+        //! Sets the max radius that is to be used in wrench computations
+        void setRadius(float r) {
+            mMaxRadius = r;
+        }
+        //! Sets the c.o.g that is to be used in wrench computations
+        void setCenter(position c) {
+            mCenter = c;
+        }
+        //! Gets the max radius that is used in wrench computations
+        double getMaxRadius() {
+            return mMaxRadius;
+        }
+        //! Gets the center that is used in wrench computations
+        position getCenter() {
+            return mCenter;
+        }
 
-	//! Returns the number of the finger that this contact is on
-	int getFingerNum(){return mFingerNum;}
-	//! Returns the number of the link that this contact is on
-	int getLinkNum(){return mLinkNum;}
+        //! The visual indicator is just a thin red cylinder
+        SoSeparator *getVisualIndicator();
+        //! Another indicator that can be atatched directly to the world root, for debug
+        void getWorldIndicator(bool useObjectData = false);
+
+        //! The location of this contact in world coordinates
+        position getWorldLocation();
+        //! The normal of this contact (pointing outwards) in world coordinates
+        vec3 getWorldNormal();
+        //! Computes the distance to the object along the contact normal and the object surface normal at the closest point
+        void getObjectDistanceAndNormal(Body *body, vec3 *objDistance, vec3 *objNormal);
+
+        //! Changes the visual marker to show that this contact is marked; for debug purposes.
+        void mark(bool m);
+
+        //! Returns the number of the finger that this contact is on
+        int getFingerNum() {
+            return mFingerNum;
+        }
+        //! Returns the number of the link that this contact is on
+        int getLinkNum() {
+            return mLinkNum;
+        }
 
         //! Changes the frame (and thus also the location and normal) of this virtual contact
         void changeFrame(transf tr);
 };
-/* just like what VirtualContact class has done, VirtualContactOnObject Class is nothing weird except that
-it changes the virtual contacts' loaction from the finger to an object imported before.
-with these virtual contacts, we continue to study the grasp quality. Hao 10.04
+/*  just like what VirtualContact class has done, VirtualContactOnObject Class is nothing weird except that
+    it changes the virtual contacts' loaction from the finger to an object imported before.
+    with these virtual contacts, we continue to study the grasp quality. Hao 10.04
 */
-class VirtualContactOnObject : public VirtualContact
-{
-public:
-	VirtualContactOnObject ();
-	~VirtualContactOnObject ();
-	void readFromFile(FILE * fp);
-#ifdef ARIZONA_PROJECT_ENABLED
-	void readFromRawData(ArizonaRawExp* are, QString file, int index, bool flipNormal = false);
-#endif
-	void writeToFile(FILE * fp);
+class VirtualContactOnObject : public VirtualContact {
+    public:
+        VirtualContactOnObject();
+        ~VirtualContactOnObject();
+        void readFromFile(FILE *fp);
+        #ifdef ARIZONA_PROJECT_ENABLED
+        void readFromRawData(ArizonaRawExp *are, QString file, int index, bool flipNormal = false);
+        #endif
+        void writeToFile(FILE *fp);
 };
 #define CONTACT_HXX
 #endif

--- a/include/contactSetting.h
+++ b/include/contactSetting.h
@@ -23,20 +23,20 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief A number of global functions that are used by the GraspIt world 
-  to set up new contacts between bodies. We should find a home for them
-  inside a class at some point.
- */
+/*! \file
+    \brief A number of global functions that are used by the GraspIt world
+    to set up new contacts between bodies. We should find a home for them
+    inside a class at some point.
+*/
 
 #include "collisionStructures.h"
 
 class Body;
 
 //! Adds a new pair of contacts between two bodies
-void addContacts(Body *body1, Body *body2, ContactReport &contactSet, 
-				 bool softContactsOn = false );
+void addContacts(Body *body1, Body *body2, ContactReport &contactSet,
+                 bool softContactsOn = false);
 
 //! Adds a virtual contact on a body pointing at another body
-void addVirtualContacts(Body *body1, int f, int l, Body *body2, 
-						ContactReport &contactSet, bool softContactsOn );
+void addVirtualContacts(Body *body1, int f, int l, Body *body2,
+                        ContactReport &contactSet, bool softContactsOn);

--- a/include/debug.h
+++ b/include/debug.h
@@ -24,17 +24,17 @@
 //######################################################################
 
 /*! \file
-	Defines some convenience macros for output and debug, which behave 
-	differently depending on whether GRASPITDBG is defined:
+    Defines some convenience macros for output and debug, which behave
+    differently depending on whether GRASPITDBG is defined:
 
-	DBGA(msg) always prints the message to std::err
+    DBGA(msg) always prints the message to std::err
 
-	DBGP(msg) only prints the message if GRASPITDBG is defined, and 
-	swallows it otherwise. 
+    DBGP(msg) only prints the message if GRASPITDBG is defined, and
+    swallows it otherwise.
 
-	To use this, include "debug.h" in your source file, and then 
-	define GRASPITDBG just before the #include if you want the debug
-	output.
+    To use this, include "debug.h" in your source file, and then
+    define GRASPITDBG just before the #include if you want the debug
+    output.
 */
 
 #ifndef _DEBUG_H_
@@ -46,7 +46,7 @@
 #define DBGP(STMT) std::cerr<<STMT<<std::endl;
 #define DBGST(STMT) STMT;
 #else
-#define DBGP(STMT) 
+#define DBGP(STMT)
 #define DBGST(STMT)
 #endif
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -24,7 +24,7 @@
 //######################################################################
 
 /*! \file
-\brief Contains the graspit version number and other constants as needed
+    \brief Contains the graspit version number and other constants as needed
 */
 
 #define GRASPIT_VERSION "2.1"

--- a/include/dlfcn-win32.h
+++ b/include/dlfcn-win32.h
@@ -1,28 +1,28 @@
 /*
- * dlfcn-win32
- * Copyright (c) 2007 Ramiro Polla
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- */
+    dlfcn-win32
+    Copyright (c) 2007 Ramiro Polla
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 #ifndef DLFCN_H
 #define DLFCN_H
 
-/* POSIX says these are implementation-defined.
- * To simplify use with Windows API, we treat them the same way.
- */
+/*  POSIX says these are implementation-defined.
+    To simplify use with Windows API, we treat them the same way.
+*/
 
 #define RTLD_LAZY   0
 #define RTLD_NOW    0
@@ -30,16 +30,16 @@
 #define RTLD_GLOBAL (1 << 1)
 #define RTLD_LOCAL  (1 << 2)
 
-/* These two were added in The Open Group Base Specifications Issue 6.
- * Note: All other RTLD_* flags in any dlfcn.h are not standard compliant.
- */
+/*  These two were added in The Open Group Base Specifications Issue 6.
+    Note: All other RTLD_* flags in any dlfcn.h are not standard compliant.
+*/
 
 #define RTLD_DEFAULT    0
 #define RTLD_NEXT       0
 
-void *dlopen ( const char *file, int mode );
-int   dlclose( void *handle );
-void *dlsym  ( void *handle, const char *name );
-char *dlerror( void );
+void *dlopen(const char *file, int mode);
+int   dlclose(void *handle);
+void *dlsym(void *handle, const char *name);
+char *dlerror(void);
 
 #endif /* DLFCN_H */

--- a/include/dof.h
+++ b/include/dof.h
@@ -41,390 +41,445 @@ class QTextStream;
 
 //! A single degree of freedom in a robot
 /*! The best way to think about a DOF is as a motor, connected to one or
-	multiple joints by some transmission type. It is the only way that
-	an external user has at his disposal to change the joint positions of a 
-	robot. A single DOF must be connected to at least one joint, but can be 
-	connected to multiple joints as well. Currently though each joint can 
-	only be connected to a single DOF.
+    multiple joints by some transmission type. It is the only way that
+    an external user has at his disposal to change the joint positions of a
+    robot. A single DOF must be connected to at least one joint, but can be
+    connected to multiple joints as well. Currently though each joint can
+    only be connected to a single DOF.
 
-	Each DOF has a value associated with it (which usually translates directly
-	to a joint angle), limits on that value, a velocity, and a generalized force 
-	acting on it. The simplest type of DOF has a 1-to-1 relationship with a joint
-	and can be considered as a motor that only affects that joint. In this case, 
-	the DOF value will be equal to the joint value, and the dof limits equal to 
-	the joint limits.
+    Each DOF has a value associated with it (which usually translates directly
+    to a joint angle), limits on that value, a velocity, and a generalized force
+    acting on it. The simplest type of DOF has a 1-to-1 relationship with a joint
+    and can be considered as a motor that only affects that joint. In this case,
+    the DOF value will be equal to the joint value, and the dof limits equal to
+    the joint limits.
 
-	More complex DOF's are connected to multiple joints. In this case, depending
-	on how the connection is done, different DOF's behave differently. This is the
-	reason for having a hierarchy of different DOF types. The main difference is
-	what happens when a joint from one DOF is stopped due to contact: how are the
-	other joints of the same DOF affected? See implementations of the DOF interface
-	for details.
+    More complex DOF's are connected to multiple joints. In this case, depending
+    on how the connection is done, different DOF's behave differently. This is the
+    reason for having a hierarchy of different DOF types. The main difference is
+    what happens when a joint from one DOF is stopped due to contact: how are the
+    other joints of the same DOF affected? See implementations of the DOF interface
+    for details.
 
-	In static mode, the desired value of the DOF can be set directly, and then the
-	DOF itself will tell you what joint values result from that value. In dynamics,
-	the only way to go is to apply a force to a DOF and let the dynamic engine 
-	compute	body motions in response. The DOF can also simulate controllers to 
-	create desired joint motion, although simulating better DOF controllers would 
-	be needed.
+    In static mode, the desired value of the DOF can be set directly, and then the
+    DOF itself will tell you what joint values result from that value. In dynamics,
+    the only way to go is to apply a force to a DOF and let the dynamic engine
+    compute body motions in response. The DOF can also simulate controllers to
+    create desired joint motion, although simulating better DOF controllers would
+    be needed.
 */
 class DOF {
-  friend class Robot;
+        friend class Robot;
 
-public:
-  enum Type{RIGID, BREAKAWAY, COMPLIANT};
+    public:
+        enum Type {RIGID, BREAKAWAY, COMPLIANT};
 
-protected:
-  //! The robot that this DOF is a part of
-  Robot *owner;
+    protected:
+        //! The robot that this DOF is a part of
+        Robot *owner;
 
-  //! The number of this DOF within the robot definition
-  int dofNum;
+        //! The number of this DOF within the robot definition
+        int dofNum;
 
-  //! The current value of this DOF
-  double q;
-  
-  //! Tha maximum allowable value
-  double maxq;
+        //! The current value of this DOF
+        double q;
 
-  //! The minimum allowable value
-  double minq;
+        //! Tha maximum allowable value
+        double maxq;
 
-  //! The desired value
-  double desiredq;
+        //! The minimum allowable value
+        double minq;
 
-  //! The current trajectory set point
-  double setPoint;
+        //! The desired value
+        double desiredq;
 
-  double desiredVelocity;
-  double defaultVelocity;
-  double defaultValue;
-  double actualVelocity;
-  double maxAccel;
+        //! The current trajectory set point
+        double setPoint;
 
-  //! The current force acting on this DOF
-  double force;
+        double desiredVelocity;
+        double defaultVelocity;
+        double defaultValue;
+        double actualVelocity;
+        double maxAccel;
 
-  //! The maximum force this DOF can exert
-  double maxForce;
+        //! The current force acting on this DOF
+        double force;
 
-  //! The sum of external forces acting on the this DOF
-  double extForce;
+        //! The maximum force this DOF can exert
+        double maxForce;
 
-  //! Derivative gain used for PD controller
-  double Kv;
+        //! The sum of external forces acting on the this DOF
+        double extForce;
 
-  //! Proportional gain used for PD controller
-  double Kp;
+        //! Derivative gain used for PD controller
+        double Kv;
 
-  //! The dynamics error over the last dynamics steps; most recent is first
-  std::list<double> mErrorHistory;
+        //! Proportional gain used for PD controller
+        double Kp;
 
-  //! The position of this dof over the last steps
-  std::list<double> mPositionHistory;
+        //! The dynamics error over the last dynamics steps; most recent is first
+        std::list<double> mErrorHistory;
 
-  //! The velocity of the dof over the last steps
-  std::list<double> mVelocityHistory;
+        //! The position of this dof over the last steps
+        std::list<double> mPositionHistory;
 
-  //! The force applied to this dof over the last step
-  std::list<double> mForceHistory;
+        //! The velocity of the dof over the last steps
+        std::list<double> mVelocityHistory;
 
-  //! The max number of error values remembered
-  int mHistoryMaxSize;
+        //! The force applied to this dof over the last step
+        std::list<double> mForceHistory;
 
-  //! The world time when the current desired trajectory was set
-  double mDynStartTime;
+        //! The max number of error values remembered
+        int mHistoryMaxSize;
 
-  //! A vector of set points
-  std::vector<double> trajectory;
+        //! The world time when the current desired trajectory was set
+        double mDynStartTime;
 
-  //! Index of the current set point within the trajectory vector
-  int currTrajPt;
+        //! A vector of set points
+        std::vector<double> trajectory;
 
-  //! List of robot joints that are connected to this DOF
-  std::vector<Joint *> jointList;
+        //! Index of the current set point within the trajectory vector
+        int currTrajPt;
 
-  //! How large we want the UI dragger for this DOF to be
-  double draggerScale;
+        //! List of robot joints that are connected to this DOF
+        std::vector<Joint *> jointList;
 
-public:
+        //! How large we want the UI dragger for this DOF to be
+        double draggerScale;
 
-  //! Initializes everything to zero.
-  DOF();
-  //! This copy constructor only copies some of the fields; use with care.
-  DOF(const DOF *original);
-  //! Stub destructor
-  virtual ~DOF() {}
-  //! Initializes a DOF based on a list of joints it controls
-  virtual void initDOF(Robot *myRobot,const std::vector<Joint *>& jList);
-  //! Sets the max and min vals of the DOF from the smallest range of the joint limits.
-  void updateMinMax();
+    public:
 
-  //! Returns the type of this DOF
-  virtual Type getType() const = 0;
-  //! Resets the DOF. This is a fairly abstract concept, see implementations for details.
-  virtual void reset() = 0;
+        //! Initializes everything to zero.
+        DOF();
+        //! This copy constructor only copies some of the fields; use with care.
+        DOF(const DOF *original);
+        //! Stub destructor
+        virtual ~DOF() {}
+        //! Initializes a DOF based on a list of joints it controls
+        virtual void initDOF(Robot *myRobot, const std::vector<Joint *> &jList);
+        //! Sets the max and min vals of the DOF from the smallest range of the joint limits.
+        void updateMinMax();
 
-  //------------------- STATICS ----------------------
-  /*! Computes the values of the joints controlled by this DOF for the case where the DOF 
-      value was set to \a q1. The vector \a jointVals lists all the joints of the owning robot, 
-	  but this function only affects the values for those joints controlled by this DOF. 
-	  \a stoppedJoints is a binary vector that has information about what joints are stopped 
-	  (presumably due to some contact). The DOF can take that into account. This vector
-	  also has an entry for each joint in the owning robot. */
-  virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints) = 0;
-  /*! Attempts to compute the value of the DOF based on the values of the controlled joints. 
-	  \a jointVals lists the joint values to be used. If NULL, the current joint values as 
-	  reported by the joints themselves are used */
-  virtual void updateFromJointValues(const double *jointVals = NULL) = 0;
-  /*! Informs the dof that the robot has set joint values according to the given DOF value. 
-	  This typically happens due to some interpolation in joint value space */
-  virtual void updateVal(double q1) = 0;
-  /*! Gets the values of the joints for the current position of the DOF. 
-      Does no checking whatsoever */
-  virtual void getJointValues(double *jointVals) const = 0;
-  /*! Computes the static forces that are applied at each joint for a given level of DOF force
-	  If dofForce is negative, it computes instead the joint forces that have to be applied 
-	  just to keep the joints in the given position. This is relevant in the case of coupled 
-	  and compliant dof's. */
-  virtual bool computeStaticJointTorques(double *jointTorques, double dofForce = -1) = 0;
-  /*! Returns the ratio of joint \a j to this dof when static computations are performed */
-  virtual double getStaticRatio(Joint *j) const = 0;
+        //! Returns the type of this DOF
+        virtual Type getType() const = 0;
+        //! Resets the DOF. This is a fairly abstract concept, see implementations for details.
+        virtual void reset() = 0;
 
-  //------------------- DYNAMICS ---------------------
-  //! Returns the number of limit constraints that this DOF needs
-  virtual int getNumLimitConstraints() = 0;
-  //! Computes the dynamic constraints that prevent this DOF from exceeding its range 
-  virtual void buildDynamicLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-                                            double* H, double *g, int &hcn) = 0;
-  //! Returns the number of dynamic coupling constraints this DOF needs
-  virtual int getNumCouplingConstraints() = 0;
-  //! Computes the dynamic constraints that ensure that the coupling of this DOF is respected
-  virtual void buildDynamicCouplingConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-                                               double* Nu, double *eps, int &ncn) = 0;
-  /*! Sets the motor force applied on this DOF */
-  virtual void setForce(double f) = 0;
+        //------------------- STATICS ----------------------
+        /*! Computes the values of the joints controlled by this DOF for the case where the DOF
+            value was set to \a q1. The vector \a jointVals lists all the joints of the owning robot,
+            but this function only affects the values for those joints controlled by this DOF.
+            \a stoppedJoints is a binary vector that has information about what joints are stopped
+            (presumably due to some contact). The DOF can take that into account. This vector
+            also has an entry for each joint in the owning robot. */
+        virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints) = 0;
+        /*! Attempts to compute the value of the DOF based on the values of the controlled joints.
+            \a jointVals lists the joint values to be used. If NULL, the current joint values as
+            reported by the joints themselves are used */
+        virtual void updateFromJointValues(const double *jointVals = NULL) = 0;
+        /*! Informs the dof that the robot has set joint values according to the given DOF value.
+            This typically happens due to some interpolation in joint value space */
+        virtual void updateVal(double q1) = 0;
+        /*! Gets the values of the joints for the current position of the DOF.
+            Does no checking whatsoever */
+        virtual void getJointValues(double *jointVals) const = 0;
+        /*! Computes the static forces that are applied at each joint for a given level of DOF force
+            If dofForce is negative, it computes instead the joint forces that have to be applied
+            just to keep the joints in the given position. This is relevant in the case of coupled
+            and compliant dof's. */
+        virtual bool computeStaticJointTorques(double *jointTorques, double dofForce = -1) = 0;
+        /*! Returns the ratio of joint \a j to this dof when static computations are performed */
+        virtual double getStaticRatio(Joint *j) const = 0;
 
-  //! Does the bookkeeping and calls an appropriate controller to set the force on the DOF
-  virtual void callController(double timeStep);
+        //------------------- DYNAMICS ---------------------
+        //! Returns the number of limit constraints that this DOF needs
+        virtual int getNumLimitConstraints() = 0;
+        //! Computes the dynamic constraints that prevent this DOF from exceeding its range
+        virtual void buildDynamicLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                                  double *H, double *g, int &hcn) = 0;
+        //! Returns the number of dynamic coupling constraints this DOF needs
+        virtual int getNumCouplingConstraints() = 0;
+        //! Computes the dynamic constraints that ensure that the coupling of this DOF is respected
+        virtual void buildDynamicCouplingConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                                     double *Nu, double *eps, int &ncn) = 0;
+        /*! Sets the motor force applied on this DOF */
+        virtual void setForce(double f) = 0;
 
-  //! Calls the PD controller which will set the appropriate force on this DOF
-  virtual double PDPositionController(double timeStep);
+        //! Does the bookkeeping and calls an appropriate controller to set the force on the DOF
+        virtual void callController(double timeStep);
 
-  //! Returns true if this DOF is still progrssing towards its dynamic target
-  virtual bool dynamicsProgress();
+        //! Calls the PD controller which will set the appropriate force on this DOF
+        virtual double PDPositionController(double timeStep);
 
-  /*! Writes the state of this DOF to a stream in the format that \a readFromStream() can read in*/
-  virtual bool writeToStream(QTextStream &stream);
-  /*! Reads the state of this DOF from a stream */
-  virtual bool readFromStream(QTextStream &stream);
-  /*! Reads in the force parameters from XML*/
-	virtual bool readParametersFromXml(const TiXmlElement* root);
-  /*! Returns the current value. */
-  double getVal() const {return q;}
-  //! Get a value of this DOF that is later used to restore the state.
-  /*! See Robot::storeDOFVals(...) for more details on why this was needed. */
-  virtual double getSaveVal() const {return q;}
-  /*! Returns the number of this DOF within the robot definition. */
-  int getDOFNum() const {return dofNum;}
-  /*! Returns the maximum allowable value. */
-  double getMax() const { return maxq;}
-  /*! Returns the minimum allowable value. */
-  double getMin() const { return minq;}
+        //! Returns true if this DOF is still progrssing towards its dynamic target
+        virtual bool dynamicsProgress();
 
-  /*! Returns the desired velocity. */
-  double getDesiredVelocity() const {return desiredVelocity;}
-  /*! Returns the default velocity. */
-  double getDefaultVelocity() const {return defaultVelocity;}
-  /*! Returns the default value. */
-  double getDefaultValue() const {return defaultValue;}
-  /*! Returns the actual velocity. */
-  double getActualVelocity() const {return actualVelocity;}
-  /*! Returns the max. acceleration */
-  double getMaxAccel() const {return maxAccel;}
-  /*! Returns the current force acting on the DOF. */
-  double getForce() const {return force;}
-  /*! Returns the desired (target) level of force to be applied to this DOF */
-  double getDesiredForce() const {return force;}
-  /*! Returns the maximum force that can be applied by this DOF (think torque limit). */
-  double getMaxForce() const {return maxForce;}
-  /*! Returns the sum of all external forces applied to this DOF */
-  double getExtForce() const {return extForce;}
-  /*! Returns the dragger scale for this DOF */
-  float getDraggerScale() const {return draggerScale;}
+        /*! Writes the state of this DOF to a stream in the format that \a readFromStream() can read in*/
+        virtual bool writeToStream(QTextStream &stream);
+        /*! Reads the state of this DOF from a stream */
+        virtual bool readFromStream(QTextStream &stream);
+        /*! Reads in the force parameters from XML*/
+        virtual bool readParametersFromXml(const TiXmlElement *root);
+        /*! Returns the current value. */
+        double getVal() const {
+            return q;
+        }
+        //! Get a value of this DOF that is later used to restore the state.
+        /*! See Robot::storeDOFVals(...) for more details on why this was needed. */
+        virtual double getSaveVal() const {
+            return q;
+        }
+        /*! Returns the number of this DOF within the robot definition. */
+        int getDOFNum() const {
+            return dofNum;
+        }
+        /*! Returns the maximum allowable value. */
+        double getMax() const {
+            return maxq;
+        }
+        /*! Returns the minimum allowable value. */
+        double getMin() const {
+            return minq;
+        }
 
-  /*! Returns the current trajectory set point. */
-  double getSetPoint() const {return setPoint;}
-  double getDesiredPos() const {return desiredq;}
-  void updateSetPoint();
-  void setDesiredPos(double p) {desiredq = MIN(maxq,MAX(minq,p));}
-  void setDesiredVelocity(double v) {desiredVelocity = v;}
-  void setDefaultVelocity(double v) {defaultVelocity = v;}
-  void setTrajectory(double *traj,int numPts);
-  void addToTrajectory(double *traj,int numPts);
+        /*! Returns the desired velocity. */
+        double getDesiredVelocity() const {
+            return desiredVelocity;
+        }
+        /*! Returns the default velocity. */
+        double getDefaultVelocity() const {
+            return defaultVelocity;
+        }
+        /*! Returns the default value. */
+        double getDefaultValue() const {
+            return defaultValue;
+        }
+        /*! Returns the actual velocity. */
+        double getActualVelocity() const {
+            return actualVelocity;
+        }
+        /*! Returns the max. acceleration */
+        double getMaxAccel() const {
+            return maxAccel;
+        }
+        /*! Returns the current force acting on the DOF. */
+        double getForce() const {
+            return force;
+        }
+        /*! Returns the desired (target) level of force to be applied to this DOF */
+        double getDesiredForce() const {
+            return force;
+        }
+        /*! Returns the maximum force that can be applied by this DOF (think torque limit). */
+        double getMaxForce() const {
+            return maxForce;
+        }
+        /*! Returns the sum of all external forces applied to this DOF */
+        double getExtForce() const {
+            return extForce;
+        }
+        /*! Returns the dragger scale for this DOF */
+        float getDraggerScale() const {
+            return draggerScale;
+        }
 
-  /*! Get the jointlist of that DOF */
-  std::vector<Joint *> getJointList() const {return jointList;}
+        /*! Returns the current trajectory set point. */
+        double getSetPoint() const {
+            return setPoint;
+        }
+        double getDesiredPos() const {
+            return desiredq;
+        }
+        void updateSetPoint();
+        void setDesiredPos(double p) {
+            desiredq = MIN(maxq, MAX(minq, p));
+        }
+        void setDesiredVelocity(double v) {
+            desiredVelocity = v;
+        }
+        void setDefaultVelocity(double v) {
+            defaultVelocity = v;
+        }
+        void setTrajectory(double *traj, int numPts);
+        void addToTrajectory(double *traj, int numPts);
+
+        /*! Get the jointlist of that DOF */
+        std::vector<Joint *> getJointList() const {
+            return jointList;
+        }
 };
 
-/*! The RigidDOF is the simplest form of DOF. All of its joints are rigidly 
-	connected, so if one stops, all stop.
+/*! The RigidDOF is the simplest form of DOF. All of its joints are rigidly
+    connected, so if one stops, all stop.
 */
-class RigidDOF : public DOF 
-{
-private:
-	//! Checks the most that any of the joints is outside of its legal range by
-	double getClosestJointLimit(int *direction);
-public:
-	RigidDOF() : DOF() {}
-	RigidDOF(RigidDOF *original) : DOF(original) {}
-	Type getType() const {return RIGID;}
+class RigidDOF : public DOF {
+    private:
+        //! Checks the most that any of the joints is outside of its legal range by
+        double getClosestJointLimit(int *direction);
+    public:
+        RigidDOF() : DOF() {}
+        RigidDOF(RigidDOF *original) : DOF(original) {}
+        Type getType() const {
+            return RIGID;
+        }
 
-    //------------------- STATICS ---------------------
-	//! Any stopped joint stops all joints of this DOF
-	virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints);
-	//! Sets based on first joint in the list
-	virtual void updateFromJointValues(const double *jointVals = NULL);
-	//! Nothing special to do here
-	virtual void updateVal(double q1){q = q1;}
-	//! This is empty for the rigid DOF which is entirely state-less, nothing to reset
-	virtual void reset(){}
-	//! For a rigid DOF, the coupling ratio decides the ratio of movement, since the coupling is rigid
-	virtual double getStaticRatio(Joint *j) const;
-	//! Each joint only depepends on dof value
-	virtual void getJointValues(double *jointVals) const;
-	//! Zero everywhere, no static torques
-	/*! In the RigidDOF there is never any excess force applied at any joint. All joints are 
-		rigidly connected to the DOF, so once a joint is stopped the DOF can not advance any 
-		more so no more force is applied. */
-	virtual bool computeStaticJointTorques(double*,double){return true;}
+        //------------------- STATICS ---------------------
+        //! Any stopped joint stops all joints of this DOF
+        virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints);
+        //! Sets based on first joint in the list
+        virtual void updateFromJointValues(const double *jointVals = NULL);
+        //! Nothing special to do here
+        virtual void updateVal(double q1) {
+            q = q1;
+        }
+        //! This is empty for the rigid DOF which is entirely state-less, nothing to reset
+        virtual void reset() {}
+        //! For a rigid DOF, the coupling ratio decides the ratio of movement, since the coupling is rigid
+        virtual double getStaticRatio(Joint *j) const;
+        //! Each joint only depepends on dof value
+        virtual void getJointValues(double *jointVals) const;
+        //! Zero everywhere, no static torques
+        /*! In the RigidDOF there is never any excess force applied at any joint. All joints are
+            rigidly connected to the DOF, so once a joint is stopped the DOF can not advance any
+            more so no more force is applied. */
+        virtual bool computeStaticJointTorques(double *, double) {
+            return true;
+        }
 
-    //------------------- DYNAMICS ---------------------
-	//! At most one, if any of the joints is close or outside limit
-	virtual int getNumLimitConstraints();
-	//! Only one, applied to first joint in the DOF
-	virtual void buildDynamicLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-                                                  double* H, double *g, int &hcn);
-	//! Rigid coupling constraints ensure all joints move together
-	virtual int getNumCouplingConstraints(){return jointList.size() - 1;}
-	//! Rigid coupling constraints ensure all joints move together
-	virtual void buildDynamicCouplingConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-                                                     double* Nu, double *eps, int &ncn);
-	//! Only sets force to first joint, coupling constraints should take care of rest
-	virtual void setForce(double f);
+        //------------------- DYNAMICS ---------------------
+        //! At most one, if any of the joints is close or outside limit
+        virtual int getNumLimitConstraints();
+        //! Only one, applied to first joint in the DOF
+        virtual void buildDynamicLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                                  double *H, double *g, int &hcn);
+        //! Rigid coupling constraints ensure all joints move together
+        virtual int getNumCouplingConstraints() {
+            return jointList.size() - 1;
+        }
+        //! Rigid coupling constraints ensure all joints move together
+        virtual void buildDynamicCouplingConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                                     double *Nu, double *eps, int &ncn);
+        //! Only sets force to first joint, coupling constraints should take care of rest
+        virtual void setForce(double f);
 };
 
-/*! The BreakAwayDOF is a model of the Barrett Hand finger DOFs. If a 
-	proximal joint is stopped by contact, the transmission breaks away 
-	from that joint and distal joints continue to close. However, a joint 
-	that has been disengaged is only re-engaged when the DOF goes back to 
-	the value that is had when the joint was disengaged.
+/*! The BreakAwayDOF is a model of the Barrett Hand finger DOFs. If a
+    proximal joint is stopped by contact, the transmission breaks away
+    from that joint and distal joints continue to close. However, a joint
+    that has been disengaged is only re-engaged when the DOF goes back to
+    the value that is had when the joint was disengaged.
 
-	Dynamically, breakaway happens when a torque limit on breakaway joints 
-	is exceeded. We take that into account in the static joint torque 
-	computation. However, for the moment, the dynamics engine does not take 
-	that into account.
+    Dynamically, breakaway happens when a torque limit on breakaway joints
+    is exceeded. We take that into account in the static joint torque
+    computation. However, for the moment, the dynamics engine does not take
+    that into account.
 
-	This class assumes that breakaway only function in one direction, towards 
-	the max value of the dof. In real life this is true, as the barrett hand 
-	disengages finger joints only when the finger is closing. In simulation, this 
-	also helps because it removes any ambiguity when you have to decide what the 
-	dof value is based only on joint values.
+    This class assumes that breakaway only function in one direction, towards
+    the max value of the dof. In real life this is true, as the barrett hand
+    disengages finger joints only when the finger is closing. In simulation, this
+    also helps because it removes any ambiguity when you have to decide what the
+    dof value is based only on joint values.
 */
-class BreakAwayDOF : public RigidDOF
-{
-private:
-	//! Marks which joints controlled by this DOF are disengaged
-	int *mInBreakAway;
-	//! Saves the breakaway values for disengaged joints
-	double *mBreakAwayValues;
-	//! The level of torque that a breakaway joint applies before disengaging
-	double mBreakAwayTorque;
+class BreakAwayDOF : public RigidDOF {
+    private:
+        //! Marks which joints controlled by this DOF are disengaged
+        int *mInBreakAway;
+        //! Saves the breakaway values for disengaged joints
+        double *mBreakAwayValues;
+        //! The level of torque that a breakaway joint applies before disengaging
+        double mBreakAwayTorque;
 
-public:
-	Type getType()const {return BREAKAWAY;}
-	BreakAwayDOF() : RigidDOF(), mInBreakAway(NULL), mBreakAwayValues(NULL),mBreakAwayTorque(0.0) {}
-	BreakAwayDOF(BreakAwayDOF *original) : RigidDOF(original), mInBreakAway(NULL), 
-                                               mBreakAwayValues(NULL), 
-                                               mBreakAwayTorque(original->mBreakAwayTorque) {}
-	~BreakAwayDOF();
+    public:
+        Type getType()const {
+            return BREAKAWAY;
+        }
+        BreakAwayDOF() : RigidDOF(), mInBreakAway(NULL), mBreakAwayValues(NULL), mBreakAwayTorque(0.0) {}
+        BreakAwayDOF(BreakAwayDOF *original) : RigidDOF(original), mInBreakAway(NULL),
+            mBreakAwayValues(NULL),
+            mBreakAwayTorque(original->mBreakAwayTorque) {}
+        ~BreakAwayDOF();
 
-	//! Initializes breakaway flags
-    void initDOF(Robot *myRobot,const std::vector<Joint *>& jList);
-	//! Takes breakaway into account
-	virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints);
-	//! Looks at a joint that's not in breakaway
-	virtual void updateFromJointValues(const double *jointVals = NULL);
-	//! Sets breakaway values if breakaway has occured
-	virtual void updateVal(double q1);
-	//! Takes breakaway into account
-	virtual void getJointValues(double *jointVals) const;
-	//! Clears all breakaway flags, re-enages all joints
-	virtual void reset();
-	//! Applies breakaway torques
-	virtual bool computeStaticJointTorques(double *jointTorques, double dofForce = -1);
-	//! Returns the breakaway value rather than the current value
-	virtual double getSaveVal() const;
+        //! Initializes breakaway flags
+        void initDOF(Robot *myRobot, const std::vector<Joint *> &jList);
+        //! Takes breakaway into account
+        virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints);
+        //! Looks at a joint that's not in breakaway
+        virtual void updateFromJointValues(const double *jointVals = NULL);
+        //! Sets breakaway values if breakaway has occured
+        virtual void updateVal(double q1);
+        //! Takes breakaway into account
+        virtual void getJointValues(double *jointVals) const;
+        //! Clears all breakaway flags, re-enages all joints
+        virtual void reset();
+        //! Applies breakaway torques
+        virtual bool computeStaticJointTorques(double *jointTorques, double dofForce = -1);
+        //! Returns the breakaway value rather than the current value
+        virtual double getSaveVal() const;
 
-	//! Also writes the breakaway status
-	virtual bool writeToStream(QTextStream &stream);
-	//! Also reads in the breakaway status
-	virtual bool readFromStream(QTextStream &stream);
-	//!Also reads in the breakaway torque level
-	virtual bool readParametersFromXml(const TiXmlElement* root);
+        //! Also writes the breakaway status
+        virtual bool writeToStream(QTextStream &stream);
+        //! Also reads in the breakaway status
+        virtual bool readFromStream(QTextStream &stream);
+        //!Also reads in the breakaway torque level
+        virtual bool readParametersFromXml(const TiXmlElement *root);
 };
 
-/*! The compliant DOF is modeled after the Harvard Hand. It assumes compliant 
-	joints coupled through tendon actuation. As in the Breakaway DOF, if a 
-	proximal joint is stopped, distal joints continue to close. However, there 
-	is no breakaway mechanism, to joints that are stopped due to contact are 
-	always connected to the DOF.
+/*! The compliant DOF is modeled after the Harvard Hand. It assumes compliant
+    joints coupled through tendon actuation. As in the Breakaway DOF, if a
+    proximal joint is stopped, distal joints continue to close. However, there
+    is no breakaway mechanism, to joints that are stopped due to contact are
+    always connected to the DOF.
 */
-class CompliantDOF : public DOF
-{
-private:
-	//! Attempts to create a smooth profile directly from current and target positions
-	double smoothProfileController(double timeStep);
-public:
-	CompliantDOF() : DOF() {}
-	CompliantDOF(CompliantDOF *original) : DOF(original) {}
-	Type getType() const {return COMPLIANT;}
+class CompliantDOF : public DOF {
+    private:
+        //! Attempts to create a smooth profile directly from current and target positions
+        double smoothProfileController(double timeStep);
+    public:
+        CompliantDOF() : DOF() {}
+        CompliantDOF(CompliantDOF *original) : DOF(original) {}
+        Type getType() const {
+            return COMPLIANT;
+        }
 
-    //------------------- STATICS ---------------------
-	//! Makes sure all the joints have spring stiffness defined 
-    virtual void initDOF(Robot *myRobot,const std::vector<Joint *>& jList);
-	//! Static ratio depends on both coupling ratio and joint spring ratio.
-	virtual double getStaticRatio(Joint *j) const;
-	//! Returns the values as if no contact were present and links were free
-	virtual void getJointValues(double* jointVals) const;
-	//! Nothing to keep track of here
-	virtual void updateVal(double q1){q = q1;}
-	//! This can not always work, as states can be ambigous
-	virtual void updateFromJointValues(const double* jointVals= NULL);
-	//! Distal joints are unaffected by proximal joints
-	virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints);
-	//! Takes joint springs and coupling ratios into account
-	virtual bool computeStaticJointTorques(double* jointTorques, double dofForce = -1);
-	//! This DOF is stateless, nothing to reset
-	virtual void reset(){}
+        //------------------- STATICS ---------------------
+        //! Makes sure all the joints have spring stiffness defined
+        virtual void initDOF(Robot *myRobot, const std::vector<Joint *> &jList);
+        //! Static ratio depends on both coupling ratio and joint spring ratio.
+        virtual double getStaticRatio(Joint *j) const;
+        //! Returns the values as if no contact were present and links were free
+        virtual void getJointValues(double *jointVals) const;
+        //! Nothing to keep track of here
+        virtual void updateVal(double q1) {
+            q = q1;
+        }
+        //! This can not always work, as states can be ambigous
+        virtual void updateFromJointValues(const double *jointVals = NULL);
+        //! Distal joints are unaffected by proximal joints
+        virtual bool accumulateMove(double q1, double *jointVals, int *stoppedJoints);
+        //! Takes joint springs and coupling ratios into account
+        virtual bool computeStaticJointTorques(double *jointTorques, double dofForce = -1);
+        //! This DOF is stateless, nothing to reset
+        virtual void reset() {}
 
-	//------------------- DYNAMICS ---------------------
-	//! No dynamic coupling constraints, all joint forces are set explicitly
-	virtual int getNumCouplingConstraints(){return 0;}
-	//! No dynamic coupling constraints, all joint forces are set explicitly
-	virtual void buildDynamicCouplingConstraints(std::map<Body*,int>&, int, 
-		double*, double*, int&){}
-	//! One constraint for each joint that exceeds it range
-	virtual int getNumLimitConstraints();
-	//! Computes one constraint for each joint that exceeds it range
-	virtual void buildDynamicLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-                                                  double* H, double *g, int &hcn);
-	//! Explicitly sets force to all joints in the DOF
-	virtual void setForce(double f);
-	//! A simple stub for now, always applying max force
-	virtual double PDPositionController(double timeStep);
-	//! Returns true if this DOF is still progrssing towards its dynamic target
-	virtual bool dynamicsProgress();
+        //------------------- DYNAMICS ---------------------
+        //! No dynamic coupling constraints, all joint forces are set explicitly
+        virtual int getNumCouplingConstraints() {
+            return 0;
+        }
+        //! No dynamic coupling constraints, all joint forces are set explicitly
+        virtual void buildDynamicCouplingConstraints(std::map<Body *, int> &, int,
+                                                     double *, double *, int &) {}
+        //! One constraint for each joint that exceeds it range
+        virtual int getNumLimitConstraints();
+        //! Computes one constraint for each joint that exceeds it range
+        virtual void buildDynamicLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                                  double *H, double *g, int &hcn);
+        //! Explicitly sets force to all joints in the DOF
+        virtual void setForce(double f);
+        //! A simple stub for now, always applying max force
+        virtual double PDPositionController(double timeStep);
+        //! Returns true if this DOF is still progrssing towards its dynamic target
+        virtual bool dynamicsProgress();
 };
 
 #endif

--- a/include/eigenGrasp.h
+++ b/include/eigenGrasp.h
@@ -31,12 +31,12 @@
 #include <QString>
 #include <QTextStream>
 
-/*!	If this is not defined, than motion along eigengrasps is permitted only 
-	if NO joint values are taken outside the legal range. If it defined, we 
-	allow motion as long as at least one joint is still legal, while 
-	artificially constraining the ones that would leave the legal range of motion
-	This kind of constraining is unwanted because it implies movement that is not 
-	in eigen space and produces artifacts.
+/*! If this is not defined, than motion along eigengrasps is permitted only
+    if NO joint values are taken outside the legal range. If it defined, we
+    allow motion as long as at least one joint is still legal, while
+    artificially constraining the ones that would leave the legal range of motion
+    This kind of constraining is unwanted because it implies movement that is not
+    in eigen space and produces artifacts.
 */
 #define EIGENGRASP_LOOSE
 
@@ -45,190 +45,223 @@ class Matrix;
 class Robot;
 class QTextStream;
 //! A single eigengrasp direction
-/*!	An eigengrasp holds a generalized direction of motion in \a mSize 
-	dimensions. mSize is assumed to be the number of dofs of the robot 
-	that this is used for. It is essentially an msize-dimensional vector.
+/*! An eigengrasp holds a generalized direction of motion in \a mSize
+    dimensions. mSize is assumed to be the number of dofs of the robot
+    that this is used for. It is essentially an msize-dimensional vector.
 
-	mMin and mMax store the min and max amplitudes of motion along this 
-	eigengrasp that will not take the robot outside the acceptable DOF 
-	range. They only make sense when defined relative to an ORIGIN of 
-	motion!
+    mMin and mMax store the min and max amplitudes of motion along this
+    eigengrasp that will not take the robot outside the acceptable DOF
+    range. They only make sense when defined relative to an ORIGIN of
+    motion!
 */
-class EigenGrasp
-{
-private:
-	//! Dimension of this eigengrasp
-	int mSize;
-	//! The actual vector
-	double *mVals;
-	//! The eigenvalue corresponding to this EG. Not actually used anywhere, just here if ever needed
-	double mEigenValue;
+class EigenGrasp {
+    private:
+        //! Dimension of this eigengrasp
+        int mSize;
+        //! The actual vector
+        double *mVals;
+        //! The eigenvalue corresponding to this EG. Not actually used anywhere, just here if ever needed
+        double mEigenValue;
 
-public:
-	//! Stores the min value along this eigengrasp that is inside the legal joint range.
-	double mMin;
-	//! Stores the max value along this eigengrasp that is inside the legal joint range.
-	double mMax;
-	//! True if limits loaded from EigenGrasp File. If this is false Graspit! will attempt to compute limits at runtime.
-	bool mPredefinedLimits;
-	//! Remembers if the amplitude along this EG is fixed (no motion along this EG is allowed)
-	bool mFixed;
-	//! If this eigengrasp is fixed, this is the value that is was fixed at
-	double fixedAmplitude;
+    public:
+        //! Stores the min value along this eigengrasp that is inside the legal joint range.
+        double mMin;
+        //! Stores the max value along this eigengrasp that is inside the legal joint range.
+        double mMax;
+        //! True if limits loaded from EigenGrasp File. If this is false Graspit! will attempt to compute limits at runtime.
+        bool mPredefinedLimits;
+        //! Remembers if the amplitude along this EG is fixed (no motion along this EG is allowed)
+        bool mFixed;
+        //! If this eigengrasp is fixed, this is the value that is was fixed at
+        double fixedAmplitude;
 
-	//! Initializes an empty eigengrasp of a given size
-	EigenGrasp(int size, double e=0);
-	//! Copy constructor
-	EigenGrasp(const EigenGrasp *orig);
-	~EigenGrasp();
+        //! Initializes an empty eigengrasp of a given size
+        EigenGrasp(int size, double e = 0);
+        //! Copy constructor
+        EigenGrasp(const EigenGrasp *orig);
+        ~EigenGrasp();
 
-	int getSize() const {return mSize;}
+        int getSize() const {
+            return mSize;
+        }
 
-	//! Returns the mSize-dimensional vector itself
-	void getEigenGrasp (double *eg) const;
-	//! Sets the mSize-dimensional vector itself
-	void setEigenGrasp(const double *eg);
-	
-	//! Gets the eigenvalue associated w. this eigengrasp; not used.
-	double getEigenValue() const {return mEigenValue;}
-	//! Sets the eigenvalue associated w. this eigengrasp; not used.
-	void setEigenValue(double e){mEigenValue = e;}
+        //! Returns the mSize-dimensional vector itself
+        void getEigenGrasp(double *eg) const;
+        //! Sets the mSize-dimensional vector itself
+        void setEigenGrasp(const double *eg);
 
-	//! Sets this eigengrasp to the vector [1,...,1]
-	void setOnes(){for (int i=0; i<mSize; i++) mVals[i]=1.0;}
+        //! Gets the eigenvalue associated w. this eigengrasp; not used.
+        double getEigenValue() const {
+            return mEigenValue;
+        }
+        //! Sets the eigenvalue associated w. this eigengrasp; not used.
+        void setEigenValue(double e) {
+            mEigenValue = e;
+        }
 
-	//! Returns the comonent of this eigengrasp along the i-th dimension
-	double getAxisValue(int i) const {assert(i<mSize&&i>=0); return mVals[i];}
-	//! Sets the component of this eigengrasp along the i-th dimension
-	void setAxisValue(int i, double val){assert(i<mSize&&i>=0); mVals[i]=val;}
+        //! Sets this eigengrasp to the vector [1,...,1]
+        void setOnes() {
+            for (int i = 0; i < mSize; i++) mVals[i] = 1.0;
+        }
 
-	//! Normalizes this eigengrasp to norm 1
-	double normalize();
+        //! Returns the comonent of this eigengrasp along the i-th dimension
+        double getAxisValue(int i) const {
+            assert(i < mSize && i >= 0);
+            return mVals[i];
+        }
+        //! Sets the component of this eigengrasp along the i-th dimension
+        void setAxisValue(int i, double val) {
+            assert(i < mSize && i >= 0);
+            mVals[i] = val;
+        }
 
-	//! This is the main function that is used: dot the EG against another mSize-dimensional vector
-	double dot(double *d);
+        //! Normalizes this eigengrasp to norm 1
+        double normalize();
 
-	void writeToFile(FILE *fp);
-	void writeToFile(TiXmlElement *ep);
-	void readFromFile(FILE *fp);
+        //! This is the main function that is used: dot the EG against another mSize-dimensional vector
+        double dot(double *d);
 
-	int readFromStream(QTextStream *stream);
-	int readFromXml(const TiXmlElement *element);
-	
-	//! Tells this eigengrasp that it is fixed at the given value
-	void fix(double a){mFixed = true; fixedAmplitude = a;}
-	//! Tells this eigengrasp that it can move freely
-	void unfix(){mFixed = false;}
+        void writeToFile(FILE *fp);
+        void writeToFile(TiXmlElement *ep);
+        void readFromFile(FILE *fp);
+
+        int readFromStream(QTextStream *stream);
+        int readFromXml(const TiXmlElement *element);
+
+        //! Tells this eigengrasp that it is fixed at the given value
+        void fix(double a) {
+            mFixed = true;
+            fixedAmplitude = a;
+        }
+        //! Tells this eigengrasp that it can move freely
+        void unfix() {
+            mFixed = false;
+        }
 };
 
-/*!	This is the complete interface for controlling a robot in an eigengrasp
-	subspace. It holds a set of eigengrasps for a particular robot. It also 
-	has AN ORIGIN OF MOTION which is VERY IMPORTANT: it completely defines 
-	the subspace of the eigengrasps.
+/*! This is the complete interface for controlling a robot in an eigengrasp
+    subspace. It holds a set of eigengrasps for a particular robot. It also
+    has AN ORIGIN OF MOTION which is VERY IMPORTANT: it completely defines
+    the subspace of the eigengrasps.
 
-	The main role of this interface is to go back and forth between two spaces:
-	the dof, of dimensionality \a dSize, and the eigengrasp space, of 
-	dimensionality \a eSize. It simply defines the eigengrasp subspace and 
-	provides a linear mapping between the two.
+    The main role of this interface is to go back and forth between two spaces:
+    the dof, of dimensionality \a dSize, and the eigengrasp space, of
+    dimensionality \a eSize. It simply defines the eigengrasp subspace and
+    provides a linear mapping between the two.
 */
-class EigenGraspInterface
-{
-private:
-	//! The robot that this interface refers to. Should have the right number of joints.
-	Robot *mRobot;
-	//! The dimensionality of the dof space
-	int dSize;
-	//! The dimensionality of the eigengrasp space.
-	int eSize;
+class EigenGraspInterface {
+    private:
+        //! The robot that this interface refers to. Should have the right number of joints.
+        Robot *mRobot;
+        //! The dimensionality of the dof space
+        int dSize;
+        //! The dimensionality of the eigengrasp space.
+        int eSize;
 
-	//! The eigengrasps themselves; the bases of the subspace
-	std::vector<EigenGrasp*> mGrasps;
-	//! The origin of the EG subspace
-	EigenGrasp *mOrigin;
+        //! The eigengrasps themselves; the bases of the subspace
+        std::vector<EigenGrasp *> mGrasps;
+        //! The origin of the EG subspace
+        EigenGrasp *mOrigin;
 
-	//! Used if each EG has been "normalized". 
-	/*! Values along each axis are first multiplied by the respective
-		value in here, then added back to the origin (mean). */
-	EigenGrasp *mNorm;
+        //! Used if each EG has been "normalized".
+        /*! Values along each axis are first multiplied by the respective
+            value in here, then added back to the origin (mean). */
+        EigenGrasp *mNorm;
 
-	//! Helper that allows us to display what file the EG's where loaded from .
-	QString mName;
+        //! Helper that allows us to display what file the EG's where loaded from .
+        QString mName;
 
-	//!Matrix that projects from dof space to eigen space
-	Matrix *mP;
-	//!Matrix that projects from eigen space to dof space
-	Matrix *mPInv;
+        //!Matrix that projects from dof space to eigen space
+        Matrix *mP;
+        //!Matrix that projects from eigen space to dof space
+        Matrix *mPInv;
 
-	//! Shows if motion of the robot is RIGID 
-	/*! In rigid motion, only configuration that are strictly inside the
-		EG subspace are allowed. Otherwise, any configuration is allowed. 
-		This is relevant when getAmp(...) and getDOF(...) are used. */
-	mutable bool mRigid;
+        //! Shows if motion of the robot is RIGID
+        /*! In rigid motion, only configuration that are strictly inside the
+            EG subspace are allowed. Otherwise, any configuration is allowed.
+            This is relevant when getAmp(...) and getDOF(...) are used. */
+        mutable bool mRigid;
 
-	void clear();
+        void clear();
 
-	//! Builds the projection matrices based on eigengrasp definitions.
-	void computeProjectionMatrices();
+        //! Builds the projection matrices based on eigengrasp definitions.
+        void computeProjectionMatrices();
 
-	//! Goes from EG space to DOF space
-	void toDOFSpace(const double *amp, double *dof, const double *origin) const;
-	//! Goes from DOF space to EG space
-	void toEigenSpace(double *amp, const double *dof, const double *origin) const;
-public:
-	EigenGraspInterface(Robot *r);
-	EigenGraspInterface(const EigenGraspInterface *orig);
-	~EigenGraspInterface();
+        //! Goes from EG space to DOF space
+        void toDOFSpace(const double *amp, double *dof, const double *origin) const;
+        //! Goes from DOF space to EG space
+        void toEigenSpace(double *amp, const double *dof, const double *origin) const;
+    public:
+        EigenGraspInterface(Robot *r);
+        EigenGraspInterface(const EigenGraspInterface *orig);
+        ~EigenGraspInterface();
 
-	//! Returns the g-th eigengrasp
-	const EigenGrasp* getGrasp(int g) const {return mGrasps[g];}
-	//! Returns the size of the eigengrasp space (the number of eigengrasps)
-	int getSize() const {return (int)mGrasps.size();}
+        //! Returns the g-th eigengrasp
+        const EigenGrasp *getGrasp(int g) const {
+            return mGrasps[g];
+        }
+        //! Returns the size of the eigengrasp space (the number of eigengrasps)
+        int getSize() const {
+            return (int)mGrasps.size();
+        }
 
-	//! Returns whether the interface is rigid.
-	bool isRigid() const {return mRigid;}
-	//! Sets the interface to rigid mode or non-rigis mode
-	/*! In rigid motion, only configuration that are strictly inside the
-		EG subspace are allowed. Otherwise, any configuration is allowed. 
-		This is relevant when getAmp(...) and getDOF(...) are used. */
-	void setRigid(bool r) const {mRigid = r;}
+        //! Returns whether the interface is rigid.
+        bool isRigid() const {
+            return mRigid;
+        }
+        //! Sets the interface to rigid mode or non-rigis mode
+        /*! In rigid motion, only configuration that are strictly inside the
+            EG subspace are allowed. Otherwise, any configuration is allowed.
+            This is relevant when getAmp(...) and getDOF(...) are used. */
+        void setRigid(bool r) const {
+            mRigid = r;
+        }
 
-	//! Saves all the eigengrasps that define the subspace to a file, then also writes the origin
-	int writeToFile(const char *filename);
-	//! Loads all the eigengrasps, as well as the origin, from a file
-	int readFromFile(QString filename);
-	//! The trivial set of EG's is the identity set, where the EG (sub)space is identical to the dof space
-	int setTrivial();
+        //! Saves all the eigengrasps that define the subspace to a file, then also writes the origin
+        int writeToFile(const char *filename);
+        //! Loads all the eigengrasps, as well as the origin, from a file
+        int readFromFile(QString filename);
+        //! The trivial set of EG's is the identity set, where the EG (sub)space is identical to the dof space
+        int setTrivial();
 
-	//! Sets the name of this space; used used to show what file these eigengrasps were loaded from
-	void setName(QString n){mName = n;}
-	//! Gets the name of this space; used only for gui and debug purposes
-	const QString getName() const {return mName;}
+        //! Sets the name of this space; used used to show what file these eigengrasps were loaded from
+        void setName(QString n) {
+            mName = n;
+        }
+        //! Gets the name of this space; used only for gui and debug purposes
+        const QString getName() const {
+            return mName;
+        }
 
-	//! Sets the origin of the eigengrasp space, as a point in the dof space
-	void setOrigin(const double *dof);
-	//! Sets the origin of eigengrasp space as the point halfway between each dof's range
-	void setSimpleOrigin();
+        //! Sets the origin of the eigengrasp space, as a point in the dof space
+        void setOrigin(const double *dof);
+        //! Sets the origin of eigengrasp space as the point halfway between each dof's range
+        void setSimpleOrigin();
 
-	//! Re-computes the min and max allowable amplitudes along each EG direction. 
-	void setMinMax();
-	//! Checks if the origin of the eigengrasp space is inside the legal range of the dofs
-	void checkOrigin();
+        //! Re-computes the min and max allowable amplitudes along each EG direction.
+        void setMinMax();
+        //! Checks if the origin of the eigengrasp space is inside the legal range of the dofs
+        void checkOrigin();
 
-	//! Sets one of the eigengrasps as "fixed", meaning no movement is allowed along it
-	/*! This is relevant when a point in dof space has to be projected in eigengrasp
-		space and then back to dof space; if a certain eigengrasp is fixed, the projection
-		is forced to assume the fixed value for that eigengrasp.
-	*/
-	void fixEigenGrasp(int i, double fa){mGrasps[i]->fix(fa);}
-	//! Removes the "fixed" tag from an eigengrasp, allowing free movement
-	void unfixEigenGrasp(int i){mGrasps[i]->unfix();}
+        //! Sets one of the eigengrasps as "fixed", meaning no movement is allowed along it
+        /*! This is relevant when a point in dof space has to be projected in eigengrasp
+            space and then back to dof space; if a certain eigengrasp is fixed, the projection
+            is forced to assume the fixed value for that eigengrasp.
+        */
+        void fixEigenGrasp(int i, double fa) {
+            mGrasps[i]->fix(fa);
+        }
+        //! Removes the "fixed" tag from an eigengrasp, allowing free movement
+        void unfixEigenGrasp(int i) {
+            mGrasps[i]->unfix();
+        }
 
-	// These are the main functions that interface the EG:
+        // These are the main functions that interface the EG:
 
-	//! Converts a set of eigengrasp amplitudes into dof values
-	void getDOF (const double *amp, double *dof) const;
-	//! Converts a set of dof values to eigengrasp amplitudes
-	void getAmp(double *amp, const double *dof) const;
+        //! Converts a set of eigengrasp amplitudes into dof values
+        void getDOF(const double *amp, double *dof) const;
+        //! Converts a set of dof values to eigengrasp amplitudes
+        void getAmp(double *amp, const double *dof) const;
 };
 
 #endif

--- a/include/gloveInterface.h
+++ b/include/gloveInterface.h
@@ -38,225 +38,249 @@ class Robot;
 #include "matvec3D.h"
 
 //! A data structure for conveniently storing hand data used for calibration
-/*!	A calibration pose matches a set of joint values to a set of raw sensor 
-	readings (individual CyberGlove joint readings) for a given pose. It is 
-	ready to be used if both joint values and raw sensor values have been set.
+/*! A calibration pose matches a set of joint values to a set of raw sensor
+    readings (individual CyberGlove joint readings) for a given pose. It is
+    ready to be used if both joint values and raw sensor values have been set.
 */
 class CalibrationPose {
-private:
-	//! The number of raw sensor values from the glove. Usually hard-coded to 24
-	int mSize;
-	//! A set of joint values that the given sensor values should correspond to
-	double *jointValues;
-	//! A set of raw sensor values that the given joint values should correspond to
-	int *sensorValues;
-	//! Tells us to which robot DOF number each CyberGlove sensor is related to. 
-	/*! A map of -1 means this sensor is not calibrated by this pose (like for 
-		example the thumb, which this calibration poses ignore)*/
-	int *sensorMap;
-	//! A transform that is associated with this pose, for doing calibrations wrt objects or using flocks
-	transf mTransf;
-	//! Initializes an empty pose with no recorded information
-	void init(int size);
-public:
-	CalibrationPose(int size);
-	CalibrationPose(int size, double *joints, int *map);
-	~CalibrationPose();
+    private:
+        //! The number of raw sensor values from the glove. Usually hard-coded to 24
+        int mSize;
+        //! A set of joint values that the given sensor values should correspond to
+        double *jointValues;
+        //! A set of raw sensor values that the given joint values should correspond to
+        int *sensorValues;
+        //! Tells us to which robot DOF number each CyberGlove sensor is related to.
+        /*! A map of -1 means this sensor is not calibrated by this pose (like for
+            example the thumb, which this calibration poses ignore)*/
+        int *sensorMap;
+        //! A transform that is associated with this pose, for doing calibrations wrt objects or using flocks
+        transf mTransf;
+        //! Initializes an empty pose with no recorded information
+        void init(int size);
+    public:
+        CalibrationPose(int size);
+        CalibrationPose(int size, double *joints, int *map);
+        ~CalibrationPose();
 
-	void setJointValue(int j, double jv);
-	void setAllJointValues(double *jv);
-	void setSensorValue(int i, int sv);
-	void setAllSensorValues(int *sv);
-	void setMap(int i, int mv);
-	void setAllMaps(int *m);
-	void setTransf(transf t){mTransf = t;}
+        void setJointValue(int j, double jv);
+        void setAllJointValues(double *jv);
+        void setSensorValue(int i, int sv);
+        void setAllSensorValues(int *sv);
+        void setMap(int i, int mv);
+        void setAllMaps(int *m);
+        void setTransf(transf t) {
+            mTransf = t;
+        }
 
-	double getJointValue(int i){return jointValues[i];}
-	double *getAllJointValues(){return jointValues;}
-	int getSensorValue(int i){return sensorValues[i];}
-	int *getAllSensorValues(){return sensorValues;}
-	int getMap(int i){return sensorMap[i];}
-	int *getAllMaps(){return sensorMap;}
-	transf getTransf(){return mTransf;}
+        double getJointValue(int i) {
+            return jointValues[i];
+        }
+        double *getAllJointValues() {
+            return jointValues;
+        }
+        int getSensorValue(int i) {
+            return sensorValues[i];
+        }
+        int *getAllSensorValues() {
+            return sensorValues;
+        }
+        int getMap(int i) {
+            return sensorMap[i];
+        }
+        int *getAllMaps() {
+            return sensorMap;
+        }
+        transf getTransf() {
+            return mTransf;
+        }
 
-	//! Tells us if this pose is ready to be used (i.e. all the required data has been set)
-	bool isSet();
-	int getSize(){return mSize;}
-	bool jointsSet, sensorsSet, mapSet, poseSet;
+        //! Tells us if this pose is ready to be used (i.e. all the required data has been set)
+        bool isSet();
+        int getSize() {
+            return mSize;
+        }
+        bool jointsSet, sensorsSet, mapSet, poseSet;
 
-	//! Used for thumb calibration to record the expected distance between the index and the thumb
-	double recordedDistance;
+        //! Used for thumb calibration to record the expected distance between the index and the thumb
+        double recordedDistance;
 
-	//! Some misc. info you might need later. Actually used to store object file name for grasp poses
-	QString miscInfo;
+        //! Some misc. info you might need later. Actually used to store object file name for grasp poses
+        QString miscInfo;
 
-	void writeToFile(FILE *fp);
-	void readFromFile(FILE *fp);
+        void writeToFile(FILE *fp);
+        void readFromFile(FILE *fp);
 };
 
 //! Holds the information for linear conversion of raw glove senor readings to dof values
 /*! The CData (stands for conversion data) class holds the information
-	for converting raw glove readings to dof values. The conversions are
-	all linear, so for each sensor, we store a slope and an intercept.
-	It does not know how to match sensors with individual dof's. It also
-	contains a couple of convenience functions to help calibration.
+    for converting raw glove readings to dof values. The conversions are
+    all linear, so for each sensor, we store a slope and an intercept.
+    It does not know how to match sensors with individual dof's. It also
+    contains a couple of convenience functions to help calibration.
 
-	In general, any glove sensor can affect any robot dof, there is not a 
-	1-to-1 mapping. The slopes store the effect that each glove sensor
-	has on each robot dof. It is therefore a sparse nd x ns matrix, where
-	nd is the number of dofs and ns is the number of sensors. The intercepts
-	are specific to each dof.
+    In general, any glove sensor can affect any robot dof, there is not a
+    1-to-1 mapping. The slopes store the effect that each glove sensor
+    has on each robot dof. It is therefore a sparse nd x ns matrix, where
+    nd is the number of dofs and ns is the number of sensors. The intercepts
+    are specific to each dof.
 
-	In general, the value of the dof #d is obtained by:
-	dof_d = intercepts_d + sum_over_all_sensors_s[slope(s,d) * raw_sensor(s)]
+    In general, the value of the dof #d is obtained by:
+    dof_d = intercepts_d + sum_over_all_sensors_s[slope(s,d) * raw_sensor(s)]
 */
 class CData {
-private:
-	double *slopes,*intercepts;
-	int nDOF, nSensors;
-public:
-	CData(int nd, int ns);
-	~CData();
-	double getSlope(int d, int s);
-	double getIntercept(int d);
-	void setSlope(int d, int s, double val);
-	void setIntercept(int d, double val);
-	void addToSlope(int d, int s, double val);
-	void addToIntercept(int d, double val);
-	void reset();
+    private:
+        double *slopes, *intercepts;
+        int nDOF, nSensors;
+    public:
+        CData(int nd, int ns);
+        ~CData();
+        double getSlope(int d, int s);
+        double getIntercept(int d);
+        void setSlope(int d, int s, double val);
+        void setIntercept(int d, double val);
+        void addToSlope(int d, int s, double val);
+        void addToIntercept(int d, double val);
+        void reset();
 };
 
 //! Interface between a GraspIt robot and the CyberGlove
-/*! This class interfaces a Robot with a CyberGlove. The Raw Cyber Glove 
-	(in the Sensors library) just talks to the serial port and gets raw 
-	glove sensor values between 1 and 255. This interface converts them to
-	joint angle values, can perform calibration to compute the parameters 
-	for this conversion, and matches glove sensor numbers to robot DOF 
-	numbers.
+/*! This class interfaces a Robot with a CyberGlove. The Raw Cyber Glove
+    (in the Sensors library) just talks to the serial port and gets raw
+    glove sensor values between 1 and 255. This interface converts them to
+    joint angle values, can perform calibration to compute the parameters
+    for this conversion, and matches glove sensor numbers to robot DOF
+    numbers.
 
-	This class can also calibrate the CyberGlove (compute the conversion
-	parameters from raw sensor data to dof values). Unfortunately, the 
-	calibrations are rather poorly engineered from a software standpoint,
-	they should really have a dedicated interface and inheritance
-	hierarchies.
+    This class can also calibrate the CyberGlove (compute the conversion
+    parameters from raw sensor data to dof values). Unfortunately, the
+    calibrations are rather poorly engineered from a software standpoint,
+    they should really have a dedicated interface and inheritance
+    hierarchies.
 
-	Up to some degree, all calibrations behave the same way: the user must
-	supply a set of postures that are expected to match a pre-defined
-	set of joint angles. Alternatively, the calibration postures can
-	also be read from a file. After the record step, the calibration step
-	uses these postures to compute the parameters. This step depends on
-	the calibration type. See the enum \a calibrationType for details.
+    Up to some degree, all calibrations behave the same way: the user must
+    supply a set of postures that are expected to match a pre-defined
+    set of joint angles. Alternatively, the calibration postures can
+    also be read from a file. After the record step, the calibration step
+    uses these postures to compute the parameters. This step depends on
+    the calibration type. See the enum \a calibrationType for details.
 
-	The most difficult to calibrate is the thumb, where a couple of 
-	glove sensors are affected by more then one dof. See the paper by
-	Griffin, Findley, Turner and Cutkosky, "Calibration and Mapping of 
-	a Human Hand for Dexterous Telemanipulation" for some details that
-	have inspired the calibration done here.
+    The most difficult to calibrate is the thumb, where a couple of
+    glove sensors are affected by more then one dof. See the paper by
+    Griffin, Findley, Turner and Cutkosky, "Calibration and Mapping of
+    a Human Hand for Dexterous Telemanipulation" for some details that
+    have inspired the calibration done here.
 */
 class GloveInterface {
-private:
-	//! The instance of the raw glove where raw sensor values come from
-	CyberGlove *rawGlove;
-	//! The robot that uses this interface.
-	Robot *mRobot;
-	//! The data for performing linear conversion from raw sensor data to dof values
-	CData *mData;
+    private:
+        //! The instance of the raw glove where raw sensor values come from
+        CyberGlove *rawGlove;
+        //! The robot that uses this interface.
+        Robot *mRobot;
+        //! The data for performing linear conversion from raw sensor data to dof values
+        CData *mData;
 
-	//! A list of poses currently used for calibration
-	std::list<CalibrationPose*> cPoses;
-	//! The current pose selected (for recording data or for display)
-	std::list<CalibrationPose*>::iterator currentPose;
-	//! The type of calibration currently being performed
-	int cType;
-	//! Whether this interface is calibrated (and ready to use) or not
-	bool mCalibrated;
+        //! A list of poses currently used for calibration
+        std::list<CalibrationPose *> cPoses;
+        //! The current pose selected (for recording data or for display)
+        std::list<CalibrationPose *>::iterator currentPose;
+        //! The type of calibration currently being performed
+        int cType;
+        //! Whether this interface is calibrated (and ready to use) or not
+        bool mCalibrated;
 
-	double *savedDOFVals;
+        double *savedDOFVals;
 
-	bool computeMeanPose();
-	bool performSimpleCalibration();
-	bool performThumbCalibration();
-	bool performComplexCalibration();
-	bool complexCalibrationStep();
+        bool computeMeanPose();
+        bool performSimpleCalibration();
+        bool performThumbCalibration();
+        bool performComplexCalibration();
+        bool complexCalibrationStep();
 
-	//! Main interface function, gets a dof value from a list of raw sensor readings
-	float getDOFValue(int d, int *rawValues);
-public:
-	GloveInterface(Robot *robot);
-	~GloveInterface();
-	Robot* getRobot(){return mRobot;}
-	void setGlove(CyberGlove *glove);
+        //! Main interface function, gets a dof value from a list of raw sensor readings
+        float getDOFValue(int d, int *rawValues);
+    public:
+        GloveInterface(Robot *robot);
+        ~GloveInterface();
+        Robot *getRobot() {
+            return mRobot;
+        }
+        void setGlove(CyberGlove *glove);
 
-	//! Initializes the glove, in case we want to use it during the calibration
-	/*! We can also use pre-recorded poses if we don't want to. */
-	void startGlove();
-	//! Asks the raw CyberGlove to refresh its readings from the sensors via the serial port
-	int instantRead();
+        //! Initializes the glove, in case we want to use it during the calibration
+        /*! We can also use pre-recorded poses if we don't want to. */
+        void startGlove();
+        //! Asks the raw CyberGlove to refresh its readings from the sensors via the serial port
+        int instantRead();
 
-	//! Tells wether a particular robot DOF is controlled via the CyberGlove or not
-	bool isDOFControlled(int d);
-	//! Uses the latest sensor values from the CyberGlove and computes the values of a particular DOF
-	float getDOFValue(int d);
+        //! Tells wether a particular robot DOF is controlled via the CyberGlove or not
+        bool isDOFControlled(int d);
+        //! Uses the latest sensor values from the CyberGlove and computes the values of a particular DOF
+        float getDOFValue(int d);
 
-	//! Returns the number of raw sensors in the CyberGlove
-	int getNumSensors();
-	//! Computes parametes for linear conversion for a particular combination of raw sensor and dof number
-	void setParameters(int s, int d, float sMin, float sMax, float dMin, float dMax);
-	//! Sets the parametes for linear conversion for a particular combination of raw sensor and dof number
-	void setParameters(int s, int d, float slope, float intercept);
+        //! Returns the number of raw sensors in the CyberGlove
+        int getNumSensors();
+        //! Computes parametes for linear conversion for a particular combination of raw sensor and dof number
+        void setParameters(int s, int d, float sMin, float sMax, float dMin, float dMax);
+        //! Sets the parametes for linear conversion for a particular combination of raw sensor and dof number
+        void setParameters(int s, int d, float slope, float intercept);
 
-	/* All the other function here are used for calibration of various types*/		
+        /* All the other function here are used for calibration of various types*/
 
-	//! The types of calibrations available with this interface
-	/*! Here is what each does:
+        //! The types of calibrations available with this interface
+        /*! Here is what each does:
 
-		FIST: asks the user for only two poses: with the hand flat and with the fist
-		closed. Then, uses the two resulting values for each finger flexion dof
-		to compute the slope and intercept. Does NOT calibrate the thumb at all,
-		or the abduction / adduction dofs.
+            FIST: asks the user for only two poses: with the hand flat and with the fist
+            closed. Then, uses the two resulting values for each finger flexion dof
+            to compute the slope and intercept. Does NOT calibrate the thumb at all,
+            or the abduction / adduction dofs.
 
-		SIMPLE_THUMB:
+            SIMPLE_THUMB:
 
-		COMPLEX_THUMB: asks the user to record as many poses as pssible where the
-		distance between the index finger and the thumb is known. This is done
-		either by touching the index and the thumb, or by holding between them
-		an object of know size. Then attempts to use this data to calibrate
-		the thumb sensors.
+            COMPLEX_THUMB: asks the user to record as many poses as pssible where the
+            distance between the index finger and the thumb is known. This is done
+            either by touching the index and the thumb, or by holding between them
+            an object of know size. Then attempts to use this data to calibrate
+            the thumb sensors.
 
-		ABD_ADD: asks for two poses, at the two ends of abd / add to compute
-		the linear parameters for those dofs.
+            ABD_ADD: asks for two poses, at the two ends of abd / add to compute
+            the linear parameters for those dofs.
 
-		MEAN_POSE: not really a calibration; the user records as many poses
-		as she want, then this computes the mean of those poses.
-	*/
-	enum calibrationTypes{FIST, SIMPLE_THUMB, COMPLEX_THUMB, ABD_ADD, MEAN_POSE};
+            MEAN_POSE: not really a calibration; the user records as many poses
+            as she want, then this computes the mean of those poses.
+        */
+        enum calibrationTypes {FIST, SIMPLE_THUMB, COMPLEX_THUMB, ABD_ADD, MEAN_POSE};
 
-	void nextPose(int direction);
-	void showCurrentPose();
-	void recordPoseFromGlove(int d=0);
+        void nextPose(int direction);
+        void showCurrentPose();
+        void recordPoseFromGlove(int d = 0);
 
-	bool poseSet();
-	bool readyToCalibrate();
-	bool calibrated(){return mCalibrated;}
+        bool poseSet();
+        bool readyToCalibrate();
+        bool calibrated() {
+            return mCalibrated;
+        }
 
-	void saveCalibrationPoses(const char* filename);
-	void loadCalibrationPoses(const char* filename);
-	void clearPoses();
-	int getNumPoses(){return cPoses.size();}
+        void saveCalibrationPoses(const char *filename);
+        void loadCalibrationPoses(const char *filename);
+        void clearPoses();
+        int getNumPoses() {
+            return cPoses.size();
+        }
 
-	bool loadCalibration(const char* filename);
-	void saveCalibration(const char* filename);
+        bool loadCalibration(const char *filename);
+        void saveCalibration(const char *filename);
 
-	void initCalibration(int type);
-	bool performCalibration();
+        void initCalibration(int type);
+        bool performCalibration();
 
-	double getPoseError(vec3* error=NULL, position* thumbLocation=NULL);
-	double getTotalError();
-	void getPoseJacobian(double *J);
-	void assembleJMatrix(double *D, int lda);
-	void assemblePMatrix( double *P );
+        double getPoseError(vec3 *error = NULL, position *thumbLocation = NULL);
+        double getTotalError();
+        void getPoseJacobian(double *J);
+        void assembleJMatrix(double *D, int lda);
+        void assemblePMatrix(double *P);
 
-	void saveRobotPose();
-	void revertRobotPose();
+        void saveRobotPose();
+        void revertRobotPose();
 };
 #endif

--- a/include/grasp.h
+++ b/include/grasp.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the grasp class, which analyzes grasps
- */
+/*! \file
+    \brief Defines the grasp class, which analyzes grasps
+*/
 #ifndef GRASP_HXX
 
 #include <list>
@@ -56,226 +56,243 @@ class Matrix;
 class Joint;
 
 //! Max iteration steps in a feasibility phase
-#define MAX_FEAS_LOOPS	100 
+#define MAX_FEAS_LOOPS  100
 //! Max iteration steps in a optimization phase
-#define MAX_OPTM_LOOPS  100 
+#define MAX_OPTM_LOOPS  100
 
 extern bool saveSetup;
 extern int saveCounter;
 
-//! A grasp occurs between a hand and an object and has quality measures associated with it.  
+//! A grasp occurs between a hand and an object and has quality measures associated with it.
 //  It also has methods to optimize grasping forces.
 /*! Each hand object has a grasp associated with it, and the grasp occurs
     between the hand and a graspableBody.  Each grasp is incharge of
-	maintaining	a set of computed grasp wrench spaces, which are then used
-	by various quality measures.  When contacts change between the two, the 
-	grasp is updated, meaning each grasp wrench space associated with the 
-	grasp is rebuilt, as well as any grasp wrench space projections.  All
-    grasp quality measures are also re-evaluated. 
+    maintaining a set of computed grasp wrench spaces, which are then used
+    by various quality measures.  When contacts change between the two, the
+    grasp is updated, meaning each grasp wrench space associated with the
+    grasp is rebuilt, as well as any grasp wrench space projections.  All
+    grasp quality measures are also re-evaluated.
 
-	The grasp wrench spaces are designed to be shared by different quality 
-	metrics. When a new metric is added, if a GWS of the needed type already
-	exists in the list maintained by thhis grasp, the new QM will use it, 
-	and a reference count on the GWS is increased. GWS are automatically 
-	deleted when no QM that needs them exist anymore.
-	
-	A grasp can also perform many of the same services on set of 
-	VirtualCotacts (see documentation of that class for details). This part
-	however has not neen competely tested, and might produce behavior that
-	is not entirely consistent with how it handles traditional contacts.
+    The grasp wrench spaces are designed to be shared by different quality
+    metrics. When a new metric is added, if a GWS of the needed type already
+    exists in the list maintained by thhis grasp, the new QM will use it,
+    and a reference count on the GWS is increased. GWS are automatically
+    deleted when no QM that needs them exist anymore.
 
-	This class also provides the mechanism for performing Grasp Force
-	Optimization (GFO) computations using a Quadratic Program (QP) formulation.
-	There are many variants of this computation; some of them are already
-	written. You can generally mix and match between optimization criteria
-	and constraints in any way you want. A good starting point is the
-	computeQuasistaticForcesAndTorques(...) function.
+    A grasp can also perform many of the same services on set of
+    VirtualCotacts (see documentation of that class for details). This part
+    however has not neen competely tested, and might produce behavior that
+    is not entirely consistent with how it handles traditional contacts.
+
+    This class also provides the mechanism for performing Grasp Force
+    Optimization (GFO) computations using a Quadratic Program (QP) formulation.
+    There are many variants of this computation; some of them are already
+    written. You can generally mix and match between optimization criteria
+    and constraints in any way you want. A good starting point is the
+    computeQuasistaticForcesAndTorques(...) function.
 */
-class Grasp : public QObject{
-  Q_OBJECT
+class Grasp : public QObject {
+        Q_OBJECT
 
-public:
-  //! Default option for building a GWS on all 6 dimensions
-  static const std::vector<int> ALL_DIMENSIONS;
+    public:
+        //! Default option for building a GWS on all 6 dimensions
+        static const std::vector<int> ALL_DIMENSIONS;
 
-protected:
-  friend class LMIOptimizer;
+    protected:
+        friend class LMIOptimizer;
 
-  //! A pointer to the hand that owns this grasp object
-  Hand *hand;
+        //! A pointer to the hand that owns this grasp object
+        Hand *hand;
 
-  //! A pointer to the object that is the focus of this grasp
-  GraspableBody *object;
+        //! A pointer to the object that is the focus of this grasp
+        GraspableBody *object;
 
-  //! \c TRUE if the grasp has been updated since the last time the contacts changed
-  bool valid;
+        //! \c TRUE if the grasp has been updated since the last time the contacts changed
+        bool valid;
 
-  //! A list of pointers to the associated grasp wrench spaces
-  std::list<GWS *> gwsList;
+        //! A list of pointers to the associated grasp wrench spaces
+        std::list<GWS *> gwsList;
 
-  //! A list of pointers to the associated quality measures
-  std::list<QualityMeasure *> qmList;
+        //! A list of pointers to the associated quality measures
+        std::list<QualityMeasure *> qmList;
 
-  //! A list of pointer to the associated grasp wrench space projections
-  std::list<GWSprojection *> projectionList;
+        //! A list of pointer to the associated grasp wrench space projections
+        std::list<GWSprojection *> projectionList;
 
-  //! Number of quality meausre in the list
-  int numQM;
+        //! Number of quality meausre in the list
+        int numQM;
 
-  //! A vector of pointers to the contacts on the object where it touches the hand 
-  std::vector<Contact *> contactVec;
+        //! A vector of pointers to the contacts on the object where it touches the hand
+        std::vector<Contact *> contactVec;
 
-  //! Number of grasp contacts
-  int numContacts;
+        //! Number of grasp contacts
+        int numContacts;
 
-  //! Minimum grasp wrench that can be applied given contact forces that sum to 1
-  double minWrench[6];  
+        //! Minimum grasp wrench that can be applied given contact forces that sum to 1
+        double minWrench[6];
 
-  //! Tells us if quality metrics should take into account gravity
-  bool useGravity;
+        //! Tells us if quality metrics should take into account gravity
+        bool useGravity;
 
-  //! Computes the Jacobian of a link wrt the base of the finger, in link coordinates
-  double *getLinkJacobian(int f, int l);
+        //! Computes the Jacobian of a link wrt the base of the finger, in link coordinates
+        double *getLinkJacobian(int f, int l);
 
-  //! Sets the reference point that is used for grasp wrench computations as the center of the virtual contacts
-  void setVirtualCentroid();
+        //! Sets the reference point that is used for grasp wrench computations as the center of the virtual contacts
+        void setVirtualCentroid();
 
-  //! Computes the virtual center of the internally assembled list of virtual contacts
-  vec3 virtualCentroid();
+        //! Computes the virtual center of the internally assembled list of virtual contacts
+        vec3 virtualCentroid();
 
-  //! Sets the reference points of all virtual contacts using the c.o.g of the given object 
-  void setRealCentroid(GraspableBody *body);
+        //! Sets the reference points of all virtual contacts using the c.o.g of the given object
+        void setRealCentroid(GraspableBody *body);
 
-  friend class QMDlg;
+        friend class QMDlg;
 
-Q_SIGNALS:
-  //! Called when contacts have changes and the wrench spaces need to be updated
-  void graspUpdated();
+    Q_SIGNALS:
+        //! Called when contacts have changes and the wrench spaces need to be updated
+        void graspUpdated();
 
-public:
-  Grasp(Hand *h);
+    public:
+        Grasp(Hand *h);
 
-  ~Grasp();
+        ~Grasp();
 
-  /*! Returns whether the grasp has been updated since the last time grasp
-    contacts have changed. */
-  bool                    isValid() const {return valid;}
+        /*! Returns whether the grasp has been updated since the last time grasp
+            contacts have changed. */
+        bool                    isValid() const {
+            return valid;
+        }
 
-  /*! Returns whether the grasp force optimization problem is feasible. */
-  //bool                    isFeasible() const {return feasible;}
+        /*! Returns whether the grasp force optimization problem is feasible. */
+        //bool                    isFeasible() const {return feasible;}
 
-  /*! Returns the number of quality measures defined for this grasp. */
-  int                     getNumQM() const {return numQM;}
+        /*! Returns the number of quality measures defined for this grasp. */
+        int                     getNumQM() const {
+            return numQM;
+        }
 
-  /*! Return a pointer to the object that is the focus of this grasp. */
-  GraspableBody *         getObject() const {return object;}
+        /*! Return a pointer to the object that is the focus of this grasp. */
+        GraspableBody          *getObject() const {
+            return object;
+        }
 
-  /*! Return the number of grasp contacts. */
-  int                     getNumContacts() const {return numContacts;}
+        /*! Return the number of grasp contacts. */
+        int                     getNumContacts() const {
+            return numContacts;
+        }
 
-  /*! Return a pointer to the i-th grasp contact on the object. */
-  Contact *               getContact(int i) const {return contactVec[i];}
+        /*! Return a pointer to the i-th grasp contact on the object. */
+        Contact                *getContact(int i) const {
+            return contactVec[i];
+        }
 
-  void                    getMinWrench(double *w) const
-  {
-    if (w) memcpy(w,minWrench,6*sizeof(double));
-  }
+        void                    getMinWrench(double *w) const {
+            if (w) memcpy(w, minWrench, 6 * sizeof(double));
+        }
 
-  void                    setMinWrench(double *w)
-  {
-    if (w) memcpy(minWrench,w,6*sizeof(double));
-  }
+        void                    setMinWrench(double *w) {
+            if (w) memcpy(minWrench, w, 6 * sizeof(double));
+        }
 
-  /*! Sets graspableBody \a g to be the new focus of the grasp and updates the
-    grasp. */
-  void                    setObject(GraspableBody *g) {object = g; update();}
+        /*! Sets graspableBody \a g to be the new focus of the grasp and updates the
+            grasp. */
+        void                    setObject(GraspableBody *g) {
+            object = g;
+            update();
+        }
 
-  /* this is a hack; I had to do it due to some bug I was never able to trace down*/
-  void                    setObjectNoUpdate(GraspableBody *g) {object = g;}
+        /* this is a hack; I had to do it due to some bug I was never able to trace down*/
+        void                    setObjectNoUpdate(GraspableBody *g) {
+            object = g;
+        }
 
-  //! Collects all the contacts between the hand and the object in an internal list
-  void collectContacts();
-  //! Collects all the virtual contacts on the hand n an internal list
-  void collectVirtualContacts();
-  //! Collect all the virtual contacts on the object
-  void collectVirtualContactsOnObject();
+        //! Collects all the contacts between the hand and the object in an internal list
+        void collectContacts();
+        //! Collects all the virtual contacts on the hand n an internal list
+        void collectVirtualContacts();
+        //! Collect all the virtual contacts on the object
+        void collectVirtualContactsOnObject();
 
-  //! Collects all the contacts in the internal list and updates the wrench spaces
-  void update(std::vector<int> useDimensions = ALL_DIMENSIONS);
-  //! Updates (re-computes) the wrench spaces of this grasp and all of their projections
-  void updateWrenchSpaces(std::vector<int> useDimensions = ALL_DIMENSIONS);
+        //! Collects all the contacts in the internal list and updates the wrench spaces
+        void update(std::vector<int> useDimensions = ALL_DIMENSIONS);
+        //! Updates (re-computes) the wrench spaces of this grasp and all of their projections
+        void updateWrenchSpaces(std::vector<int> useDimensions = ALL_DIMENSIONS);
 
-  //! Returns the max radius used in GWS computations, either from the object of from virtual contacts
-  double getMaxRadius();
-  //! Returns the c.o.g. used in GWS computations, either from the object of from virtual contacts
-  position getCoG();
+        //! Returns the max radius used in GWS computations, either from the object of from virtual contacts
+        double getMaxRadius();
+        //! Returns the c.o.g. used in GWS computations, either from the object of from virtual contacts
+        position getCoG();
 
-  //! Adds a GWS of a given type to the grasp, unless one exists already
-  GWS *addGWS(const char *type);
-  GWS *getGWS(const char *type);
-  //! Decrements the reference count on a GWS of the given type, and deletes it if the ref count reaches 0
-  void removeGWS(GWS *gws);
-  //! Adds a quality measure to this grasp
-  void addQM(QualityMeasure *qm);
-  //! Replaces a QM in the list associated with this grasp with another QM
-  void replaceQM(int which,QualityMeasure *qm);
-  //! Returns one of the quality measures that have been associated with this grasp
-  QualityMeasure *getQM(int which);
-  //! Removes a quality measure that has been associated with this grasp
-  void removeQM(int which);
-  
-  void addProjection(GWSprojection *gp);
-  void removeProjection(GWSprojection *gp);
-  static void destroyProjection(void * user, SoQtComponent * component);
+        //! Adds a GWS of a given type to the grasp, unless one exists already
+        GWS *addGWS(const char *type);
+        GWS *getGWS(const char *type);
+        //! Decrements the reference count on a GWS of the given type, and deletes it if the ref count reaches 0
+        void removeGWS(GWS *gws);
+        //! Adds a quality measure to this grasp
+        void addQM(QualityMeasure *qm);
+        //! Replaces a QM in the list associated with this grasp with another QM
+        void replaceQM(int which, QualityMeasure *qm);
+        //! Returns one of the quality measures that have been associated with this grasp
+        QualityMeasure *getQM(int which);
+        //! Removes a quality measure that has been associated with this grasp
+        void removeQM(int which);
 
-  //! Sets whether QM's should take gravity into account; not very thoroughly tested yet
-  void setGravity(bool g){useGravity = g;}
-  bool isGravitySet(){return useGravity;}
+        void addProjection(GWSprojection *gp);
+        void removeProjection(GWSprojection *gp);
+        static void destroyProjection(void *user, SoQtComponent *component);
 
-  //------------------- Grasp Force Optimization (GFO) routines --------------------------
+        //! Sets whether QM's should take gravity into account; not very thoroughly tested yet
+        void setGravity(bool g) {
+            useGravity = g;
+        }
+        bool isGravitySet() {
+            return useGravity;
+        }
 
-  static const int CONTACT_FORCE_EXISTENCE;
-  static const int CONTACT_FORCE_OPTIMIZATION;
-  static const int GRASP_FORCE_EXISTENCE;
-  static const int GRASP_FORCE_OPTIMIZATION;
+        //------------------- Grasp Force Optimization (GFO) routines --------------------------
 
-  //! Computes the contact forces and joint torques that give the most robust equilibrium
-  int computeQuasistaticForcesAndTorques(Matrix *robotTau, int computation);
+        static const int CONTACT_FORCE_EXISTENCE;
+        static const int CONTACT_FORCE_OPTIMIZATION;
+        static const int GRASP_FORCE_EXISTENCE;
+        static const int GRASP_FORCE_OPTIMIZATION;
 
-  //! Given a vector of joint torques, computes the contact forces that balance the system
-  int computeQuasistaticForces(const Matrix &robotTau);
+        //! Computes the contact forces and joint torques that give the most robust equilibrium
+        int computeQuasistaticForcesAndTorques(Matrix *robotTau, int computation);
 
-  //! Gets a list with only the joints on chains that have contacts on them
-  std::list<Joint*> getJointsOnContactChains();
+        //! Given a vector of joint torques, computes the contact forces that balance the system
+        int computeQuasistaticForces(const Matrix &robotTau);
 
-  //! A version of the contact grasp Jacobian, used for GFO routines
-  Matrix contactJacobian(const std::list<Joint*> &joints, 
-                         const std::list< std::pair<transf, Link*> > &contact_locations);
+        //! Gets a list with only the joints on chains that have contacts on them
+        std::list<Joint *> getJointsOnContactChains();
 
-  //! A convenience version of the Jacobian function that takes in a list of contacts
-  Matrix contactJacobian(const std::list<Joint*> &joints, 
-                         const std::list<Contact*> &contacts);
+        //! A version of the contact grasp Jacobian, used for GFO routines
+        Matrix contactJacobian(const std::list<Joint *> &joints,
+                               const std::list< std::pair<transf, Link *> > &contact_locations);
 
-  //! A convenience version of the Jacobian function that takes in a list of virtual contacts
-  Matrix contactJacobian(const std::list<Joint*> &joints, 
-                         const std::list<VirtualContact*> &contacts);
+        //! A convenience version of the Jacobian function that takes in a list of contacts
+        Matrix contactJacobian(const std::list<Joint *> &joints,
+                               const std::list<Contact *> &contacts);
 
-  //! A convenience function that returns the Jacobian of the CoG locations for the links
-  Matrix CoGJacobian(const std::list<Joint*> &joints, 
-                     const std::list<Link*> &links);
+        //! A convenience version of the Jacobian function that takes in a list of virtual contacts
+        Matrix contactJacobian(const std::list<Joint *> &joints,
+                               const std::list<VirtualContact *> &contacts);
 
-  //! Returns the matrix that gives the gravity torque at each joint, considering the given links
-  Matrix gravityMatrix(const std::list<Joint*> &joints, const std::list<Link*> &links,
-                       vec3 gravityWorldDirection);
+        //! A convenience function that returns the Jacobian of the CoG locations for the links
+        Matrix CoGJacobian(const std::list<Joint *> &joints,
+                           const std::list<Link *> &links);
 
-  //! Computes the grasp map matrix G from friction and normal force matrices R and D
-  static Matrix graspMapMatrix(const Matrix &R, const Matrix &D);
+        //! Returns the matrix that gives the gravity torque at each joint, considering the given links
+        Matrix gravityMatrix(const std::list<Joint *> &joints, const std::list<Link *> &links,
+                             vec3 gravityWorldDirection);
 
-  //! Sets local contact wrenches into the contact wrench Q_SLOTS so they can be rendered
-  void displayContactWrenches(std::list<Contact*> *contacts, const Matrix &contactWrenches);
-  //! Accumulates object wrenches in the external wrench accumulator for the objects
-  void accumulateAndDisplayObjectWrenches(std::list<Contact*> *contacts, 
-										  const Matrix &objectWrenches);
+        //! Computes the grasp map matrix G from friction and normal force matrices R and D
+        static Matrix graspMapMatrix(const Matrix &R, const Matrix &D);
+
+        //! Sets local contact wrenches into the contact wrench Q_SLOTS so they can be rendered
+        void displayContactWrenches(std::list<Contact *> *contacts, const Matrix &contactWrenches);
+        //! Accumulates object wrenches in the external wrench accumulator for the objects
+        void accumulateAndDisplayObjectWrenches(std::list<Contact *> *contacts,
+                                                const Matrix &objectWrenches);
 };
 
 #define GRASP_HXX

--- a/include/graspRecord.h
+++ b/include/graspRecord.h
@@ -35,36 +35,35 @@
 class CalibrationPose;
 
 //! Obsolete class used for saving a hand pose and posture for a grasp of an object
-/*!	This class records a grasp. It just knows a hand pose and a transform.
-	It uses the CalibrationPose to record the pose, but makes use of very 
-	little from that class. It keeps the pose in DOF space, not in 
-	EigenGrasp space.
+/*! This class records a grasp. It just knows a hand pose and a transform.
+    It uses the CalibrationPose to record the pose, but makes use of very
+    little from that class. It keeps the pose in DOF space, not in
+    EigenGrasp space.
 
-	This class is obsolete, only used by the GraspCaptureDlg. It is in a very
-	poor state, not recommended for use.
+    This class is obsolete, only used by the GraspCaptureDlg. It is in a very
+    poor state, not recommended for use.
 */
-class GraspRecord
-{
-private:
-	int mSize;
-public:
-	GraspRecord(int size);
-	~GraspRecord();
+class GraspRecord {
+    private:
+        int mSize;
+    public:
+        GraspRecord(int size);
+        ~GraspRecord();
 
-	CalibrationPose *mPose;
-	QString mObjectName;
-	QString mRobotName;
-	transf mTran;
+        CalibrationPose *mPose;
+        QString mObjectName;
+        QString mRobotName;
+        transf mTran;
 
-	//modified to DBase project
-	double quality;
-	int originalIndex;
+        //modified to DBase project
+        double quality;
+        int originalIndex;
 
-	void writeToFile(FILE *fp);
-	void readFromFile(FILE *fp);
+        void writeToFile(FILE *fp);
+        void readFromFile(FILE *fp);
 };
 
-void loadGraspListFromFile(std::vector<GraspRecord*> *list, const char *filename);
-void writeGraspListToFile (std::vector<GraspRecord*> *list, const char *filename);
+void loadGraspListFromFile(std::vector<GraspRecord *> *list, const char *filename);
+void writeGraspListToFile(std::vector<GraspRecord *> *list, const char *filename);
 
 #endif

--- a/include/graspitApp.h
+++ b/include/graspitApp.h
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: graspitApp.h,v 1.4 2010/01/13 23:08:10 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Defines GraspItApp, a subclass of QApplication.
+    \brief Defines GraspItApp, a subclass of QApplication.
 */
 
 #ifndef _GRASPITAPP_H_
@@ -36,33 +36,35 @@ class QLabel;
 
 //! This is the specific QApplication class for this program, and it defines routines for the splash screen.
 /*!
-  The main purpose of this class is to show the splash screen at the
-  beginning when the application is started.  In the future, more may be
-  added to this.  One instance of this class should be defined in the main
-  program.
+    The main purpose of this class is to show the splash screen at the
+    beginning when the application is started.  In the future, more may be
+    added to this.  One instance of this class should be defined in the main
+    program.
 */
-class GraspItApp : public QApplication
-{
- private:
-  bool splash_enabled_;
- public:
-  /*! Stub constructor */
- GraspItApp(int &argc, char **argv) : QApplication(argc,argv), splash_enabled_(true) 
-    {
-      //for db_dispatch jobs, splash is disabled
-      if (argc > 1 && !strcmp(argv[1],"db_dispatch")) {
-	splash_enabled_ = false;
-      }
-    }
+class GraspItApp : public QApplication {
+    private:
+        bool splash_enabled_;
+    public:
+        /*! Stub constructor */
+        GraspItApp(int &argc, char **argv) : QApplication(argc, argv), splash_enabled_(true) {
+            //for db_dispatch jobs, splash is disabled
+            if (argc > 1 && !strcmp(argv[1], "db_dispatch")) {
+                splash_enabled_ = false;
+            }
+        }
 
-  /*! Returns the name of this class. */
-  const char *className() const { return "GraspItApp"; }
+        /*! Returns the name of this class. */
+        const char *className() const {
+            return "GraspItApp";
+        }
 
-  /*! Returns wether the splash is enabled or not */
-  bool splashEnabled() const {return splash_enabled_;}
+        /*! Returns wether the splash is enabled or not */
+        bool splashEnabled() const {
+            return splash_enabled_;
+        }
 
-  static void showSplash();
-  static void closeSplash();
+        static void showSplash();
+        static void closeSplash();
 
 };
 #define _GRASPITAPP_H_

--- a/include/graspitGUI.h
+++ b/include/graspitGUI.h
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: graspitGUI.h,v 1.5 2010/08/11 02:45:37 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines a graspit user interface class that contains subpieces of the UI.
+/*! \file
+    \brief Defines a graspit user interface class that contains subpieces of the UI.
 */
 
 #ifndef GRASPITGUI_HXX
@@ -45,82 +45,87 @@ class World;
 
 //! This is the main user interface class that is responsible for creating and destroying the MainWindow and IVmgr.
 /*!
-  This class also processes command line arguments and holds pointers to both
-  the MainWindow and IVmgr.  There is one global instance of this class, which
-  allows access to these two main pieces of the UI.  This class also has
-  methods for both the entry and exit to the interactive program loop.
+    This class also processes command line arguments and holds pointers to both
+    the MainWindow and IVmgr.  There is one global instance of this class, which
+    allows access to these two main pieces of the UI.  This class also has
+    methods for both the entry and exit to the interactive program loop.
 
-  This class can also initialize a task dispatcher which is then in charge of 
-  batch execution of tasks based on information form a grasp database.
+    This class can also initialize a task dispatcher which is then in charge of
+    batch execution of tasks based on information form a grasp database.
 */
-class GraspItGUI
-{
-  //! A pointer to the MainWindow.
-  MainWindow *mainWindow;
+class GraspItGUI {
+        //! A pointer to the MainWindow.
+        MainWindow *mainWindow;
 
-  //! A pointer to the IVmgr.
-  IVmgr *ivmgr;
+        //! A pointer to the IVmgr.
+        IVmgr *ivmgr;
 
-  //! A pointer to the Task Dispatcher, if any
-  TaskDispatcher *mDispatch;
+        //! A pointer to the Task Dispatcher, if any
+        TaskDispatcher *mDispatch;
 
-  //! TRUE if this class has been initialized.
-  static bool initialized;
+        //! TRUE if this class has been initialized.
+        static bool initialized;
 
-  //! Holds result of UI initialization.
-  static int initResult;
+        //! Holds result of UI initialization.
+        static int initResult;
 
-  //! Holds the exit code of the UI execution
-  int mExitCode;
-  
-  //! Plugins currently running
-  std::list< std::pair<Plugin*,std::string> > mActivePlugins;
+        //! Holds the exit code of the UI execution
+        int mExitCode;
 
-  //! Available plugin creators
-  std::vector<PluginCreator*> mPluginCreators;
+        //! Plugins currently running
+        std::list< std::pair<Plugin *, std::string> > mActivePlugins;
 
-  //! Idle sensor for calling the plugins from GraspIt's event loop
-  SoIdleSensor *mPluginSensor;
+        //! Available plugin creators
+        std::vector<PluginCreator *> mPluginCreators;
 
- protected:
-  int processArgs(int argc, char **argv);
+        //! Idle sensor for calling the plugins from GraspIt's event loop
+        SoIdleSensor *mPluginSensor;
 
- public:
-  GraspItGUI(int argc,char **argv);
-  ~GraspItGUI();
-  
-  /*! Returns whether the UI pieces were successfully initialized. */
-  bool terminalFailure() const;
+    protected:
+        int processArgs(int argc, char **argv);
 
-  //! Returns the exit code (set internally based on the application)
-  int getExitCode() const {return mExitCode;}
+    public:
+        GraspItGUI(int argc, char **argv);
+        ~GraspItGUI();
 
-  /*! Returns a pointer to the MainWindow. */
-  MainWindow *getMainWindow() const {return mainWindow;}
+        /*! Returns whether the UI pieces were successfully initialized. */
+        bool terminalFailure() const;
 
-  /*! Returns a pointer to the World (obtained through the main window) */
-  World *getMainWorld() const;
+        //! Returns the exit code (set internally based on the application)
+        int getExitCode() const {
+            return mExitCode;
+        }
 
-  /*! Returns a pointer to the IVmgr. */
-  IVmgr *getIVmgr() const {return ivmgr;}
+        /*! Returns a pointer to the MainWindow. */
+        MainWindow *getMainWindow() const {
+            return mainWindow;
+        }
 
-  //! Static sensor callback, just calls processPlugins()
-  static void sensorCB(void *data, SoSensor*);
-  
-  //! Calls the main processing routine of all active plugins
-  void processPlugins();
+        /*! Returns a pointer to the World (obtained through the main window) */
+        World *getMainWorld() const;
 
-  //! Starts a plugin from the given creator
-  void startPlugin(PluginCreator* creator, int argc, char** argv);
+        /*! Returns a pointer to the IVmgr. */
+        IVmgr *getIVmgr() const {
+            return ivmgr;
+        }
 
-  //! Stops and deletes the specified plugin
-  void stopPlugin(Plugin *plugin);
+        //! Static sensor callback, just calls processPlugins()
+        static void sensorCB(void *data, SoSensor *);
 
-  //! Stops and deletes all currently active plugins
-  void stopAllPlugins();
+        //! Calls the main processing routine of all active plugins
+        void processPlugins();
 
-  void startMainLoop();
-  void exitMainLoop();
+        //! Starts a plugin from the given creator
+        void startPlugin(PluginCreator *creator, int argc, char **argv);
+
+        //! Stops and deletes the specified plugin
+        void stopPlugin(Plugin *plugin);
+
+        //! Stops and deletes all currently active plugins
+        void stopAllPlugins();
+
+        void startMainLoop();
+        void exitMainLoop();
 };
 
 #ifdef WIN32

--- a/include/graspitParser.h
+++ b/include/graspitParser.h
@@ -5,22 +5,22 @@ class GraspitParser
 
 {
 
-public:
-    GraspitParser();
-    ~GraspitParser();
-    cmdline::parser* parseArgs(int argc, char *argv[]);
+    public:
+        GraspitParser();
+        ~GraspitParser();
+        cmdline::parser *parseArgs(int argc, char *argv[]);
 
-    static const std::string usage;
-    static const std::string version;
-    static const std::string footer;
-    static const std::string help_help;
-    static const std::string plugin_help;
-    static const std::string world_help;
-    static const std::string object_help;
-    static const std::string obstacle_help;
-    static const std::string robot_help;
-    static const std::string version_help;
+        static const std::string usage;
+        static const std::string version;
+        static const std::string footer;
+        static const std::string help_help;
+        static const std::string plugin_help;
+        static const std::string world_help;
+        static const std::string object_help;
+        static const std::string obstacle_help;
+        static const std::string robot_help;
+        static const std::string version_help;
 
-private:
-     cmdline::parser *parser;
+    private:
+        cmdline::parser *parser;
 };

--- a/include/graspitServer.h
+++ b/include/graspitServer.h
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: graspitServer.h,v 1.3 2009/03/25 22:10:23 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the GraspItServer and the ClientSocket classes
- */
+/*! \file
+    \brief Defines the GraspItServer and the ClientSocket classes
+*/
 
 #ifndef GRASPITSERVER_HXX
 #include <q3serversocket.h>
@@ -39,111 +39,110 @@ class Robot;
 
 //! Subclass of QSocket that parses input, implements commands, and writes output
 /*!
-  A ClientSocket is created whenever the GraspitServer accepts a new
-  connection.  Whenever there is data ready to be read, it calls the
-  readClient method, which parses the text command and calls the appropriate
-  method.  Some of these methods write results back to the socket.  When
-  it receives a connection closed signal the ClientSocekt deletes itself.
+    A ClientSocket is created whenever the GraspitServer accepts a new
+    connection.  Whenever there is data ready to be read, it calls the
+    readClient method, which parses the text command and calls the appropriate
+    method.  Some of these methods write results back to the socket.  When
+    it receives a connection closed signal the ClientSocekt deletes itself.
 
-  The following commands are currently recognized and processed:
+    The following commands are currently recognized and processed:
 
-  - \p getContacts   numData   bodyIndexList
-  - \p getAverageContacts   bodyIndexList
-  - \p getBodyName   bodyIndexList
-  - \p getRobotName   robotIndexList
-  - \p getDOFVals   robotIndexList
-  - \p moveDOFs   robotIndexList
-  - \p render
-  - \p moveDynamicBodies   timeStepLength
-  - \p computeNewVelocities   timeStepLength
+    - \p getContacts   numData   bodyIndexList
+    - \p getAverageContacts   bodyIndexList
+    - \p getBodyName   bodyIndexList
+    - \p getRobotName   robotIndexList
+    - \p getDOFVals   robotIndexList
+    - \p moveDOFs   robotIndexList
+    - \p render
+    - \p moveDynamicBodies   timeStepLength
+    - \p computeNewVelocities   timeStepLength
 
-  Each command requiring an index list, accept the word "ALL" meaning every
-  body or robot in the world, or a number of bodies or robots followed by a
-  space sparated list of the body or robot indicies.
+    Each command requiring an index list, accept the word "ALL" meaning every
+    body or robot in the world, or a number of bodies or robots followed by a
+    space sparated list of the body or robot indicies.
 
-  getContacts also requires numData, which specifies the number of vectors
-  of data that should be returned (1, 2 or 3) about each contact.
+    getContacts also requires numData, which specifies the number of vectors
+    of data that should be returned (1, 2 or 3) about each contact.
 
-  The routines will send back an error message if there is a problem with
-  the input.
+    The routines will send back an error message if there is a problem with
+    the input.
 
 */
-class ClientSocket : public Q3Socket
-{
-  Q_OBJECT
-    
-public:
+class ClientSocket : public Q3Socket {
+        Q_OBJECT
 
-  /*! 
-    Connects the readyRead signal to the readClient slot, and the
-    connectionClosed signal to the connectionClosed slot.  Sets the socket
-    to use \a sock .
-  */
-  ClientSocket( int sock, QObject *parent=0, const char *name=0 ) :
-    Q3Socket( parent, name )
-    {
-      connect( this, SIGNAL(readyRead()), SLOT(readClient()) );
-      connect( this, SIGNAL(connectionClosed()), SLOT(connectionClosed()) );
-      setSocket( sock );
-    }
-  
-  ~ClientSocket();
-  
-private:
+    public:
 
-  //! The current line of text read from the socket
-  QString line;
-  
-  //! The list of strings after splitting the line at each space character
-  QStringList lineStrList;
+        /*!
+            Connects the readyRead signal to the readClient slot, and the
+            connectionClosed signal to the connectionClosed slot.  Sets the socket
+            to use \a sock .
+        */
+        ClientSocket(int sock, QObject *parent = 0, const char *name = 0) :
+            Q3Socket(parent, name) {
+            connect(this, SIGNAL(readyRead()), SLOT(readClient()));
+            connect(this, SIGNAL(connectionClosed()), SLOT(connectionClosed()));
+            setSocket(sock);
+        }
 
-  //! An iterator into the string list
-  QStringList::const_iterator strPtr;
+        ~ClientSocket();
 
-  int readBodyIndList(std::vector<Body *> &bodyVec);
-  int readRobotIndList(std::vector<Robot *> &robVec);
-  void sendContacts(Body *bod,int numData);
-  void sendAverageContacts(Body *bod);
-  void sendBodyName(Body* bod);
-  void computeNewVelocities(double ts);
-  void moveDynamicBodies(double ts);
+    private:
 
-  void sendRobotName(Robot* rob);
-  void sendDOFVals(Robot *rob);
+        //! The current line of text read from the socket
+        QString line;
 
-  int readDOFVals();
-  int readDOFForces(Robot *rob);
+        //! The list of strings after splitting the line at each space character
+        QStringList lineStrList;
 
-  // not finished yet:
-  // void readTorques();
-  // void moveBody(Body* bod); 
+        //! An iterator into the string list
+        QStringList::const_iterator strPtr;
 
-private Q_SLOTS:
-  void readClient();
+        int readBodyIndList(std::vector<Body *> &bodyVec);
+        int readRobotIndList(std::vector<Robot *> &robVec);
+        void sendContacts(Body *bod, int numData);
+        void sendAverageContacts(Body *bod);
+        void sendBodyName(Body *bod);
+        void computeNewVelocities(double ts);
+        void moveDynamicBodies(double ts);
 
-/*! Deletes this instance of ClientSocket */ 
-  void connectionClosed() { delete this;}
+        void sendRobotName(Robot *rob);
+        void sendDOFVals(Robot *rob);
+
+        int readDOFVals();
+        int readDOFForces(Robot *rob);
+
+        // not finished yet:
+        // void readTorques();
+        // void moveBody(Body* bod);
+
+    private Q_SLOTS:
+        void readClient();
+
+        /*! Deletes this instance of ClientSocket */
+        void connectionClosed() {
+            delete this;
+        }
 
 };
 
-//! TCP server that listens for connections and spawns new ClientSockets 
+//! TCP server that listens for connections and spawns new ClientSockets
 /*!
-  The server is a subclass of the QT QServerSocket and listens on a particular
-  port and if a connection is requested, it creates a new ClientSocket, which
-  will handle all communication.
+    The server is a subclass of the QT QServerSocket and listens on a particular
+    port and if a connection is requested, it creates a new ClientSocket, which
+    will handle all communication.
 */
-class GraspItServer : public Q3ServerSocket
-{
-  Q_OBJECT
-  //  std::vector<SocketNotifier *> snVec;
+class GraspItServer : public Q3ServerSocket {
+        Q_OBJECT
+        //  std::vector<SocketNotifier *> snVec;
 
- public:
-  GraspItServer(Q_UINT16 port, int backlog = 1, QObject *parent = 0,
-		const char *name = 0);
+    public:
+        GraspItServer(Q_UINT16 port, int backlog = 1, QObject *parent = 0,
+                      const char *name = 0);
 
-  /*! Stub */
-  ~GraspItServer() {}
-  void newConnection(int socket);
+        /*! Stub */
+        ~GraspItServer() {}
+        void newConnection(int socket);
 };
 #define GRASPITSERVER_HXX
 #endif

--- a/include/gws.h
+++ b/include/gws.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the abstract Grasp Wrench Space class and specific GWS classes
- */
+/*! \file
+    \brief Defines the abstract Grasp Wrench Space class and specific GWS classes
+*/
 #ifndef GWS_H
 
 #include <vector>
@@ -37,148 +37,169 @@ struct coordT;
 
 //! An abstract base class for 6D grasp wrench spaces
 /*!
-  Specific grasp wrench spaces should be defined as subclasses of this
-  class.
+    Specific grasp wrench spaces should be defined as subclasses of this
+    class.
 */
 class GWS {
-public:
-  //! Default option for building a GWS on all 6 dimensions
-  static const std::vector<int> ALL_DIMENSIONS;
-protected:
-	//! Consider the effects of gravity on the object
-	bool useGravity;
+    public:
+        //! Default option for building a GWS on all 6 dimensions
+        static const std::vector<int> ALL_DIMENSIONS;
+    protected:
+        //! Consider the effects of gravity on the object
+        bool useGravity;
 
-	//! The direction and magnitude of gravity along each GWS axis
-	vec3 gravDirection;
+        //! The direction and magnitude of gravity along each GWS axis
+        vec3 gravDirection;
 
-	//! Calls QHull to build from an array of pre-specified wrenches
-	int buildHyperplanesFromWrenches(void *wr, int numWrenches, 
-									 std::vector<int> useDimensions);
+        //! Calls QHull to build from an array of pre-specified wrenches
+        int buildHyperplanesFromWrenches(void *wr, int numWrenches,
+                                         std::vector<int> useDimensions);
 
-	//! After the hyperplanes are computed we can look at other metrics
-	void computeHyperplaneMetrics();
+        //! After the hyperplanes are computed we can look at other metrics
+        void computeHyperplaneMetrics();
 
-	//! Deletes the hyperplanes of the currently computed GWS
-	void clearGWS();
+        //! Deletes the hyperplanes of the currently computed GWS
+        void clearGWS();
 
- public:
+    public:
 
-  //! Tells is wether to use gravity, and if yes it's direction and magnitude
-  void setGravity(bool use, vec3 gd=vec3(0,0,0));
+        //! Tells is wether to use gravity, and if yes it's direction and magnitude
+        void setGravity(bool use, vec3 gd = vec3(0, 0, 0));
 
-  //! A pointer to the associated grasp
-  Grasp *grasp;
-  
-  //! number of 6D hyperplanes bounding this GWS
-  int numHyperPlanes;
+        //! A pointer to the associated grasp
+        Grasp *grasp;
 
-  //! 7 x numHyperPlanes matrix of plane coefficients
-  double **hyperPlanes;
+        //! number of 6D hyperplanes bounding this GWS
+        int numHyperPlanes;
 
-  //! Keeps track of the dimensions used to build this gws
-  std::vector<int> mUsedDimensions;
-  
-  //! Surface area of 6D hull (returned by qhull)
-  double hullArea;
-  
-  //! Volume of 6D hull (returned by qhull)
-  double hullVolume;
+        //! 7 x numHyperPlanes matrix of plane coefficients
+        double **hyperPlanes;
 
-  //! If GWS contains the origin, the grasp has force closure
-  bool forceClosure;
+        //! Keeps track of the dimensions used to build this gws
+        std::vector<int> mUsedDimensions;
 
-  //! Number of reference to this GWS.  When it is 0, GWS may be deleted
-  int refCount;
+        //! Surface area of 6D hull (returned by qhull)
+        double hullArea;
 
-  //! Initializes grasp to \a g.  Zeros hyperplanes and refCount.
-  GWS(Grasp *g) : useGravity(false), grasp(g),numHyperPlanes(0),hyperPlanes(NULL),refCount(0) {}
+        //! Volume of 6D hull (returned by qhull)
+        double hullVolume;
 
-  virtual ~GWS();
+        //! If GWS contains the origin, the grasp has force closure
+        bool forceClosure;
 
-  /*! Returns a pointer to the grasp associated with this GWS */
-  Grasp *getGrasp() const {return grasp;}
+        //! Number of reference to this GWS.  When it is 0, GWS may be deleted
+        int refCount;
 
-  /*! Adds one reference to this GWS */
-  void ref() {refCount++;}
+        //! Initializes grasp to \a g.  Zeros hyperplanes and refCount.
+        GWS(Grasp *g) : useGravity(false), grasp(g), numHyperPlanes(0), hyperPlanes(NULL), refCount(0) {}
 
-  /*! Removes one reference to this GWS */
-  void unref() {refCount--;}
+        virtual ~GWS();
 
-  /*! Returns the current number of references to this GWS */
-  int getRefCount() {return refCount;}
+        /*! Returns a pointer to the grasp associated with this GWS */
+        Grasp *getGrasp() const {
+            return grasp;
+        }
 
-  /*! Returns whether this grasp has force closure. */
-  bool isForceClosure() {return forceClosure;}
+        /*! Adds one reference to this GWS */
+        void ref() {
+            refCount++;
+        }
 
-  /*! Returns whether the 6D GWS has non-zero volume. */
-  bool hasPositiveVolume(){ if (hullVolume>0) return true; return false;}
+        /*! Removes one reference to this GWS */
+        void unref() {
+            refCount--;
+        }
 
-  /*! Returns a string that is the name of the type of GWS. */
-  virtual const char *getType() =0;
+        /*! Returns the current number of references to this GWS */
+        int getRefCount() {
+            return refCount;
+        }
 
-  /*! Builds the GWS from the contact wrenches. */
-  virtual int build(std::vector<int> useDimensions = ALL_DIMENSIONS) = 0;
+        /*! Returns whether this grasp has force closure. */
+        bool isForceClosure() {
+            return forceClosure;
+        }
 
-  //! Creates a 3D projection of the 6D wrench space
-  virtual int projectTo3D(double *projCoords,std::set<int> fixedCoordSet,
-			  std::vector<position> &hullCoords,
-			  std::vector<int> &hullIndices);
+        /*! Returns whether the 6D GWS has non-zero volume. */
+        bool hasPositiveVolume() {
+            if (hullVolume > 0) return true;
+            return false;
+        }
 
-  //! Array of strings of possible GWS types
-  static const char *TYPE_LIST[];
+        /*! Returns a string that is the name of the type of GWS. */
+        virtual const char *getType() = 0;
 
-  static GWS *createInstance(const char *type,Grasp *g);
+        /*! Builds the GWS from the contact wrenches. */
+        virtual int build(std::vector<int> useDimensions = ALL_DIMENSIONS) = 0;
+
+        //! Creates a 3D projection of the 6D wrench space
+        virtual int projectTo3D(double *projCoords, std::set<int> fixedCoordSet,
+                                std::vector<position> &hullCoords,
+                                std::vector<int> &hullIndices);
+
+        //! Array of strings of possible GWS types
+        static const char *TYPE_LIST[];
+
+        static GWS *createInstance(const char *type, Grasp *g);
 };
 
 //! A class to build an L1 GWS
 /*!
-  A unit grasp wrench space constructed using the L1 norm of the
-  grasp vector (i.e. The sum magnitude of all contact normal forces is 1).
+    A unit grasp wrench space constructed using the L1 norm of the
+    grasp vector (i.e. The sum magnitude of all contact normal forces is 1).
 */
 class L1GWS : public GWS {
 
-  //! Name of this type of GWS
-  static const char *type;
+        //! Name of this type of GWS
+        static const char *type;
 
- public:
+    public:
 
-  /*! Stub */
-  L1GWS(Grasp *g) : GWS(g) {}
+        /*! Stub */
+        L1GWS(Grasp *g) : GWS(g) {}
 
-  //! Build the GWS using individual contact wrenches
-  int build(std::vector<int> useDimensions = ALL_DIMENSIONS);
+        //! Build the GWS using individual contact wrenches
+        int build(std::vector<int> useDimensions = ALL_DIMENSIONS);
 
-  /*! Returns the name of this type of GWS */
-  static const char *getClassType() {return type;}
+        /*! Returns the name of this type of GWS */
+        static const char *getClassType() {
+            return type;
+        }
 
-  /*! Returns the name of this type of GWS */
-  virtual const char *getType() {return type;}
+        /*! Returns the name of this type of GWS */
+        virtual const char *getType() {
+            return type;
+        }
 };
 
 //! A class to build an L-Infinity GWS
 /*!
-  A unit grasp wrench space constructed using the L-Infinity norm of the
-  grasp vector (i.e. The maximum magnitude of any contact normal force is 1).
+    A unit grasp wrench space constructed using the L-Infinity norm of the
+    grasp vector (i.e. The maximum magnitude of any contact normal force is 1).
 */
 class LInfGWS : public GWS {
 
-  //! Name of this type of GWS
-  static const char *type;
+        //! Name of this type of GWS
+        static const char *type;
 
- public:
+    public:
 
-  /*! Stub */
-  LInfGWS(Grasp *g) : GWS(g) {}
-  //  virtual ~LInfGWS() {}
+        /*! Stub */
+        LInfGWS(Grasp *g) : GWS(g) {}
+        //  virtual ~LInfGWS() {}
 
-  //! Build the GWS using the Minkowski sum of all contact wrenches
-  int build(std::vector<int> useDimensions = ALL_DIMENSIONS);
+        //! Build the GWS using the Minkowski sum of all contact wrenches
+        int build(std::vector<int> useDimensions = ALL_DIMENSIONS);
 
-  /*! Returns the name of this type of GWS */
-  static const char *getClassType() {return type;}
+        /*! Returns the name of this type of GWS */
+        static const char *getClassType() {
+            return type;
+        }
 
-  /*! Returns the name of this type of GWS */
-  virtual const char *getType() {return type;}
+        /*! Returns the name of this type of GWS */
+        virtual const char *getType() {
+            return type;
+        }
 
 };
 

--- a/include/gwsprojection.h
+++ b/include/gwsprojection.h
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: gwsprojection.h,v 1.5 2009/06/16 22:53:24 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the grasp wrench space projection class.
- */
+/*! \file
+    \brief Defines the grasp wrench space projection class.
+*/
 
 #include <set>
 class SoQtRenderArea;
@@ -36,60 +36,66 @@ class SoSeparator;
 class QWidget;
 class GWS;
 
-//! Produces an Inventor window with a 3-D projection of a GWS.  
+//! Produces an Inventor window with a 3-D projection of a GWS.
 /*!
-  The projection window uses the same camera as the mainViewer.  The GWS
-  uses the 3 fixed coordinate values to project each of its 6D
-  hyperplanes into 3D. These are then intersected with qhull, and the
-  hull boundary is sent back to this class, where it is used to create
-  an indexed face set.  This geometry, along with axes is then viewable
-  in the new window. 
-*/ 
+    The projection window uses the same camera as the mainViewer.  The GWS
+    uses the 3 fixed coordinate values to project each of its 6D
+    hyperplanes into 3D. These are then intersected with qhull, and the
+    hull boundary is sent back to this class, where it is used to create
+    an indexed face set.  This geometry, along with axes is then viewable
+    in the new window.
+*/
 class GWSprojection {
 
-  //! A pointer to the GWS that this projection comes from
-  GWS *gws;
+        //! A pointer to the GWS that this projection comes from
+        GWS *gws;
 
-  //! Coordinate of the projection (only 3 values are used)
-  double projCoords[6];
+        //! Coordinate of the projection (only 3 values are used)
+        double projCoords[6];
 
-  //! A set of 3 indices that are fixed (3 coordinates)
-  std::set<int> fixedCoordIndex;
+        //! A set of 3 indices that are fixed (3 coordinates)
+        std::set<int> fixedCoordIndex;
 
-  //! A pointer to the QT widget holding the projection window.
-  QWidget *projWin;
+        //! A pointer to the QT widget holding the projection window.
+        QWidget *projWin;
 
-  //! A pointer to the viewer for this window
-  SoQtRenderArea *projectionViewer;
+        //! A pointer to the viewer for this window
+        SoQtRenderArea *projectionViewer;
 
-  //! Root of the convex hull geometry
-  SoSeparator *hullSep;
+        //! Root of the convex hull geometry
+        SoSeparator *hullSep;
 
-  //! 3D hull vertices
-  SoCoordinate3 *hullCoords;
+        //! 3D hull vertices
+        SoCoordinate3 *hullCoords;
 
-  //! Inventor geometry node for the hull
-  SoIndexedFaceSet *hullIFS;
+        //! Inventor geometry node for the hull
+        SoIndexedFaceSet *hullIFS;
 
-  //! Inventor node for the projection
-  SoSeparator *sg;
+        //! Inventor node for the projection
+        SoSeparator *sg;
 
-  void setWinTitle();
+        void setWinTitle();
 
-public:
+    public:
 
-  GWSprojection(SoQtExaminerViewer* mainViewer,GWS *g,double *c, std::set<int> whichFixed);
-  ~GWSprojection();
+        GWSprojection(SoQtExaminerViewer *mainViewer, GWS *g, double *c, std::set<int> whichFixed);
+        ~GWSprojection();
 
-  /*! Returns a pointer to the main QT widget for the projection window. */
-  QWidget *getProjWin() const {return projWin;}
+        /*! Returns a pointer to the main QT widget for the projection window. */
+        QWidget *getProjWin() const {
+            return projWin;
+        }
 
-  /*! Returns a pointer to the gws. */
-  GWS *getGWS() const {return gws;}
+        /*! Returns a pointer to the gws. */
+        GWS *getGWS() const {
+            return gws;
+        }
 
-  /*! Returns a pointer to the root of the GWS*/
-  SoSeparator * getGWSRoot() { return sg; }
+        /*! Returns a pointer to the root of the GWS*/
+        SoSeparator *getGWSRoot() {
+            return sg;
+        }
 
-  void update();
-  void deleteHull();
+        void update();
+        void deleteHull();
 };

--- a/include/handController.h
+++ b/include/handController.h
@@ -24,4 +24,4 @@
 //######################################################################
 
 
-void HandController(Hand *hand,Grasp *grasp,double timeInterval);
+void HandController(Hand *hand, Grasp *grasp, double timeInterval);

--- a/include/ivmgr.h
+++ b/include/ivmgr.h
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: ivmgr.h,v 1.20 2009/06/16 19:29:41 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the IVmgr class which handles 3D user interaction.
- */
+/*! \file
+    \brief Defines the IVmgr class which handles 3D user interaction.
+*/
 #ifndef IVMGR_HXX
 #include <Inventor/SbBasic.h>
 #include <Inventor/SbLinear.h>
@@ -78,7 +78,7 @@ class QualityMeasure;
 struct DraggerInfo;
 
 namespace db_planner {
-	class DatabaseManager;
+    class DatabaseManager;
 }
 
 #define HANDS_DIR "../../hands/"
@@ -90,208 +90,224 @@ typedef double col_Mat4[4][4];
 
 //! Adds a couple of convenience function for better stereo viewing
 /*! The native SoQt stereo mode has a couple of annoying problems setting
-	inter-eye distance. This provides an easy way to switch between normal
-	and stereo viewing, asks to use the quad buffer and takes care of the
-	camera stereo adjustment. 
+    inter-eye distance. This provides an easy way to switch between normal
+    and stereo viewing, asks to use the quad buffer and takes care of the
+    camera stereo adjustment.
 
-	For normal (non-stereo) rendering, you can ignore its existance.
+    For normal (non-stereo) rendering, you can ignore its existance.
 */
 class StereoViewer : public SoQtExaminerViewer {
-protected:
-	bool stereoOn;
-	void computeSeekFinalOrientation();
-public:
-	void setStereo(bool s);
-	bool isStereoOn(){return stereoOn;}
-	StereoViewer(QWidget *parent);
-	float mFocalPlane;
+    protected:
+        bool stereoOn;
+        void computeSeekFinalOrientation();
+    public:
+        void setStereo(bool s);
+        bool isStereoOn() {
+            return stereoOn;
+        }
+        StereoViewer(QWidget *parent);
+        float mFocalPlane;
 };
 
-enum ToolType {TRANSLATE_TOOL,ROTATE_TOOL,SELECT_TOOL};
+enum ToolType {TRANSLATE_TOOL, ROTATE_TOOL, SELECT_TOOL};
 
 //! Handles 3D interactions with the world
 /*!
-  There is one instance of the Inventor Manager within the application.  It
-  handles all 3D user interaction with the main world.  An examiner viewer
-  provides the user with a way to manipulate a virtual camera to view the
-  simulation world.  The user can also use the mouse to select bodies, or
-  create draggers that allow manipulation of elements within the world.
-  This class also handles the display of contact forces and some other
-  indicators, and can render and save an image of the current scene.
- */
+    There is one instance of the Inventor Manager within the application.  It
+    handles all 3D user interaction with the main world.  An examiner viewer
+    provides the user with a way to manipulate a virtual camera to view the
+    simulation world.  The user can also use the mouse to select bodies, or
+    create draggers that allow manipulation of elements within the world.
+    This class also handles the display of contact forces and some other
+    indicators, and can render and save an image of the current scene.
+*/
 class IVmgr : public QWidget {
-  Q_OBJECT
+        Q_OBJECT
 
- private:
-  //! Global ivmgr pointer for use with static callback routines.  There is only one ivmgr.    
-  static IVmgr *ivmgr;
+    private:
+        //! Global ivmgr pointer for use with static callback routines.  There is only one ivmgr.
+        static IVmgr *ivmgr;
 
-  //! Points to the main world associated with this iteraction manager
-  World *world;
+        //! Points to the main world associated with this iteraction manager
+        World *world;
 
-  //! File pointer used to read or record camera positions when making a movie
-  FILE *camerafp;
+        //! File pointer used to read or record camera positions when making a movie
+        FILE *camerafp;
 
-  //! Base filename fir recording an image sequence 
-  const char *imgSeqStr;
+        //! Base filename fir recording an image sequence
+        const char *imgSeqStr;
 
-  //! Current frame counter used in recording an image sequence
-  int imgSeqCounter;
+        //! Current frame counter used in recording an image sequence
+        int imgSeqCounter;
 
-  //! Current interaction tool selected (translate, rotate, or select)
-  ToolType currTool;
+        //! Current interaction tool selected (translate, rotate, or select)
+        ToolType currTool;
 
-  //! A flag indicating whether the control key is down during a mouse click
-  SbBool CtrlDown;
+        //! A flag indicating whether the control key is down during a mouse click
+        SbBool CtrlDown;
 
-  //! A flag indicating whether the shift key is down during a mouse click
-  SbBool ShiftDown;
+        //! A flag indicating whether the shift key is down during a mouse click
+        SbBool ShiftDown;
 
-  //! Pointers to various structures used for visual feedback.
-  SoSeparator *pointers;
+        //! Pointers to various structures used for visual feedback.
+        SoSeparator *pointers;
 
-  //! An array of pointers to blinker nodes that correspond to individual contact force indicators
-  std::vector<SoBlinker*> contactForceBlinkerVec;
+        //! An array of pointers to blinker nodes that correspond to individual contact force indicators
+        std::vector<SoBlinker *> contactForceBlinkerVec;
 
-  //! A pointer to the examiner viewer which inventor component facilitating user interaction
-  //SoQtExaminerViewer *myViewer;
-  StereoViewer *myViewer;
+        //! A pointer to the examiner viewer which inventor component facilitating user interaction
+        //SoQtExaminerViewer *myViewer;
+        StereoViewer *myViewer;
 
-  //! Pointer to the root of the entire Inventor scene graph
-  SoSeparator *sceneRoot;
+        //! Pointer to the root of the entire Inventor scene graph
+        SoSeparator *sceneRoot;
 
-  //! Pointer to the sub-tree of selectable Inventor objects
-  SoSelection *selectionRoot;
+        //! Pointer to the sub-tree of selectable Inventor objects
+        SoSelection *selectionRoot;
 
-  //! Pointer to the sub-tree of 
-  SoSeparator *draggerRoot;
+        //! Pointer to the sub-tree of
+        SoSeparator *draggerRoot;
 
-  //! Pointer to sub-tree containing wireframe versions of bodies when they are selected
-  SoSeparator *wireFrameRoot;
+        //! Pointer to sub-tree containing wireframe versions of bodies when they are selected
+        SoSeparator *wireFrameRoot;
 
-  //! Pointer to an empty separator
-  SoSeparator *junk;
+        //! Pointer to an empty separator
+        SoSeparator *junk;
 
-  //! Pointer to the material node controlling the color of dynamic force indicatores
-  SoMaterial *dynForceMat;
+        //! Pointer to the material node controlling the color of dynamic force indicatores
+        SoMaterial *dynForceMat;
 
-  //! The main and only interface for the CGDB; all interaction with the CGDB should go through this.
-  db_planner::DatabaseManager *mDBMgr;
+        //! The main and only interface for the CGDB; all interaction with the CGDB should go through this.
+        db_planner::DatabaseManager *mDBMgr;
 
-  void setupPointers();
-  void transRot(DraggerInfo *dInfo);
-  void revoluteJointChanged(DraggerInfo *dInfo);
-  void revoluteJointFinished(DraggerInfo *dInfo);
-  void revoluteJointClicked(DraggerInfo *dInfo);  
-  void prismaticJointChanged(DraggerInfo *dInfo);
-  void makeCenterball(WorldElement *selectedElement,Body *surroundMe);
-  void makeHandleBox(WorldElement *selectedElement,Body *surroundMe);
-  void makeJointDraggers(Robot *robot,KinematicChain *chain);
-  void drawWireFrame(SoSeparator *elementRoot);
-  SoPath *pickFilter(const SoPickedPoint *pick);
-  void handleSelection(SoPath* p);
-  void handleDeselection(SoPath* p);  
-  void deleteSelections();
-  void setCtrlDown(SbBool status) {CtrlDown = status;}
-  void setShiftDown(SbBool status) {ShiftDown = status;}
-  void spaceBar();
-  void keyPressed(SoEventCallback *eventCB);
+        void setupPointers();
+        void transRot(DraggerInfo *dInfo);
+        void revoluteJointChanged(DraggerInfo *dInfo);
+        void revoluteJointFinished(DraggerInfo *dInfo);
+        void revoluteJointClicked(DraggerInfo *dInfo);
+        void prismaticJointChanged(DraggerInfo *dInfo);
+        void makeCenterball(WorldElement *selectedElement, Body *surroundMe);
+        void makeHandleBox(WorldElement *selectedElement, Body *surroundMe);
+        void makeJointDraggers(Robot *robot, KinematicChain *chain);
+        void drawWireFrame(SoSeparator *elementRoot);
+        SoPath *pickFilter(const SoPickedPoint *pick);
+        void handleSelection(SoPath *p);
+        void handleDeselection(SoPath *p);
+        void deleteSelections();
+        void setCtrlDown(SbBool status) {
+            CtrlDown = status;
+        }
+        void setShiftDown(SbBool status) {
+            ShiftDown = status;
+        }
+        void spaceBar();
+        void keyPressed(SoEventCallback *eventCB);
 
-  //! Draws a wrench indicator on a body
-  void drawBodyWrench(GraspableBody *body, const double *wrench);
+        //! Draws a wrench indicator on a body
+        void drawBodyWrench(GraspableBody *body, const double *wrench);
 
-  //! static callback routine for when a body dragger is moved
-  static void transRotCB(void *dInfo,SoDragger *dragger);
+        //! static callback routine for when a body dragger is moved
+        static void transRotCB(void *dInfo, SoDragger *dragger);
 
-  //! static callback routine for when a disc dragger is moved
-  static void revoluteJointChangedCB(void *dInfo,SoDragger *dragger);
-  
-  //! static callback routine for when a disc dragger is clicked
-  static void revoluteJointClickedCB(void *dInfo,SoDragger *dragger);
+        //! static callback routine for when a disc dragger is moved
+        static void revoluteJointChangedCB(void *dInfo, SoDragger *dragger);
 
-  //! static callback routine for when a disc dragger is released
-  static void revoluteJointFinishedCB(void *dInfo,SoDragger *dragger);
+        //! static callback routine for when a disc dragger is clicked
+        static void revoluteJointClickedCB(void *dInfo, SoDragger *dragger);
 
-  //! static callback routine for when an arrow dragger is moved
-  static void prismaticJointChangedCB(void *dInfo,SoDragger *dragger);
+        //! static callback routine for when a disc dragger is released
+        static void revoluteJointFinishedCB(void *dInfo, SoDragger *dragger);
 
-  //! static callback routine for mouse events
-  static void shiftOrCtrlDownCB(void *,SoEventCallback *eventCB);
+        //! static callback routine for when an arrow dragger is moved
+        static void prismaticJointChangedCB(void *dInfo, SoDragger *dragger);
 
-  //! static callback routine for keyboard events
-  static void keyPressedCB(void *,SoEventCallback *eventCB);
+        //! static callback routine for mouse events
+        static void shiftOrCtrlDownCB(void *, SoEventCallback *eventCB);
 
-  //! static callback routine for selections
-  static void selectionCB(void *,SoPath *p);
+        //! static callback routine for keyboard events
+        static void keyPressedCB(void *, SoEventCallback *eventCB);
 
-  //! static callback routine for deselections
-  static void deselectionCB(void *,SoPath *p);
+        //! static callback routine for selections
+        static void selectionCB(void *, SoPath *p);
 
-  //! static callback routine for pick events (before selections or deselections)
-  static SoPath *pickFilterCB(void *,const SoPickedPoint *pick);
+        //! static callback routine for deselections
+        static void deselectionCB(void *, SoPath *p);
 
-public Q_SLOTS:
-  void drawDynamicForces();
-  void drawWorstCaseWrenches();
-  void drawUnbalancedForces();
-  void saveNextImage();
-  void saveCameraPos();
-  void restoreCameraPos();
+        //! static callback routine for pick events (before selections or deselections)
+        static SoPath *pickFilterCB(void *, const SoPickedPoint *pick);
 
-public:
-  IVmgr(QWidget *parent=0,const char *name=0,Qt::WFlags f=0);
-  ~IVmgr();
+    public Q_SLOTS:
+        void drawDynamicForces();
+        void drawWorstCaseWrenches();
+        void drawUnbalancedForces();
+        void saveNextImage();
+        void saveCameraPos();
+        void restoreCameraPos();
 
-  void deselectBody(Body *b);
+    public:
+        IVmgr(QWidget *parent = 0, const char *name = 0, Qt::WFlags f = 0);
+        ~IVmgr();
 
-  /*! 
-    Returns a pointer to the main World that the user interacts with through
-    this manager.
-   */
-  World *getWorld() const {return world;}
+        void deselectBody(Body *b);
 
-  /*!
-    Returns a pointer to the Inventor examiner viewer.
-  */
-  StereoViewer *getViewer() const {return myViewer;}  
+        /*!
+            Returns a pointer to the main World that the user interacts with through
+            this manager.
+        */
+        World *getWorld() const {
+            return world;
+        }
 
-  /*!
-    Returns the Inventor sub-tree that holds the pointer shapes (arrow and
-    torque pointer) read in during start up.
-  */
-  SoSeparator *getPointers() const {return pointers;}
+        /*!
+            Returns a pointer to the Inventor examiner viewer.
+        */
+        StereoViewer *getViewer() const {
+            return myViewer;
+        }
 
-  void setTool(ToolType newTool);
-  void emptyWorld();
-  void hilightObjContact(int contactNum);
-  void unhilightObjContact(int contactNum);
+        /*!
+            Returns the Inventor sub-tree that holds the pointer shapes (arrow and
+            torque pointer) read in during start up.
+        */
+        SoSeparator *getPointers() const {
+            return pointers;
+        }
 
-  void saveImageSequence(const char *fileStr);
-  int saveCameraPositions(const char *filename);
-  int useSavedCameraPositions(const char *filename);
-  //! Sets the camera position, orientaion and focal distance
-  void setCamera(double px, double py, double pz, double q1, double q2, double q3, double q4, double fd);
-  //! Gets the camera position, orientaion and focal distance
-  void getCamera(float &px, float &py, float &pz, float &q1, float &q2, float &q3, float &q4, float &fd);
-  void setCameraTransf(transf tr);
-  transf getCameraTransf();
+        void setTool(ToolType newTool);
+        void emptyWorld();
+        void hilightObjContact(int contactNum);
+        void unhilightObjContact(int contactNum);
 
-  void saveImage(QString filename);
-  void beginMainLoop();
+        void saveImageSequence(const char *fileStr);
+        int saveCameraPositions(const char *filename);
+        int useSavedCameraPositions(const char *filename);
+        //! Sets the camera position, orientaion and focal distance
+        void setCamera(double px, double py, double pz, double q1, double q2, double q3, double q4, double fd);
+        //! Gets the camera position, orientaion and focal distance
+        void getCamera(float &px, float &py, float &pz, float &q1, float &q2, float &q3, float &q4, float &fd);
+        void setCameraTransf(transf tr);
+        transf getCameraTransf();
 
-  void setStereo(bool s);
-  //! Not implemented
-  void flipStereo();
+        void saveImage(QString filename);
+        void beginMainLoop();
 
-  //! Get the main database manager, when CGDB support is enabled
-  db_planner::DatabaseManager* getDBMgr(){return mDBMgr;}
-  //! Set the main database manager. Should only be called by the DB connection dialog
-#ifdef CGDB_ENABLED
-  void setDBMgr(db_planner::DatabaseManager *mgr){mDBMgr = mgr;}
-#else
-  void setDBMgr(db_planner::DatabaseManager*){}
-#endif
-  void setStereoWindow(QWidget *parent);
+        void setStereo(bool s);
+        //! Not implemented
+        void flipStereo();
+
+        //! Get the main database manager, when CGDB support is enabled
+        db_planner::DatabaseManager *getDBMgr() {
+            return mDBMgr;
+        }
+        //! Set the main database manager. Should only be called by the DB connection dialog
+        #ifdef CGDB_ENABLED
+        void setDBMgr(db_planner::DatabaseManager *mgr) {
+            mDBMgr = mgr;
+        }
+        #else
+        void setDBMgr(db_planner::DatabaseManager *) {}
+        #endif
+        void setStereoWindow(QWidget *parent);
 };
 #define IVMGR_HXX
 #endif

--- a/include/jacobian.h
+++ b/include/jacobian.h
@@ -27,13 +27,13 @@
 #define _jacobian_h_
 
 /*! \file
-	A hard-coded jacobian and derivative for the thumb of the human 
-	hand, computed in Mathematica and then translated here. Used 
-	only for CyberGlove thumb calibration. 
+    A hard-coded jacobian and derivative for the thumb of the human
+    hand, computed in Mathematica and then translated here. Used
+    only for CyberGlove thumb calibration.
 
-	This file needs a less generic name - this is only a very 
-	specific thing for the human hand and glove calibration. More
-	general Jacobian computations can be found in the Grasp class.
+    This file needs a less generic name - this is only a very
+    specific thing for the human hand and glove calibration. More
+    general Jacobian computations can be found in the Grasp class.
 */
 
 void jacobian(double t1, double t2, double t3, double t4, double px, double py, double pz, double *J);

--- a/include/joint.h
+++ b/include/joint.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the classes: DHTransform, Joint, RevoluteJoint, and PrismaticJoint.
- */
+/*! \file
+    \brief Defines the classes: DHTransform, Joint, RevoluteJoint, and PrismaticJoint.
+*/
 #ifndef JOINT_H
 
 #include <list>
@@ -42,363 +42,434 @@ class Matrix;
 class SoTransform;
 class TiXmlElement;
 
-enum JointT {REVOLUTE,PRISMATIC};
+enum JointT {REVOLUTE, PRISMATIC};
 
 //! Converts 4 parameter Denavit-Hartenberg notation to a 4x4 transform.
-/*! 
-  Stores the 4 Denavit-Hartenberg parameters that define a transform between
-  the joints of a robot.  Each joint has its axis aligned with the z-axis of
-  the joint frame.  The four values are theta, d, a, and alpha.  Theta is
-  the rotation about the z-axis of the current joint frame (this value is
-  variable for revolute joints).  D is the translation along the z-axis of
-  the joint frame (this value is variable for prismatic joints).  A is the
-  transaltion along the x-axis of the joint frame, and alpha is the rotation
-  about the x-axis.  
- */
+/*!
+    Stores the 4 Denavit-Hartenberg parameters that define a transform between
+    the joints of a robot.  Each joint has its axis aligned with the z-axis of
+    the joint frame.  The four values are theta, d, a, and alpha.  Theta is
+    the rotation about the z-axis of the current joint frame (this value is
+    variable for revolute joints).  D is the translation along the z-axis of
+    the joint frame (this value is variable for prismatic joints).  A is the
+    transaltion along the x-axis of the joint frame, and alpha is the rotation
+    about the x-axis.
+*/
 class DHTransform {
 
-  //! Translation vector along the z-axis
-  vec3 dtrans;
+        //! Translation vector along the z-axis
+        vec3 dtrans;
 
-  //! Translation vector along the x-axis
-  vec3 atrans;
+        //! Translation vector along the x-axis
+        vec3 atrans;
 
-  //! Precomputed value of transform 4 times transform 3
-  transf tr4TimesTr3;
+        //! Precomputed value of transform 4 times transform 3
+        transf tr4TimesTr3;
 
-  //! Translation transform of d along z-axis
-  transf tr2;
+        //! Translation transform of d along z-axis
+        transf tr2;
 
-  //! Rotation transform of theta about z-axis
-  transf tr1;
+        //! Rotation transform of theta about z-axis
+        transf tr1;
 
-  //! Final transform
-  transf tran;
+        //! Final transform
+        transf tran;
 
-  //! Rotation about z-axis in radians
-  double theta;
+        //! Rotation about z-axis in radians
+        double theta;
 
-  //! Translation along z-axis in mm
-  double d;
+        //! Translation along z-axis in mm
+        double d;
 
-  //! Translation along x-axis in mm
-  double a;
+        //! Translation along x-axis in mm
+        double a;
 
-  //! Rotation about x-axis in radians
-  double alpha;
+        //! Rotation about x-axis in radians
+        double alpha;
 
-  //! Re-computes the transform from scratch based on theta, d, a and alpha
-  void computeTran();
+        //! Re-computes the transform from scratch based on theta, d, a and alpha
+        void computeTran();
 
-public:
-  DHTransform(double thval=0.0,double dval=0.0,double aval=0.0,
-	      double alval=0.0);
-  DHTransform( const DHTransform *d ){
-	  memcpy( this, d, sizeof(DHTransform));
-  }
+    public:
+        DHTransform(double thval = 0.0, double dval = 0.0, double aval = 0.0,
+                    double alval = 0.0);
+        DHTransform(const DHTransform *d) {
+            memcpy(this, d, sizeof(DHTransform));
+        }
 
-  /*! Returns the current d value. */
-  double getD() const {return d;}
+        /*! Returns the current d value. */
+        double getD() const {
+            return d;
+        }
 
-  /*! Returns the current theta value. */
-  double getTheta() const {return theta;}
+        /*! Returns the current theta value. */
+        double getTheta() const {
+            return theta;
+        }
 
-  /*! Returns the current a value. */
-  double getA() const {return a;}
+        /*! Returns the current a value. */
+        double getA() const {
+            return a;
+        }
 
-  /*! Sets the d value. */
-  void setD(double q);
+        /*! Sets the d value. */
+        void setD(double q);
 
-  /*! Sets the theta value. */
-  void setTheta(double q);
+        /*! Sets the theta value. */
+        void setTheta(double q);
 
-  /*! Sets the a value and re-computes the transform (from scratch). */
-  void setA(double q){a=q; computeTran();}
+        /*! Sets the a value and re-computes the transform (from scratch). */
+        void setA(double q) {
+            a = q;
+            computeTran();
+        }
 
-  /*! Returns the current value of this transform. */
-  const transf& getTran() const {return tran;}
-  
-  /*!
-    Returns the value of this transform if \a thetaVal is substituted for
-    theta and \a dval is substituted for d. It does not change any values
-    within the DHTransform.
-  */
-  transf getTran(double thetaVal,double dVal) const
-    {
-      return tr4TimesTr3 * translate_transf(vec3(0,0,dVal)) * 
-	rotate_transf(thetaVal,vec3(0,0,1));
-    }
+        /*! Returns the current value of this transform. */
+        const transf &getTran() const {
+            return tran;
+        }
+
+        /*!
+            Returns the value of this transform if \a thetaVal is substituted for
+            theta and \a dval is substituted for d. It does not change any values
+            within the DHTransform.
+        */
+        transf getTran(double thetaVal, double dVal) const {
+            return tr4TimesTr3 * translate_transf(vec3(0, 0, dVal)) *
+                   rotate_transf(thetaVal, vec3(0, 0, 1));
+        }
 
 };
 
 //! Abstract base class for a single axis robot joint.
 /*!
-  A robot joint allows either translation or rotation on a single axis.
-  It is part of a kinematic chain, which is a serial set of links and joints.
-  Multiple joints can be defined between two links.  The value of the joint is
-  linearly related to a robot DOF value, and has its own minimum and maximum
-  values.  The joint also computes its friction value during dynamic simulation
-  using viscous and Coulomb friction values defined in the robot configuration
-  file. The joint can also have a spring behavior, and it computes its own 
-  spring forces based on a linear stiffness coefficient.
+    A robot joint allows either translation or rotation on a single axis.
+    It is part of a kinematic chain, which is a serial set of links and joints.
+    Multiple joints can be defined between two links.  The value of the joint is
+    linearly related to a robot DOF value, and has its own minimum and maximum
+    values.  The joint also computes its friction value during dynamic simulation
+    using viscous and Coulomb friction values defined in the robot configuration
+    file. The joint can also have a spring behavior, and it computes its own
+    spring forces based on a linear stiffness coefficient.
 */
 class Joint {
-protected:
-  //! Index of the robot DOF this joint is connected to
-  int DOFnum;
+    protected:
+        //! Index of the robot DOF this joint is connected to
+        int DOFnum;
 
-  //! A pointer to the kinematic chain that this joint is a part of
-  KinematicChain *owner;
+        //! A pointer to the kinematic chain that this joint is a part of
+        KinematicChain *owner;
 
-  //! The number of this joint in the robot's list
-  int jointNum;
+        //! The number of this joint in the robot's list
+        int jointNum;
 
-  //! \c TRUE if an Inventor dragger is currently attached to this joint
-  bool draggerAttached;
+        //! \c TRUE if an Inventor dragger is currently attached to this joint
+        bool draggerAttached;
 
-  //! The current value of the joint computed by inverse kinematic during dynamics
-  double dynamicsVal;
+        //! The current value of the joint computed by inverse kinematic during dynamics
+        double dynamicsVal;
 
-  //! The current velocity of the joint (first order approximation)
-  double velocity;
+        //! The current velocity of the joint (first order approximation)
+        double velocity;
 
-  //! Joint limit
-  double minVal,maxVal;
+        //! Joint limit
+        double minVal, maxVal;
 
-  //! Linear multiplier of DOF value.  JointVal = mCouplingRatio * (DOFVal) + c
-  double mCouplingRatio;  
+        //! Linear multiplier of DOF value.  JointVal = mCouplingRatio * (DOFVal) + c
+        double mCouplingRatio;
 
-  //! Joint offset 
-  double c;  
+        //! Joint offset
+        double c;
 
-  //! The coefficient of viscous friction
-  double f1;
+        //! The coefficient of viscous friction
+        double f1;
 
-  //! Coulomb friction value (constant offset)
-  double f0;
+        //! Coulomb friction value (constant offset)
+        double f0;
 
-  //! Joint spring stiffness, in N * 1.0e6 mm / rad for torque or N * 1.0e6 / mm for force. 
-  //! 0 if this joint has no spring.
-  double mK;
+        //! Joint spring stiffness, in N * 1.0e6 mm / rad for torque or N * 1.0e6 / mm for force.
+        //! 0 if this joint has no spring.
+        double mK;
 
-  //! The rest value of the joint spring
-  double mRestVal;
+        //! The rest value of the joint spring
+        double mRestVal;
 
-  //! Current joint axis expressed in world coordinates
-  vec3 worldAxis;
+        //! Current joint axis expressed in world coordinates
+        vec3 worldAxis;
 
-  //! The DHTransform from this joint frame to the next
-  DHTransform *DH;
+        //! The DHTransform from this joint frame to the next
+        DHTransform *DH;
 
-  //! A pointer to the associated Inventor transform used for joint draggers
-  SoTransform *IVTran;
+        //! A pointer to the associated Inventor transform used for joint draggers
+        SoTransform *IVTran;
 
-  //! this points to the DynJoint that contains this joint
-  DynJoint *dynJoint;
+        //! this points to the DynJoint that contains this joint
+        DynJoint *dynJoint;
 
-public:
+    public:
 
-  /*! Initializes all values and pointers to zero.  Joint should set up
-  with initJoint.  */
- Joint(KinematicChain *k) : DOFnum(0), owner(k), jointNum(-1), draggerAttached(false), dynamicsVal(0.0),
-    velocity(0.0),minVal(0.0),maxVal(0.0),mCouplingRatio(1.0),c(0.0),f1(0.0),f0(0.0),mK(0.0),
-	mRestVal(0.0), DH(NULL),
-    IVTran(NULL), dynJoint(NULL) {IVTran = new SoTransform(); IVTran->ref();}
+        /*! Initializes all values and pointers to zero.  Joint should set up
+            with initJoint.  */
+        Joint(KinematicChain *k) : DOFnum(0), owner(k), jointNum(-1), draggerAttached(false), dynamicsVal(0.0),
+            velocity(0.0), minVal(0.0), maxVal(0.0), mCouplingRatio(1.0), c(0.0), f1(0.0), f0(0.0), mK(0.0),
+            mRestVal(0.0), DH(NULL),
+            IVTran(NULL), dynJoint(NULL) {
+            IVTran = new SoTransform();
+            IVTran->ref();
+        }
 
-  virtual ~Joint();
+        virtual ~Joint();
 
-  /*! Set up the joint using values from an XML DOM read from the robot
-	  configuration file.
-  */
-  virtual int initJointFromXml(const TiXmlElement* root, int jnum) =0;
+        /*! Set up the joint using values from an XML DOM read from the robot
+            configuration file.
+        */
+        virtual int initJointFromXml(const TiXmlElement *root, int jnum) = 0;
 
-  /*! Clones this joint from another joint */
-  void cloneFrom(const Joint *original);
+        /*! Clones this joint from another joint */
+        void cloneFrom(const Joint *original);
 
-  /*! This sets the joint value */
-  virtual int setVal(double q)=0;
+        /*! This sets the joint value */
+        virtual int setVal(double q) = 0;
 
-  /*! Sets the minimum joint limit */
-  void setMin(double min) {minVal = min;}
+        /*! Sets the minimum joint limit */
+        void setMin(double min) {
+            minVal = min;
+        }
 
-  /*! Set the maximum joint limit. */
-  void setMax(double max) {maxVal = max;}
+        /*! Set the maximum joint limit. */
+        void setMax(double max) {
+            maxVal = max;
+        }
 
-  /*! This applies an internal wrench to this joint*/
-  virtual void applyInternalWrench(double magnitude)=0;
+        /*! This applies an internal wrench to this joint*/
+        virtual void applyInternalWrench(double magnitude) = 0;
 
-  /*! Applies internal passive joint wrenches (such as friction or springs) */
-  virtual void applyPassiveInternalWrenches();
- 
-  /*! Sets the current joint velocity (computed during dynamics). */
-  void setVelocity(double v) {velocity = v;}
+        /*! Applies internal passive joint wrenches (such as friction or springs) */
+        virtual void applyPassiveInternalWrenches();
 
-  /*! Sets the current value of the joint (computed during dynamics). */
-  void setDynamicsVal(double v) {dynamicsVal = v;}
+        /*! Sets the current joint velocity (computed during dynamics). */
+        void setVelocity(double v) {
+            velocity = v;
+        }
 
-  /*! Sets the current orientation of the joint axis in world coordinates. 
-	  (computed during dynamics) */
-  void setWorldAxis(const vec3 &wa) {worldAxis = normalise(wa);}
+        /*! Sets the current value of the joint (computed during dynamics). */
+        void setDynamicsVal(double v) {
+            dynamicsVal = v;
+        }
 
-  /*! Updates \a draggerAttached when a dragger is added or removed from this joint.*/
-  void setDraggerAttached(bool b) {draggerAttached = b;}
+        /*! Sets the current orientation of the joint axis in world coordinates.
+            (computed during dynamics) */
+        void setWorldAxis(const vec3 &wa) {
+            worldAxis = normalise(wa);
+        }
 
-  //! Sets the linear stiffness coefficient of this joint spring
-  void setSpringStiffness(double k) {mK = k;}
+        /*! Updates \a draggerAttached when a dragger is added or removed from this joint.*/
+        void setDraggerAttached(bool b) {
+            draggerAttached = b;
+        }
 
-  //! Sets the rest value of the attached joint spring
-  void setRestValue(double r){mRestVal = r;}
+        //! Sets the linear stiffness coefficient of this joint spring
+        void setSpringStiffness(double k) {
+            mK = k;
+        }
 
-  //Accessors:
+        //! Sets the rest value of the attached joint spring
+        void setRestValue(double r) {
+            mRestVal = r;
+        }
 
-  /*! Returns the number of this joint in its kinematic chain */
-  int getNum() const {return jointNum;}
+        //Accessors:
 
-  //! Returns the index of the chain this belongs to in the robot scheme
-  int getChainNum() const;
+        /*! Returns the number of this joint in its kinematic chain */
+        int getNum() const {
+            return jointNum;
+        }
 
-  /*! Returns the current joint value. */
-  virtual double getVal() const =0;
+        //! Returns the index of the chain this belongs to in the robot scheme
+        int getChainNum() const;
 
-  //! Returns the current displacement of the joint compared to the rest value
-  double getDisplacement() const {return getVal() - mRestVal;}
+        /*! Returns the current joint value. */
+        virtual double getVal() const = 0;
 
-  /*! Return type of this joint, either REVOLUE or PRISMATIC. */
-  virtual JointT getType() const =0;
+        //! Returns the current displacement of the joint compared to the rest value
+        double getDisplacement() const {
+            return getVal() - mRestVal;
+        }
 
-  /*! Returns the transform to the next joint frame the results from
-      substituting \a jointVal for the current joint value. */
-  virtual transf getTran(double jointVal) const =0;
+        /*! Return type of this joint, either REVOLUE or PRISMATIC. */
+        virtual JointT getType() const = 0;
 
-  /*! Returns the current joint transform as computed from IK during dynamic
-      simulation. */
-  virtual transf getDynamicsTran() const =0;
+        /*! Returns the transform to the next joint frame the results from
+            substituting \a jointVal for the current joint value. */
+        virtual transf getTran(double jointVal) const = 0;
 
-  /*! Returns the index of the robot DOF this joint is connected to. */
-  int getDOFNum() const {return DOFnum;}
+        /*! Returns the current joint transform as computed from IK during dynamic
+            simulation. */
+        virtual transf getDynamicsTran() const = 0;
 
-  /*! Returns the linear multiplier relating this joint value to the DOF value.*/
-  double getCouplingRatio() const {return mCouplingRatio;}
+        /*! Returns the index of the robot DOF this joint is connected to. */
+        int getDOFNum() const {
+            return DOFnum;
+        }
 
-  //! Returns the linear stiffness coefficient of this joint spring
-  double getSpringStiffness() {return mK;}
+        /*! Returns the linear multiplier relating this joint value to the DOF value.*/
+        double getCouplingRatio() const {
+            return mCouplingRatio;
+        }
 
-  /*! Returns the constant joint offset value.  */
-  double getOffset() const {return c;}
+        //! Returns the linear stiffness coefficient of this joint spring
+        double getSpringStiffness() {
+            return mK;
+        }
 
-  /*! Returns the minimum joint limit */
-  double getMin() const {return minVal;}
+        /*! Returns the constant joint offset value.  */
+        double getOffset() const {
+            return c;
+        }
 
-  /*! Returns the maximum joint limit. */
-  double getMax() const {return maxVal;}
+        /*! Returns the minimum joint limit */
+        double getMin() const {
+            return minVal;
+        }
 
-  /*! Returns the current velocity of this joint (computed during dynamics).*/
-  double getVelocity() const {return velocity;}
+        /*! Returns the maximum joint limit. */
+        double getMax() const {
+            return maxVal;
+        }
 
-  /*! Returns the magnitude of friction acting on this joint.  This uses
-     both viscous friction, which is proportional to the joint velocity,
-     and Coulomb friction, which is constant. */
-  double getFriction() const {
-    return -f1 * velocity + (velocity<0 ? f0 : (velocity>0 ? -f0 : 0.0));
-  }
+        /*! Returns the current velocity of this joint (computed during dynamics).*/
+        double getVelocity() const {
+            return velocity;
+        }
 
-  /*! Returns the spring force acting on this joint. This assumes a linear
-    spring model, with constant stifness \a mK. Units are N*1.0e6 mm for torque
-    or N*1.0e6 for force. */
-  double getSpringForce() const;
+        /*! Returns the magnitude of friction acting on this joint.  This uses
+            both viscous friction, which is proportional to the joint velocity,
+            and Coulomb friction, which is constant. */
+        double getFriction() const {
+            return -f1 * velocity + (velocity < 0 ? f0 : (velocity > 0 ? -f0 : 0.0));
+        }
 
-  /*! Returns the current joint value as computed from the IK during dyanmic
-    simulation. */
-  double getDynamicsVal() const {return dynamicsVal;}
+        /*! Returns the spring force acting on this joint. This assumes a linear
+            spring model, with constant stifness \a mK. Units are N*1.0e6 mm for torque
+            or N*1.0e6 for force. */
+        double getSpringForce() const;
 
-  DynJoint* getDynJoint() const {return dynJoint;}
+        /*! Returns the current joint value as computed from the IK during dyanmic
+            simulation. */
+        double getDynamicsVal() const {
+            return dynamicsVal;
+        }
 
-  void setDynJoint(DynJoint* _dynJoint) {dynJoint = _dynJoint;}
+        DynJoint *getDynJoint() const {
+            return dynJoint;
+        }
 
-  bool hasDynJoint() const {return dynJoint != NULL;}
+        void setDynJoint(DynJoint *_dynJoint) {
+            dynJoint = _dynJoint;
+        }
 
-  /*! Returns the current value of the DHTransform associated with this joint.*/
-  transf const& getTran() const {return DH->getTran();}
+        bool hasDynJoint() const {
+            return dynJoint != NULL;
+        }
 
-  /*! Returns the current direction of the joint axis in world coordinates.*/
-  vec3 const& getWorldAxis() const {return worldAxis;}
+        /*! Returns the current value of the DHTransform associated with this joint.*/
+        transf const &getTran() const {
+            return DH->getTran();
+        }
 
-  /*! Returns a pointer to the DHTransform associated with this joint. */
-  DHTransform *getDH() {return DH;}
+        /*! Returns the current direction of the joint axis in world coordinates.*/
+        vec3 const &getWorldAxis() const {
+            return worldAxis;
+        }
 
-  /*! Returns a pointer to the Inventor transform associated with this joint
-    that is used in the joint dragger sub graph.*/
-  SoTransform *getIVTran() const {return IVTran;}
+        /*! Returns a pointer to the DHTransform associated with this joint. */
+        DHTransform *getDH() {
+            return DH;
+        }
 
-  //! The Jacobian relating movement of this joint to movement of a point in the world
-  static Matrix jacobian(const Joint *joint, const transf &jointTran, 
-						 const transf &toTarget, bool worldCoords);
+        /*! Returns a pointer to the Inventor transform associated with this joint
+            that is used in the joint dragger sub graph.*/
+        SoTransform *getIVTran() const {
+            return IVTran;
+        }
+
+        //! The Jacobian relating movement of this joint to movement of a point in the world
+        static Matrix jacobian(const Joint *joint, const transf &jointTran,
+                               const transf &toTarget, bool worldCoords);
 };
 
 
 //! A type of joint that translates along the z-axis of the joint frame.
 /*!
-  A specific type of joint used for linear motion.
+    A specific type of joint used for linear motion.
 */
 class PrismaticJoint : public Joint {
 
-public:
+    public:
 
-  /*! Stub */
-  PrismaticJoint(KinematicChain *k) : Joint(k) {}
+        /*! Stub */
+        PrismaticJoint(KinematicChain *k) : Joint(k) {}
 
-  virtual int initJointFromXml(const TiXmlElement* root, int jnum);
-  
-  virtual void applyInternalWrench(double magnitude);
+        virtual int initJointFromXml(const TiXmlElement *root, int jnum);
 
-  virtual int setVal(double q);
+        virtual void applyInternalWrench(double magnitude);
 
-  /*! Returns the current value of this joint. */
-  virtual double getVal() const {return DH->getD() - c;}
+        virtual int setVal(double q);
 
-  /*! Returns the type of this joint: PRISMATIC. */
-  virtual JointT getType() const {return PRISMATIC;}
+        /*! Returns the current value of this joint. */
+        virtual double getVal() const {
+            return DH->getD() - c;
+        }
 
-  transf getTran(double jointVal) const {
-    return DH->getTran(DH->getTheta(),jointVal + c);
-  }
+        /*! Returns the type of this joint: PRISMATIC. */
+        virtual JointT getType() const {
+            return PRISMATIC;
+        }
 
-  transf getDynamicsTran() const {
-    return DH->getTran(DH->getTheta(),dynamicsVal);
-  }
+        transf getTran(double jointVal) const {
+            return DH->getTran(DH->getTheta(), jointVal + c);
+        }
+
+        transf getDynamicsTran() const {
+            return DH->getTran(DH->getTheta(), dynamicsVal);
+        }
 
 };
 
 //! A type of joint that rotates about the z-axis of the joint frame.
 /*!
-  A specific type of joint used for rotary motion.
+    A specific type of joint used for rotary motion.
 */
 class RevoluteJoint : public Joint {
 
-public:
+    public:
 
-  /*! Stub */
-  RevoluteJoint(KinematicChain *k) : Joint(k) {}
+        /*! Stub */
+        RevoluteJoint(KinematicChain *k) : Joint(k) {}
 
-  virtual int initJointFromXml(const TiXmlElement* root, int jnum);
+        virtual int initJointFromXml(const TiXmlElement *root, int jnum);
 
-  /*! Returns the current value of this joint. */
-  virtual double getVal() const {return DH->getTheta() - c;}
+        /*! Returns the current value of this joint. */
+        virtual double getVal() const {
+            return DH->getTheta() - c;
+        }
 
-  virtual void applyInternalWrench(double magnitude);
+        virtual void applyInternalWrench(double magnitude);
 
-  virtual int setVal(double q);
+        virtual int setVal(double q);
 
-  /*! Returns the type of this joint: REVOLUTE. */
-  virtual JointT getType() const {return REVOLUTE;}
+        /*! Returns the type of this joint: REVOLUTE. */
+        virtual JointT getType() const {
+            return REVOLUTE;
+        }
 
 
-  transf getTran(double jointVal) const {
-    return DH->getTran(jointVal + c,DH->getD());
-  }
-  transf getDynamicsTran() const {
-    return DH->getTran(dynamicsVal,DH->getD());
-  }
+        transf getTran(double jointVal) const {
+            return DH->getTran(jointVal + c, DH->getD());
+        }
+        transf getDynamicsTran() const {
+            return DH->getTran(dynamicsVal, DH->getD());
+        }
 
 };
 

--- a/include/kinematicChain.h
+++ b/include/kinematicChain.h
@@ -53,159 +53,192 @@ class TiXmlElement;
     robot.  Given values for the joint positions, this class solves the
     forward kinematics for each link in the chain.
 
-	In general, the only way that robot links should ever be moved is 
-	through the kinematic chains: the robot asks the dof's for joint values, 
-	tells the chains to set those values then tells the chains to update link 
-	poses.
+    In general, the only way that robot links should ever be moved is
+    through the kinematic chains: the robot asks the dof's for joint values,
+    tells the chains to set those values then tells the chains to update link
+    poses.
 */
 class KinematicChain {
-  //! Pointer to the robot that this chain is a part of
-  Robot *owner;
-  
-  //! Indicates which chain this is within the robot definition
-  int chainNum;
-  
-  //! The number of the first joint in this chain in the robot's list of joints
-  /*! This allows us to compute correspondances between joints in this chain's
-	  list and joints in the robot's overall list, which spans all chains.*/
-  int firstJointNum;
+        //! Pointer to the robot that this chain is a part of
+        Robot *owner;
 
-  //! The number of degrees of freedom in the chain
-  int numDOF;
+        //! Indicates which chain this is within the robot definition
+        int chainNum;
 
-  //! The number of joints in the chain
-  int numJoints;
+        //! The number of the first joint in this chain in the robot's list of joints
+        /*! This allows us to compute correspondances between joints in this chain's
+            list and joints in the robot's overall list, which spans all chains.*/
+        int firstJointNum;
 
-  //! The number of links in the chain
-  int numLinks;
-  
-  //! A vector of pointers to the joints in the chain
-  std::vector<Joint *> jointVec;
+        //! The number of degrees of freedom in the chain
+        int numDOF;
 
-  //! A vector of pointers to the links in the chain
-  std::vector<Link *> linkVec;
+        //! The number of joints in the chain
+        int numJoints;
 
-  //! For any link, gives us the number of the last joint in the chain that affects its pose
-  /*! An array where each element corresponds to a link in the chain and the 
-	  value is the index of the last joint affecting the pose of that link. */
-  int *lastJoint;
+        //! The number of links in the chain
+        int numLinks;
 
-  //! The base transform of the chain relative to the robot base
-  transf tran;
+        //! A vector of pointers to the joints in the chain
+        std::vector<Joint *> jointVec;
 
-  //! The current end transform of the chain relative to the robot base
-  transf endTran;
+        //! A vector of pointers to the links in the chain
+        std::vector<Link *> linkVec;
 
-  //! A pointer to the root of the chain's Inventor scene graph
-  SoSeparator *IVRoot;
+        //! For any link, gives us the number of the last joint in the chain that affects its pose
+        /*! An array where each element corresponds to a link in the chain and the
+            value is the index of the last joint affecting the pose of that link. */
+        int *lastJoint;
 
-  //! A pointer to the Inventor transform corresponding to the base transform of the chain
-  SoTransform *IVTran;
+        //! The base transform of the chain relative to the robot base
+        transf tran;
 
-  //! Indicates whether any of the joints in the chain have moved since the last update of the kinematics
-  bool jointsMoved;
+        //! The current end transform of the chain relative to the robot base
+        transf endTran;
 
-  //! A vector of child robots connected to the last link of the chain
-  std::vector<Robot *> children;
+        //! A pointer to the root of the chain's Inventor scene graph
+        SoSeparator *IVRoot;
 
-  //! The offset transforms relating the base frame of each child robot to the end transform of the chain
-  std::vector<transf> childOffsetTran;
+        //! A pointer to the Inventor transform corresponding to the base transform of the chain
+        SoTransform *IVTran;
 
-  //! The number of child robots connected to the chain
-  int numChildren;
+        //! Indicates whether any of the joints in the chain have moved since the last update of the kinematics
+        bool jointsMoved;
 
-  //! Creates the dynamic joints for each link, based on the regular joints which must already exist
-  int createDynamicJoints(const std::vector<int> &dynJointTypes);
+        //! A vector of child robots connected to the last link of the chain
+        std::vector<Robot *> children;
 
-  //! Creates a list of the dynamic joints that make up this chain
-  void getDynamicJoints(std::vector<DynJoint*> *dj) const;
- 
-public:
-  /*! The constructor is called from a robot's load method, and requires a
-      a pointer to the robot owning this chain, and the index of which chain
-      this is within the robot.*/
-  KinematicChain(Robot *r,int chainNumber, int jointNum);
+        //! The offset transforms relating the base frame of each child robot to the end transform of the chain
+        std::vector<transf> childOffsetTran;
 
-  ~KinematicChain();
+        //! The number of child robots connected to the chain
+        int numChildren;
 
-  //! Builds the complete link jacobian wrt to dynamic joints of this chain.
-  Matrix linkJacobian(bool worldCoords) const;
-  //! Builds the link jacobian but removes the rows corresponding to links that have no contacts
-  Matrix activeLinkJacobian(bool worldCoords);
-  //! Returns a matrix that only contains the columns of the Jacobian that correspond to actuated joint dofs
-  Matrix actuatedJacobian(const Matrix &fullColumnJ) const;
+        //! Creates the dynamic joints for each link, based on the regular joints which must already exist
+        int createDynamicJoints(const std::vector<int> &dynJointTypes);
 
-  Matrix jointTorquesVector(Matrix fullRobotTorques);
+        //! Creates a list of the dynamic joints that make up this chain
+        void getDynamicJoints(std::vector<DynJoint *> *dj) const;
 
-  //! Returns the number of contacts between links of this chain and a given object
-  int getNumContacts(Body *body);
+    public:
+        /*! The constructor is called from a robot's load method, and requires a
+            a pointer to the robot owning this chain, and the index of which chain
+            this is within the robot.*/
+        KinematicChain(Robot *r, int chainNumber, int jointNum);
 
-  //! Returns all the contacts between links of this chain and a given object
-  std::list<Contact*> getContacts(Body *body);
+        ~KinematicChain();
 
-  /*! Loads the chain information from XML, expected in the standard format
-      of GraspIt! .xml robot files */
-  int initChainFromXml(const TiXmlElement* root,QString &linkDir);
-  
-  /*! Creates an indentical copy of another chain, sharing things such as geometry */
-  void cloneFrom(const KinematicChain *original);
+        //! Builds the complete link jacobian wrt to dynamic joints of this chain.
+        Matrix linkJacobian(bool worldCoords) const;
+        //! Builds the link jacobian but removes the rows corresponding to links that have no contacts
+        Matrix activeLinkJacobian(bool worldCoords);
+        //! Returns a matrix that only contains the columns of the Jacobian that correspond to actuated joint dofs
+        Matrix actuatedJacobian(const Matrix &fullColumnJ) const;
 
-  //! Sets joint values (without updating poses) based on a vector with values for all robot joints
-  void setJointValues(const double *jointVals);
-  //! Gets joint values in a vector with values for all robot joints
-  void getJointValues(double *jointVals) const;
-  //! Compute the link transforms that correspond to a given set of joint values
-  void fwdKinematics(const double *jointVals, std::vector<transf> &newLinkTranVec) const;
-  //! Compute the locations and orientations of all the joints in this chain for some set of joint values
-  void getJointLocations(const double *jointVals, std::vector<transf> &jointTranVec) const;
-  //! Compute the link transforms for an infinitesimal joint motion in specified direction
-  void infinitesimalMotion(const double *jointVals, std::vector<transf> &newLinkTranVec) const;
-  //! Set the transforms of the links to match the current joint values
-  void updateLinkPoses();
-  //! Keep in the report only those collisions which involve at least a link from this chain
-  void filterCollisionReport(CollisionReport &colReport);
-  //! Returns the number of the first joint in this chain in the robot numbering scheme
-  int getFirstJointNum(){return firstJointNum;}
+        Matrix jointTorquesVector(Matrix fullRobotTorques);
 
-  //! Returns the index of this chain in the robot's list of chains
-  int getNum() const {return chainNum;}
+        //! Returns the number of contacts between links of this chain and a given object
+        int getNumContacts(Body *body);
 
-  void attachRobot(Robot *r,const transf &offsetTr);
-  void detachRobot(Robot *r);
+        //! Returns all the contacts between links of this chain and a given object
+        std::list<Contact *> getContacts(Body *body);
 
-  /*! Return the robot that owns this chain */
-  const Robot* getOwner() const {return owner;}
-  /*! Returns the number of joints in the chain */
-  int getNumJoints() const {return numJoints;}
-  /*! Returns the number of links in the chain */
-  int getNumLinks() const {return numLinks;}
-  /*! Returns a pointer to the i-th joint in the chain */
-  Joint *getJoint(int i) const {return jointVec[i];}
-  //! Returns a list of all joints in this chain
-  std::list<Joint*> getJoints();
-  /*! Returns a pointer to the i-th link in the chain */
-  Link *getLink(int i) const {return linkVec[i];}
-  /*! Returns the index of the last joint in the chain that affects the pose of link i*/
-  int getLastJoint(int i) const {return lastJoint[i];}
-  /*! Returns a pointer to the root of the chain's Inventor scene graph */
-  SoSeparator *getIVRoot() const {return IVRoot;}
-  /*! Returns a pointer to the Inventor transform corresponding to the base transform of the chain */
-  SoTransform *getIVTran() const {return IVTran;}
-  /*! Returns the base transform of the chain relative to the robot base */
-  transf const &getTran() const {return tran;}
-  /*! Sets the base transform of the chain relative to the robot base. Does NOT update poses.*/
-  void setTran(transf tr){tran = tr;tran.toSoTransform(IVTran);}
-  /*! Returns the value of the flag indicating whether the joints have been
-    moved since the last time the link poses have been updated */
-  bool jointsHaveMoved() const {return jointsMoved;}
-  /*! Returns the number of robots attached to the end of the chain */
-  int getNumAttachedRobots() const {return numChildren;}
-  /*! Returns the i-th robot attached to the end of the chain */
-  Robot *getAttachedRobot(int i) const {return children[i];}
+        /*! Loads the chain information from XML, expected in the standard format
+            of GraspIt! .xml robot files */
+        int initChainFromXml(const TiXmlElement *root, QString &linkDir);
 
-  /*! Returns the offset transform between the end of the chain and the base
-      of the i-th attached robot*/
-  transf const &getAttachedRobotOffset(int i) const{return childOffsetTran[i];}
+        /*! Creates an indentical copy of another chain, sharing things such as geometry */
+        void cloneFrom(const KinematicChain *original);
+
+        //! Sets joint values (without updating poses) based on a vector with values for all robot joints
+        void setJointValues(const double *jointVals);
+        //! Gets joint values in a vector with values for all robot joints
+        void getJointValues(double *jointVals) const;
+        //! Compute the link transforms that correspond to a given set of joint values
+        void fwdKinematics(const double *jointVals, std::vector<transf> &newLinkTranVec) const;
+        //! Compute the locations and orientations of all the joints in this chain for some set of joint values
+        void getJointLocations(const double *jointVals, std::vector<transf> &jointTranVec) const;
+        //! Compute the link transforms for an infinitesimal joint motion in specified direction
+        void infinitesimalMotion(const double *jointVals, std::vector<transf> &newLinkTranVec) const;
+        //! Set the transforms of the links to match the current joint values
+        void updateLinkPoses();
+        //! Keep in the report only those collisions which involve at least a link from this chain
+        void filterCollisionReport(CollisionReport &colReport);
+        //! Returns the number of the first joint in this chain in the robot numbering scheme
+        int getFirstJointNum() {
+            return firstJointNum;
+        }
+
+        //! Returns the index of this chain in the robot's list of chains
+        int getNum() const {
+            return chainNum;
+        }
+
+        void attachRobot(Robot *r, const transf &offsetTr);
+        void detachRobot(Robot *r);
+
+        /*! Return the robot that owns this chain */
+        const Robot *getOwner() const {
+            return owner;
+        }
+        /*! Returns the number of joints in the chain */
+        int getNumJoints() const {
+            return numJoints;
+        }
+        /*! Returns the number of links in the chain */
+        int getNumLinks() const {
+            return numLinks;
+        }
+        /*! Returns a pointer to the i-th joint in the chain */
+        Joint *getJoint(int i) const {
+            return jointVec[i];
+        }
+        //! Returns a list of all joints in this chain
+        std::list<Joint *> getJoints();
+        /*! Returns a pointer to the i-th link in the chain */
+        Link *getLink(int i) const {
+            return linkVec[i];
+        }
+        /*! Returns the index of the last joint in the chain that affects the pose of link i*/
+        int getLastJoint(int i) const {
+            return lastJoint[i];
+        }
+        /*! Returns a pointer to the root of the chain's Inventor scene graph */
+        SoSeparator *getIVRoot() const {
+            return IVRoot;
+        }
+        /*! Returns a pointer to the Inventor transform corresponding to the base transform of the chain */
+        SoTransform *getIVTran() const {
+            return IVTran;
+        }
+        /*! Returns the base transform of the chain relative to the robot base */
+        transf const &getTran() const {
+            return tran;
+        }
+        /*! Sets the base transform of the chain relative to the robot base. Does NOT update poses.*/
+        void setTran(transf tr) {
+            tran = tr;
+            tran.toSoTransform(IVTran);
+        }
+        /*! Returns the value of the flag indicating whether the joints have been
+            moved since the last time the link poses have been updated */
+        bool jointsHaveMoved() const {
+            return jointsMoved;
+        }
+        /*! Returns the number of robots attached to the end of the chain */
+        int getNumAttachedRobots() const {
+            return numChildren;
+        }
+        /*! Returns the i-th robot attached to the end of the chain */
+        Robot *getAttachedRobot(int i) const {
+            return children[i];
+        }
+
+        /*! Returns the offset transform between the end of the chain and the base
+            of the i-th attached robot*/
+        transf const &getAttachedRobotOffset(int i) const {
+            return childOffsetTran[i];
+        }
 };
 
 #endif

--- a/include/lapack_wrappers.h
+++ b/include/lapack_wrappers.h
@@ -1,5 +1,5 @@
 /*! \file
-\brief C wrappers for the fortran functions so they may be called from C++ routines
+    \brief C wrappers for the fortran functions so they may be called from C++ routines
 */
 
 //cblas uses a different naming convention
@@ -11,221 +11,198 @@
 extern "C" {
 #endif /* __cplusplus */
 
-static __inline void daxpy(int n,double da,double *dx,int incx,double *dy,
-			   int incy)
-{
-  void daxpy_(int *,double *,double *,int *,double *,int *);
+static __inline void daxpy(int n, double da, double *dx, int incx, double *dy,
+                           int incy) {
+    void daxpy_(int *, double *, double *, int *, double *, int *);
 
-  daxpy_(&n,&da,dx,&incx,dy,&incy);
+    daxpy_(&n, &da, dx, &incx, dy, &incy);
 }
 
-static __inline void dcopy(int n,double *dx,int incx,double *dy,int incy)
-{
-  void dcopy_(int *,double *,int *, double *,int *);
+static __inline void dcopy(int n, double *dx, int incx, double *dy, int incy) {
+    void dcopy_(int *, double *, int *, double *, int *);
 
-  dcopy_(&n,dx,&incx,dy,&incy);
+    dcopy_(&n, dx, &incx, dy, &incy);
 }
 
-static __inline double ddot(int n,double *dx,int incx,double *dy,int incy)
-{
-    double ddot_(int *,double *,int *,double *,int *);
+static __inline double ddot(int n, double *dx, int incx, double *dy, int incy) {
+    double ddot_(int *, double *, int *, double *, int *);
 
-    return ddot_(&n,dx,&incx,dy,&incy);
+    return ddot_(&n, dx, &incx, dy, &incy);
 }
 
-static __inline void dgels(const char *trans,int m,int n,int nrhs,double *a,
-			   int lda,double *b,int ldb,double *work,
-			   int lwork,int *info)
-{
-  void dgels_(const char *,int *,int *,int *,double *,int *,double *,int *,double *,
-	      int *,int *);
+static __inline void dgels(const char *trans, int m, int n, int nrhs, double *a,
+                           int lda, double *b, int ldb, double *work,
+                           int lwork, int *info) {
+    void dgels_(const char *, int *, int *, int *, double *, int *, double *, int *, double *,
+                int *, int *);
 
-  dgels_(trans,&m,&n,&nrhs,a,&lda,b,&ldb,work,&lwork,info);
+    dgels_(trans, &m, &n, &nrhs, a, &lda, b, &ldb, work, &lwork, info);
 }
 
-static __inline void dgemm(const char *transa,const char *transb,int m,int n,int k,
-			   double alpha,double *a,int lda,double *b,int ldb,
-			   double beta,double *c,int ldc)
-{
-    void dgemm_(const char *,const char *,int *,int *, int *,double *,double *,int *,
-		double *,int *,double *,double *,int *);
+static __inline void dgemm(const char *transa, const char *transb, int m, int n, int k,
+                           double alpha, double *a, int lda, double *b, int ldb,
+                           double beta, double *c, int ldc) {
+    void dgemm_(const char *, const char *, int *, int *, int *, double *, double *, int *,
+                double *, int *, double *, double *, int *);
 
-    dgemm_(transa,transb,&m,&n,&k,&alpha,a,&lda,b,&ldb,&beta,c,&ldc);
+    dgemm_(transa, transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc);
 }
 
 
-static __inline void dgemv(const char *trans,int m,int n,double alpha,
-			   double *a,int lda,double *dx,int incx,
-			   double beta,double *dy,int incy)
-{
-     void dgemv_(const char *,int *,int *,double *,double *,int *,double *, 
-		 int *,double *,double *,int *);
+static __inline void dgemv(const char *trans, int m, int n, double alpha,
+                           double *a, int lda, double *dx, int incx,
+                           double beta, double *dy, int incy) {
+    void dgemv_(const char *, int *, int *, double *, double *, int *, double *,
+                int *, double *, double *, int *);
 
-     dgemv_(trans,&m,&n,&alpha,a,&lda,dx,&incx,&beta,dy,&incy);
+    dgemv_(trans, &m, &n, &alpha, a, &lda, dx, &incx, &beta, dy, &incy);
 }
 
 
 static __inline void dgesv(int n, int nrhs, double *a, int lda, int *ipiv,
-			   double *b, int ldb, int *info)
-{
+                           double *b, int ldb, int *info) {
 
-  void dgesv_(int *,int *,double *,int *,int *,double *,int *,int *);
+    void dgesv_(int *, int *, double *, int *, int *, double *, int *, int *);
 
-  dgesv_(&n,&nrhs,a,&lda,ipiv,b,&ldb,info);
+    dgesv_(&n, &nrhs, a, &lda, ipiv, b, &ldb, info);
 }
 
-static __inline void dgelss(int m, int n, int nrhs, double *a, int lda, double *b, int ldb, 
-			    double *s, double rcond, int *rank, 
-			    double *work, int lwork, int *info)
-{
-	void dgelss_(int *, int *, int *, double *, int *, double *, int *, 
-		     double *, double *, int *, 
-		     double *, int *, int *);
-	dgelss_(&m, &n, &nrhs, a, &lda, b, &ldb, 
-		s, &rcond, rank, 
-		work, &lwork, info);
+static __inline void dgelss(int m, int n, int nrhs, double *a, int lda, double *b, int ldb,
+                            double *s, double rcond, int *rank,
+                            double *work, int lwork, int *info) {
+    void dgelss_(int *, int *, int *, double *, int *, double *, int *,
+                 double *, double *, int *,
+                 double *, int *, int *);
+    dgelss_(&m, &n, &nrhs, a, &lda, b, &ldb,
+            s, &rcond, rank,
+            work, &lwork, info);
 }
 
 
-static __inline void dgesvd(const char *jobu,const char *jobvt, int m, int n, double *a,
-			    int lda, double *s, double *u, int ldu, double *vt,
-			    int ldvt,double *work, int lwork, int *info)
-{
+static __inline void dgesvd(const char *jobu, const char *jobvt, int m, int n, double *a,
+                            int lda, double *s, double *u, int ldu, double *vt,
+                            int ldvt, double *work, int lwork, int *info) {
 
-  void dgesvd_(const char *, const char *,int *,int *,double *,int *,double *,double *,
-	       int *,double *,int *,double *,int *,int *);
+    void dgesvd_(const char *, const char *, int *, int *, double *, int *, double *, double *,
+                 int *, double *, int *, double *, int *, int *);
 
-  dgesvd_(jobu, jobvt,&m,&n,a,&lda,s,u,&ldu,vt,&ldvt,work,&lwork,info);
+    dgesvd_(jobu, jobvt, &m, &n, a, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, info);
 }
 
 
 
-static __inline void dgetrf(int m,int n,double *a,int lda,int *ipiv,int *info)
-{
-  void dgetrf_(int *,int *,double *,int *,int *,int *);
+static __inline void dgetrf(int m, int n, double *a, int lda, int *ipiv, int *info) {
+    void dgetrf_(int *, int *, double *, int *, int *, int *);
 
-  dgetrf_(&m,&n,a,&lda,ipiv,info);
+    dgetrf_(&m, &n, a, &lda, ipiv, info);
 }
 
 
 
-static __inline void dgetri(int n,double *a,int lda,int *ipiv,double *work,
-			    int lwork,int *info)
-{
-  void dgetri_(int *,double *,int *,int *,double *,int *,int *);
+static __inline void dgetri(int n, double *a, int lda, int *ipiv, double *work,
+                            int lwork, int *info) {
+    void dgetri_(int *, double *, int *, int *, double *, int *, int *);
 
-  dgetri_(&n,a,&lda,ipiv,work,&lwork,info);
+    dgetri_(&n, a, &lda, ipiv, work, &lwork, info);
 }
 
 
 
-static __inline void dlascl(const char *type,int kl,int ku,double from,double to,
-			    int m,int n,double *a,int lda,int *info)
-{
-  void dlascl_(const char *,int *,int *,double *,double *, int *,
-	       int *, double *,int *,int *);
+static __inline void dlascl(const char *type, int kl, int ku, double from, double to,
+                            int m, int n, double *a, int lda, int *info) {
+    void dlascl_(const char *, int *, int *, double *, double *, int *,
+                 int *, double *, int *, int *);
 
-  dlascl_(type,&kl,&ku,&from,&to,&m,&n,a,&lda,info);
+    dlascl_(type, &kl, &ku, &from, &to, &m, &n, a, &lda, info);
 }
 
 
 
-static __inline double dnrm2(int n,double *dx,int incx)
-{
-  double dnrm2_(int *,double *,int *); 
+static __inline double dnrm2(int n, double *dx, int incx) {
+    double dnrm2_(int *, double *, int *);
 
-  return dnrm2_(&n,dx,&incx);
+    return dnrm2_(&n, dx, &incx);
 }
 
 
 
-static __inline void dpptrf(const char *uplo,int n,double *ap,int *info)
-{
-  void dpptrf_(const char *,int *,double *,int *);
+static __inline void dpptrf(const char *uplo, int n, double *ap, int *info) {
+    void dpptrf_(const char *, int *, double *, int *);
 
-  dpptrf_(uplo,&n,ap,info);
+    dpptrf_(uplo, &n, ap, info);
 }
 
 
-static __inline void dscal(int n,double da,double *dx,int incx)
-{
-  void dscal_(int *,double *,double *,int *);
+static __inline void dscal(int n, double da, double *dx, int incx) {
+    void dscal_(int *, double *, double *, int *);
 
-  dscal_(&n,&da,dx,&incx);
+    dscal_(&n, &da, dx, &incx);
 }
 
-static __inline void dspgst(int itype,const char *uplo,int n,double *ap,
-			    double *bp,int *info)
-{
-  void dspgst_(int *,const char *,int *,double *,double *,int *);
+static __inline void dspgst(int itype, const char *uplo, int n, double *ap,
+                            double *bp, int *info) {
+    void dspgst_(int *, const char *, int *, double *, double *, int *);
 
-  dspgst_(&itype, uplo,&n,ap,bp,info);
-}
-
-
-
-static __inline void dspev(const char *jobz,const char *uplo, int n, double *ap,
-			   double *w, double *z, int ldz, double *work,
-			   int *info)
-{
-  void dspev_(const char *,const char *,int *,double *,double *,double *,int *,double *,
-	      int *);
-
-  dspev_(jobz,uplo,&n,ap,w,z,&ldz,work,info);
+    dspgst_(&itype, uplo, &n, ap, bp, info);
 }
 
 
 
-static __inline void dspgv(int itype,const char *jobz,const char *uplo, int n, double *ap,
-			   double *bp, double *w,double *z, int ldz,
-			   double *work,int *info)
-{
-  void dspgv_(int *,const char *,const char *,int *,double *,double *,double *,double *,
-	      int *,double *,int *);
+static __inline void dspev(const char *jobz, const char *uplo, int n, double *ap,
+                           double *w, double *z, int ldz, double *work,
+                           int *info) {
+    void dspev_(const char *, const char *, int *, double *, double *, double *, int *, double *,
+                int *);
 
-  dspgv_(&itype,jobz,uplo,&n,ap,bp,w,z,&ldz,work,info);
+    dspev_(jobz, uplo, &n, ap, w, z, &ldz, work, info);
 }
 
 
 
-static __inline void dtptri(const char *uplo,const char *diag,int n,double *ap,int *info)
-{
-  void dtptri_(const char *,const char *,int *,double *,int *);
+static __inline void dspgv(int itype, const char *jobz, const char *uplo, int n, double *ap,
+                           double *bp, double *w, double *z, int ldz,
+                           double *work, int *info) {
+    void dspgv_(int *, const char *, const char *, int *, double *, double *, double *, double *,
+                int *, double *, int *);
 
-  dtptri_(uplo,diag,&n,ap,info);
+    dspgv_(&itype, jobz, uplo, &n, ap, bp, w, z, &ldz, work, info);
 }
 
 
-static __inline void dtrcon(const char *norm,const char *uplo,const char *diag,int n,double *a,
-			    int lda,double *rcond,double *work,int *iwork,
-			    int *info)
-{
-  void dtrcon_(const char *,const char *,const char *,int *,double *,int *,double *,double *,
-	       int *,int *);
 
-  dtrcon_(norm,uplo,diag,&n,a,&lda,rcond,work,iwork,info);
+static __inline void dtptri(const char *uplo, const char *diag, int n, double *ap, int *info) {
+    void dtptri_(const char *, const char *, int *, double *, int *);
+
+    dtptri_(uplo, diag, &n, ap, info);
 }
 
-static __inline void dgeqp3(int m, int n, double *a, int lda, int *jpvt, 
-							double *tau, double *work, int lwork, int *info)
-{
-  void dgeqp3_(int*, int*, double*, int*, int*, double*, double*, int*, int*);
-  dgeqp3_(&m, &n, a, &lda, jpvt, tau, work, &lwork, info);
+
+static __inline void dtrcon(const char *norm, const char *uplo, const char *diag, int n, double *a,
+                            int lda, double *rcond, double *work, int *iwork,
+                            int *info) {
+    void dtrcon_(const char *, const char *, const char *, int *, double *, int *, double *, double *,
+                 int *, int *);
+
+    dtrcon_(norm, uplo, diag, &n, a, &lda, rcond, work, iwork, info);
 }
 
-static __inline void dtrtrs(const char *uplo, const char *trans, const char *diag, int n, 
-							int nrhs, double *a, int lda, double *b, int ldb,
-							int *info)
-{
-  void dtrtrs_(const char*, const char*, const char*, int*, int*, double*, int*, double*, int*, int*);
-  dtrtrs_(uplo, trans, diag, &n, &nrhs, a, &lda, b, &ldb, info);
+static __inline void dgeqp3(int m, int n, double *a, int lda, int *jpvt,
+                            double *tau, double *work, int lwork, int *info) {
+    void dgeqp3_(int *, int *, double *, int *, int *, double *, double *, int *, int *);
+    dgeqp3_(&m, &n, a, &lda, jpvt, tau, work, &lwork, info);
+}
+
+static __inline void dtrtrs(const char *uplo, const char *trans, const char *diag, int n,
+                            int nrhs, double *a, int lda, double *b, int ldb,
+                            int *info) {
+    void dtrtrs_(const char *, const char *, const char *, int *, int *, double *, int *, double *, int *, int *);
+    dtrtrs_(uplo, trans, diag, &n, &nrhs, a, &lda, b, &ldb, info);
 }
 
 static __inline void dorgqr(int m, int n, int k, double *a, int lda, double *tau,
-							double *work, int lwork, int *info)
-{
-  void dorgqr_(int*, int*, int*, double*, int*, double*, double*, int*, int*);
-  dorgqr_(&m, &n, &k, a, &lda, tau, work, &lwork, info);
+                            double *work, int lwork, int *info) {
+    void dorgqr_(int *, int *, int *, double *, int *, double *, double *, int *, int *);
+    dorgqr_(&m, &n, &k, a, &lda, tau, work, &lwork, info);
 }
 
 

--- a/include/lmiOptimizer.h
+++ b/include/lmiOptimizer.h
@@ -29,168 +29,167 @@ class Grasp;
 
 //! Encapsulates the Grasp Force Optimization (GFO) code based on Linear Matrix Inequalitties (LMI)
 /*! This class contains the first iteration of the GFO code from GraspIt
-	release 0.9. This code is based on the linear matrix inequality 
-	technique and was adapted from code written by Li Han and Jeff Trinkle.  
-	More information regarding their algorithm can be found in: L. Han, 
-	J. Trinkle, and Z. Li, "Grasp Analysis as Linear Matrix Inequality 
-	Problems," \e IEEE \e Transactions \e on \e Robotics \e and \e 
-	Automation, Vol. 16, No. 6, pp. 663--674, December, 2000. 
-	
-	Note that this functionality is complete, but it has not been throroughly 
-	used or tested. Is is also not completely documented, so you will have to 
-	read the code and figure it out. Unfortunately, it has fallen into disrepair
-	and has not been kept up-to-date with the rest of GraspIt. As such, it is
-	not used anywhere else, and probably will not work out of the box.
+    release 0.9. This code is based on the linear matrix inequality
+    technique and was adapted from code written by Li Han and Jeff Trinkle.
+    More information regarding their algorithm can be found in: L. Han,
+    J. Trinkle, and Z. Li, "Grasp Analysis as Linear Matrix Inequality
+    Problems," \e IEEE \e Transactions \e on \e Robotics \e and \e
+    Automation, Vol. 16, No. 6, pp. 663--674, December, 2000.
 
-	We also have a new way of doing GFO based on Quadratic Programming (QP). That 
-	functionality is included with the Grasp class. It is up to date and tested.
-	We recommend to use that version for your GFO code. The LMI version is 
-	probably superior from the mathematical standpoint, but the QP version is
-	easier to follow, completely documented and up to date. A good starting
-	point is the function Grasp::computeQuasistaticForcesAndTorques(...)
+    Note that this functionality is complete, but it has not been throroughly
+    used or tested. Is is also not completely documented, so you will have to
+    read the code and figure it out. Unfortunately, it has fallen into disrepair
+    and has not been kept up-to-date with the rest of GraspIt. As such, it is
+    not used anywhere else, and probably will not work out of the box.
 
-	Note that this file and this version of the GFO code might be removed from
-	future releases of GraspIt.
+    We also have a new way of doing GFO based on Quadratic Programming (QP). That
+    functionality is included with the Grasp class. It is up to date and tested.
+    We recommend to use that version for your GFO code. The LMI version is
+    probably superior from the mathematical standpoint, but the QP version is
+    easier to follow, completely documented and up to date. A good starting
+    point is the function Grasp::computeQuasistaticForcesAndTorques(...)
+
+    Note that this file and this version of the GFO code might be removed from
+    future releases of GraspIt.
 */
-class LMIOptimizer
-{
-private:
-   //! GFO parameter
-  static double GFO_WEIGHT_FACTOR;
+class LMIOptimizer {
+    private:
+        //! GFO parameter
+        static double GFO_WEIGHT_FACTOR;
 
-  //! The grasp that the computations are performed for
-  Grasp *mGrasp;
+        //! The grasp that the computations are performed for
+        Grasp *mGrasp;
 
-  //! Number of basis wrenches for grasp map (3 * numContacts for PCWF)
-  int numWrenches; 
+        //! Number of basis wrenches for grasp map (3 * numContacts for PCWF)
+        int numWrenches;
 
-  //! A \a (6 * numWrenches) matrix containing basis wrenches for each contact vertex (stored in column-major format)
-  double *graspMap; 
+        //! A \a (6 * numWrenches) matrix containing basis wrenches for each contact vertex (stored in column-major format)
+        double *graspMap;
 
-  //! Dimension of the null space of the grasp map
-  int nullDim;
+        //! Dimension of the null space of the grasp map
+        int nullDim;
 
-  //! The null space of the grasp map; (column-major)
-  double *nullSpace;
+        //! The null space of the grasp map; (column-major)
+        double *nullSpace;
 
-  //! vector of size \a (numWrenches+1), the optimal grasp contact forces, computed from optmz0 and the objective value.
-  double *optmx0;   
+        //! vector of size \a (numWrenches+1), the optimal grasp contact forces, computed from optmz0 and the objective value.
+        double *optmx0;
 
-  //! vector of size \a numDOF storing the optimal torque for each DOF
-  double *optTorques; 
+        //! vector of size \a numDOF storing the optimal torque for each DOF
+        double *optTorques;
 
-  //! The grasp jacobian
-  double *Jacobian;
+        //! The grasp jacobian
+        double *Jacobian;
 
-  //! Min norm solution to \f$\mbox{GraspMap} * x = F_{ext}\f$
-  double *minNormSln;
+        //! Min norm solution to \f$\mbox{GraspMap} * x = F_{ext}\f$
+        double *minNormSln;
 
-  //! The number of degrees of freedom of the hand
-  int numDOF;
+        //! The number of degrees of freedom of the hand
+        int numDOF;
 
-  //! temporary: should come from hand object
-  double *externalTorques; 
-  
-  //! These variables are used by maxdet package.  Refer to maxdet manual for their explainations.
-  int L, K, GPkRow, *F_blkszs,*G_blkszs;                 
+        //! temporary: should come from hand object
+        double *externalTorques;
 
-  //! These variables are used by maxdet package.  Refer to maxdet manual for their explainations.
-  double *F, *G, *Z, *W, *c, constOffset;
+        //! These variables are used by maxdet package.  Refer to maxdet manual for their explainations.
+        int L, K, GPkRow, *F_blkszs, *G_blkszs;
 
-  //! Termination criteria used in maxdet algorithm. Refer to maxdet manual.
-  double gamma, abstol, reltol; 
+        //! These variables are used by maxdet package.  Refer to maxdet manual for their explainations.
+        double *F, *G, *Z, *W, *c, constOffset;
 
-  //! If it is 1, then terminate the force feasibility phase whenever the objective value becomes negative, i.e. find one valid grasp force. Otherwise, use the regular maxdet termination.
-  int negativeFlag;
+        //! Termination criteria used in maxdet algorithm. Refer to maxdet manual.
+        double gamma, abstol, reltol;
 
-  //! Is the grasp force optimization feasible?
-  int feasible;
+        //! If it is 1, then terminate the force feasibility phase whenever the objective value becomes negative, i.e. find one valid grasp force. Otherwise, use the regular maxdet termination.
+        int negativeFlag;
 
-  //! On entry, the maximum number of total Newton iteraions, and on exit, the real number of Newton Iterations in the feasible phase.
-  int feasNTiters;
+        //! Is the grasp force optimization feasible?
+        int feasible;
 
-  //! Used when saving output from grasp force optimization analysis
-  int graspCounter;
+        //! On entry, the maximum number of total Newton iteraions, and on exit, the real number of Newton Iterations in the feasible phase.
+        int feasNTiters;
 
-  //! Vector of size \a m, the \a z value corrsponding to the initial feasible grasp forces computed in force feasibility phase.
-  double *initz0;
+        //! Used when saving output from grasp force optimization analysis
+        int graspCounter;
 
-  //! The counterpart to feasNTiters
-  int optmNTiters;
+        //! Vector of size \a m, the \a z value corrsponding to the initial feasible grasp forces computed in force feasibility phase.
+        double *initz0;
 
-  //! Vector of size \a m, the \a z value corresponding to optimal grasp forces, computed in force optimization phase.
-  double *optmz0;
+        //! The counterpart to feasNTiters
+        int optmNTiters;
 
-  //! Vector of size \a (m+3), \a optmz0, as well as the corresponding objective value, duality gap, and number of optimization iteration steps.
-  double *extendOptmz0;
+        //! Vector of size \a m, the \a z value corresponding to optimal grasp forces, computed in force optimization phase.
+        double *optmz0;
 
-  //! array of dimension \a (m+3)*Number_of_Iterations_at_the_Feasibility_Phase, the history (iterative values) of z, objective value, duality gap and iteration number in force feasibility phase at each simulation step.
-  double *feasZHistory; 
+        //! Vector of size \a (m+3), \a optmz0, as well as the corresponding objective value, duality gap, and number of optimization iteration steps.
+        double *extendOptmz0;
 
- // array of dimension \a (m+3)*Number_of_Iterations_at_the_Optimization_Phase, the counterpart to feasZHistory in the optimization phase.
-  double *optmZHistory;
+        //! array of dimension \a (m+3)*Number_of_Iterations_at_the_Feasibility_Phase, the history (iterative values) of z, objective value, duality gap and iteration number in force feasibility phase at each simulation step.
+        double *feasZHistory;
 
-  //! array of dimension \a (m+3)*(Number_of_Iterations_at_Optimization_Phase+1), optmZHistory, + 1: the initial feasible grasp force, its objective value, duality gap and number of iterations 
-  double *extendOptmZHistory; 
+        // array of dimension \a (m+3)*Number_of_Iterations_at_the_Optimization_Phase, the counterpart to feasZHistory in the optimization phase.
+        double *optmZHistory;
 
- //! array of dimension \a (NumWrenches+1)*Number_of_Iterations_at_the_Feasibility_Phase, the history of grasp forces x and objective value in the force feasibility phase at the last simulation step.
-  double *feasXHistory;
+        //! array of dimension \a (m+3)*(Number_of_Iterations_at_Optimization_Phase+1), optmZHistory, + 1: the initial feasible grasp force, its objective value, duality gap and number of iterations
+        double *extendOptmZHistory;
 
- //! array of dimension \a (NumWrenches+1)*(Number_of_Iterations_at_the_Optimization_Phase+1), the counterpart to feasXHistory in the optimization phase at the last step.
-  double *optmXHistory;
+        //! array of dimension \a (NumWrenches+1)*Number_of_Iterations_at_the_Feasibility_Phase, the history of grasp forces x and objective value in the force feasibility phase at the last simulation step.
+        double *feasXHistory;
 
-  //! Output file pointer for saving the results of a GFO analysis
-  FILE *pRstFile;
+        //! array of dimension \a (NumWrenches+1)*(Number_of_Iterations_at_the_Optimization_Phase+1), the counterpart to feasXHistory in the optimization phase at the last step.
+        double *optmXHistory;
 
-  //! GFO routine
-  void minimalNorm();
-  //! GFO routine
-  void computeNullSpace();
+        //! Output file pointer for saving the results of a GFO analysis
+        FILE *pRstFile;
 
-  //! Constructs a version of the hand jacobian 
-  void buildJacobian();
+        //! GFO routine
+        void minimalNorm();
+        //! GFO routine
+        void computeNullSpace();
 
-  //! Builds the grasp map computing net object wrench from contact wrenches
-  void buildGraspMap();
+        //! Constructs a version of the hand jacobian
+        void buildJacobian();
 
-  //! Friction LMI helper function
-  void lmiFL(double *lmi,int rowInit, int colInit, int totalRow);
-  //! Friction LMI helper function
-  void lmiPCWF(double cof, double *lmi,int rowInit, int colInit, int totalRow);
-  //! Friction LMI helper function
-  void lmiSFCE(double cof, double cof_t,double *lmi,int rowInit, int colInit,
-	       int totalRow);
-  //! Friction LMI helper function
-  void lmiSFCL(double cof, double cof_t,double *lmi,int rowInit, int colInit,
-	       int totalRow);
-  //! Friction LMI helper function
-  double *lmiTorqueLimits();
-  //! Friction LMI helper function
-  void lmiFL();
-  //! Friction LMI helper function
-  void lmiPWCF();
-  //! Friction LMI helper function
-  void lmiSFCE();
-  //! Friction LMI helper function
-  void lmiSFCL();
-  //! Friction LMI helper function
-  double *lmiFrictionCones();
+        //! Builds the grasp map computing net object wrench from contact wrenches
+        void buildGraspMap();
 
-  //! GFO routine
-  double *weightVec();
-  //! GFO routine
-  void feasibilityAnalysis();
-  //! GFO routine
-  void optm_EffortBarrier();
-  //! GFO routine
-  void computeObjectives();
-  //! GFO routine
-  double *xzHistoryTransfrom(double *zHistory,int numIters);
+        //! Friction LMI helper function
+        void lmiFL(double *lmi, int rowInit, int colInit, int totalRow);
+        //! Friction LMI helper function
+        void lmiPCWF(double cof, double *lmi, int rowInit, int colInit, int totalRow);
+        //! Friction LMI helper function
+        void lmiSFCE(double cof, double cof_t, double *lmi, int rowInit, int colInit,
+                     int totalRow);
+        //! Friction LMI helper function
+        void lmiSFCL(double cof, double cof_t, double *lmi, int rowInit, int colInit,
+                     int totalRow);
+        //! Friction LMI helper function
+        double *lmiTorqueLimits();
+        //! Friction LMI helper function
+        void lmiFL();
+        //! Friction LMI helper function
+        void lmiPWCF();
+        //! Friction LMI helper function
+        void lmiSFCE();
+        //! Friction LMI helper function
+        void lmiSFCL();
+        //! Friction LMI helper function
+        double *lmiFrictionCones();
 
-public:
-  LMIOptimizer(Grasp *g) : mGrasp(g) {}
+        //! GFO routine
+        double *weightVec();
+        //! GFO routine
+        void feasibilityAnalysis();
+        //! GFO routine
+        void optm_EffortBarrier();
+        //! GFO routine
+        void computeObjectives();
+        //! GFO routine
+        double *xzHistoryTransfrom(double *zHistory, int numIters);
 
-  //! Main GFO routine
-  int  findOptimalGraspForce();
+    public:
+        LMIOptimizer(Grasp *g) : mGrasp(g) {}
+
+        //! Main GFO routine
+        int  findOptimalGraspForce();
 
 };

--- a/include/material.h
+++ b/include/material.h
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: material.h,v 1.3 2009/03/25 22:10:23 cmatei Exp $
 //
@@ -25,7 +25,7 @@
 
 #ifndef MATERIAL_HXX
 
-enum materialT {frictionless, glass, metal, wood,plastic, rubber, stone, invalid};
+enum materialT {frictionless, glass, metal, wood, plastic, rubber, stone, invalid};
 
 #define NUM_MATERIAL 8
 
@@ -35,7 +35,7 @@ extern char matNameList[NUM_MATERIAL][30];
 
 void initCof();
 materialT readMaterial(const char *matStr);
-void getMaterialStr(materialT mat,char *str);
+void getMaterialStr(materialT mat, char *str);
 const char *getMaterialStr(materialT mat);
 
 #define MATERIAL_HXX

--- a/include/matvec3D.h
+++ b/include/matvec3D.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the classes: vec3, position, mat3, Quaternion, and transf.
- */
+/*! \file
+    \brief Defines the classes: vec3, position, mat3, Quaternion, and transf.
+*/
 #ifndef _MATVEC_H_
 #include <math.h>
 #include <string.h>
@@ -48,499 +48,645 @@ typedef double col_Mat4[4][4];
 
 //! A 3-dimensional double vector and methods to operate on them.
 /*!
-  vec3 is stored as an array of 3 doubles.
- */
+    vec3 is stored as an array of 3 doubles.
+*/
 class vec3 {
 
-  //! Storarge for the 3 vector coordinates.
-  double vec[3];
+        //! Storarge for the 3 vector coordinates.
+        double vec[3];
 
-public:
-  /*!  Default constructor, vector is uninitialized. */
-  vec3() {}
+    public:
+        /*!  Default constructor, vector is uninitialized. */
+        vec3() {}
 
-  /*! Copy constructor. */
-  vec3(const vec3& v) {set(v);}
+        /*! Copy constructor. */
+        vec3(const vec3 &v) {
+            set(v);
+        }
 
-  /*! Initializes the vector with the three values in the array \a v. */
-  vec3(double v[3])   {set(v);}
+        /*! Initializes the vector with the three values in the array \a v. */
+        vec3(double v[3])   {
+            set(v);
+        }
 
-  /*! Initializes the vector with the values from the Inventor vector \a v. */
-  vec3(const SbVec3f& v) {set(v);}
+        /*! Initializes the vector with the values from the Inventor vector \a v. */
+        vec3(const SbVec3f &v) {
+            set(v);
+        }
 
-  /*! Initializes the vector with the values \a x,\a y,\a z. */
-  vec3(double x,double y,double z) {set(x,y,z);}
+        /*! Initializes the vector with the values \a x,\a y,\a z. */
+        vec3(double x, double y, double z) {
+            set(x, y, z);
+        }
 
-  /*! Returns a constant reference to the value at index \a i. */
-  const double& operator[](int i) const {return vec[i];}
+        /*! Returns a constant reference to the value at index \a i. */
+        const double &operator[](int i) const {
+            return vec[i];
+        }
 
-  /*! Returns a reference to the value at index \a i. */
-  double& operator[](int i) {return vec[i];}
+        /*! Returns a reference to the value at index \a i. */
+        double &operator[](int i) {
+            return vec[i];
+        }
 
-  /*! Copies vector \a v. */
-  void set(const vec3& v) {vec[0] = v[0]; vec[1] = v[1]; vec[2] = v[2];}
-  
-  /*! Sets the 3 values in this vector to the 3 values in the array \a v. */
-  void set(double v[3])   {vec[0] = v[0]; vec[1] = v[1]; vec[2] = v[2];}
+        /*! Copies vector \a v. */
+        void set(const vec3 &v) {
+            vec[0] = v[0];
+            vec[1] = v[1];
+            vec[2] = v[2];
+        }
 
-  /*! Sets the 3 values in this vector to \a x, \a y, \a z. */
-  void set(double x,double y,double z) {vec[0] = x; vec[1] = y; vec[2] = z;}
+        /*! Sets the 3 values in this vector to the 3 values in the array \a v. */
+        void set(double v[3])   {
+            vec[0] = v[0];
+            vec[1] = v[1];
+            vec[2] = v[2];
+        }
 
-  inline double len() const;
-  inline double len_sq() const;
+        /*! Sets the 3 values in this vector to \a x, \a y, \a z. */
+        void set(double x, double y, double z) {
+            vec[0] = x;
+            vec[1] = y;
+            vec[2] = z;
+        }
 
-  inline void set(const SbVec3f &v);  
-  inline void toSbVec3f(SbVec3f &v) const;
-  inline SbVec3f toSbVec3f() const;
+        inline double len() const;
+        inline double len_sq() const;
 
-  // input output
+        inline void set(const SbVec3f &v);
+        inline void toSbVec3f(SbVec3f &v) const;
+        inline SbVec3f toSbVec3f() const;
 
-  inline vec3 const& operator=(vec3 const& v);
-  inline vec3 const& operator*=(double s);
-  //  inline vec3 const& operator*=(mat3 const& m);
-  //inline vec3 const& operator*=(transf const& t);
-  inline vec3 const& operator+=(vec3 const& v);
-  inline vec3 const& operator-=(vec3 const& v);
-  inline vec3 const& operator/=(double s);
-  inline bool operator==(vec3 const& v) const;
-  inline bool operator<(vec3 const& v) const;
+        // input output
 
-  /*! Returns the x-coordinate of this vector. */
-  double x() const {return vec[0];}
+        inline vec3 const &operator=(vec3 const &v);
+        inline vec3 const &operator*=(double s);
+        //  inline vec3 const& operator*=(mat3 const& m);
+        //inline vec3 const& operator*=(transf const& t);
+        inline vec3 const &operator+=(vec3 const &v);
+        inline vec3 const &operator-=(vec3 const &v);
+        inline vec3 const &operator/=(double s);
+        inline bool operator==(vec3 const &v) const;
+        inline bool operator<(vec3 const &v) const;
 
-  /*! Returns the y-coordinate of this vector. */
-  double y() const {return vec[1];}
+        /*! Returns the x-coordinate of this vector. */
+        double x() const {
+            return vec[0];
+        }
 
-  /*! Returns the z-coordinate of this vector. */
-  double z() const {return vec[2];}
+        /*! Returns the y-coordinate of this vector. */
+        double y() const {
+            return vec[1];
+        }
 
-  /*! Returns a reference to the x-coordinate of this vector. */
-  double& x() {return vec[0];}
+        /*! Returns the z-coordinate of this vector. */
+        double z() const {
+            return vec[2];
+        }
 
-  /*! Returns a reference to the y-coordinate of this vector. */
-  double& y() {return vec[1];}
+        /*! Returns a reference to the x-coordinate of this vector. */
+        double &x() {
+            return vec[0];
+        }
 
-  /*! Returns a reference to the z-coordinate of this vector. */
-  double& z() {return vec[2];}  
+        /*! Returns a reference to the y-coordinate of this vector. */
+        double &y() {
+            return vec[1];
+        }
+
+        /*! Returns a reference to the z-coordinate of this vector. */
+        double &z() {
+            return vec[2];
+        }
 
 
-  void perpVectors(vec3 &v1,vec3 &v2); 
+        void perpVectors(vec3 &v1, vec3 &v2);
 
-  /*  friend double operator%(position const& p, vec3 const& v);
-      friend double operator%(vec3 const& v, position const& p);*/
+        /*  friend double operator%(position const& p, vec3 const& v);
+            friend double operator%(vec3 const& v, position const& p);*/
 
-  friend inline double operator%(vec3 const& v1, vec3 const& v2);  // dot prod
-  friend inline double operator%(position const& p, vec3 const& v);
-  friend inline double operator%(vec3 const& v, position const& p);
-  friend inline vec3   operator*(double s, vec3 const& v);
-  friend inline vec3   operator*(vec3 const& v, double s);
-  friend inline vec3   operator*(mat3 const& m, vec3 const& v);
+        friend inline double operator%(vec3 const &v1, vec3 const &v2);  // dot prod
+        friend inline double operator%(position const &p, vec3 const &v);
+        friend inline double operator%(vec3 const &v, position const &p);
+        friend inline vec3   operator*(double s, vec3 const &v);
+        friend inline vec3   operator*(vec3 const &v, double s);
+        friend inline vec3   operator*(mat3 const &m, vec3 const &v);
 
-  friend inline vec3   operator*(vec3 const& v, transf const& tr);
-  friend inline vec3   operator>(vec3 const& v, transf const& tr);
-  friend inline vec3   operator*(vec3 const& v1, vec3 const& v2);  // cross
-  friend inline vec3   operator+(vec3 const& v1, vec3 const& v2);
-  friend inline vec3   operator-(vec3 const& v1, vec3 const& v2);
-  friend inline vec3   operator-(vec3 const& v);  
-  friend inline vec3   operator/(vec3 const& v, double s);
-  friend inline vec3   normalise(vec3 const& v);
+        friend inline vec3   operator*(vec3 const &v, transf const &tr);
+        friend inline vec3   operator>(vec3 const &v, transf const &tr);
+        friend inline vec3   operator*(vec3 const &v1, vec3 const &v2);  // cross
+        friend inline vec3   operator+(vec3 const &v1, vec3 const &v2);
+        friend inline vec3   operator-(vec3 const &v1, vec3 const &v2);
+        friend inline vec3   operator-(vec3 const &v);
+        friend inline vec3   operator/(vec3 const &v, double s);
+        friend inline vec3   normalise(vec3 const &v);
 
-  friend std::istream &operator>>(std::istream &is, vec3 &v);
-  friend std::ostream &operator<<(std::ostream &os, const vec3 &v);
+        friend std::istream &operator>>(std::istream &is, vec3 &v);
+        friend std::ostream &operator<<(std::ostream &os, const vec3 &v);
 
-  //! The vector [0,0,0]
-  static const vec3 ZERO;
+        //! The vector [0,0,0]
+        static const vec3 ZERO;
 
-  //! The vector [1,0,0]
-  static const vec3 X;
+        //! The vector [1,0,0]
+        static const vec3 X;
 
-  //! The vector [0,1,0]
-  static const vec3 Y;
+        //! The vector [0,1,0]
+        static const vec3 Y;
 
-  //! The vector [0,0,1]
-  static const vec3 Z;
+        //! The vector [0,0,1]
+        static const vec3 Z;
 };
 
 
 //! A 3-dimensional position and methods to operate on them.
 /*!
-  position is stored as an array of 3 doubles.
- */
+    position is stored as an array of 3 doubles.
+*/
 class position {
 
-  //! Storarge for the 3 position coordinates.
-  double pos[3];
+        //! Storarge for the 3 position coordinates.
+        double pos[3];
 
-public:
+    public:
 
-  /*!  Default constructor, position is uninitialized. */
-  position() {}
+        /*!  Default constructor, position is uninitialized. */
+        position() {}
 
-  /*! Copy constructor. */
-  position(const position& p) {set(p);}
+        /*! Copy constructor. */
+        position(const position &p) {
+            set(p);
+        }
 
-  /*! Initializes the position with the three values in the array \a v. */
-  position(double p[3])       {set(p);}
+        /*! Initializes the position with the three values in the array \a v. */
+        position(double p[3])       {
+            set(p);
+        }
 
-  /*! Initializes the vector with the values from the Inventor vector \a v. */
-  position(const SbVec3f& p)  {set(p);}
+        /*! Initializes the vector with the values from the Inventor vector \a v. */
+        position(const SbVec3f &p)  {
+            set(p);
+        }
 
-  /*! Initializes the vector with the values \a x, \a y, \a z. */
-  position(double x,double y,double z) {set(x,y,z);}
-    
-  /*! Returns a constant reference to the value at index \a i. */
-  const double& operator[](int i) const {return pos[i];}
+        /*! Initializes the vector with the values \a x, \a y, \a z. */
+        position(double x, double y, double z) {
+            set(x, y, z);
+        }
 
-  /*! Returns a reference to the value at index \a i. */
-  double& operator[](int i) {return pos[i];}
+        /*! Returns a constant reference to the value at index \a i. */
+        const double &operator[](int i) const {
+            return pos[i];
+        }
 
-  /*! Copies vector \a v. */
-  void set(const position& p) {pos[0] = p[0]; pos[1] = p[1]; pos[2] = p[2];}
+        /*! Returns a reference to the value at index \a i. */
+        double &operator[](int i) {
+            return pos[i];
+        }
 
-  /*! Sets the 3 values in this vector to the 3 values in the array \a v. */
-  void set(double p[3])       {pos[0] = p[0]; pos[1] = p[1]; pos[2] = p[2];}
+        /*! Copies vector \a v. */
+        void set(const position &p) {
+            pos[0] = p[0];
+            pos[1] = p[1];
+            pos[2] = p[2];
+        }
 
-  /*! Sets the 3 values in this vector to \a x, \a y, \a z. */
-  void set(double x,double y,double z) {pos[0] = x; pos[1] = y; pos[2] = z;}
+        /*! Sets the 3 values in this vector to the 3 values in the array \a v. */
+        void set(double p[3])       {
+            pos[0] = p[0];
+            pos[1] = p[1];
+            pos[2] = p[2];
+        }
 
-  void set(const vec3 &v){pos[0] = v.x(); pos[1] = v.y(); pos[2] = v.z();}
+        /*! Sets the 3 values in this vector to \a x, \a y, \a z. */
+        void set(double x, double y, double z) {
+            pos[0] = x;
+            pos[1] = y;
+            pos[2] = z;
+        }
 
-  /*! Gets the 3 values that make up this position */
-  void get(double p[3]) const {p[0] = pos[0]; p[1] = pos[1]; p[2] = pos[2];}
+        void set(const vec3 &v) {
+            pos[0] = v.x();
+            pos[1] = v.y();
+            pos[2] = v.z();
+        }
 
-  inline void set(const SbVec3f &v);
-  inline void toSbVec3f(SbVec3f &v) const;
-  inline SbVec3f toSbVec3f() const;
+        /*! Gets the 3 values that make up this position */
+        void get(double p[3]) const {
+            p[0] = pos[0];
+            p[1] = pos[1];
+            p[2] = pos[2];
+        }
 
-  // input output
+        inline void set(const SbVec3f &v);
+        inline void toSbVec3f(SbVec3f &v) const;
+        inline SbVec3f toSbVec3f() const;
 
-  inline position const& operator=(position const& p);
-  //  inline position const& operator*=(mat3 const& m);
-  //  inline position const& operator*=(transf const& tr);
-  inline position const& operator+=(vec3 const& v);
-  inline position const& operator-=(vec3 const& v);
-  inline bool operator==(position const& p) const;
+        // input output
 
-  /*! Returns the x-coordinate of this vector. */  
-  double x() const {return pos[0];}
+        inline position const &operator=(position const &p);
+        //  inline position const& operator*=(mat3 const& m);
+        //  inline position const& operator*=(transf const& tr);
+        inline position const &operator+=(vec3 const &v);
+        inline position const &operator-=(vec3 const &v);
+        inline bool operator==(position const &p) const;
 
-  /*! Returns the y-coordinate of this vector. */
-  double y() const {return pos[1];}
+        /*! Returns the x-coordinate of this vector. */
+        double x() const {
+            return pos[0];
+        }
 
-  /*! Returns the z-coordinate of this vector. */
-  double z() const {return pos[2];}
+        /*! Returns the y-coordinate of this vector. */
+        double y() const {
+            return pos[1];
+        }
 
-  /*! Returns a reference to the x-coordinate of this vector. */
-  double& x() {return pos[0];}
+        /*! Returns the z-coordinate of this vector. */
+        double z() const {
+            return pos[2];
+        }
 
-  /*! Returns a reference to the y-coordinate of this vector. */
-  double& y() {return pos[1];}
+        /*! Returns a reference to the x-coordinate of this vector. */
+        double &x() {
+            return pos[0];
+        }
 
-  /*! Returns a reference to the z-coordinate of this vector. */
-  double& z() {return pos[2];}  
+        /*! Returns a reference to the y-coordinate of this vector. */
+        double &y() {
+            return pos[1];
+        }
 
-  friend inline double     operator%(position const& p, vec3 const& v);  // dot
-  friend inline double     operator%(vec3 const& v, position const& p);  // dot
-  //  friend inline position   operator*(mat3 const& m, position const& p);
-  inline friend position   operator*(double d, position const& p);
-  inline friend position   operator*(position const& p, transf const& tr);
-  friend inline position   operator+(position const& p, vec3 const& v);
-  friend inline position   operator-(position const& p, vec3 const& v);
-  friend inline position   operator+(vec3 const& v, position const& p);
-  friend inline vec3       operator-(position const& p1, position const& p2);
-  friend inline position   operator+(position const& p1, position const& p2);
+        /*! Returns a reference to the z-coordinate of this vector. */
+        double &z() {
+            return pos[2];
+        }
 
-  friend std::istream&       operator>>(std::istream &is, position &p);
-  friend std::ostream&       operator<<(std::ostream &os, const position &p); 
+        friend inline double     operator%(position const &p, vec3 const &v);  // dot
+        friend inline double     operator%(vec3 const &v, position const &p);  // dot
+        //  friend inline position   operator*(mat3 const& m, position const& p);
+        inline friend position   operator*(double d, position const &p);
+        inline friend position   operator*(position const &p, transf const &tr);
+        friend inline position   operator+(position const &p, vec3 const &v);
+        friend inline position   operator-(position const &p, vec3 const &v);
+        friend inline position   operator+(vec3 const &v, position const &p);
+        friend inline vec3       operator-(position const &p1, position const &p2);
+        friend inline position   operator+(position const &p1, position const &p2);
 
-  //! The position [0,0,0].
-  static const position ORIGIN;
+        friend std::istream       &operator>>(std::istream &is, position &p);
+        friend std::ostream       &operator<<(std::ostream &os, const position &p);
+
+        //! The position [0,0,0].
+        static const position ORIGIN;
 };
 
 
 //! A 3x3 matrix most often used for storing rotations.
 /*!
-  The matrix is stored as a column-major array.
- */
+    The matrix is stored as a column-major array.
+*/
 class mat3 {
-  
-  //! Storage for the matrix
-  double mat[9];
 
-public:
+        //! Storage for the matrix
+        double mat[9];
 
-  /*! Default constructor, matrix is uninitialized. */
-  mat3() {}
+    public:
 
-  /*! Copy constructor. */  
-  mat3(const double M[9]) {set(M);}
+        /*! Default constructor, matrix is uninitialized. */
+        mat3() {}
 
-  /*! Initializes the rotation matrix using the quaternion \a q. */  
-  mat3(const Quaternion &q) {set(q);}
+        /*! Copy constructor. */
+        mat3(const double M[9]) {
+            set(M);
+        }
 
-  /*! Initializes the rotation matrix using the three column vectors \a v1,
-    \a v2, \a v3.*/
-  mat3(const vec3 &v1, const vec3 &v2, const vec3 &v3) {set(v1,v2,v3);}
+        /*! Initializes the rotation matrix using the quaternion \a q. */
+        mat3(const Quaternion &q) {
+            set(q);
+        }
 
-  /*! Copies the matrix \a M. */
-  void set(const double M[9]) {memcpy(mat,M,sizeof(double)*9);}
+        /*! Initializes the rotation matrix using the three column vectors \a v1,
+            \a v2, \a v3.*/
+        mat3(const vec3 &v1, const vec3 &v2, const vec3 &v3) {
+            set(v1, v2, v3);
+        }
 
-  inline void set(const Quaternion &q);
-  inline void set(const vec3 &v1, const vec3 &v2, const vec3 &v3);
+        /*! Copies the matrix \a M. */
+        void set(const double M[9]) {
+            memcpy(mat, M, sizeof(double) * 9);
+        }
 
-  inline void setCrossProductMatrix(const vec3 &v);
+        inline void set(const Quaternion &q);
+        inline void set(const vec3 &v1, const vec3 &v2, const vec3 &v3);
 
-  void ToEulerAngles(double &roll,double &pitch, double &yaw) const;
+        inline void setCrossProductMatrix(const vec3 &v);
 
-  /*! Return a constant reference to matrix element at row \a i, col \a j. */
-  const double& element(int i,int j) const {return mat[j*3+i];}
+        void ToEulerAngles(double &roll, double &pitch, double &yaw) const;
 
-  /*! Return a reference to matrix element at row \a i, col \a j. */
-        double& element(int i,int j)       {return mat[j*3+i];}
+        /*! Return a constant reference to matrix element at row \a i, col \a j. */
+        const double &element(int i, int j) const {
+            return mat[j * 3 + i];
+        }
 
-  /*! Return a constant reference to the i-th element (in column major
-    order)  of the matrix. */
-  const double& operator[](int i) const {return mat[i];}
-  /*! Return a reference to the i-th element (in column major order) of the
-      matrix. */
-        double& operator[](int i)       {return mat[i];}
+        /*! Return a reference to matrix element at row \a i, col \a j. */
+        double &element(int i, int j)       {
+            return mat[j * 3 + i];
+        }
 
-  /*! Return a copy of the i-th row of the matrix as a vector. */
-        vec3    row(int i) const {return vec3(mat[i],mat[i+3],mat[i+6]);}
-  
-  inline        double        determinant() const;
+        /*! Return a constant reference to the i-th element (in column major
+            order)  of the matrix. */
+        const double &operator[](int i) const {
+            return mat[i];
+        }
+        /*! Return a reference to the i-th element (in column major order) of the
+            matrix. */
+        double &operator[](int i)       {
+            return mat[i];
+        }
 
-  inline        mat3          transpose() const;
-                mat3          inverse() const;
+        /*! Return a copy of the i-th row of the matrix as a vector. */
+        vec3    row(int i) const {
+            return vec3(mat[i], mat[i + 3], mat[i + 6]);
+        }
 
-                mat3 const&   operator*=(mat3 const& m);
-		 friend vec3          operator*(mat3 const& m,  vec3 const& v);
-  //     friend position      operator*(mat3 const& m,  position const& p);
-	     friend vec3          operator*(vec3 const& v,  mat3 const& m);
-         friend mat3          operator*(mat3 const& m1, mat3 const& m2);
-  inline friend mat3          operator*(double const& s,  mat3 const& m);
-  inline mat3 const& operator+=(mat3 const& v);
+        inline        double        determinant() const;
 
-  friend std::istream&     operator>>(std::istream &is, mat3 &m);
-  friend std::ostream&     operator<<(std::ostream &os, const mat3 &m);  
+        inline        mat3          transpose() const;
+        mat3          inverse() const;
+
+        mat3 const   &operator*=(mat3 const &m);
+        friend vec3          operator*(mat3 const &m,  vec3 const &v);
+        //     friend position      operator*(mat3 const& m,  position const& p);
+        friend vec3          operator*(vec3 const &v,  mat3 const &m);
+        friend mat3          operator*(mat3 const &m1, mat3 const &m2);
+        inline friend mat3          operator*(double const &s,  mat3 const &m);
+        inline mat3 const &operator+=(mat3 const &v);
+
+        friend std::istream     &operator>>(std::istream &is, mat3 &m);
+        friend std::ostream     &operator<<(std::ostream &os, const mat3 &m);
 
 
-  //! A 3x3 zero matrix.
-  static const mat3 ZERO;
-  
-  //! A 3x3 identity matrix.
-  static const mat3 IDENTITY;  
+        //! A 3x3 zero matrix.
+        static const mat3 ZERO;
+
+        //! A 3x3 identity matrix.
+        static const mat3 IDENTITY;
 };
 
 //! A 4-dimensional unit vector used to store a rotation
 /*!
-  Quaternions are an efficient way to store and manipulate rotations.
- */
+    Quaternions are an efficient way to store and manipulate rotations.
+*/
 class Quaternion {
-public:
-  //! The four scalar components of a quaternion
-  double w, x, y, z;
-  
-  /*! Default constructor, Quaternion is initialized to an identity rotation */
-  Quaternion () : w(1.0),x(0.0),y(0.0),z(0.0) {}
+    public:
+        //! The four scalar components of a quaternion
+        double w, x, y, z;
 
-  /*! Initializes quaternion with 4 scalar values (automatically normalized).*/
-  Quaternion (double W, double X, double Y, double Z) {set(W,X,Y,Z);}
+        /*! Default constructor, Quaternion is initialized to an identity rotation */
+        Quaternion() : w(1.0), x(0.0), y(0.0), z(0.0) {}
 
-  /*! Initializes quaternion using a rotation matrix \a R. */
-  Quaternion (const mat3& R) {set(R);}
+        /*! Initializes quaternion with 4 scalar values (automatically normalized).*/
+        Quaternion(double W, double X, double Y, double Z) {
+            set(W, X, Y, Z);
+        }
 
-  /*! Initializes quaternion using a rotation exressed as in angle and axis
-      format. */
-  Quaternion (const double& angle, const vec3 &axis) {set(angle,axis);}
+        /*! Initializes quaternion using a rotation matrix \a R. */
+        Quaternion(const mat3 &R) {
+            set(R);
+        }
 
-  /*! Copies the values of quaterion Q. */
-  void set(const Quaternion& Q)
-    {w = Q.w; x = Q.x; y = Q.y; z = Q.z;}
+        /*! Initializes quaternion using a rotation exressed as in angle and axis
+            format. */
+        Quaternion(const double &angle, const vec3 &axis) {
+            set(angle, axis);
+        }
 
-  /*! Sets the value of the quaternion using 4 scalars and normalizes it. */
-  void set(double W, double X, double Y, double Z)
-    {w = W; x = X; y = Y; z = Z; normalise();}
+        /*! Copies the values of quaterion Q. */
+        void set(const Quaternion &Q) {
+            w = Q.w;
+            x = Q.x;
+            y = Q.y;
+            z = Q.z;
+        }
 
-  void set(const mat3& R);
-  void set(const double& angle, const vec3 &axis);
-  void set(const SbRotation &SbRot);
-  void set(const vec3 &start, const vec3 &dest);
+        /*! Sets the value of the quaternion using 4 scalars and normalizes it. */
+        void set(double W, double X, double Y, double Z) {
+            w = W;
+            x = X;
+            y = Y;
+            z = Z;
+            normalise();
+        }
 
-  void ToRotationMatrix (mat3& m) const;  
-  void ToAngleAxis (double& angle, vec3& axis) const;
-  inline SbRotation toSbRotation() const;
+        void set(const mat3 &R);
+        void set(const double &angle, const vec3 &axis);
+        void set(const SbRotation &SbRot);
+        void set(const vec3 &start, const vec3 &dest);
 
-  // arithmetic operations
-  inline Quaternion& operator= (const Quaternion& q);
-  inline Quaternion operator+ (const Quaternion& q) const;
-  inline Quaternion operator- (const Quaternion& q) const;
-  inline Quaternion operator* (const Quaternion& q) const;
-  //inline Quaternion operator* (double c) const;
-  inline Quaternion operator- () const;
-  inline double     operator% (const Quaternion& q) const;  // dot product 
-  //  inline friend Quaternion operator* (double c, const Quaternion& q);
-  inline bool operator==(Quaternion const& q) const;
+        void ToRotationMatrix(mat3 &m) const;
+        void ToAngleAxis(double &angle, vec3 &axis) const;
+        inline SbRotation toSbRotation() const;
 
-  // functions of a quaternion
-  inline double norm () const;  // squared-length of quaternion
-  inline Quaternion inverse () const;  // apply to unit quaternion
-  
-  // rotation of a vector by a quaternion
-  inline vec3 operator* (const vec3& v) const;
-  
-  // rotation of a position by a quaternion
-  inline position operator* (const position& pt) const;
-  
-  // spherical linear interpolation
-  static Quaternion Slerp (double t, const Quaternion& p,
-			   const Quaternion& q);
-  
-  // setup for spherical quadratic interpolation
-  static void Intermediate (const Quaternion& q0, const Quaternion& q1,
-			    const Quaternion& q2, Quaternion& a, Quaternion& b);
-  
-  // spherical quadratic interpolation
-  static Quaternion Squad (double t, const Quaternion& p,
-			   const Quaternion& a, const Quaternion& b, const Quaternion& q);
-  
-  inline void normalise();
-  
-  friend std::istream& operator>>(std::istream &is, Quaternion &q);
-  friend std::ostream& operator<<(std::ostream &os, const Quaternion &q);
-  
-  //! An identity rotation [1,0,0,0]
-  static const Quaternion IDENTITY;
+        // arithmetic operations
+        inline Quaternion &operator= (const Quaternion &q);
+        inline Quaternion operator+ (const Quaternion &q) const;
+        inline Quaternion operator- (const Quaternion &q) const;
+        inline Quaternion operator* (const Quaternion &q) const;
+        //inline Quaternion operator* (double c) const;
+        inline Quaternion operator- () const;
+        inline double     operator% (const Quaternion &q) const;  // dot product
+        //  inline friend Quaternion operator* (double c, const Quaternion& q);
+        inline bool operator==(Quaternion const &q) const;
+
+        // functions of a quaternion
+        inline double norm() const;   // squared-length of quaternion
+        inline Quaternion inverse() const;   // apply to unit quaternion
+
+        // rotation of a vector by a quaternion
+        inline vec3 operator* (const vec3 &v) const;
+
+        // rotation of a position by a quaternion
+        inline position operator* (const position &pt) const;
+
+        // spherical linear interpolation
+        static Quaternion Slerp(double t, const Quaternion &p,
+                                const Quaternion &q);
+
+        // setup for spherical quadratic interpolation
+        static void Intermediate(const Quaternion &q0, const Quaternion &q1,
+                                 const Quaternion &q2, Quaternion &a, Quaternion &b);
+
+        // spherical quadratic interpolation
+        static Quaternion Squad(double t, const Quaternion &p,
+                                const Quaternion &a, const Quaternion &b, const Quaternion &q);
+
+        inline void normalise();
+
+        friend std::istream &operator>>(std::istream &is, Quaternion &q);
+        friend std::ostream &operator<<(std::ostream &os, const Quaternion &q);
+
+        //! An identity rotation [1,0,0,0]
+        static const Quaternion IDENTITY;
 
 };
 
 //! A rigid body transformation
 /*!
-  The transform is stored as a rotation quaternion and a translation vector.
-  A rotation matrix version is also stored so that it does not need to be
-  recomputed each time it is requested.  (This maybe eliminated at some point).
- */
+    The transform is stored as a rotation quaternion and a translation vector.
+    A rotation matrix version is also stored so that it does not need to be
+    recomputed each time it is requested.  (This maybe eliminated at some point).
+*/
 class transf {
 
-  //! A 3x3 matrix storing the current rotation
-  mat3 R;
+        //! A 3x3 matrix storing the current rotation
+        mat3 R;
 
-  //! A 3x1 vector storing the current translation
-  vec3 t;
+        //! A 3x1 vector storing the current translation
+        vec3 t;
 
-  //! A 4x1 Quaternion storing the current rotation
-  Quaternion rot;
+        //! A 4x1 Quaternion storing the current rotation
+        Quaternion rot;
 
-public:
+    public:
 
-  /*! Default constructor, initializes the transform to the identity */
-  transf() {R = mat3::IDENTITY; t = vec3::ZERO; rot = Quaternion::IDENTITY;}
+        /*! Default constructor, initializes the transform to the identity */
+        transf() {
+            R = mat3::IDENTITY;
+            t = vec3::ZERO;
+            rot = Quaternion::IDENTITY;
+        }
 
-  /*! Initializes transform with a rotation quaternion and translation vector*/
-  transf(const Quaternion& r, const vec3& d) {set(r,d);}
+        /*! Initializes transform with a rotation quaternion and translation vector*/
+        transf(const Quaternion &r, const vec3 &d) {
+            set(r, d);
+        }
 
-  /*! Initializes transform with a rotation matrix and translation vector */
-  transf(const mat3& r, const vec3& d) {set(r,d);}
+        /*! Initializes transform with a rotation matrix and translation vector */
+        transf(const mat3 &r, const vec3 &d) {
+            set(r, d);
+        }
 
-  /*! Initializes transform using an Inventor transform. */
-  transf(const SoTransform *IVt) {set(IVt);}
+        /*! Initializes transform using an Inventor transform. */
+        transf(const SoTransform *IVt) {
+            set(IVt);
+        }
 
-  /*! Sets value of the transform with the rotation \a r and the translation
-    \a d */
-  void set(const Quaternion& r, const vec3& d) {
-    rot = r; t = d; rot.ToRotationMatrix(R);
-  }
-  
-  /*! Sets value of the transform with the rotation \a r and the translation
-    \a d */
-  void set(const mat3& r, const vec3& d) {rot.set(r); t = d; R = r;}
+        /*! Sets value of the transform with the rotation \a r and the translation
+            \a d */
+        void set(const Quaternion &r, const vec3 &d) {
+            rot = r;
+            t = d;
+            rot.ToRotationMatrix(R);
+        }
 
-  inline void set(const SoTransform *IVt);
+        /*! Sets value of the transform with the rotation \a r and the translation
+            \a d */
+        void set(const mat3 &r, const vec3 &d) {
+            rot.set(r);
+            t = d;
+            R = r;
+        }
 
-  /*! Returns the rotation portion of the transform. */
-  const Quaternion& rotation() const {return rot;}
+        inline void set(const SoTransform *IVt);
 
-  /*! Returns the rotation portion of the transform as a 3x3 matrix. */
-  const mat3& affine() const {return R;}
+        /*! Returns the rotation portion of the transform. */
+        const Quaternion &rotation() const {
+            return rot;
+        }
 
-  /*! Returns the translation portion of the transform. */
-  const vec3& translation() const {return t;}
+        /*! Returns the rotation portion of the transform as a 3x3 matrix. */
+        const mat3 &affine() const {
+            return R;
+        }
 
-  inline void toSoTransform(SoTransform *IVt) const;
-  inline void tocol_Mat4(col_Mat4 colTran) const;
-  inline void toColMajorMatrix(double t[][4]) const;
-  inline void toRowMajorMatrix(double t[][4]) const;
-  //! Creates a 6x6 jacobian from this transform
-  void jacobian(double jac[]);
-  
-  inline transf          inverse() const;
-  
-  inline transf const&   operator=(transf const& tr);
-  inline bool operator==(transf const& tr) const;
-  
-  /*! Returns the negation of the == operator. */
-  inline bool operator!=(transf const& tr) const {return !operator==(tr);}
+        /*! Returns the translation portion of the transform. */
+        const vec3 &translation() const {
+            return t;
+        }
+
+        inline void toSoTransform(SoTransform *IVt) const;
+        inline void tocol_Mat4(col_Mat4 colTran) const;
+        inline void toColMajorMatrix(double t[][4]) const;
+        inline void toRowMajorMatrix(double t[][4]) const;
+        //! Creates a 6x6 jacobian from this transform
+        void jacobian(double jac[]);
+
+        inline transf          inverse() const;
+
+        inline transf const   &operator=(transf const &tr);
+        inline bool operator==(transf const &tr) const;
+
+        /*! Returns the negation of the == operator. */
+        inline bool operator!=(transf const &tr) const {
+            return !operator==(tr);
+        }
 
 
-  //  inline transf const&   operator*=(transf const& tr);
+        //  inline transf const&   operator*=(transf const& tr);
 
-  inline friend transf   operator*(transf const& tr1,  transf const& tr2);
-  inline friend vec3     operator*(vec3 const& v, transf const& tr);
-  inline friend vec3     operator>(vec3 const& v, transf const& tr);
-  inline friend position operator*(position const& p, transf const& tr);
+        inline friend transf   operator*(transf const &tr1,  transf const &tr2);
+        inline friend vec3     operator*(vec3 const &v, transf const &tr);
+        inline friend vec3     operator>(vec3 const &v, transf const &tr);
+        inline friend position operator*(position const &p, transf const &tr);
 
 
-  inline friend transf translate_transf(const vec3& v);
-  inline friend transf rotate_transf(double angle, const vec3& axis);
-  inline friend transf coordinate_transf(const position& origin,
-					 const vec3& xaxis, const vec3& yaxis);
-  inline friend transf rotXYZ(double, double, double);
+        inline friend transf translate_transf(const vec3 &v);
+        inline friend transf rotate_transf(double angle, const vec3 &axis);
+        inline friend transf coordinate_transf(const position &origin,
+                                               const vec3 &xaxis, const vec3 &yaxis);
+        inline friend transf rotXYZ(double, double, double);
 
-  friend std::istream& operator>>(std::istream &is, transf &tr);
-  friend std::ostream& operator<<(std::ostream &os, const transf &tr);
+        friend std::istream &operator>>(std::istream &is, transf &tr);
+        friend std::ostream &operator<<(std::ostream &os, const transf &tr);
 
-  //! The Identity transform (1,0,0,0)[0,0,0]
-  static const transf IDENTITY;
+        //! The Identity transform (1,0,0,0)[0,0,0]
+        static const transf IDENTITY;
 };
 
 //! A class for easy storage and manipulation of Flock of Birds transform
 /*! A Flock of Birds transform, when applied to a robot or object
-	in GraspIt! has to take into account where the sensor is mounted
-	on the robot. It must also be able to use the flock transform in 
-	relative terms, so we get the movement of the GraspIt body, but not
-	in absolute terms. This class stores all of that conveniently.
+    in GraspIt! has to take into account where the sensor is mounted
+    on the robot. It must also be able to use the flock transform in
+    relative terms, so we get the movement of the GraspIt body, but not
+    in absolute terms. This class stores all of that conveniently.
 
-	Assume that, at the moment where we start measuring, the object's
-	transform is Ob and the Flock transform ir Fb. The transform from 
-	object origin to sensor mount location is M.
+    Assume that, at the moment where we start measuring, the object's
+    transform is Ob and the Flock transform ir Fb. The transform from
+    object origin to sensor mount location is M.
 
-	At a given time, we read from the Flock sensor the transform F. What
-	is the correct GraspIt transform for the body?
+    At a given time, we read from the Flock sensor the transform F. What
+    is the correct GraspIt transform for the body?
 
-	- in relative operation: MInv * F * FbInv * M * Ob
+    - in relative operation: MInv * F * FbInv * M * Ob
 
-	- in absolute operation: MInv * F
+    - in absolute operation: MInv * F
 */
-class FlockTransf{
-private:
-	transf mount, mountInv;
-	transf flockBaseInv, objBase;
+class FlockTransf {
+    private:
+        transf mount, mountInv;
+        transf flockBaseInv, objBase;
 
-public:
-	void identity();
-	//! Set the tranform from object origin to sensor mounting location
-	void setMount(transf t){mount = t; mountInv = t.inverse();}
-	//! Set the base flock transform, that all subsequent flock transforms are relative to
-	void setFlockBase(transf t){flockBaseInv = t.inverse();}
-	//! Set the base object transform, the one that corresponds to the base flock trasnform
-	void setObjectBase(transf t){objBase = t;}
-	//! Get the object's GraspIt transform for a give flock transform read from the sensor
-	transf get(transf t) const;
-	//! Get the object's GraspIt transform if we are operating in absolute terms
-	transf getAbsolute(transf t) const;
-	//! Get the object transform in relative terms, but without factoring in a mount transform
-	transf get2(transf t) const;
-	transf getMount() const {return mount;}
+    public:
+        void identity();
+        //! Set the tranform from object origin to sensor mounting location
+        void setMount(transf t) {
+            mount = t;
+            mountInv = t.inverse();
+        }
+        //! Set the base flock transform, that all subsequent flock transforms are relative to
+        void setFlockBase(transf t) {
+            flockBaseInv = t.inverse();
+        }
+        //! Set the base object transform, the one that corresponds to the base flock trasnform
+        void setObjectBase(transf t) {
+            objBase = t;
+        }
+        //! Get the object's GraspIt transform for a give flock transform read from the sensor
+        transf get(transf t) const;
+        //! Get the object's GraspIt transform if we are operating in absolute terms
+        transf getAbsolute(transf t) const;
+        //! Get the object transform in relative terms, but without factoring in a mount transform
+        transf get2(transf t) const;
+        transf getMount() const {
+            return mount;
+        }
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -548,246 +694,232 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 
 /*!
-  Sets the values in this vector with the values from the Inventor vector \a v.
- */
-void
-vec3::set(const SbVec3f &v)
-{
-  vec[0] = (double) v[0];
-  vec[1] = (double) v[1];
-  vec[2] = (double) v[2];
-}
-
-/*!
-  Converts the values of this vector into floats and stores them in the
-  provided Inventor vector.
+    Sets the values in this vector with the values from the Inventor vector \a v.
 */
 void
-vec3::toSbVec3f(SbVec3f &v) const
-{
-  v[0] = (float) vec[0];
-  v[1] = (float) vec[1];
-  v[2] = (float) vec[2];
+vec3::set(const SbVec3f &v) {
+    vec[0] = (double) v[0];
+    vec[1] = (double) v[1];
+    vec[2] = (double) v[2];
 }
 
 /*!
-  Converts this vector into an Inventor vector and returns it.
+    Converts the values of this vector into floats and stores them in the
+    provided Inventor vector.
+*/
+void
+vec3::toSbVec3f(SbVec3f &v) const {
+    v[0] = (float) vec[0];
+    v[1] = (float) vec[1];
+    v[2] = (float) vec[2];
+}
+
+/*!
+    Converts this vector into an Inventor vector and returns it.
 */
 SbVec3f
-vec3::toSbVec3f() const
-{
-  return SbVec3f((float) vec[0],(float) vec[1],(float) vec[2]);
+vec3::toSbVec3f() const {
+    return SbVec3f((float) vec[0], (float) vec[1], (float) vec[2]);
 }
 
 /*!
-  Returns the dot product of vectors \a v1 and \a v2.
+    Returns the dot product of vectors \a v1 and \a v2.
 */
 double
-operator%(vec3 const& v1, vec3 const& v2)
-{
-  return v1.vec[0]*v2.vec[0] + v1.vec[1]*v2.vec[1] + v1.vec[2]*v2.vec[2];
+operator%(vec3 const &v1, vec3 const &v2) {
+    return v1.vec[0] * v2.vec[0] + v1.vec[1] * v2.vec[1] + v1.vec[2] * v2.vec[2];
 }
 
 /*!
-  Returns a new vector that is the result of scaling this vector by \a s.
+    Returns a new vector that is the result of scaling this vector by \a s.
 */
 vec3
-operator*(double s, vec3 const& v)
-{
-  return vec3(s*v.vec[0],s*v.vec[1],s*v.vec[2]);
+operator*(double s, vec3 const &v) {
+    return vec3(s * v.vec[0], s * v.vec[1], s * v.vec[2]);
 }
 
 /*!
-  Returns a new vector that is the result of scaling this vector by \a s.
-*/ 
+    Returns a new vector that is the result of scaling this vector by \a s.
+*/
 vec3
-operator*(vec3 const& v, double s)
-{
-  return vec3(s*v.vec[0],s*v.vec[1],s*v.vec[2]);
+operator*(vec3 const &v, double s) {
+    return vec3(s * v.vec[0], s * v.vec[1], s * v.vec[2]);
 }
 
 /*!
-  Returns the length of this vector.
+    Returns the length of this vector.
 */
 double
-vec3::len() const
-{
-  return sqrt(vec[0]*vec[0] + vec[1]*vec[1] + vec[2]*vec[2]);
+vec3::len() const {
+    return sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
 }
 
 /*!
-  Returns the squared length of this vector.
+    Returns the squared length of this vector.
 */
 double
-vec3::len_sq() const
-{
-  return vec[0]*vec[0] + vec[1]*vec[1] + vec[2]*vec[2];
+vec3::len_sq() const {
+    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2];
 }
 
 /*! Copies the vector \a v. */
-vec3 const&
-vec3::operator=(vec3 const& v)
-{
-  vec[0] = v[0]; vec[1] = v[1]; vec[2] = v[2];
-  return *this;
+vec3 const &
+vec3::operator=(vec3 const &v) {
+    vec[0] = v[0];
+    vec[1] = v[1];
+    vec[2] = v[2];
+    return *this;
 }
 
 /*! Scales this vector by \a s. */
-vec3 const&
-vec3::operator*=(double s)
-{
-  vec[0] *= s;   vec[1] *= s;   vec[2] *= s;
-  return *this;
+vec3 const &
+vec3::operator*=(double s) {
+    vec[0] *= s;
+    vec[1] *= s;
+    vec[2] *= s;
+    return *this;
 }
 
-/* 
-// Not used right now.
-vec3 const&
-vec3::operator*=(mat3 const& m)
-{
-  double v[3];
-  memcpy(v,vec,3*sizeof(double));
+/*
+    // Not used right now.
+    vec3 const&
+    vec3::operator*=(mat3 const& m)
+    {
+    double v[3];
+    memcpy(v,vec,3*sizeof(double));
 
-  vec[0] = m[0] * v[0] + m[3] * v[1] + m[6] * v[2];
-  vec[1] = m[1] * v[0] + m[4] * v[1] + m[7] * v[2];
-  vec[2] = m[2] * v[0] + m[5] * v[1] + m[8] * v[2];
-  return *this;
-}
+    vec[0] = m[0] * v[0] + m[3] * v[1] + m[6] * v[2];
+    vec[1] = m[1] * v[0] + m[4] * v[1] + m[7] * v[2];
+    vec[2] = m[2] * v[0] + m[5] * v[1] + m[8] * v[2];
+    return *this;
+    }
 */
 
 /*! Adds vector \a v to this vector. */
-vec3 const&
-vec3::operator+=(vec3 const& v)
-{
-  vec[0] += v[0]; vec[1] += v[1]; vec[2] += v[2];
-  return *this;
+vec3 const &
+vec3::operator+=(vec3 const &v) {
+    vec[0] += v[0];
+    vec[1] += v[1];
+    vec[2] += v[2];
+    return *this;
 }
 
 /*! Subtract vector \a v from this vector. */
-vec3 const&
-vec3::operator-=(vec3 const& v)
-{
-  vec[0] -= v[0]; vec[1] -= v[1]; vec[2] -= v[2];
-  return *this;
+vec3 const &
+vec3::operator-=(vec3 const &v) {
+    vec[0] -= v[0];
+    vec[1] -= v[1];
+    vec[2] -= v[2];
+    return *this;
 }
 
 /*! Scales this vector by 1/s. */
-vec3 const&
-vec3::operator/=(double s)
-{
-  vec[0] /= s;   vec[1] /= s;   vec[2] /= s;
-  return *this;
+vec3 const &
+vec3::operator/=(double s) {
+    vec[0] /= s;
+    vec[1] /= s;
+    vec[2] /= s;
+    return *this;
 }
 
 /*! Compares if 2 vectors are within \a resabs distance from each other. */
 bool
-vec3::operator==(vec3 const& v) const
-{
-  if ((*this - v).len_sq() < resabs * resabs)
-    return true;
-  return false;
+vec3::operator==(vec3 const &v) const {
+    if ((*this - v).len_sq() < resabs * resabs)
+        return true;
+    return false;
 }
 
-/*! 
-  Compares 2 vectors lexigraphically.  Returns true if this vector comes
-  before vector \a v.  Vectors are ordered on z axis then y and then x. 
- */
+/*!
+    Compares 2 vectors lexigraphically.  Returns true if this vector comes
+    before vector \a v.  Vectors are ordered on z axis then y and then x.
+*/
 bool
-vec3::operator<(vec3 const& v) const
-{
-  double v0diff,v1diff,v2diff;
-  v2diff = vec[2]-v[2];  
-  if (v2diff < -resabs) return true;
-  else if (v2diff < resabs) {
-    v1diff = vec[1]-v[1];
-    if (v1diff < -resabs) return true;
-    else if (v1diff < resabs) {
-      v0diff = vec[0]-v[0];
-      if (v0diff < -resabs) return true;      
+vec3::operator<(vec3 const &v) const {
+    double v0diff, v1diff, v2diff;
+    v2diff = vec[2] - v[2];
+    if (v2diff < -resabs) return true;
+    else if (v2diff < resabs) {
+        v1diff = vec[1] - v[1];
+        if (v1diff < -resabs) return true;
+        else if (v1diff < resabs) {
+            v0diff = vec[0] - v[0];
+            if (v0diff < -resabs) return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 /*! Returns the dot product of vector \a v and position \a p. */
 double
-operator%(position const& p, vec3 const& v)
-{
-  return p.pos[0]*v.vec[0] + p.pos[1]*v.vec[1] + p.pos[2]*v.vec[2];
+operator%(position const &p, vec3 const &v) {
+    return p.pos[0] * v.vec[0] + p.pos[1] * v.vec[1] + p.pos[2] * v.vec[2];
 }
 
 /*! Returns the dot product of vector \a v and position \a p. */
 double
-operator%(vec3 const& v, position const& p)
-{
-  return p.pos[0]*v.vec[0] + p.pos[1]*v.vec[1] + p.pos[2]*v.vec[2];
+operator%(vec3 const &v, position const &p) {
+    return p.pos[0] * v.vec[0] + p.pos[1] * v.vec[1] + p.pos[2] * v.vec[2];
 }
 
 
 vec3
-operator*(const mat3 &m, const vec3 &v)
-{
-  double result[3];
-  result[0] = m[0] * v.vec[0] + m[3] * v.vec[1] + m[6] * v.vec[2];
-  result[1] = m[1] * v.vec[0] + m[4] * v.vec[1] + m[7] * v.vec[2];
-  result[2] = m[2] * v.vec[0] + m[5] * v.vec[1] + m[8] * v.vec[2];
-  return vec3(result);
+operator*(const mat3 &m, const vec3 &v) {
+    double result[3];
+    result[0] = m[0] * v.vec[0] + m[3] * v.vec[1] + m[6] * v.vec[2];
+    result[1] = m[1] * v.vec[0] + m[4] * v.vec[1] + m[7] * v.vec[2];
+    result[2] = m[2] * v.vec[0] + m[5] * v.vec[1] + m[8] * v.vec[2];
+    return vec3(result);
 }
 
 
 /*! Returns the cross product of vectors \a v1 and \a v2 ( \a v1 x \a v2 ). */
 vec3
-operator*(vec3 const& v1, vec3 const& v2)  // cross pr
-{
-  return vec3(v1.vec[1]*v2.vec[2]-v1.vec[2]*v2.vec[1],
-	      v1.vec[2]*v2.vec[0]-v1.vec[0]*v2.vec[2],
-	      v1.vec[0]*v2.vec[1]-v1.vec[1]*v2.vec[0]);
+operator*(vec3 const &v1, vec3 const &v2) { // cross pr
+    return vec3(v1.vec[1] * v2.vec[2] - v1.vec[2] * v2.vec[1],
+                v1.vec[2] * v2.vec[0] - v1.vec[0] * v2.vec[2],
+                v1.vec[0] * v2.vec[1] - v1.vec[1] * v2.vec[0]);
 }
 
 /*! Returns the sum of vectors \a v1 and \a v2. */
 vec3
-operator+(vec3 const& v1, vec3 const& v2)
-{
-  return vec3(v1.vec[0]+v2.vec[0],v1.vec[1]+v2.vec[1],v1.vec[2]+v2.vec[2]);
+operator+(vec3 const &v1, vec3 const &v2) {
+    return vec3(v1.vec[0] + v2.vec[0], v1.vec[1] + v2.vec[1], v1.vec[2] + v2.vec[2]);
 }
 
 
 /*! Returns the difference between vectors \a v1 and \a v2. */
 vec3
-operator-(vec3 const& v1, vec3 const& v2)
-{
-  return vec3(v1.vec[0]-v2.vec[0],v1.vec[1]-v2.vec[1],v1.vec[2]-v2.vec[2]);
+operator-(vec3 const &v1, vec3 const &v2) {
+    return vec3(v1.vec[0] - v2.vec[0], v1.vec[1] - v2.vec[1], v1.vec[2] - v2.vec[2]);
 }
- 
+
 
 /*! Returns a vector that is the negative of vector \a v. (unary minus) */
 vec3
-operator-(vec3 const& v)
-{
-  return vec3(-v.vec[0],-v.vec[1],-v.vec[2]);
+operator-(vec3 const &v) {
+    return vec3(-v.vec[0], -v.vec[1], -v.vec[2]);
 }
-  
+
 
 /*! Returns a new vector that is the result of scaling this vector by 1/s. */
 vec3
-operator/(vec3 const& v, double s)
-{
-  return vec3(v.vec[0]/s,v.vec[1]/s,v.vec[2]/s);
+operator/(vec3 const &v, double s) {
+    return vec3(v.vec[0] / s, v.vec[1] / s, v.vec[2] / s);
 }
 
 /*! Returns a new unit vector that is the normalized version of vector \a v. */
 vec3
-normalise(vec3 const& v)
-{
-  double length = v.len();
-#ifdef GRASPITDBG
-  if (length == 0.0)
-    printf("0 length in vec3 normalise\n");
-#endif
-  return v/length;
+normalise(vec3 const &v) {
+    double length = v.len();
+    #ifdef GRASPITDBG
+    if (length == 0.0)
+        printf("0 length in vec3 normalise\n");
+    #endif
+    return v / length;
 }
 
- 
+
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -795,137 +927,130 @@ normalise(vec3 const& v)
 ///////////////////////////////////////////////////////////////////////////////
 
 /*!
-  Sets the values in this vector with the values from the Inventor vector \a v.
- */
-void
-position::set(const SbVec3f &v)
-{
-  pos[0] = (double) v[0];
-  pos[1] = (double) v[1];
-  pos[2] = (double) v[2];
-}
-
-/*!
-  Converts the values of this vector into floats and stores them in the
-  provided Inventor vector.
+    Sets the values in this vector with the values from the Inventor vector \a v.
 */
 void
-position::toSbVec3f(SbVec3f &v) const
-{
-  v[0] = (float) pos[0];
-  v[1] = (float) pos[1];
-  v[2] = (float) pos[2];
+position::set(const SbVec3f &v) {
+    pos[0] = (double) v[0];
+    pos[1] = (double) v[1];
+    pos[2] = (double) v[2];
 }
 
 /*!
-  Converts this vector into an Inventor vector and returns it.
+    Converts the values of this vector into floats and stores them in the
+    provided Inventor vector.
+*/
+void
+position::toSbVec3f(SbVec3f &v) const {
+    v[0] = (float) pos[0];
+    v[1] = (float) pos[1];
+    v[2] = (float) pos[2];
+}
+
+/*!
+    Converts this vector into an Inventor vector and returns it.
 */
 SbVec3f
-position::toSbVec3f() const
-{
-  return SbVec3f((float) pos[0],(float) pos[1],(float) pos[2]);
+position::toSbVec3f() const {
+    return SbVec3f((float) pos[0], (float) pos[1], (float) pos[2]);
 }
 
 /*! Copies the position \a p. */
-position const&
-position::operator=(position const& p)
-{
-  pos[0] = p[0]; pos[1] = p[1]; pos[2] = p[2];
-  return *this;
+position const &
+position::operator=(position const &p) {
+    pos[0] = p[0];
+    pos[1] = p[1];
+    pos[2] = p[2];
+    return *this;
 }
 
 /*
-//not used
-position const&
-position::operator*=(mat3 const& m)
-{
-  double p[3];
-  memcpy(p,pos,3*sizeof(double));
+    //not used
+    position const&
+    position::operator*=(mat3 const& m)
+    {
+    double p[3];
+    memcpy(p,pos,3*sizeof(double));
 
-  pos[0] = m[0] * p[0] + m[3] * p[1] + m[6] * p[2];
-  pos[1] = m[1] * p[0] + m[4] * p[1] + m[7] * p[2];
-  pos[2] = m[2] * p[0] + m[5] * p[1] + m[8] * p[2];
-  return *this;
-}
+    pos[0] = m[0] * p[0] + m[3] * p[1] + m[6] * p[2];
+    pos[1] = m[1] * p[0] + m[4] * p[1] + m[7] * p[2];
+    pos[2] = m[2] * p[0] + m[5] * p[1] + m[8] * p[2];
+    return *this;
+    }
 */
 
 /*! Adds vector \a v to this position. */
-position const&
-position::operator+=(vec3 const& v)
-{
-  pos[0] += v[0]; pos[1] += v[1]; pos[2] += v[2];
-  return *this;
+position const &
+position::operator+=(vec3 const &v) {
+    pos[0] += v[0];
+    pos[1] += v[1];
+    pos[2] += v[2];
+    return *this;
 }
 
 /*! Subtracts vector \a v from this position. */
-position const&
-position::operator-=(vec3 const& v)
-{
-  pos[0] -= v[0]; pos[1] -= v[1]; pos[2] -= v[2];
-  return *this;
+position const &
+position::operator-=(vec3 const &v) {
+    pos[0] -= v[0];
+    pos[1] -= v[1];
+    pos[2] -= v[2];
+    return *this;
 }
 
 /*
-position
-operator*(const mat3 &m, const position &p)
-{
-  double result[3];
-  result[0] = m.mat[0] * p.pos[0] + m.mat[3] * p.pos[1] + m.mat[6] * p.pos[2];
-  result[1] = m.mat[1] * p.pos[0] + m.mat[4] * p.pos[1] + m.mat[7] * p.pos[2];
-  result[2] = m.mat[2] * p.pos[0] + m.mat[5] * p.pos[1] + m.mat[8] * p.pos[2];
-  return position(result);
-}
+    position
+    operator*(const mat3 &m, const position &p)
+    {
+    double result[3];
+    result[0] = m.mat[0] * p.pos[0] + m.mat[3] * p.pos[1] + m.mat[6] * p.pos[2];
+    result[1] = m.mat[1] * p.pos[0] + m.mat[4] * p.pos[1] + m.mat[7] * p.pos[2];
+    result[2] = m.mat[2] * p.pos[0] + m.mat[5] * p.pos[1] + m.mat[8] * p.pos[2];
+    return position(result);
+    }
 */
 
 /*! Returns the result of adding vector \a v to position \a p. */
 position
-operator+(position const& p, vec3 const& v)
-{
-  return position(p[0]+v[0], p[1]+v[1], p[2]+v[2]);
+operator+(position const &p, vec3 const &v) {
+    return position(p[0] + v[0], p[1] + v[1], p[2] + v[2]);
 }
 
 /*! Returns the result of subtracting vector \a v from position \a p. */
 position
-operator-(position const& p, vec3 const& v)
-{
-  return position(p[0]-v[0], p[1]-v[1], p[2]-v[2]);
+operator-(position const &p, vec3 const &v) {
+    return position(p[0] - v[0], p[1] - v[1], p[2] - v[2]);
 }
 
 /*! Returns the result of adding vector \a v to position \a p. */
 position
-operator+(vec3 const& v, position const& p)
-{
-  return position(p[0]+v[0], p[1]+v[1], p[2]+v[2]);
+operator+(vec3 const &v, position const &p) {
+    return position(p[0] + v[0], p[1] + v[1], p[2] + v[2]);
 }
 
 /*! Returns the result of subtracting position \a p2 from position \a p1. */
 vec3
-operator-(position const& p1, position const& p2)
-{
-  return vec3(p1[0]-p2[0], p1[1]-p2[1], p1[2]-p2[2]);
+operator-(position const &p1, position const &p2) {
+    return vec3(p1[0] - p2[0], p1[1] - p2[1], p1[2] - p2[2]);
 }
 
 position
-operator+(position const& p1, position const& p2)
-{
-  return position(p1[0]+p2[0], p1[1]+p2[1], p1[2]+p2[2]);
+operator+(position const &p1, position const &p2) {
+    return position(p1[0] + p2[0], p1[1] + p2[1], p1[2] + p2[2]);
 }
 
 position
-operator*(double d, position const& p)
-{
-	return position(d*p[0], d*p[1], d*p[2]);
+operator*(double d, position const &p) {
+    return position(d * p[0], d * p[1], d * p[2]);
 }
 
 /*! Returns true if two positions are separated by a distance less the
-  \a resabs.
- */
+    \a resabs.
+*/
 bool
-position::operator==(position const& p) const
-{
-  if ((*this - p).len_sq() < resabs * resabs)
-    return true;
-  return false;
+position::operator==(position const &p) const {
+    if ((*this - p).len_sq() < resabs * resabs)
+        return true;
+    return false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -937,111 +1062,122 @@ position::operator==(position const& p) const
     value.
 */
 void
-mat3::set(const Quaternion &q)
-{
-  double tx  = 2.0*q.x;
-  double ty  = 2.0*q.y;
-  double tz  = 2.0*q.z;
-  double twx = tx*q.w;
-  double twy = ty*q.w;
-  double twz = tz*q.w;
-  double txx = tx*q.x;
-  double txy = ty*q.x;
-  double txz = tz*q.x;
-  double tyy = ty*q.y;
-  double tyz = tz*q.y;
-  double tzz = tz*q.z;
-  
-  mat[0] = 1.0-(tyy+tzz);    mat[1] = txy-twz;          mat[2] = txz+twy;
-  mat[3] = txy+twz;          mat[4] = 1.0-(txx+tzz);    mat[5] = tyz-twx;
-  mat[6] = txz-twy;          mat[7] = tyz+twx;          mat[8] = 1.0-(txx+tyy);
+mat3::set(const Quaternion &q) {
+    double tx  = 2.0 * q.x;
+    double ty  = 2.0 * q.y;
+    double tz  = 2.0 * q.z;
+    double twx = tx * q.w;
+    double twy = ty * q.w;
+    double twz = tz * q.w;
+    double txx = tx * q.x;
+    double txy = ty * q.x;
+    double txz = tz * q.x;
+    double tyy = ty * q.y;
+    double tyz = tz * q.y;
+    double tzz = tz * q.z;
+
+    mat[0] = 1.0 - (tyy + tzz);
+    mat[1] = txy - twz;
+    mat[2] = txz + twy;
+    mat[3] = txy + twz;
+    mat[4] = 1.0 - (txx + tzz);
+    mat[5] = tyz - twx;
+    mat[6] = txz - twy;
+    mat[7] = tyz + twx;
+    mat[8] = 1.0 - (txx + tyy);
 }
 
 /*! Value of the mat3 is set using the 3 column vectors \a v1, \a v2, \a v3. */
 void
-mat3::set(const vec3 &v1, const vec3 &v2, const vec3 &v3)
-{
-  mat[0] = v1[0]; mat[3] = v1[1]; mat[6] = v1[2];
-  mat[1] = v2[0]; mat[4] = v2[1]; mat[7] = v2[2];
-  mat[2] = v3[0]; mat[5] = v3[1]; mat[8] = v3[2];
+mat3::set(const vec3 &v1, const vec3 &v2, const vec3 &v3) {
+    mat[0] = v1[0];
+    mat[3] = v1[1];
+    mat[6] = v1[2];
+    mat[1] = v2[0];
+    mat[4] = v2[1];
+    mat[7] = v2[2];
+    mat[2] = v3[0];
+    mat[5] = v3[1];
+    mat[8] = v3[2];
 }
 
-/*! This matrix becomes the cross product matrix for the given vector. 
- In other words, multiplying a second vector v2 with this matrix is 
- equivalent with perrforming the cross product v2 * v */
-void 
-mat3::setCrossProductMatrix(const vec3 &v)
-{
-	mat[0]=0.0;
-	mat[1]= v.z();
-	mat[2]=-v.y();
-  
-	mat[3]=-v.z();
-	mat[4]=0.0;
-	mat[5]= v.x();
-  
-	mat[6]= v.y();
-	mat[7]=-v.x();
-	mat[8]=0.0;
+/*! This matrix becomes the cross product matrix for the given vector.
+    In other words, multiplying a second vector v2 with this matrix is
+    equivalent with perrforming the cross product v2 * v */
+void
+mat3::setCrossProductMatrix(const vec3 &v) {
+    mat[0] = 0.0;
+    mat[1] = v.z();
+    mat[2] = -v.y();
+
+    mat[3] = -v.z();
+    mat[4] = 0.0;
+    mat[5] = v.x();
+
+    mat[6] = v.y();
+    mat[7] = -v.x();
+    mat[8] = 0.0;
 
 }
 
 /*! Returns the determinant of the matrix. */
 double
-mat3::determinant() const
-{
-  return  mat[0] * (mat[4] * mat[8] - mat[7] * mat[5])
-        + mat[3] * (mat[7] * mat[2] - mat[1] * mat[8])
-        + mat[6] * (mat[1] * mat[5] - mat[4] * mat[2]);
+mat3::determinant() const {
+    return  mat[0] * (mat[4] * mat[8] - mat[7] * mat[5])
+            + mat[3] * (mat[7] * mat[2] - mat[1] * mat[8])
+            + mat[6] * (mat[1] * mat[5] - mat[4] * mat[2]);
 }
 
 /*! Returns a mat3 that is the transpose of this one. */
 mat3
-mat3::transpose() const
-{
-  double M[9];
+mat3::transpose() const {
+    double M[9];
 
-  M[0] = mat[0];
-  M[1] = mat[3];
-  M[2] = mat[6];
+    M[0] = mat[0];
+    M[1] = mat[3];
+    M[2] = mat[6];
 
-  M[3] = mat[1];
-  M[4] = mat[4];
-  M[5] = mat[7];
-  
-  M[6] = mat[2];
-  M[7] = mat[5];
-  M[8] = mat[8];
+    M[3] = mat[1];
+    M[4] = mat[4];
+    M[5] = mat[7];
 
-  return mat3(M);
+    M[6] = mat[2];
+    M[7] = mat[5];
+    M[8] = mat[8];
+
+    return mat3(M);
 }
 
 /*! Scales matrix \a m by the scalar \a s. */
 mat3
-operator*(double const& s,  mat3 const& m)
-{
-  double M[9];
+operator*(double const &s,  mat3 const &m) {
+    double M[9];
 
-  M[0] = s*m.mat[0];
-  M[1] = s*m.mat[1];
-  M[2] = s*m.mat[2];
-  M[3] = s*m.mat[3];
-  M[4] = s*m.mat[4];
-  M[5] = s*m.mat[5];
-  M[6] = s*m.mat[6];
-  M[7] = s*m.mat[7];
-  M[8] = s*m.mat[8];
-  return mat3(M);
+    M[0] = s * m.mat[0];
+    M[1] = s * m.mat[1];
+    M[2] = s * m.mat[2];
+    M[3] = s * m.mat[3];
+    M[4] = s * m.mat[4];
+    M[5] = s * m.mat[5];
+    M[6] = s * m.mat[6];
+    M[7] = s * m.mat[7];
+    M[8] = s * m.mat[8];
+    return mat3(M);
 }
 
 /*! Adds matrix \a m to this matrix. */
-mat3 const&
-mat3::operator+=(mat3 const& m)
-{
-  mat[0] += m[0]; mat[1] += m[1]; mat[2] += m[2];
-  mat[3] += m[3]; mat[4] += m[4]; mat[5] += m[5];
-  mat[6] += m[6]; mat[7] += m[7]; mat[8] += m[8];
-  return *this;
+mat3 const &
+mat3::operator+=(mat3 const &m) {
+    mat[0] += m[0];
+    mat[1] += m[1];
+    mat[2] += m[2];
+    mat[3] += m[3];
+    mat[4] += m[4];
+    mat[5] += m[5];
+    mat[6] += m[6];
+    mat[7] += m[7];
+    mat[8] += m[8];
+    return *this;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1052,93 +1188,83 @@ mat3::operator+=(mat3 const& m)
     stores their quaternions in a slightly different order, and uses floats.
 */
 SbRotation
-Quaternion::toSbRotation() const
-{
-  return SbRotation((float) x,(float) y, (float) z, (float) w);
+Quaternion::toSbRotation() const {
+    return SbRotation((float) x, (float) y, (float) z, (float) w);
 }
 
 /*! Assignment operator, copies quaternion \a q. */
-Quaternion&
-Quaternion::operator=(const Quaternion& q)
-{
-  set(q);
-  return *this;
+Quaternion &
+Quaternion::operator=(const Quaternion &q) {
+    set(q);
+    return *this;
 }
 
 /*! Returns the normalized result of adding \a q to this quaternion. */
 Quaternion
-Quaternion::operator+(const Quaternion& q) const
-{
-    return Quaternion(w+q.w,x+q.x,y+q.y,z+q.z);
+Quaternion::operator+(const Quaternion &q) const {
+    return Quaternion(w + q.w, x + q.x, y + q.y, z + q.z);
 }
 
 /*! Returns the normalized result of subtracting \a q from this quaternion. */
 Quaternion
-Quaternion::operator-(const Quaternion& q) const
-{
-    return Quaternion(w-q.w,x-q.x,y-q.y,z-q.z);
+Quaternion::operator-(const Quaternion &q) const {
+    return Quaternion(w - q.w, x - q.x, y - q.y, z - q.z);
 }
 
 /*! Returns the normalized result of multiplying this quaternion by \a q. */
 Quaternion
-Quaternion::operator*(const Quaternion& q) const
-{
+Quaternion::operator*(const Quaternion &q) const {
     return Quaternion(
-		w*q.w-x*q.x-y*q.y-z*q.z,
-		w*q.x+x*q.w+y*q.z-z*q.y,
-		w*q.y+y*q.w+z*q.x-x*q.z,
-		w*q.z+z*q.w+x*q.y-y*q.x
-    );
+               w * q.w - x * q.x - y * q.y - z * q.z,
+               w * q.x + x * q.w + y * q.z - z * q.y,
+               w * q.y + y * q.w + z * q.x - x * q.z,
+               w * q.z + z * q.w + x * q.y - y * q.x
+           );
 }
 
 
-/*Quaternion
-Quaternion::operator*(double c) const
-{
+/*  Quaternion
+    Quaternion::operator*(double c) const
+    {
     return Quaternion(c*w,c*x,c*y,c*z);
-}
+    }
 
 
-Quaternion
-operator*(double c, const Quaternion& q)
-{
+    Quaternion
+    operator*(double c, const Quaternion& q)
+    {
     return Quaternion(c*q.w,c*q.x,c*q.y,c*q.z);
-}
+    }
 */
 
 /*! Unary negation operator.  Negates each component of the quaternion. */
 Quaternion
-Quaternion::operator-() const
-{
-    return Quaternion(-w,-x,-y,-z);
+Quaternion::operator-() const {
+    return Quaternion(-w, -x, -y, -z);
 }
 
 /*! Returns the dot product of this quaternion and \a q. */
 double
-Quaternion::operator%(const Quaternion& q) const
-{
-    return w*q.w+x*q.x+y*q.y+z*q.z;
+Quaternion::operator%(const Quaternion &q) const {
+    return w * q.w + x * q.x + y * q.y + z * q.z;
 }
 
 /*! Returns the norm of the quaternion. */
 double
-Quaternion::norm() const
-{
-    return w*w+x*x+y*y+z*z;
+Quaternion::norm() const {
+    return w * w + x * x + y * y + z * z;
 }
 
 /*! Returns the inverse quaternion. */
 Quaternion
-Quaternion::inverse() const
-{
+Quaternion::inverse() const {
     // assert:  'this' is unit length
-    return Quaternion(w,-x,-y,-z);
+    return Quaternion(w, -x, -y, -z);
 }
 
 /*! Returns the vector \a v after it has been rotated by this quaternion. */
 vec3
-Quaternion::operator*(const vec3& v) const
-{
+Quaternion::operator*(const vec3 &v) const {
     // Given a vector u = (x0,y0,z0) and a unit length quaternion
     // q = <w,x,y,z>, the vector v = (x1,y1,z1) which represents the
     // rotation of u by q is v = q*u*q^{-1} where * indicates quaternion
@@ -1161,54 +1287,54 @@ Quaternion::operator*(const vec3& v) const
     ToRotationMatrix(R);
 
     vec3 result;
-    result[0] = v.x()*R.element(0,0)+v.y()*R.element(1,0)+v.z()*R.element(2,0);
-    result[1] = v.x()*R.element(0,1)+v.y()*R.element(1,1)+v.z()*R.element(2,1);
-    result[2] = v.x()*R.element(0,2)+v.y()*R.element(1,2)+v.z()*R.element(2,2);
+    result[0] = v.x() * R.element(0, 0) + v.y() * R.element(1, 0) + v.z() * R.element(2, 0);
+    result[1] = v.x() * R.element(0, 1) + v.y() * R.element(1, 1) + v.z() * R.element(2, 1);
+    result[2] = v.x() * R.element(0, 2) + v.y() * R.element(1, 2) + v.z() * R.element(2, 2);
 
     return result;
 }
 
 /*! Returns the position \a p after it has been rotated by this quaternion. */
 position
-Quaternion::operator*(const position& p) const
-{
-  mat3 R;
-  ToRotationMatrix(R);
-  
-  position result;
-  result[0] = p.x()*R.element(0,0)+p.y()*R.element(1,0)+p.z()*R.element(2,0);
-  result[1] = p.x()*R.element(0,1)+p.y()*R.element(1,1)+p.z()*R.element(2,1);
-  result[2] = p.x()*R.element(0,2)+p.y()*R.element(1,2)+p.z()*R.element(2,2);
-  
-  return result;
+Quaternion::operator*(const position &p) const {
+    mat3 R;
+    ToRotationMatrix(R);
+
+    position result;
+    result[0] = p.x() * R.element(0, 0) + p.y() * R.element(1, 0) + p.z() * R.element(2, 0);
+    result[1] = p.x() * R.element(0, 1) + p.y() * R.element(1, 1) + p.z() * R.element(2, 1);
+    result[2] = p.x() * R.element(0, 2) + p.y() * R.element(1, 2) + p.z() * R.element(2, 2);
+
+    return result;
 }
 
 /*! Comparison operator, returns true if the L2 distance between this
     quaternion and \a q is less than resabs.
 */
 bool
-Quaternion::operator==(Quaternion const& q) const
-{
-  if ((w-q.w)*(w-q.w)+(x-q.x)*(x-q.x)+(y-q.y)*(y-q.y)+(z-q.z)*(z-q.z) < 
-      resabs * resabs)
-    return true;
-  return false;
+Quaternion::operator==(Quaternion const &q) const {
+    if ((w - q.w) * (w - q.w) + (x - q.x) * (x - q.x) + (y - q.y) * (y - q.y) + (z - q.z) * (z - q.z) <
+            resabs * resabs)
+        return true;
+    return false;
 }
 
 /*! Normalizes this quaternion. */
 void
-Quaternion::normalise()
-{
-  double nm=norm();
-  double invnorm;
-  if (nm==0.0) {
-#ifdef GRASPITDBG
-    printf("0 norm in Quaternion normalise\n");
-#endif	
-	return;
-  }
-  invnorm =1.0/sqrt(nm);
-  w*=invnorm; x*=invnorm; y*=invnorm; z*=invnorm;
+Quaternion::normalise() {
+    double nm = norm();
+    double invnorm;
+    if (nm == 0.0) {
+        #ifdef GRASPITDBG
+        printf("0 norm in Quaternion normalise\n");
+        #endif
+        return;
+    }
+    invnorm = 1.0 / sqrt(nm);
+    w *= invnorm;
+    x *= invnorm;
+    y *= invnorm;
+    z *= invnorm;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1216,249 +1342,237 @@ Quaternion::normalise()
 ///////////////////////////////////////////////////////////////////////////////
 
 /*!
-  Returns the inverse transformation.
+    Returns the inverse transformation.
 */
 transf
-transf::inverse() const
-{ 
-  return transf(rot.inverse(),-(rot.inverse() * t));
+transf::inverse() const {
+    return transf(rot.inverse(), -(rot.inverse() * t));
 }
 
 /*! Assignment operator, copies transform \a tr. */
-transf const&
-transf::operator=(transf const& tr)
-{
-  rot = tr.rotation();
-  R = tr.affine();
-  t = tr.translation();
-  return *this;
+transf const &
+transf::operator=(transf const &tr) {
+    rot = tr.rotation();
+    R = tr.affine();
+    t = tr.translation();
+    return *this;
 }
 
-/*transf const&
-transf::operator*=(transf const& tr)
-{
-  rot = tr.rotation() * rot;
-  rot.ToRotationMatrix(R);
-  t  += tr.translation + rot * t;
-  return *this;
-}
+/*  transf const&
+    transf::operator*=(transf const& tr)
+    {
+    rot = tr.rotation() * rot;
+    rot.ToRotationMatrix(R);
+    t  += tr.translation + rot * t;
+    return *this;
+    }
 */
 
 
 /*! Converts this transform to Inventor format. */
 void
-transf::toSoTransform(SoTransform *IVt) const
-{  
-  IVt->rotation.setValue(rot.toSbRotation());
-  IVt->translation.setValue(t.toSbVec3f());
+transf::toSoTransform(SoTransform *IVt) const {
+    IVt->rotation.setValue(rot.toSbRotation());
+    IVt->translation.setValue(t.toSbVec3f());
 }
 /*! Converts this transform to a column major 4x4 matrix*/
 void
-transf::toColMajorMatrix(double mat[][4]) const
-{
-  for (int i=0; i<3; i++) {
-    for(int j=0; j<3; j++) {
-      mat[j][i] = R.element(j,i);
-	}
-    mat[i][3] = 0.0;
-  }
-  mat[3][0] = t[0];
-  mat[3][1] = t[1];
-  mat[3][2] = t[2];
-  mat[3][3] = 1.0;
+transf::toColMajorMatrix(double mat[][4]) const {
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            mat[j][i] = R.element(j, i);
+        }
+        mat[i][3] = 0.0;
+    }
+    mat[3][0] = t[0];
+    mat[3][1] = t[1];
+    mat[3][2] = t[2];
+    mat[3][3] = 1.0;
 }
 
 /*! Converts this transform to a row major 4x4 matrix*/
 void
-transf::toRowMajorMatrix(double mat[][4]) const
-{
-  for (int i=0; i<3; i++) {
-    for(int j=0; j<3; j++) {
-      mat[i][j] = R.element(j,i);
-	}
-    mat[3][i] = 0.0;
-  }
-  mat[0][3] = t[0];
-  mat[1][3] = t[1];
-  mat[2][3] = t[2];
-  mat[3][3] = 1.0;
+transf::toRowMajorMatrix(double mat[][4]) const {
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            mat[i][j] = R.element(j, i);
+        }
+        mat[3][i] = 0.0;
+    }
+    mat[0][3] = t[0];
+    mat[1][3] = t[1];
+    mat[2][3] = t[2];
+    mat[3][3] = 1.0;
 }
 
 /*! Converts this transform to the collision system format, a 4x4 matrix. */
 void
-transf::tocol_Mat4(col_Mat4 colTran) const
-{
-  for (int j=0;j<3;j++) {
-    for(int i=0;i<3;i++)
-      colTran[i][j] = R.element(j,i);
-    colTran[3][j] = 0.0;
-  }
-  colTran[0][3] = t[0];
-  colTran[1][3] = t[1];
-  colTran[2][3] = t[2];
-  colTran[3][3] = 1.0;
+transf::tocol_Mat4(col_Mat4 colTran) const {
+    for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 3; i++)
+            colTran[i][j] = R.element(j, i);
+        colTran[3][j] = 0.0;
+    }
+    colTran[0][3] = t[0];
+    colTran[1][3] = t[1];
+    colTran[2][3] = t[2];
+    colTran[3][3] = 1.0;
 }
 
 /*! Sets the value of this transform by converting an Inventor transform. */
 void
-transf::set(const SoTransform *IVt)
-{
-  float q1,q2,q3,q4,x,y,z;
+transf::set(const SoTransform *IVt) {
+    float q1, q2, q3, q4, x, y, z;
 
-  // Inventor stores the quaternion as qx,qy,qz,qw
-  IVt->rotation.getValue().getValue(q2,q3,q4,q1);
-  IVt->translation.getValue().getValue(x,y,z);  
-  rot.w=(double)q1; rot.x=(double)q2; rot.y=(double)q3; rot.z=(double)q4;
-  t[0]=(double)x; t[1]=(double)y; t[2]=(double)z;
-  rot.ToRotationMatrix(R);
+    // Inventor stores the quaternion as qx,qy,qz,qw
+    IVt->rotation.getValue().getValue(q2, q3, q4, q1);
+    IVt->translation.getValue().getValue(x, y, z);
+    rot.w = (double)q1;
+    rot.x = (double)q2;
+    rot.y = (double)q3;
+    rot.z = (double)q4;
+    t[0] = (double)x;
+    t[1] = (double)y;
+    t[2] = (double)z;
+    rot.ToRotationMatrix(R);
 }
 
 /*! Multiplies two transforms.  */
 transf
-operator*(const transf& tr2,  const transf& tr1)
-{
-  Quaternion newRot = tr1.rotation() * tr2.rotation();
-  return transf(newRot, tr1.translation() + tr1.rotation() * tr2.translation());
+operator*(const transf &tr2,  const transf &tr1) {
+    Quaternion newRot = tr1.rotation() * tr2.rotation();
+    return transf(newRot, tr1.translation() + tr1.rotation() * tr2.translation());
 }
 
 /*!
-  Returns a vector that is the result of rotating vector \a v using transform
-  \a tr.
- */
+    Returns a vector that is the result of rotating vector \a v using transform
+    \a tr.
+*/
 vec3
-operator*(const vec3& v, const transf& tr)
-{
-  return tr.rot * v;
+operator*(const vec3 &v, const transf &tr) {
+    return tr.rot * v;
 }
 /*returns the vector under transformation tr*/
 vec3
-operator>(const vec3& v, const transf& tr)
-{
-	return tr.rot*v + tr.t;
+operator>(const vec3 &v, const transf &tr) {
+    return tr.rot * v + tr.t;
 }
 
 
 /*!
-  Returns the result of transforming position \a p with transform \a tr.
- */
+    Returns the result of transforming position \a p with transform \a tr.
+*/
 position
-operator*(const position& p, const transf& tr)
-{
-  return tr.rot * p + tr.t;
+operator*(const position &p, const transf &tr) {
+    return tr.rot * p + tr.t;
 }
 
 /*!
-  Compares two transforms.  Returns true if both the rotations and translations
-  are equal (according to their comparators).
+    Compares two transforms.  Returns true if both the rotations and translations
+    are equal (according to their comparators).
 */
 bool
-transf::operator==(transf const& tr) const
-{
-  if (tr.rot == rot && tr.t == t)
-    return true;
-  return false;
-}
-
-/*! 
-  Helper function that creates a transform with an identity rotation and
-  a translation equal to vector \a v.
-*/
-transf
-translate_transf(const vec3& v)
-{
-  return transf(Quaternion::IDENTITY,v);
+transf::operator==(transf const &tr) const {
+    if (tr.rot == rot && tr.t == t)
+        return true;
+    return false;
 }
 
 /*!
-  Helper function that creates a tranform that has a rotation of \a angle
-  radians about \a axis, and a zero translation.
+    Helper function that creates a transform with an identity rotation and
+    a translation equal to vector \a v.
 */
 transf
-rotate_transf(double angle, const vec3& axis)
-{
-  return transf(Quaternion(angle,axis),vec3::ZERO);
+translate_transf(const vec3 &v) {
+    return transf(Quaternion::IDENTITY, v);
 }
 
 /*!
-  Helper function that creates a tranform from the global frame to the
-  new frame with its origin at position \a o, and with the given x and y axes.
+    Helper function that creates a tranform that has a rotation of \a angle
+    radians about \a axis, and a zero translation.
 */
 transf
-coordinate_transf(const position& o, const vec3& xaxis, const vec3& yaxis)
-{ 
-  vec3 newxaxis = normalise(xaxis);
-  vec3 newzaxis = normalise(newxaxis * yaxis);
-  vec3 newyaxis = normalise(newzaxis * newxaxis);
-  return transf(mat3(newxaxis,newyaxis,newzaxis),o - position::ORIGIN);
+rotate_transf(double angle, const vec3 &axis) {
+    return transf(Quaternion(angle, axis), vec3::ZERO);
+}
+
+/*!
+    Helper function that creates a tranform from the global frame to the
+    new frame with its origin at position \a o, and with the given x and y axes.
+*/
+transf
+coordinate_transf(const position &o, const vec3 &xaxis, const vec3 &yaxis) {
+    vec3 newxaxis = normalise(xaxis);
+    vec3 newzaxis = normalise(newxaxis * yaxis);
+    vec3 newyaxis = normalise(newzaxis * newxaxis);
+    return transf(mat3(newxaxis, newyaxis, newzaxis), o - position::ORIGIN);
 }
 
 transf
-rotXYZ(double rx, double ry, double rz)
-{
-	transf r;
-	vec3 x(1,0,0), y(0,1,0), z(0,0,1);
-	
-	r = rotate_transf(rx, x);
-	y = y * r.inverse();
-	r = rotate_transf(ry, y) * r;
-	z = z * r.inverse();
-	r = rotate_transf(rz, z) * r;
+rotXYZ(double rx, double ry, double rz) {
+    transf r;
+    vec3 x(1, 0, 0), y(0, 1, 0), z(0, 0, 1);
 
-	return r;
+    r = rotate_transf(rx, x);
+    y = y * r.inverse();
+    r = rotate_transf(ry, y) * r;
+    z = z * r.inverse();
+    r = rotate_transf(rz, z) * r;
+
+    return r;
 }
 
-/*! Given two line segments, P1-P2 and P3-P4, returns the line segment 
-	Pa-Pb that is the shortest route between them. Calculates also the 
-	values of \a mua and \a mub where
+/*! Given two line segments, P1-P2 and P3-P4, returns the line segment
+    Pa-Pb that is the shortest route between them. Calculates also the
+    values of \a mua and \a mub where
       Pa = P1 + mua (P2 - P1)
       Pb = P3 + mub (P4 - P3)
-   Returns FALSE if no solution exists.
-   adapted from http://astronomy.swin.edu.au/~pbourke/geometry/lineline3d/
+    Returns FALSE if no solution exists.
+    adapted from http://astronomy.swin.edu.au/~pbourke/geometry/lineline3d/
 */
-inline int LineLineIntersect(vec3 p1,vec3 p2,vec3 p3,vec3 p4,vec3 *pa,vec3 *pb,double *mua, double *mub)
-{
-   vec3 p13,p43,p21;
-   double d1343,d4321,d1321,d4343,d2121;
-   double numer,denom;
-   double EPS = 1.0e-5;
+inline int LineLineIntersect(vec3 p1, vec3 p2, vec3 p3, vec3 p4, vec3 *pa, vec3 *pb, double *mua, double *mub) {
+    vec3 p13, p43, p21;
+    double d1343, d4321, d1321, d4343, d2121;
+    double numer, denom;
+    double EPS = 1.0e-5;
 
-   p13.x() = p1.x() - p3.x();
-   p13.y() = p1.y() - p3.y();
-   p13.z() = p1.z() - p3.z();
-   p43.x() = p4.x() - p3.x();
-   p43.y() = p4.y() - p3.y();
-   p43.z() = p4.z() - p3.z();
-   if ( fabs(p43.x())  < EPS && fabs(p43.y())  < EPS && fabs(p43.z())  < EPS )
-      return false;
+    p13.x() = p1.x() - p3.x();
+    p13.y() = p1.y() - p3.y();
+    p13.z() = p1.z() - p3.z();
+    p43.x() = p4.x() - p3.x();
+    p43.y() = p4.y() - p3.y();
+    p43.z() = p4.z() - p3.z();
+    if (fabs(p43.x())  < EPS && fabs(p43.y())  < EPS && fabs(p43.z())  < EPS)
+        return false;
 
-   p21.x() = p2.x() - p1.x();
-   p21.y() = p2.y() - p1.y();
-   p21.z() = p2.z() - p1.z();
-   if ( fabs(p21.x())  < EPS && fabs(p21.y())  < EPS && fabs(p21.z())  < EPS )
-      return false;
+    p21.x() = p2.x() - p1.x();
+    p21.y() = p2.y() - p1.y();
+    p21.z() = p2.z() - p1.z();
+    if (fabs(p21.x())  < EPS && fabs(p21.y())  < EPS && fabs(p21.z())  < EPS)
+        return false;
 
-   d1343 = p13.x() * p43.x() + p13.y() * p43.y() + p13.z() * p43.z();
-   d4321 = p43.x() * p21.x() + p43.y() * p21.y() + p43.z() * p21.z();
-   d1321 = p13.x() * p21.x() + p13.y() * p21.y() + p13.z() * p21.z();
-   d4343 = p43.x() * p43.x() + p43.y() * p43.y() + p43.z() * p43.z();
-   d2121 = p21.x() * p21.x() + p21.y() * p21.y() + p21.z() * p21.z();
+    d1343 = p13.x() * p43.x() + p13.y() * p43.y() + p13.z() * p43.z();
+    d4321 = p43.x() * p21.x() + p43.y() * p21.y() + p43.z() * p21.z();
+    d1321 = p13.x() * p21.x() + p13.y() * p21.y() + p13.z() * p21.z();
+    d4343 = p43.x() * p43.x() + p43.y() * p43.y() + p43.z() * p43.z();
+    d2121 = p21.x() * p21.x() + p21.y() * p21.y() + p21.z() * p21.z();
 
-   denom = d2121 * d4343 - d4321 * d4321;
-   if ( fabs(denom) < EPS )
-      return false;
-   numer = d1343 * d4321 - d1321 * d4343;
+    denom = d2121 * d4343 - d4321 * d4321;
+    if (fabs(denom) < EPS)
+        return false;
+    numer = d1343 * d4321 - d1321 * d4343;
 
-   *mua = numer / denom;
-   *mub = (d1343 + d4321 * (*mua)) / d4343;
+    *mua = numer / denom;
+    *mub = (d1343 + d4321 * (*mua)) / d4343;
 
-   pa->x() = p1.x() + (*mua) * p21.x();
-   pa->y() = p1.y() + (*mua) * p21.y();
-   pa->z() = p1.z() + (*mua) * p21.z();
-   pb->x() = p3.x() + (*mub) * p43.x();
-   pb->y() = p3.y() + (*mub) * p43.y();
-   pb->z() = p3.z() + (*mub) * p43.z();
+    pa->x() = p1.x() + (*mua) * p21.x();
+    pa->y() = p1.y() + (*mua) * p21.y();
+    pa->z() = p1.z() + (*mua) * p21.z();
+    pb->x() = p3.x() + (*mub) * p43.x();
+    pb->y() = p3.y() + (*mub) * p43.y();
+    pb->z() = p3.z() + (*mub) * p43.z();
 
-   return true;
+    return true;
 }
 
 #define _MATVEC_H_

--- a/include/matvecIO.h
+++ b/include/matvecIO.h
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: matvecIO.h,v 1.4 2009/03/25 22:10:23 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Prototypes of QTextStream input and output operators for various matrices and vectors.
+    \brief Prototypes of QTextStream input and output operators for various matrices and vectors.
 */
 
 #ifndef _MATVECIO_H_
@@ -32,22 +32,22 @@
 #include "matvec3D.h"
 
 
-QTextStream& operator>>(QTextStream &is, vec3 &v);
-QTextStream& operator<<(QTextStream &os, const vec3 &v);  
+QTextStream &operator>>(QTextStream &is, vec3 &v);
+QTextStream &operator<<(QTextStream &os, const vec3 &v);
 
-QTextStream& operator>>(QTextStream &is, position &p);
-QTextStream& operator<<(QTextStream &os, const position &p);
+QTextStream &operator>>(QTextStream &is, position &p);
+QTextStream &operator<<(QTextStream &os, const position &p);
 
-QTextStream& operator>>(QTextStream &is, mat3 &m);
-QTextStream& operator<<(QTextStream &os, const mat3 &m);  
+QTextStream &operator>>(QTextStream &is, mat3 &m);
+QTextStream &operator<<(QTextStream &os, const mat3 &m);
 
-QTextStream& operator>>(QTextStream &is, Quaternion &q);
-QTextStream& operator<<(QTextStream &os, const Quaternion &q);
+QTextStream &operator>>(QTextStream &is, Quaternion &q);
+QTextStream &operator<<(QTextStream &os, const Quaternion &q);
 
-QTextStream& operator>>(QTextStream &is, transf &tr);
-QTextStream& operator<<(QTextStream &os, const transf &tr);
+QTextStream &operator>>(QTextStream &is, transf &tr);
+QTextStream &operator<<(QTextStream &os, const transf &tr);
 
-int readTransRotFromQTextStream(QTextStream &is,transf &tr);
+int readTransRotFromQTextStream(QTextStream &is, transf &tr);
 
 #define _MATVECIO_H_
 #endif

--- a/include/maxdet.h
+++ b/include/maxdet.h
@@ -1,30 +1,30 @@
 #ifndef MAXDET_H
 /*
- * maxdet, version alpha
- * C source for solving MAXDET problems
- *
- * Shao-Po Wu, Lieven Vandenberghe and Stephen Boyd
- * Feb. 23, 1996, last major update
- *
- * COPYRIGHT 1996 SHAO-PO WU, LIEVEN VANDENBERGHE AND STEPHEN BOYD
- * Permission to use, copy, modify, and distribute this software for
- * any purpose without fee is hereby granted, provided that this entire
- * notice is included in all copies of any software which is or includes
- * a copy or modification of this software and in all copies of the
- * supporting documentation for such software.
- * This software is being provided "as is", without any express or
- * implied warranty.  In particular, the authors do not make any
- * representation or warranty of any kind concerning the merchantability
- * of this software or its fitness for any particular purpose.
- */
+    maxdet, version alpha
+    C source for solving MAXDET problems
+
+    Shao-Po Wu, Lieven Vandenberghe and Stephen Boyd
+    Feb. 23, 1996, last major update
+
+    COPYRIGHT 1996 SHAO-PO WU, LIEVEN VANDENBERGHE AND STEPHEN BOYD
+    Permission to use, copy, modify, and distribute this software for
+    any purpose without fee is hereby granted, provided that this entire
+    notice is included in all copies of any software which is or includes
+    a copy or modification of this software and in all copies of the
+    supporting documentation for such software.
+    This software is being provided "as is", without any express or
+    implied warranty.  In particular, the authors do not make any
+    representation or warranty of any kind concerning the merchantability
+    of this software or its fitness for any particular purpose.
+*/
 
 /*! \file
-  \brief Constants and prototypes for the maxdet package.
+    \brief Constants and prototypes for the maxdet package.
 */
 
 /*
- * macros
- */
+    macros
+*/
 #ifndef SQR
 #define SQR(x)    ((x)*(x))
 #endif
@@ -36,8 +36,8 @@
 #endif
 
 /*
- * constant parameters
- */
+    constant parameters
+*/
 #define NB        32        /* block size for dgels, must be at least 1 */
 #define MINABSTOL 1e-10     /* min absolute tolerance allowed */
 #define MAXITERS  100       /* default max number of iterations */
@@ -45,7 +45,7 @@
 #define LSTOL     1e-3      /* tolerance used in line search */
 #define TOLC      1e-5      /* tolerance used for dual infeasibility */
 #define SIGTOL    1e-5      /* tolerance used for detecting zero steps 
-                             * dF or dZ */ 
+                               dF or dZ */
 #define MINRCOND  1e-10     /* minimum rcond to declare F_i dependent */
 #define LSITERUB  30        /* maximum number of line-search iterations */
 
@@ -65,18 +65,18 @@
 #endif
 
 
-void mydlascl(double from,double to,int m,int n,double *A);
+void mydlascl(double from, double to, int m, int n, double *A);
 
-void disp_imat(FILE* fp, int* ip, int r, int c);
-void disp_mat(FILE* fp, double* dp,int r, int c);
+void disp_imat(FILE *fp, int *ip, int r, int c);
+void disp_mat(FILE *fp, double *dp, int r, int c);
 /* double inprd(double *X, double *Z, int L, int* blck_szs); */
-double eig_val(double*sig, double* ap, int L, int* blck_szs, int Npd, double* work);
+double eig_val(double *sig, double *ap, int L, int *blck_szs, int Npd, double *work);
 
 int maxdet(
- int m, int L, double *F, int *F_blkszs, int K, double *G, int *G_blkszs,
- double *c, double *x, double *Z, double *W, double *ul, double *hist,        
- double gamma, double abstol, double reltol, int *NTiters, double *work,
- int lwork, int *iwork, int *info, int negativeFlag
+    int m, int L, double *F, int *F_blkszs, int K, double *G, int *G_blkszs,
+    double *c, double *x, double *Z, double *W, double *ul, double *hist,
+    double gamma, double abstol, double reltol, int *NTiters, double *work,
+    int lwork, int *iwork, int *info, int negativeFlag
 );
 #define MAXDET_H
 #endif

--- a/include/mkl_wrappers.h
+++ b/include/mkl_wrappers.h
@@ -17,178 +17,155 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: mkl_wrappers.h,v 1.4 2009/03/25 22:10:23 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief c wrappers for the math kernel library fortran functions so they may be called from c++ routines
+    \brief c wrappers for the math kernel library fortran functions so they may be called from c++ routines
 */
 
 #include "mkl_blas.h"
 #include "mkl_lapack.h"
 
-static __inline void daxpy(int n,double da,double *dx,int incx,double *dy,
-			   int incy)
-{
-  daxpy(&n,&da,dx,&incx,dy,&incy);
+static __inline void daxpy(int n, double da, double *dx, int incx, double *dy,
+                           int incy) {
+    daxpy(&n, &da, dx, &incx, dy, &incy);
 }
 
-static __inline void dcopy(int n,double *dx,int incx,double *dy,int incy)
-{
-  dcopy(&n,dx,&incx,dy,&incy);
+static __inline void dcopy(int n, double *dx, int incx, double *dy, int incy) {
+    dcopy(&n, dx, &incx, dy, &incy);
 }
 
-static __inline double ddot(int n,double *dx,int incx,double *dy,int incy)
-{
-    return ddot(&n,dx,&incx,dy,&incy);
+static __inline double ddot(int n, double *dx, int incx, double *dy, int incy) {
+    return ddot(&n, dx, &incx, dy, &incy);
 }
 
-static __inline void dgels(char *trans,int m,int n,int nrhs,double *a,
-			   int lda,double *b,int ldb,double *work,
-			   int lwork,int *info)
-{
-  dgels(trans,&m,&n,&nrhs,a,&lda,b,&ldb,work,&lwork,info);
+static __inline void dgels(char *trans, int m, int n, int nrhs, double *a,
+                           int lda, double *b, int ldb, double *work,
+                           int lwork, int *info) {
+    dgels(trans, &m, &n, &nrhs, a, &lda, b, &ldb, work, &lwork, info);
 }
 
-static __inline void dgelss(int m, int n, int nrhs, 
-							double *a, int lda, double *b, int ldb, double *s, 
-							double rcond, int *rank,
-							double *work, int lwork, int *info)
-{
-	dgelss(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, rank, work, &lwork, info);
+static __inline void dgelss(int m, int n, int nrhs,
+                            double *a, int lda, double *b, int ldb, double *s,
+                            double rcond, int *rank,
+                            double *work, int lwork, int *info) {
+    dgelss(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, rank, work, &lwork, info);
 }
 
 
-static __inline void dgemm(char *transa,char *transb,int m,int n,int k,
-			   double alpha,double *a,int lda,double *b,int ldb,
-			   double beta,double *c,int ldc)
-{
-    dgemm(transa,transb,&m,&n,&k,&alpha,a,&lda,b,&ldb,&beta,c,&ldc);
+static __inline void dgemm(char *transa, char *transb, int m, int n, int k,
+                           double alpha, double *a, int lda, double *b, int ldb,
+                           double beta, double *c, int ldc) {
+    dgemm(transa, transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc);
 }
 
 
-static __inline void dgemv(char *trans,int m,int n,double alpha,
-			   double *a,int lda,double *dx,int incx,
-			   double beta,double *dy,int incy)
-{
-     dgemv(trans,&m,&n,&alpha,a,&lda,dx,&incx,&beta,dy,&incy);
+static __inline void dgemv(char *trans, int m, int n, double alpha,
+                           double *a, int lda, double *dx, int incx,
+                           double beta, double *dy, int incy) {
+    dgemv(trans, &m, &n, &alpha, a, &lda, dx, &incx, &beta, dy, &incy);
 }
 
 
 static __inline void dgesv(int n, int nrhs, double *a, int lda, int *ipiv,
-			   double *b, int ldb, int *info)
-{
-  dgesv(&n,&nrhs,a,&lda,ipiv,b,&ldb,info);
+                           double *b, int ldb, int *info) {
+    dgesv(&n, &nrhs, a, &lda, ipiv, b, &ldb, info);
 }
 
 
-static __inline void dgesvd(char *jobu,char *jobvt, int m, int n, double *a,
-			    int lda, double *s, double *u, int ldu, double *vt,
-			    int ldvt,double *work, int lwork, int *info)
-{
-  dgesvd(jobu,jobvt,&m,&n,a,&lda,s,u,&ldu,vt,&ldvt,work,&lwork,info);
-}
-
-
-
-static __inline void dgetrf(int m,int n,double *a,int lda,int *ipiv,int *info)
-{
-  dgetrf(&m,&n,a,&lda,ipiv,info);
+static __inline void dgesvd(char *jobu, char *jobvt, int m, int n, double *a,
+                            int lda, double *s, double *u, int ldu, double *vt,
+                            int ldvt, double *work, int lwork, int *info) {
+    dgesvd(jobu, jobvt, &m, &n, a, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, info);
 }
 
 
 
-static __inline void dgetri(int n,double *a,int lda,int *ipiv,double *work,
-			    int lwork,int *info)
-{
-  dgetri(&n,a,&lda,ipiv,work,&lwork,info);
+static __inline void dgetrf(int m, int n, double *a, int lda, int *ipiv, int *info) {
+    dgetrf(&m, &n, a, &lda, ipiv, info);
 }
 
 
 
-static __inline void dlascl(char *type,int kl,int ku,double from,double to,
-			    int m,int n,double *a,int lda,int *info)
-{
-  dlascl(type,&kl,&ku,&from,&to,&m,&n,a,&lda,info);
+static __inline void dgetri(int n, double *a, int lda, int *ipiv, double *work,
+                            int lwork, int *info) {
+    dgetri(&n, a, &lda, ipiv, work, &lwork, info);
 }
 
 
 
-static __inline double dnrm2(int n,double *dx,int incx)
-{
-  return dnrm2(&n,dx,&incx);
+static __inline void dlascl(char *type, int kl, int ku, double from, double to,
+                            int m, int n, double *a, int lda, int *info) {
+    dlascl(type, &kl, &ku, &from, &to, &m, &n, a, &lda, info);
 }
 
 
 
-static __inline void dpptrf(char *uplo,int n,double *ap,int *info)
-{
-  dpptrf(uplo,&n,ap,info);
-}
-
-
-static __inline void dscal(int n,double da,double *dx,int incx)
-{
-  dscal(&n,&da,dx,&incx);
-}
-
-static __inline void dspgst(int itype,char *uplo,int n,double *ap,
-			    double *bp,int *info)
-{
-  dspgst(&itype,uplo,&n,ap,bp,info);
+static __inline double dnrm2(int n, double *dx, int incx) {
+    return dnrm2(&n, dx, &incx);
 }
 
 
 
-static __inline void dspev(char *jobz,char *uplo, int n, double *ap,
-			   double *w, double *z, int ldz, double *work,
-			   int *info)
-{
-  dspev(jobz,uplo,&n,ap,w,z,&ldz,work,info);
+static __inline void dpptrf(char *uplo, int n, double *ap, int *info) {
+    dpptrf(uplo, &n, ap, info);
+}
+
+
+static __inline void dscal(int n, double da, double *dx, int incx) {
+    dscal(&n, &da, dx, &incx);
+}
+
+static __inline void dspgst(int itype, char *uplo, int n, double *ap,
+                            double *bp, int *info) {
+    dspgst(&itype, uplo, &n, ap, bp, info);
 }
 
 
 
-static __inline void dspgv(int itype,char *jobz,char *uplo, int n, double *ap,
-			   double *bp, double *w,double *z, int ldz,
-			   double *work,int *info)
-{
-  dspgv(&itype,jobz,uplo,&n,ap,bp,w,z,&ldz,work,info);
+static __inline void dspev(char *jobz, char *uplo, int n, double *ap,
+                           double *w, double *z, int ldz, double *work,
+                           int *info) {
+    dspev(jobz, uplo, &n, ap, w, z, &ldz, work, info);
 }
 
 
 
-static __inline void dtptri(char *uplo,char *diag,int n,double *ap,int *info)
-{
-  dtptri(uplo,diag,&n,ap,info);
+static __inline void dspgv(int itype, char *jobz, char *uplo, int n, double *ap,
+                           double *bp, double *w, double *z, int ldz,
+                           double *work, int *info) {
+    dspgv(&itype, jobz, uplo, &n, ap, bp, w, z, &ldz, work, info);
 }
 
 
-static __inline void dtrcon(char *norm,char *uplo,char *diag,int n,double *a,
-			    int lda,double *rcond,double *work,int *iwork,
-			    int *info)
-{
-  dtrcon(norm,uplo,diag,&n,a,&lda,rcond,work,iwork,info);
+
+static __inline void dtptri(char *uplo, char *diag, int n, double *ap, int *info) {
+    dtptri(uplo, diag, &n, ap, info);
 }
 
-static __inline void dorgqr(int m, int n, int k, double *a, int lda, 
-							double *tau, double *work, int lwork, int *info)
-{
-  dorgqr(&m, &n, &k, a, &lda, tau, work, &lwork, info); 
+
+static __inline void dtrcon(char *norm, char *uplo, char *diag, int n, double *a,
+                            int lda, double *rcond, double *work, int *iwork,
+                            int *info) {
+    dtrcon(norm, uplo, diag, &n, a, &lda, rcond, work, iwork, info);
 }
 
-static __inline void dgeqp3(int m, int n, double *a, int lda, int *jpvt, 
-							double *tau, double *work, int lwork, int *info)
-{
-	dgeqp3(&m, &n, a, &lda, jpvt, tau, work, &lwork, info);
+static __inline void dorgqr(int m, int n, int k, double *a, int lda,
+                            double *tau, double *work, int lwork, int *info) {
+    dorgqr(&m, &n, &k, a, &lda, tau, work, &lwork, info);
+}
+
+static __inline void dgeqp3(int m, int n, double *a, int lda, int *jpvt,
+                            double *tau, double *work, int lwork, int *info) {
+    dgeqp3(&m, &n, a, &lda, jpvt, tau, work, &lwork, info);
 }
 
 static __inline void dtrtrs(char *uplo, char *trans, char *diag, int n,
-							int nrhs, double *a, int lda, double *b,
-							int ldb, int *info)
-{
-	dtrtrs(uplo, trans, diag, &n, &nrhs, a, &lda, b, &ldb, info);
+                            int nrhs, double *a, int lda, double *b,
+                            int ldb, int *info) {
+    dtrtrs(uplo, trans, diag, &n, &nrhs, a, &lda, b, &ldb, info);
 }

--- a/include/myRegistry.h
+++ b/include/myRegistry.h
@@ -24,7 +24,7 @@
 //######################################################################
 
 /*! \file
-  \brief Defines the company and application keys for accessing the registry.
+    \brief Defines the company and application keys for accessing the registry.
 */
 #ifndef MYREGISTRY_HXX
 #define MYREGISTRY_HXX

--- a/include/mytools.h
+++ b/include/mytools.h
@@ -24,7 +24,7 @@
 //######################################################################
 
 /*! \file
-  \brief Various useful macros and functions for dealing with errors and other common operations.
+    \brief Various useful macros and functions for dealing with errors and other common operations.
 */
 
 #ifndef _MY_TOOLS_HXX_
@@ -45,14 +45,14 @@ class vec3;
 #define FAILURE -1
 #define TERMINAL_FAILURE -2
 
-void show_errors(int, char* = NULL);
+void show_errors(int, char * = NULL);
 
 #ifndef MAX
-#define MAX(A,B)	((A) > (B) ? (A) : (B))
+#define MAX(A,B)    ((A) > (B) ? (A) : (B))
 #endif
 
 #ifndef MIN
-#define MIN(A,B)	((A) < (B) ? (A) : (B))
+#define MIN(A,B)    ((A) < (B) ? (A) : (B))
 #endif
 
 #ifndef ROUND
@@ -61,19 +61,18 @@ void show_errors(int, char* = NULL);
 
 //std::ostream& operator<< (std::ostream& os, QString& str)
 //{
-//	return os << str.latin1();
+//  return os << str.latin1();
 //}
 
-inline void printQString(QString q)
-{
-  std::string str = q.toStdString();
-  std::cerr << str << std::endl;
+inline void printQString(QString q) {
+    std::string str = q.toStdString();
+    std::cerr << str << std::endl;
 }
 
 #ifndef BATCH_PROCESSING
 //! Puts up a QT warning box with the given message
 #define QTWARNING(MSG_) QMessageBox::warning(NULL,"GraspIt!",MSG_,QMessageBox::Ok, \
-											 Qt::NoButton,Qt::NoButton)
+                                             Qt::NoButton,Qt::NoButton)
 #else
 //If batch processing is enabled we supress error messages that require user attention
 //alternatively, we could redirect this into a log file
@@ -91,19 +90,19 @@ QPixmap load_pixmap(const QString &name);
 
 //useful macros for standardizing error printing
 #define pr_error(EXPR_)                         \
-{                                               \
-    fprintf(stderr,">>!>> ");                   \
-    fprintf(stderr,EXPR_);                      \
-    fprintf(stderr,"\n");                       \
-}
+    {                                               \
+        fprintf(stderr,">>!>> ");                   \
+        fprintf(stderr,EXPR_);                      \
+        fprintf(stderr,"\n");                       \
+    }
 
 // EXPR_ must be of the form: (stderr,"..%...%...%...",args)
 #define pr_errArgs(EXPR_)                       \
-{                                               \
-    fprintf(stderr,">>!>> ");                   \
-    fprintf EXPR_;                              \
-    fprintf(stderr,"\n");                       \
-}
+    {                                               \
+        fprintf(stderr,">>!>> ");                   \
+        fprintf EXPR_;                              \
+        fprintf(stderr,"\n");                       \
+    }
 
 //! Finds the next line in a stream that is not blank or a comment
 int nextValidLine(QTextStream *stream, QString *line);
@@ -118,23 +117,23 @@ int findString(QTextStream *stream, QString target);
 QString relativePath(QString absolutePath, QString relativeToDir);
 
 //! Returns the child of the XML node \a root of the type specified in \a defStr
-const TiXmlElement* findXmlElement(const TiXmlElement *root, QString defStr);
+const TiXmlElement *findXmlElement(const TiXmlElement *root, QString defStr);
 
 //! Returns the children of the XML node \a root of the type specified in \a defStr
-std::list<const TiXmlElement*> findAllXmlElements(const TiXmlElement *root, QString defStr);
+std::list<const TiXmlElement *> findAllXmlElements(const TiXmlElement *root, QString defStr);
 
 //! Returns the number of chilren in the XML node \a root of the type specified in \a defStr
 int countXmlElements(const TiXmlElement *root, QString defStr);
 
 //! Returns the double value in the child f the XML node \a root of the type specified in \a defStr
-bool getDouble(const TiXmlElement *root, QString defStr, double& val);
+bool getDouble(const TiXmlElement *root, QString defStr, double &val);
 
 //! Returns the int value in the child f the XML node \a root of the type specified in \a defStr
-bool getInt(const TiXmlElement *root, QString defStr, int& val);
+bool getInt(const TiXmlElement *root, QString defStr, int &val);
 
-//! Returns the position vector specified by the XML node \a root 
+//! Returns the position vector specified by the XML node \a root
 bool getPosition(const TiXmlElement *root, vec3 &pos);
 
-//! Returns the total transformation specified by the XML node \a root 
-bool getTransform(const TiXmlElement *root,transf &totalTran);
+//! Returns the total transformation specified by the XML node \a root
+bool getTransform(const TiXmlElement *root, transf &totalTran);
 #endif

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -24,62 +24,64 @@
 //######################################################################
 
 /*! \file
-  \brief Defines the interface for a plugin that can be loaded dynamically and used with GraspIt
+    \brief Defines the interface for a plugin that can be loaded dynamically and used with GraspIt
 */
 #ifndef __PLUGIN_H__
 #include <string>
 
 //! Defines a plugin that can can be loaded dynamically and used with GraspIt
-class Plugin
-{
-public:
-  //! Stub destructor
-  virtual ~Plugin(){}
-  //! Called once when user starts the plugin (or on startup if the plugin is automatically started)
-  virtual int init(int argc, char **argv) = 0;
-  //! Called whenever GraspIt's main loop is idle
-  virtual int mainLoop() = 0;
+class Plugin {
+    public:
+        //! Stub destructor
+        virtual ~Plugin() {}
+        //! Called once when user starts the plugin (or on startup if the plugin is automatically started)
+        virtual int init(int argc, char **argv) = 0;
+        //! Called whenever GraspIt's main loop is idle
+        virtual int mainLoop() = 0;
 };
 
-class PluginCreator
-{
-public:
-  typedef Plugin* (*CreatePluginFctn)();
-  typedef std::string (*GetTypeFctn)();
-private:
-  void* mLibraryHandle;
-  CreatePluginFctn mCreatePluginFctn;
+class PluginCreator {
+    public:
+        typedef Plugin *(*CreatePluginFctn)();
+        typedef std::string(*GetTypeFctn)();
+    private:
+        void *mLibraryHandle;
+        CreatePluginFctn mCreatePluginFctn;
 
-  bool mAutoStart;
-  std::string mType;
+        bool mAutoStart;
+        std::string mType;
 
-public:
-  PluginCreator(void* libraryHandle, CreatePluginFctn createPluginFctn,
-                bool autoStart, std::string type) :
-    mLibraryHandle(libraryHandle),
-    mCreatePluginFctn(createPluginFctn),
-    mAutoStart(autoStart),
-    mType(type)
-  {}
-  
-  ~PluginCreator();
+    public:
+        PluginCreator(void *libraryHandle, CreatePluginFctn createPluginFctn,
+                      bool autoStart, std::string type) :
+            mLibraryHandle(libraryHandle),
+            mCreatePluginFctn(createPluginFctn),
+            mAutoStart(autoStart),
+            mType(type) {
+        }
 
-  Plugin* createPlugin(int argc, char** argv);
-  
-  bool autoStart() const {return mAutoStart;}
-  std::string type() const {return mType;}
+        ~PluginCreator();
 
-  static PluginCreator* loadFromLibrary(std::string libName);
+        Plugin *createPlugin(int argc, char **argv);
+
+        bool autoStart() const {
+            return mAutoStart;
+        }
+        std::string type() const {
+            return mType;
+        }
+
+        static PluginCreator *loadFromLibrary(std::string libName);
 };
 
 
 
 
-/*Under windows, DLL files only export symbols prefaced with this compiler macro.
+/*  Under windows, DLL files only export symbols prefaced with this compiler macro.
 
 
-For both linux and windows, extern "C" are necessary.
-I.E. 
+    For both linux and windows, extern "C" are necessary.
+    I.E.
      namespace fooplugin{
      class fooPlugin: Plugin{
      --stuff--
@@ -92,10 +94,10 @@ I.E.
      but this does not appear to cause any problems.
 
 
-}
+    }
 
 
-Both the createPlugin and getType functions must be declared using these macros.
+    Both the createPlugin and getType functions must be declared using these macros.
 */
 #ifdef WIN32
 #define PLUGIN_API __declspec(dllexport)

--- a/include/profiling.h
+++ b/include/profiling.h
@@ -27,81 +27,81 @@
 #define _profiling_h_
 
 /*! \file
-	Implements a number of tools for simple, but easy to use and efficient 
-	code profiling. It should add a tiny overhead to the caller code, so
-	it can be called lots of times.
+    Implements a number of tools for simple, but easy to use and efficient
+    code profiling. It should add a tiny overhead to the caller code, so
+    it can be called lots of times.
 
-	Usage example:
-	----------------------------
-	#define PROF_ENABLED
-	#include "profiling.h"
+    Usage example:
+    ----------------------------
+    #define PROF_ENABLED
+    #include "profiling.h"
 
-	PROF_DECLARE(TOTAL_TIMER);
-	PROF_DECLARE(FOO_TIMER);
+    PROF_DECLARE(TOTAL_TIMER);
+    PROF_DECLARE(FOO_TIMER);
 
-	void foo() {
-		PROF_TIMER_FUNC(FOO_TIMER);
-		for (int i=0; i<1000; i++) {}
-	}
+    void foo() {
+        PROF_TIMER_FUNC(FOO_TIMER);
+        for (int i=0; i<1000; i++) {}
+    }
 
-	int main(int, char**) {
+    int main(int, char**) {
 
-		PROF_START_TIMER(TOTAL_TIMER);
-		for (int i=0; i<100000; i++) {
-			for (int j=0; j<2000; j++) {}
-			foo();
-		}
-		PROF_STOP_TIMER(TOTAL_TIMER);
+        PROF_START_TIMER(TOTAL_TIMER);
+        for (int i=0; i<100000; i++) {
+            for (int j=0; j<2000; j++) {}
+            foo();
+        }
+        PROF_STOP_TIMER(TOTAL_TIMER);
 
-		//Total time in program
-		PROF_PRINT(TOTAL_TIMER);
-		//Number of calls to and time spent in foo() function
-		PROF_PRINT(FOO_TIMER);
+        //Total time in program
+        PROF_PRINT(TOTAL_TIMER);
+        //Number of calls to and time spent in foo() function
+        PROF_PRINT(FOO_TIMER);
 
-		return 0;
-	}
-	-------------------------------
+        return 0;
+    }
+    -------------------------------
 
-	Usage "manual":
+    Usage "manual":
 
-	The main concept is a "timer", of which you can define as many as you 
-	want. When you define a timer, you associate a name with it, and then 
-	you can start it, stop it, print it, or have it time a particular 
-	function. Any timer will also double as a counter, and you can reset or 
-	increment its count whenever you want.
+    The main concept is a "timer", of which you can define as many as you
+    want. When you define a timer, you associate a name with it, and then
+    you can start it, stop it, print it, or have it time a particular
+    function. Any timer will also double as a counter, and you can reset or
+    increment its count whenever you want.
 
-	<ul>
-	<li> #include "profiling.h" in any source file. 
-	<li> to enable the profiler, also #define PROF_ENABLED just before 
-	the include directive. To disable profiling, just remove the PROF_ENABLED 
-	definition and you can leave all the other profiler calls in, they will be 
-	pre-processed out.
-	<li> it is preferable to include your profiling definitions in source, not
-	header files, so that the definition PROF_ENABLED doesn't propagate to 
-	unexpected places.
-	</ul>
-	To declare a new timer, use:
+    <ul>
+    <li> #include "profiling.h" in any source file.
+    <li> to enable the profiler, also #define PROF_ENABLED just before
+    the include directive. To disable profiling, just remove the PROF_ENABLED
+    definition and you can leave all the other profiler calls in, they will be
+    pre-processed out.
+    <li> it is preferable to include your profiling definitions in source, not
+    header files, so that the definition PROF_ENABLED doesn't propagate to
+    unexpected places.
+    </ul>
+    To declare a new timer, use:
 
-	PROF_DECLARE(my_timer_name);
+    PROF_DECLARE(my_timer_name);
 
-	This can be placed in any source file in your project. Just be sure to place
-	timer declarations at the global scope (not inside of any functions). Don't
-	worry about namespace pollution, everything profiler-related ends up in its
-	own namespace behind the scenes.
+    This can be placed in any source file in your project. Just be sure to place
+    timer declarations at the global scope (not inside of any functions). Don't
+    worry about namespace pollution, everything profiler-related ends up in its
+    own namespace behind the scenes.
 
-	The name then becomes the unique identifier that you can refer to a timer
-	through. The main feature of this framework is that you can use literal 
-	names, thus making it easy to use. However, behind the scenes they are 
-	converted into static ints and add no overhead when they need to be 
-	matched against timers. On the other hand, using any undeclared timer is 
-	caught at compile-time.
+    The name then becomes the unique identifier that you can refer to a timer
+    through. The main feature of this framework is that you can use literal
+    names, thus making it easy to use. However, behind the scenes they are
+    converted into static ints and add no overhead when they need to be
+    matched against timers. On the other hand, using any undeclared timer is
+    caught at compile-time.
 
-	To use the same timer in a different file than it was declared in, place 
-	an extern declaration in the file you use it in:
+    To use the same timer in a different file than it was declared in, place
+    an extern declaration in the file you use it in:
 
-	PROF_EXTERN(my_timer_name);
+    PROF_EXTERN(my_timer_name);
 
-	See below macros for what you can do with a timer.
+    See below macros for what you can do with a timer.
 */
 
 #include <iostream>
@@ -110,14 +110,14 @@
 #include "assert.h"
 
 namespace Profiling {
-	class Profiler;
-	inline Profiler &getProfiler();
+    class Profiler;
+    inline Profiler &getProfiler();
 }
 
 #ifdef PROF_ENABLED
 
 //declarations
-//! Declares a new timer. 
+//! Declares a new timer.
 #define PROF_DECLARE(STR) namespace Profiling{extern const int STR = getProfiler().getNewIndex(#STR);}
 //! Allows the usage of a timer which was declared (with PROF_DECLARE) in a different file
 #define PROF_EXTERN(STR) namespace Profiling{extern const int STR;}
@@ -166,118 +166,127 @@ namespace Profiling {
 
 namespace Profiling {
 
-class ProfileInstance 
-{
-private:
-  int mCount;
-  bool mRunning;
-  std::string mName;
-  //! The units here might be different depending on the operating system
-  /*! use getTotalTimeMicroseconds() to get total timer time in microseconds. */
-  PROF_TIME_UNIT mStartTime;
-  PROF_DURATION_UNIT mElapsedTime;
-public:
-  ProfileInstance();
-  void setName(const char *name){mName = name;}
+    class ProfileInstance {
+        private:
+            int mCount;
+            bool mRunning;
+            std::string mName;
+            //! The units here might be different depending on the operating system
+            /*! use getTotalTimeMicroseconds() to get total timer time in microseconds. */
+            PROF_TIME_UNIT mStartTime;
+            PROF_DURATION_UNIT mElapsedTime;
+        public:
+            ProfileInstance();
+            void setName(const char *name) {
+                mName = name;
+            }
 
-  void count(){mCount++;}
-  int getCount(){return mCount;}
-  void reset()
-  {
-    mCount=0;
-    PROF_RESET_DURATION(mElapsedTime);
-    if (mRunning) 
-    {
-      PROF_GET_TIME(mStartTime);
+            void count() {
+                mCount++;
+            }
+            int getCount() {
+                return mCount;
+            }
+            void reset() {
+                mCount = 0;
+                PROF_RESET_DURATION(mElapsedTime);
+                if (mRunning) {
+                    PROF_GET_TIME(mStartTime);
+                }
+            }
+            void startTimer() {
+                if (!mRunning) {
+                    PROF_GET_TIME(mStartTime);
+                    mRunning = true;
+                }
+                else {
+                    std::cerr << "Timer " << mName << " already running.\n";
+                }
+            }
+            void stopTimer() {
+                if (mRunning) {
+                    PROF_TIME_UNIT currentTime;
+                    PROF_GET_TIME(currentTime);
+                    PROF_ADD_DURATION(mElapsedTime, mStartTime, currentTime);
+                    mRunning = false;
+                }
+                else {
+                    std::cerr << "Timer " << mName << " is not running.\n";
+                }
+            }
+            /*! This returns the elapsed time. It does whatever conversion is necessary,
+                depending on the OS, to convert to microseconds. If the timer is running
+                at the moment when this is called, is also adds the currently ellapsed
+                time.
+
+                This call is slower than start or stop timer, so don't abuse it.
+            */
+            double getTotalTimeMicroseconds();
+            void print();
+    };
+
+    class Profiler {
+        private:
+            int mNextIndex;
+            int mSize;
+            std::vector<ProfileInstance> mPI;
+            #ifdef WIN32
+            UINT64 COUNTS_PER_SEC;
+            #endif
+        public:
+            Profiler();
+            ~Profiler();
+
+            void resize(int size);
+            int getNewIndex(const char *name);
+
+            void count(int index) {
+                mPI[index].count();
+            }
+            int getCount(int index) {
+                return mPI[index].getCount();
+            }
+            void reset(int index) {
+                mPI[index].reset();
+            }
+            void startTimer(int index) {
+                mPI[index].startTimer();
+            }
+            void stopTimer(int index) {
+                mPI[index].stopTimer();
+            }
+            void print(int index) {
+                mPI[index].print();
+            }
+
+            void resetAll();
+            void printAll();
+            #ifdef WIN32
+            UINT64 getCountsPerSec() {
+                return COUNTS_PER_SEC;
+            }
+            #endif
+    };
+
+    Profiler &getProfiler() {
+        //the one and only instance of the profiler
+        static Profiler profInstance;
+        return profInstance;
     }
-  }
-  void startTimer()
-  {
-    if (!mRunning) 
-    {
-      PROF_GET_TIME(mStartTime);
-      mRunning = true;
-    } 
-    else 
-    {
-      std::cerr << "Timer " << mName << " already running.\n";
-    }
-  }
-  void stopTimer()
-  {
-    if (mRunning) 
-    {
-      PROF_TIME_UNIT currentTime;
-      PROF_GET_TIME(currentTime);
-      PROF_ADD_DURATION( mElapsedTime, mStartTime, currentTime);
-      mRunning = false;
-    } 
-    else 
-    {
-      std::cerr << "Timer " << mName << " is not running.\n";
-    }
-  }
-  /*! This returns the elapsed time. It does whatever conversion is necessary,
-    depending on the OS, to convert to microseconds. If the timer is running
-    at the moment when this is called, is also adds the currently ellapsed 
-    time.
-    
-    This call is slower than start or stop timer, so don't abuse it.
-  */
-  double getTotalTimeMicroseconds();
-  void print();
-};
 
-class Profiler 
-{
-private:
-  int mNextIndex;
-  int mSize;
-  std::vector<ProfileInstance> mPI;
-#ifdef WIN32
-  UINT64 COUNTS_PER_SEC;
-#endif
-public:
-  Profiler();
-  ~Profiler();
-  
-  void resize(int size);
-  int getNewIndex(const char *name);
-
-  void count(int index){mPI[index].count();}
-  int getCount(int index){return mPI[index].getCount();}
-  void reset(int index){mPI[index].reset();}
-  void startTimer(int index){mPI[index].startTimer();}
-  void stopTimer(int index){mPI[index].stopTimer();}
-  void print(int index){mPI[index].print();}
-  
-  void resetAll();
-  void printAll();
-#ifdef WIN32
-  UINT64 getCountsPerSec(){return COUNTS_PER_SEC;}
-#endif
-};
-
-Profiler& getProfiler()
-{
-  //the one and only instance of the profiler
-  static Profiler profInstance;
-  return profInstance;
- }
-
-class FunctionTimer 
-{
-private:
-  Profiler &mProfiler;
-  int mIndex;
-public:
- FunctionTimer(Profiler &prof, int index) : mProfiler(prof), mIndex(index) 
- {
-   mProfiler.count(mIndex);
-   mProfiler.startTimer(mIndex);
- }
-  ~FunctionTimer(){mProfiler.stopTimer(mIndex);}
-};
+    class FunctionTimer {
+        private:
+            Profiler &mProfiler;
+            int mIndex;
+        public:
+            FunctionTimer(Profiler &prof, int index) : mProfiler(prof), mIndex(index) {
+                mProfiler.count(mIndex);
+                mProfiler.startTimer(mIndex);
+            }
+            ~FunctionTimer() {
+                mProfiler.stopTimer(mIndex);
+            }
+    };
 
 }
 

--- a/include/qhull_mutex.h
+++ b/include/qhull_mutex.h
@@ -1,10 +1,10 @@
 #ifndef _qhull_mutex_h_
 #define _qhull_mutex_h_
 
-/*!	\file
-    This is the mutex that should be used to constrain access to qhull, 
-    which is not thread-safe. Any file using qhull should include this 
-	header and use the defined mutex.
+/*! \file
+    This is the mutex that should be used to constrain access to qhull,
+    which is not thread-safe. Any file using qhull should include this
+    header and use the defined mutex.
 */
 
 #include <qmutex.h>

--- a/include/quality.h
+++ b/include/quality.h
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s):  Andrew T. Miller 
+// Author(s):  Andrew T. Miller
 //
 // $Id: quality.h,v 1.8 2009/03/31 15:37:06 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the base QualityMeasure class and specific qm classes.
- */
+/*! \file
+    \brief Defines the base QualityMeasure class and specific qm classes.
+*/
 #ifndef QUALITY_H
 
 #include <QString>
@@ -43,148 +43,158 @@ class Grasp;
 
 //! A collection of pointers to exchange data with the qm dialog box
 /*!
-  A collection of pointers to exchange data with the qm dialog box.
+    A collection of pointers to exchange data with the qm dialog box.
 */
 struct qmDlgDataT {
-  //! The current grasp
-  Grasp *grasp;
+    //! The current grasp
+    Grasp *grasp;
 
-  //! A pointer to the settings area widget of the dlg box (qm must populate)
-  QWidget *settingsArea;
+    //! A pointer to the settings area widget of the dlg box (qm must populate)
+    QWidget *settingsArea;
 
-  //! A pointer to the qm Type selection box in the dlg box
-  QComboBox *qmTypeComboBox;
+    //! A pointer to the qm Type selection box in the dlg box
+    QComboBox *qmTypeComboBox;
 
-  //! The pointer to the name field in the dlg box
-  QLineEdit *qmName;
+    //! The pointer to the name field in the dlg box
+    QLineEdit *qmName;
 
-  //! The string quality measure type
-  const char *qmType;
+    //! The string quality measure type
+    const char *qmType;
 
-  //! The current quality measure
-  QualityMeasure *currQM;
+    //! The current quality measure
+    QualityMeasure *currQM;
 
-  //! Pointer to another stucture containing data for this specific type of QM
-  void *paramPtr;
+    //! Pointer to another stucture containing data for this specific type of QM
+    void *paramPtr;
 };
 
 
 //! Abstract base class for quality measures
 /*!
-  A quality measure is associated with a particular grasp.  Each individual
-  type of quality measure must be able to build a parameters area for the
-  quality measure dialog box.  It also must be able to produce a scalar real
-  value that evaluates its grasp in someway.
+    A quality measure is associated with a particular grasp.  Each individual
+    type of quality measure must be able to build a parameters area for the
+    quality measure dialog box.  It also must be able to produce a scalar real
+    value that evaluates its grasp in someway.
 */
 class QualityMeasure {
-  //! The user chosen name of this qm instance
-  QString name;
+        //! The user chosen name of this qm instance
+        QString name;
 
- protected:
-  //! A pointer to the grasp this qm is associated with
-  Grasp *grasp;
+    protected:
+        //! A pointer to the grasp this qm is associated with
+        Grasp *grasp;
 
-  //! The current value of the qm
-  double val;
+        //! The current value of the qm
+        double val;
 
- public:
-  QualityMeasure(qmDlgDataT *data);
-  QualityMeasure(Grasp *g, QString n);
-  virtual ~QualityMeasure();
+    public:
+        QualityMeasure(qmDlgDataT *data);
+        QualityMeasure(Grasp *g, QString n);
+        virtual ~QualityMeasure();
 
-  /*! Returns the type of this quality measure expressed as a string */
-  virtual const char *getType() const =0;
-  
-  /*! Returns the user chosen name of this qm instance */
-  virtual QString getName() {return name;}
+        /*! Returns the type of this quality measure expressed as a string */
+        virtual const char *getType() const = 0;
 
-  /*! Returns the quality of the grasp associated with this qm */
-  virtual double evaluate() =0;
-  virtual double evaluate3D() =0;
-      
-  static void buildParamArea(qmDlgDataT *qmData);
-  static QualityMeasure *createInstance(qmDlgDataT *qmData);
-  static const char *TYPE_LIST[];
+        /*! Returns the user chosen name of this qm instance */
+        virtual QString getName() {
+            return name;
+        }
+
+        /*! Returns the quality of the grasp associated with this qm */
+        virtual double evaluate() = 0;
+        virtual double evaluate3D() = 0;
+
+        static void buildParamArea(qmDlgDataT *qmData);
+        static QualityMeasure *createInstance(qmDlgDataT *qmData);
+        static const char *TYPE_LIST[];
 
 };
 
 //! The epsilon quality measure
 /*!
-  The epsilon quality measure measures the size of the largest Task Wrench
-  Space (TWS_ that can fit within the unit Grasp Wrench Space (GWS).  In the
-  case of the ball TWS, the measure because simply the euclidean distance from
-  the wrench space origin to the closest point on the  hull bouandary.  This
-  is a worst case grasp quality measure.  The parameters for this quality
-  measure are:
+    The epsilon quality measure measures the size of the largest Task Wrench
+    Space (TWS_ that can fit within the unit Grasp Wrench Space (GWS).  In the
+    case of the ball TWS, the measure because simply the euclidean distance from
+    the wrench space origin to the closest point on the  hull bouandary.  This
+    is a worst case grasp quality measure.  The parameters for this quality
+    measure are:
      The GWS type
      The TWS type
 */
 class QualEpsilon : public QualityMeasure {
-  //! A pointer to the GWS that this qm should use for its calculation
-  GWS *gws;
+        //! A pointer to the GWS that this qm should use for its calculation
+        GWS *gws;
 
-  //! The string identifying this qm type
-  static const char *type;
+        //! The string identifying this qm type
+        static const char *type;
 
- public:
-  QualEpsilon(qmDlgDataT *data);
-  QualEpsilon(Grasp *g, QString n, const char *gwsType);
-  ~QualEpsilon();
+    public:
+        QualEpsilon(qmDlgDataT *data);
+        QualEpsilon(Grasp *g, QString n, const char *gwsType);
+        ~QualEpsilon();
 
-  /*! Returns the type of this quality measure expressed as a string */
-  const char *getType() const {return type;}
+        /*! Returns the type of this quality measure expressed as a string */
+        const char *getType() const {
+            return type;
+        }
 
-  double evaluate();
-  double evaluate3D();
+        double evaluate();
+        double evaluate3D();
 
-  static void buildParamArea(qmDlgDataT *qmData);
+        static void buildParamArea(qmDlgDataT *qmData);
 
-  /*! Returns the type of this class expressed as a string. */
-  static const char *getClassType() {return type;}
+        /*! Returns the type of this class expressed as a string. */
+        static const char *getClassType() {
+            return type;
+        }
 };
 
 //! The volume quality measure
 /*!
-  The volume quality measure measures the volume of the unit Grasp Wrench
-  Space (GWS). This is an average case grasp quality measure.  The parameter
-  for this quality measure is:
+    The volume quality measure measures the volume of the unit Grasp Wrench
+    Space (GWS). This is an average case grasp quality measure.  The parameter
+    for this quality measure is:
      The GWS type
 */
 class QualVolume : public QualityMeasure {
-  //! A pointer to the GWS that this qm should use for its calculation
-  GWS *gws;
+        //! A pointer to the GWS that this qm should use for its calculation
+        GWS *gws;
 
-  //! The string identifying this qm type
-  static const char *type;
+        //! The string identifying this qm type
+        static const char *type;
 
- public:
-  QualVolume(qmDlgDataT *data);
-  QualVolume(Grasp *g, QString n, const char *gwsType);
-  ~QualVolume();
-  
-  /*! Returns the type of this quality measure expressed as a string */
-  const char *getType() const {return type;}
+    public:
+        QualVolume(qmDlgDataT *data);
+        QualVolume(Grasp *g, QString n, const char *gwsType);
+        ~QualVolume();
 
-  double evaluate();
-  double evaluate3D();
+        /*! Returns the type of this quality measure expressed as a string */
+        const char *getType() const {
+            return type;
+        }
 
-  static void buildParamArea(qmDlgDataT *qmData);
+        double evaluate();
+        double evaluate3D();
 
-  /*! Returns the type of this class expressed as a string. */
-  static const char *getClassType() {return type;}
+        static void buildParamArea(qmDlgDataT *qmData);
+
+        /*! Returns the type of this class expressed as a string. */
+        static const char *getClassType() {
+            return type;
+        }
 };
 
 /*
-class QualWeighted : public QualityMeasure {
-  QualityMeausre *qm1,*qm2;
-  double weight1,weight2;
+    class QualWeighted : public QualityMeasure {
+    QualityMeausre *qm1,*qm2;
+    double weight1,weight2;
 
- public:
-  QualWeighted(Grasp *g, char *n, QualityMeasure *q1, QualityMeasure *q2,
-	       double w1, double w2);
-  double evalute() {return weight1*qm1->evaluate() + weight2*qm2->evaluate();}
+    public:
+    QualWeighted(Grasp *g, char *n, QualityMeasure *q1, QualityMeasure *q2,
+           double w1, double w2);
+    double evalute() {return weight1*qm1->evaluate() + weight2*qm2->evaluate();}
 
-};
+    };
 
 */
 #define QUALITY_H

--- a/include/robot.h
+++ b/include/robot.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the robot class hierarchy.
- */
+/*! \file
+    \brief Defines the robot class hierarchy.
+*/
 
 #ifndef ROBOT_H
 
@@ -51,629 +51,699 @@ class TiXmlElement;
 
 //! Base class for all robots which are collections of links connected by moveable joints
 /*! A robot is collection of link bodies orgainized around a base link.
-   Connected to the base link may be 1 or more kinematic chains of links and
-   joints.  When a robot is attached to another robot an additional mount
-   piece that connects to the base of the child robot may also be defined.
-   The structure of a robot is defined in a text configuration file
-   [see user documentation] that is parsed by the load method. 
-   
-   Each robot has a collection of DOF's (degrees of freedom) that are
-   linked to the individual joints of a kinematic chain.  In general, a robot
-   can not set its joints directly. All joint motion has to be obtained from
-   the DOF's then set using the kinematic chains. In general, we will refer to
-   the position of the robot's base in world coordinate systems as the robot's
-   "pose" while the value of the joints (and implicitly the DOF's) is the robot's
-   "posture".
-   
-   To set the robot pose, think of it as a general \a WorldElement; nothing 
-   complicated here. Posture is more involved, and depends on whether you are
-   in static or dynamic mode.
-   
-   In static mode, you can have the robot move to some desired *DOF* values. The
-   DOF's will then compute appropriate joint values, and the robot will have the
-   chains execute those. The settings come in two flavors:
-   
-   \a moveDOFToContacts(...) will perform the move in small steps and detect 
-   contacts along the way. It is guaranteed to leave your robot in a legal 
-   configuration, and detect all contacts that occur.
-   
-   \a forceDOFVals(...) will force the final joint values and perform no collision
-   detection. Therefore, it might leave the robot in inter-penetration with some 
-   other object.
-   
-   If dynamics are on, then new desired DOF positions are set with a call
-   to \a setDesiredDOFVals, and a number of intermediate set points are generated
-   for each joint that will ensure a smooth velocity and acceleration profile.
-   Built in PD DOF controllers use gains specified in the robot configuration
-   file to apply approriate forces to each joint to correct error between the
-   current joint position and the current set point.
-   
-   If a linear cartesian moves are desired, a trajectory generator can smoothly
-   interpolate between the desired poses by creating a number of intermediate
-   poses.  The inverse kinematics for each of these positions is computed and
-   and the resulting joint positions are used as set points for the PD
-   controllers.   
+    Connected to the base link may be 1 or more kinematic chains of links and
+    joints.  When a robot is attached to another robot an additional mount
+    piece that connects to the base of the child robot may also be defined.
+    The structure of a robot is defined in a text configuration file
+    [see user documentation] that is parsed by the load method.
+
+    Each robot has a collection of DOF's (degrees of freedom) that are
+    linked to the individual joints of a kinematic chain.  In general, a robot
+    can not set its joints directly. All joint motion has to be obtained from
+    the DOF's then set using the kinematic chains. In general, we will refer to
+    the position of the robot's base in world coordinate systems as the robot's
+    "pose" while the value of the joints (and implicitly the DOF's) is the robot's
+    "posture".
+
+    To set the robot pose, think of it as a general \a WorldElement; nothing
+    complicated here. Posture is more involved, and depends on whether you are
+    in static or dynamic mode.
+
+    In static mode, you can have the robot move to some desired *DOF* values. The
+    DOF's will then compute appropriate joint values, and the robot will have the
+    chains execute those. The settings come in two flavors:
+
+    \a moveDOFToContacts(...) will perform the move in small steps and detect
+    contacts along the way. It is guaranteed to leave your robot in a legal
+    configuration, and detect all contacts that occur.
+
+    \a forceDOFVals(...) will force the final joint values and perform no collision
+    detection. Therefore, it might leave the robot in inter-penetration with some
+    other object.
+
+    If dynamics are on, then new desired DOF positions are set with a call
+    to \a setDesiredDOFVals, and a number of intermediate set points are generated
+    for each joint that will ensure a smooth velocity and acceleration profile.
+    Built in PD DOF controllers use gains specified in the robot configuration
+    file to apply approriate forces to each joint to correct error between the
+    current joint position and the current set point.
+
+    If a linear cartesian moves are desired, a trajectory generator can smoothly
+    interpolate between the desired poses by creating a number of intermediate
+    poses.  The inverse kinematics for each of these positions is computed and
+    and the resulting joint positions are used as set points for the PD
+    controllers.
 */
 class Robot : public WorldElement {
-  Q_OBJECT
-
-Q_SIGNALS:
-  //! This signal informs that dof values have changed
-  void configurationChanged();
-
-  //! This signal informs that user has begun interaction by clicking on a robot handler
-  void userInteractionStart();
-
-  //! This signal is the complement of userInteractionStart().
-  void userInteractionEnd();
-
-  //! Emitted by moveDOFToCOntacts each time a step is taken
-  void moveDOFStepTaken(int numCols, bool &stopRequest);
-
-private:
-  // Connection to a parent robot 
-  //! Points to a parent robot that this robot is attached to
-  Robot *parent;
-  //! Records which chain of the parent robot this robot is attached to
-  int parentChainNum;
-  //! The inverse of the offset transform from parent chain end to this robot's base
-  transf tranToParentEnd;
-  //! A pointer to an optional mount piece link
-  Link *mountPiece;
-
-protected:
-
-  // The structure of the robot itself	
-  //! The number of kinematic chains (or fingers) this robot has
-  int numChains;
-  //! The number of degrees of freedom this robot has
-  int numDOF;
-  //! The total number of joints of this robot. Set when robot is loaded
-  int numJoints;
-  //! A vector of pointers to this robot's kinematic chains
-  std::vector<KinematicChain *> chainVec;
-  //! A vector of pointers to this robot's DOF's
-  std::vector<DOF *> dofVec;
-  //! A pointer to the base link (or palm) of the robot
-  Link *base;
-
-  // Save and restore state
-  //! Is used to save the current transform if we want to restore it later
-  transf savedTran;
-  //! Is used to store the states of the DOF; a stream is convenient as it can pack all dofs
-  QString savedDOF;
-  //! Tells us whether the state has been previously saved or not
-  bool savedState;
-
-  //! Whether changes to the position / geometry of the robot should trigger a scene graph redraw
-  bool mRenderGeometry;
-
-  // Dynamic simulation: parameters and trajectory generation
-  //! The simulation time of when the next change of DOF setpoints should occur
-  double dofUpdateTime;
-  //! The default translational velocity (mm/sec) to use when generating cartesian trajectories
-  double defaultTranslVel;
-  //! The default rotational velocity (rad/sec) to use when generating cartesian trajectories
-  double defaultRotVel;
-
-  // Input from external hardware
-  //! Shows if this robot is to be controlled via a CyberGlove
-  bool mUseCyberGlove;
-  //! Provides translation between the CyberGlove and this robot's DOFs
-  GloveInterface *mGloveInterface;
-  //! Shows if this robot is to be controlled by the Flock of Birds
-  bool mUsesFlock;
-  //! If robot is controlled by Flock of Birds, shows which bird it is attached to
-  int mBirdNumber;
-  //! Geometry for a visual model that shows where the bird is attached to the robot
-  SoSeparator *IVFlockRoot;
-  //! The relative tranform used for the Flock of Birds
-  FlockTransf mFlockTran;
-
-  //!Holds the DatabaseName for this robot if different than the name
-  QString myDatabaseName;
-
-  //!Holds all information about this robot's eigengrasps
-  EigenGraspInterface* mEigenGrasps;
-
-  //! Pre-specified information on how to best approach an object for grasping
-  /*! This transform sets the origin and the z axis to match the best approach 
-	  direction for this hand */
-  transf approachTran;
-  //! Geometry for the visual model of the approach direction
-  SoSeparator *IVApproachRoot;
-
-  //! Adds a visual image of the Flock of Birds sensor to the base of the robot
-  void addFlockSensorGeometry();
-  //! Adds a visual indicator of the pre-specified approach direction for this hand
-  void addApproachGeometry();
-
-  //! Recurses to all chains of this robot and any attached robots
-  virtual bool simpleContactsPreventMotion(const transf& motion) const;
-
-  //! An internal method called by setTran.  
-  inline virtual void simpleSetTran(transf const& tr);
-
-  //! Asks all chains to set the given joint values
-  virtual void setJointValues(const double* jointVals);
-  //! Asks all chains to set the given joint values, then update the position of all links
-  virtual void setJointValuesAndUpdate(const double* jointVals);
-  //! Gets the current joint values from the chains
-  inline void getJointValues(double* jointVals) const;
-  //! Informs the dof's that certain values have been set.
-  inline void updateDofVals(double *dofVals);
-  //! Main function for obtaining joint values from the dofs given desired dof values
-  virtual bool getJointValuesFromDOF(const double *desireddofVals, double *actualDofVals,
-									 double *jointVals, int *stoppedJoints);
-  //! Gets the Jacobian matrix of Joints w.r.t. DOF
-  Matrix getJacobianJointToDOF(int chainNum);
+        Q_OBJECT
+
+    Q_SIGNALS:
+        //! This signal informs that dof values have changed
+        void configurationChanged();
+
+        //! This signal informs that user has begun interaction by clicking on a robot handler
+        void userInteractionStart();
+
+        //! This signal is the complement of userInteractionStart().
+        void userInteractionEnd();
+
+        //! Emitted by moveDOFToCOntacts each time a step is taken
+        void moveDOFStepTaken(int numCols, bool &stopRequest);
+
+    private:
+        // Connection to a parent robot
+        //! Points to a parent robot that this robot is attached to
+        Robot *parent;
+        //! Records which chain of the parent robot this robot is attached to
+        int parentChainNum;
+        //! The inverse of the offset transform from parent chain end to this robot's base
+        transf tranToParentEnd;
+        //! A pointer to an optional mount piece link
+        Link *mountPiece;
+
+    protected:
+
+        // The structure of the robot itself
+        //! The number of kinematic chains (or fingers) this robot has
+        int numChains;
+        //! The number of degrees of freedom this robot has
+        int numDOF;
+        //! The total number of joints of this robot. Set when robot is loaded
+        int numJoints;
+        //! A vector of pointers to this robot's kinematic chains
+        std::vector<KinematicChain *> chainVec;
+        //! A vector of pointers to this robot's DOF's
+        std::vector<DOF *> dofVec;
+        //! A pointer to the base link (or palm) of the robot
+        Link *base;
+
+        // Save and restore state
+        //! Is used to save the current transform if we want to restore it later
+        transf savedTran;
+        //! Is used to store the states of the DOF; a stream is convenient as it can pack all dofs
+        QString savedDOF;
+        //! Tells us whether the state has been previously saved or not
+        bool savedState;
+
+        //! Whether changes to the position / geometry of the robot should trigger a scene graph redraw
+        bool mRenderGeometry;
+
+        // Dynamic simulation: parameters and trajectory generation
+        //! The simulation time of when the next change of DOF setpoints should occur
+        double dofUpdateTime;
+        //! The default translational velocity (mm/sec) to use when generating cartesian trajectories
+        double defaultTranslVel;
+        //! The default rotational velocity (rad/sec) to use when generating cartesian trajectories
+        double defaultRotVel;
+
+        // Input from external hardware
+        //! Shows if this robot is to be controlled via a CyberGlove
+        bool mUseCyberGlove;
+        //! Provides translation between the CyberGlove and this robot's DOFs
+        GloveInterface *mGloveInterface;
+        //! Shows if this robot is to be controlled by the Flock of Birds
+        bool mUsesFlock;
+        //! If robot is controlled by Flock of Birds, shows which bird it is attached to
+        int mBirdNumber;
+        //! Geometry for a visual model that shows where the bird is attached to the robot
+        SoSeparator *IVFlockRoot;
+        //! The relative tranform used for the Flock of Birds
+        FlockTransf mFlockTran;
+
+        //!Holds the DatabaseName for this robot if different than the name
+        QString myDatabaseName;
+
+        //!Holds all information about this robot's eigengrasps
+        EigenGraspInterface *mEigenGrasps;
+
+        //! Pre-specified information on how to best approach an object for grasping
+        /*! This transform sets the origin and the z axis to match the best approach
+            direction for this hand */
+        transf approachTran;
+        //! Geometry for the visual model of the approach direction
+        SoSeparator *IVApproachRoot;
+
+        //! Adds a visual image of the Flock of Birds sensor to the base of the robot
+        void addFlockSensorGeometry();
+        //! Adds a visual indicator of the pre-specified approach direction for this hand
+        void addApproachGeometry();
+
+        //! Recurses to all chains of this robot and any attached robots
+        virtual bool simpleContactsPreventMotion(const transf &motion) const;
+
+        //! An internal method called by setTran.
+        inline virtual void simpleSetTran(transf const &tr);
+
+        //! Asks all chains to set the given joint values
+        virtual void setJointValues(const double *jointVals);
+        //! Asks all chains to set the given joint values, then update the position of all links
+        virtual void setJointValuesAndUpdate(const double *jointVals);
+        //! Gets the current joint values from the chains
+        inline void getJointValues(double *jointVals) const;
+        //! Informs the dof's that certain values have been set.
+        inline void updateDofVals(double *dofVals);
+        //! Main function for obtaining joint values from the dofs given desired dof values
+        virtual bool getJointValuesFromDOF(const double *desireddofVals, double *actualDofVals,
+                                           double *jointVals, int *stoppedJoints);
+        //! Gets the Jacobian matrix of Joints w.r.t. DOF
+        Matrix getJacobianJointToDOF(int chainNum);
+
+        //! Attempts to set the desired dof values, detecting contacts along the way
+        bool jumpDOFToContact(double *desiredVals, int *stoppedJoints, int *numCols = NULL);
+        //! Finds the contact time between a collision and a collision-free posture
+        int interpolateJoints(double *initialVals, double *finalVals, CollisionReport *colReport,
+                              double *interpolationTime);
+        //! Stops all the joints that affect a link that is in contact
+        void stopJointsFromLink(Link *link, double *desiredJointVals, int *stoppedJoints);
+
+        //! Adds all of the bodies that make up this robot to the given vector
+        virtual void getBodyList(std::vector<Body *> *bodies);
+
+        friend void KinematicChain::updateLinkPoses();
+        friend void KinematicChain::attachRobot(Robot *r, const transf &offsetTr);
+
+    public:
+
+        /*! Simply initializes an empty robot within world w.  The load method must be called to read a
+            configuration file and give structure to the robot. */
+        Robot(World *w, const char *name) : WorldElement(w, name) {
+            parent = NULL;
+            parentChainNum = -1;
+            mountPiece = NULL;
+            numChains = numDOF = 0;
+            base = NULL;
+            dofUpdateTime = 0.0;
+            mUseCyberGlove = false;
+            mGloveInterface = NULL;
+            mUsesFlock = false;
+            mEigenGrasps = NULL;
+            mRenderGeometry = true;
+            savedState = false;
+            approachTran = transf::IDENTITY;
+            // temporary
+            defaultTranslVel = 50;
+            defaultRotVel = M_PI / 4.0;
+        }
 
-  //! Attempts to set the desired dof values, detecting contacts along the way
-  bool jumpDOFToContact(double *desiredVals, int *stoppedJoints, int *numCols = NULL);
-  //! Finds the contact time between a collision and a collision-free posture
-  int interpolateJoints(double *initialVals, double *finalVals, CollisionReport *colReport, 
-						double *interpolationTime);
-  //! Stops all the joints that affect a link that is in contact
-  void stopJointsFromLink(Link *link, double *desiredJointVals, int *stoppedJoints);
+        //! Deletes all kinematic chains, the base and mount piece, etc.
+        virtual ~Robot();
 
-  //! Adds all of the bodies that make up this robot to the given vector
-  virtual void getBodyList(std::vector<Body*> *bodies);
+        //--------------------------load and populate a robot-------------------------------
 
-  friend void KinematicChain::updateLinkPoses();
-  friend void KinematicChain::attachRobot(Robot *r,const transf &offsetTr);
+        //! The main load function that loads all the information from XML
+        virtual int loadFromXml(const TiXmlElement *root, QString rootPath);
 
- public:
+        //! Makes this robot into a clone of the original
+        virtual void cloneFrom(Robot *original);
 
-  /*! Simply initializes an empty robot within world w.  The load method must be called to read a 
-	  configuration file and give structure to the robot. */
-  Robot(World *w,const char *name) : WorldElement(w,name) {
-    parent=NULL; parentChainNum = -1;  mountPiece=NULL;
-    numChains = numDOF = 0; base = NULL; dofUpdateTime=0.0;
-	mUseCyberGlove = false; mGloveInterface = NULL; mUsesFlock = false;
-	mEigenGrasps = NULL; mRenderGeometry = true; savedState = false;
-	approachTran = transf::IDENTITY;
-	// temporary
-	defaultTranslVel = 50; defaultRotVel = M_PI/4.0;
-  }
-  
-  //! Deletes all kinematic chains, the base and mount piece, etc.
-  virtual ~Robot();
+        //--------------------------statics-------------------------------------------------
 
-  //--------------------------load and populate a robot-------------------------------
+        //! The main way to move robot dofs IN STATICS. Checks collisions and finds contacts.
+        bool moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtContact,
+                               bool renderIt = false);
 
-  //! The main load function that loads all the information from XML
-  virtual int loadFromXml(const TiXmlElement* root,QString rootPath);
+        //! Sets the location (pose) of the base of this robot in the world coordinate system
+        virtual int setTran(transf const &tr);
 
-  //! Makes this robot into a clone of the original
-  virtual void cloneFrom(Robot *original);
+        //! Sets the given DOF to the given value and updates the link poses. Collisions are NOT checked.
+        inline void forceDOFVal(int dofNum, double val);
 
-  //--------------------------statics-------------------------------------------------
+        //! Sets the values of the DOF's to the values in the array dofVals. Collisions are NOT checked.
+        inline void forceDOFVals(double *dofVals);
 
-  //! The main way to move robot dofs IN STATICS. Checks collisions and finds contacts.
-  bool moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtContact, 
-						 bool renderIt=false);
+        //! Sets the DOF values to defaults, which are 0.0 unless that falls outside of a joint range
+        inline void forceDefaultDOFVals();
 
-  //! Sets the location (pose) of the base of this robot in the world coordinate system
-  virtual int setTran(transf const& tr);
+        //-------------------------dynamics-------------------------------------------------
 
-  //! Sets the given DOF to the given value and updates the link poses. Collisions are NOT checked.
-  inline void forceDOFVal(int dofNum,double val);
+        //! The main way to move the robot dofs IN DYNAMICS mode.
+        void setDesiredDOFVals(double *dofVals);
 
-  //! Sets the values of the DOF's to the values in the array dofVals. Collisions are NOT checked.
-  inline void forceDOFVals(double *dofVals);
+        //! Returns true if any of the contacts on the fingers are slipping during dynamics
+        bool contactSlip();
 
-  //! Sets the DOF values to defaults, which are 0.0 unless that falls outside of a joint range
-  inline void forceDefaultDOFVals();
+        //! Attempt to check if the dynamic autograsp is complete
+        bool dynamicAutograspComplete();
 
-  //-------------------------dynamics-------------------------------------------------
+        //! Computes the joint angles after a dynamic step has been completed
+        virtual void updateJointValuesFromDynamics();
 
-  //! The main way to move the robot dofs IN DYNAMICS mode. 
-  void setDesiredDOFVals(double *dofVals);
+        //! Applies internal joint forces (if any), such as friction or joint springs
+        void applyJointPassiveInternalWrenches();
 
-  //! Returns true if any of the contacts on the fingers are slipping during dynamics
-  bool contactSlip();
+        //! Calls the DOF controllers which set dof forces based on current and desired posture
+        virtual void DOFController(double timeStep);
 
-  //! Attempt to check if the dynamic autograsp is complete
-  bool dynamicAutograspComplete();
+        //! Builds dynamic constraints for all the coupled dof's of this robot
+        virtual void buildDOFCouplingConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                                 double *Nu, double *eps, int &ncn);
 
-  //! Computes the joint angles after a dynamic step has been completed
-  virtual void updateJointValuesFromDynamics();
+        //! Builds dynamic dof limit constraints for all the dof's of this robot.
+        virtual void buildDOFLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                              double *H, double *g, int &hcn);
 
-  //! Applies internal joint forces (if any), such as friction or joint springs
-  void applyJointPassiveInternalWrenches();
+        //-------------------------get position and pose information------------------------
 
-  //! Calls the DOF controllers which set dof forces based on current and desired posture
-  virtual void DOFController(double timeStep);
+        /*! Return the transform which describes the world pose of the robot base
+            frame with respect to the world coordinate system. */
+        transf const &getTran() const {
+            return base->getTran();
+        }
 
-  //! Builds dynamic constraints for all the coupled dof's of this robot
-  virtual void buildDOFCouplingConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-										   double* Nu,double *eps,int &ncn);
+        //! Computes the transform of all links in a chain for a given set of dof vals
+        virtual void fwdKinematics(double *dofVals, std::vector<transf> &trVec, int chainNum);
 
-  //! Builds dynamic dof limit constraints for all the dof's of this robot.
-  virtual void buildDOFLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-									    double* H, double *g, int &hcn);
+        //! Computes the dofvals that achieve a desired end pose for a chain.
+        virtual int invKinematics(const transf &endTran, double *dofVals, int chainNum);
 
-  //-------------------------get position and pose information------------------------
+        //! Returns the current values of all of the DOF's of the robot.
+        inline void getDOFVals(double *dofVals) const;
 
-  /*! Return the transform which describes the world pose of the robot base
-      frame with respect to the world coordinate system. */
-  transf const &getTran() const {return base->getTran();}
+        //! Returns the values of the DOFs that can be used to save the current state
+        inline void storeDOFVals(double *dofVals) const;
 
-  //! Computes the transform of all links in a chain for a given set of dof vals
-  virtual void fwdKinematics(double *dofVals,std::vector<transf>& trVec,int chainNum);
+        //------------------------- static checks and range of motion
 
-  //! Computes the dofvals that achieve a desired end pose for a chain.
-  virtual int invKinematics(const transf& endTran,double* dofVals, int chainNum); 
+        //! Returns true if all specified dof vals are within their respective legal ranges
+        inline bool checkDOFVals(double *dofVals) const;
 
-  //! Returns the current values of all of the DOF's of the robot.
-  inline void getDOFVals(double *dofVals) const;
+        //! Clamps the given dofVals to be within their respective legal ranges
+        inline bool checkSetDOFVals(double *dofVals) const;
 
-  //! Returns the values of the DOFs that can be used to save the current state
-  inline void storeDOFVals(double *dofVals) const;
+        //! Returns true of contacts on the palm, a link or a parent robot prevent given motion
+        virtual bool contactsPreventMotion(const transf &motion) const;
 
-  //------------------------- static checks and range of motion
+        //! Checks if the path between current and a desired posture is free of collisions
+        bool checkDOFPath(double *desiredVals, double desiredStep);
 
-  //! Returns true if all specified dof vals are within their respective legal ranges
-  inline bool checkDOFVals(double *dofVals) const;
+        //! Sets the DOF values based on the current values of the joints
+        inline void updateDOFFromJoints(double *jointVals);
 
-  //! Clamps the given dofVals to be within their respective legal ranges
-  inline bool checkSetDOFVals(double *dofVals) const;
+        //! Returns the closest distance between a joint value and its limit
+        inline double jointLimitDist() const;
 
-  //! Returns true of contacts on the palm, a link or a parent robot prevent given motion
-  virtual bool contactsPreventMotion(const transf& motion) const;
+        //-------------------------connections to real input devices (CyberGlove, FLock etc.)
 
-  //! Checks if the path between current and a desired posture is free of collisions
-  bool checkDOFPath(double *desiredVals, double desiredStep);
+        //! Returns true if this robot is controlled by a CyberGlove
+        bool useCyberGlove() {
+            return mUseCyberGlove;
+        }
 
-  //! Sets the DOF values based on the current values of the joints
-  inline void updateDOFFromJoints(double *jointVals);
+        //! Sets the instance of the class which translates CyberGlove informration for this robot
+        void setGlove(CyberGlove *glove);
 
-  //! Returns the closest distance between a joint value and its limit
-  inline double jointLimitDist() const;
+        //! Processes a new reading from the CyberGlove
+        void processCyberGlove();
 
-  //-------------------------connections to real input devices (CyberGlove, FLock etc.)
+        //! Returns the class that interfaces between the CyberGlove and this robot
+        GloveInterface *getGloveInterface() {
+            return mGloveInterface;
+        }
 
-  //! Returns true if this robot is controlled by a CyberGlove
-  bool useCyberGlove(){return mUseCyberGlove;}
+        //! Returns the number of the bird that this robot is connected to
+        int getBirdNumber() {
+            return mBirdNumber;
+        }
 
-  //! Sets the instance of the class which translates CyberGlove informration for this robot
-  void setGlove(CyberGlove *glove);
+        //! Returns true if this robot is connected to a Flock of Birds
+        bool usesFlock() {
+            return mUsesFlock;
+        }
 
-  //! Processes a new reading from the CyberGlove
-  void processCyberGlove();
+        //! Returns the transform that indicates where the flock sensor is mounted on this robot
+        const FlockTransf *getFlockTran() const {
+            return &mFlockTran;
+        }
 
-  //! Returns the class that interfaces between the CyberGlove and this robot
-  GloveInterface* getGloveInterface(){return mGloveInterface;}
+        //! Returns the class that keeps track of flock transforms for this robot
+        FlockTransf *getFlockTran() {
+            return &mFlockTran;
+        }
 
-  //! Returns the number of the bird that this robot is connected to
-  int getBirdNumber(){return mBirdNumber;}
+        //-------------------------eigengrasps----------------------------------------------
 
-  //! Returns true if this robot is connected to a Flock of Birds
-  bool usesFlock(){return mUsesFlock;}
+        //! Looks for and loads eigengrasp information from a given file
+        int loadEigenData(QString filename);
 
-  //! Returns the transform that indicates where the flock sensor is mounted on this robot
-  const FlockTransf* getFlockTran() const {return &mFlockTran;}
+        //! Sets the trivial eigengrasp set, where we have 1 eg per dof
+        int useIdentityEigenData();
 
-  //! Returns the class that keeps track of flock transforms for this robot
-  FlockTransf* getFlockTran(){return &mFlockTran;}
+        //! Returns the eigengrasps of this robot
+        const EigenGraspInterface *getEigenGrasps() const {
+            return mEigenGrasps;
+        }
 
-  //-------------------------eigengrasps----------------------------------------------
+        //! Returns the eigengrasps of this robot
+        EigenGraspInterface *getEigenGrasps() {
+            return mEigenGrasps;
+        }
 
-  //! Looks for and loads eigengrasp information from a given file
-  int loadEigenData(QString filename);
+        //-------------------------save and load the state----------------------------------
 
-  //! Sets the trivial eigengrasp set, where we have 1 eg per dof
-  int useIdentityEigenData();
+        //! Reads the values of all dofs from a text stream, then updates posture accordingly
+        virtual QTextStream &readDOFVals(QTextStream &is);
 
-  //! Returns the eigengrasps of this robot
-  const EigenGraspInterface* getEigenGrasps() const {return mEigenGrasps;}
+        //! Writes the values of all dofs to a text stream
+        virtual QTextStream &writeDOFVals(QTextStream &os);
 
-  //! Returns the eigengrasps of this robot
-  EigenGraspInterface* getEigenGrasps() {return mEigenGrasps;}
+        //! Saves the state of the robot (pose and posture). Overwrites any previously saved state.
+        virtual void saveState();
 
-  //-------------------------save and load the state----------------------------------
+        //! Restores the previously saved state (if any).
+        virtual void restoreState();
 
-  //! Reads the values of all dofs from a text stream, then updates posture accordingly
-  virtual QTextStream &readDOFVals(QTextStream &is);
+        /*! Returns the Database name of this element */
+        QString getDBName() const {
+            return myDatabaseName;
+        }
 
-  //! Writes the values of all dofs to a text stream
-  virtual QTextStream &writeDOFVals(QTextStream &os);
+        //! Sets the Database name of this element
+        virtual void setDBName(QString newName) {
+            myDatabaseName = newName;
+        }
 
-  //! Saves the state of the robot (pose and posture). Overwrites any previously saved state.
-  virtual void saveState();
+        //-------------------------contacts-------------------------------------------------
 
-  //! Restores the previously saved state (if any).
-  virtual void restoreState();
+        //! Returns the total number of contacts on this robot against a given body
+        int getNumContacts(Body *body = NULL);
 
-  /*! Returns the Database name of this element */
-  QString getDBName() const {return myDatabaseName;}
+        //! Returns all the contacts on this robot against a given body
+        std::list<Contact *> getContacts(Body *body = NULL);
 
-  //! Sets the Database name of this element
-  virtual void setDBName(QString newName){myDatabaseName = newName;}
+        //! Breaks all the contacts on this robot
+        void breakContacts();
 
-  //-------------------------contacts-------------------------------------------------
+        //! Returns the total number of virtual contacts on this robot
+        int getNumVirtualContacts();
 
-  //! Returns the total number of contacts on this robot against a given body
-  int getNumContacts(Body* body = NULL);
+        //! Shows or hides virtual contacts
+        void showVirtualContacts(bool on);
 
-  //! Returns all the contacts on this robot against a given body
-  std::list<Contact*> getContacts(Body* body = NULL);
+        //! Looks for and loads virtual contact data from a given file
+        int loadContactData(QString filename);
 
-  //! Breaks all the contacts on this robot
-  void breakContacts();
+        //-------------------------attached robots------------------------------------------
 
-  //! Returns the total number of virtual contacts on this robot
-  int getNumVirtualContacts();
+        //! Given a chain or tree of connected robots, returns a pointer to the root or base robot.
+        Robot *getBaseRobot() {
+            if (parent) return parent->getBaseRobot();
+            return this;
+        }
 
-  //! Shows or hides virtual contacts
-  void showVirtualContacts(bool on);
+        //! Returns a pointer to the parent robot (whose chain this robot is connected to).
+        Robot *getParent() {
+            return parent;
+        }
 
-  //! Looks for and loads virtual contact data from a given file
-  int loadContactData(QString filename);
+        //! Returns the index of the chain that this robot is connected to.
+        int getParentChainNum() {
+            return parentChainNum;
+        }
 
-  //-------------------------attached robots------------------------------------------
+        /*! Returns the transform from the base of this robot to end frame of the
+            parent's kinematic chain that this robot is connected to. */
+        const transf &getTranToParentEnd() {
+            return tranToParentEnd;
+        }
 
-  //! Given a chain or tree of connected robots, returns a pointer to the root or base robot.
-  Robot *getBaseRobot() {if (parent) return parent->getBaseRobot(); return this;}
+        //! Returns a vector of all robots attached to this one
+        void getAllAttachedRobots(std::vector<Robot *> &robotVec);
 
-  //! Returns a pointer to the parent robot (whose chain this robot is connected to).
-  Robot *getParent() {return parent;}
+        //! Attaches another robot to the end of a chain of this robot
+        void attachRobot(Robot *r, int chainNum, const transf &offsetTr);
 
-  //! Returns the index of the chain that this robot is connected to.
-  int getParentChainNum() {return parentChainNum;}
+        //! Detaches a previously attached robot
+        void detachRobot(Robot *r);
 
-  /*! Returns the transform from the base of this robot to end frame of the
-      parent's kinematic chain that this robot is connected to. */
-  const transf &getTranToParentEnd() {return tranToParentEnd;}
+        //! Loads a mount piece from a file, if this robot is atatched to another
+        Link *importMountPiece(QString filename);
 
-  //! Returns a vector of all robots attached to this one
-  void getAllAttachedRobots(std::vector<Robot *> &robotVec);
+        //! Returns a point to the mountpiece link (NULL if none exists)
+        Link *getMountPiece() const {
+            return mountPiece;
+        }
 
-  //! Attaches another robot to the end of a chain of this robot
-  void attachRobot(Robot *r,int chainNum,const transf &offsetTr);
+        //-------------------------other functions and accessors----------------------------
 
-  //! Detaches a previously attached robot
-  void detachRobot(Robot *r);
+        bool snapChainToContacts(int chainNum, CollisionReport colReport);
 
-  //! Loads a mount piece from a file, if this robot is atatched to another
-  Link *importMountPiece(QString filename);
+        //! Sets the name of this robot
+        void setName(QString newName);
 
-  //! Returns a point to the mountpiece link (NULL if none exists)
-  Link *getMountPiece() const {return mountPiece;}
+        //! Return the number of links for this robot (including palm and mount piece).
+        int getNumLinks() const;
 
-  //-------------------------other functions and accessors----------------------------
+        //! Returns the number of degrees of freedom for this robot.
+        int getNumDOF() const {
+            return numDOF;
+        }
 
-  bool snapChainToContacts(int chainNum, CollisionReport colReport);
+        //! Returns a pointer to the i-th DOF.
+        DOF *getDOF(int i) const {
+            return dofVec[i];
+        }
 
-//! Sets the name of this robot
-  void setName(QString newName);
+        //! Returns the scale of the i-th DOF dragger.
+        float getDOFDraggerScale(int i) const {
+            return dofVec[i]->getDraggerScale();
+        }
 
-  //! Return the number of links for this robot (including palm and mount piece).
-  int getNumLinks() const;
+        //! Returns the number of kinematic chains in this robot.
+        int getNumChains() const {
+            return numChains;
+        }
 
-  //! Returns the number of degrees of freedom for this robot. 
-  int getNumDOF() const {return numDOF;}
+        //! Returns the number of joints in this robot, as set when robot was loaded
+        int getNumJoints() const {
+            return numJoints;
+        }
 
-  //! Returns a pointer to the i-th DOF. 
-  DOF *getDOF(int i) const {return dofVec[i];}
+        //! Returns a pointer to the cnumber of kinematic chains in this robot
+        KinematicChain *getChain(int i) const {
+            return chainVec[i];
+        }
 
-  //! Returns the scale of the i-th DOF dragger.
-  float getDOFDraggerScale(int i) const {return dofVec[i]->getDraggerScale();}
+        //! Return a pointer to the base link of this robot
+        Link *getBase() const {
+            return base;
+        }
 
-  //! Returns the number of kinematic chains in this robot.
-  int getNumChains() const {return numChains;}
+        //! Sets the transparency of the entire robot to the given value
+        void setTransparency(float t);
 
-  //! Returns the number of joints in this robot, as set when robot was loaded
-  int getNumJoints() const {return numJoints;}
+        //! Returns the default translational velocity (mm/sec) for the robot.
+        double getDefaultTranslVel() const {
+            return defaultTranslVel;
+        }
 
-  //! Returns a pointer to the cnumber of kinematic chains in this robot
-  KinematicChain *getChain(int i) const {return chainVec[i];}
+        //! Returns the default rotational velocity (rad/sec) for the robot.
+        double getDefaultRotVel() const  {
+            return defaultRotVel;
+        }
 
-  //! Return a pointer to the base link of this robot
-  Link *getBase() const {return base;}
+        //! Sets the default translational velocity (mm/sec) for the robot.
+        void setDefaultTranslVel(double v) {
+            defaultTranslVel = v;
+        }
 
-  //! Sets the transparency of the entire robot to the given value
-  void setTransparency(float t);
+        //! Sets the default rotational velocity (rad/sec) for the robot.
+        void setDefaultRotVel(double v) {
+            defaultRotVel = v;
+        }
 
-   //! Returns the default translational velocity (mm/sec) for the robot.
-  double getDefaultTranslVel() const {return defaultTranslVel;}
+        //! Enables or disables the automatic render when the pose or porture of the robot are changed
+        void setRenderGeometry(bool s);
 
-  //! Returns the default rotational velocity (rad/sec) for the robot.
-  double getDefaultRotVel() const  {return defaultRotVel;}
+        //! Returns whether the automatic render flag is set
+        bool getRenderGeometry() const {
+            return mRenderGeometry;
+        }
 
-  //! Sets the default translational velocity (mm/sec) for the robot.
-  void setDefaultTranslVel(double v) {defaultTranslVel = v;}
+        //! Returns a vector of all links associated with this robot
+        void getAllLinks(std::vector<DynamicBody *> &allLinkVec);
 
-  //! Sets the default rotational velocity (rad/sec) for the robot.
-  void setDefaultRotVel(double v) {defaultRotVel = v;}
+        //! Computes a smooth trajectory so that a given chain goes through a set of poses
+        void setChainEndTrajectory(std::vector<transf> &traj, int chainNum);
 
-  //! Enables or disables the automatic render when the pose or porture of the robot are changed
-  void setRenderGeometry(bool s);
+        //! Computes a trajectory that interpolates linearly between a start and end poses
+        void generateCartesianTrajectory(const transf &startTr, const transf &endTr,
+                                         std::vector<transf> &traj,
+                                         double startVel, double endVel = 0.0, double timeNeeded = -1.0);
 
-  //! Returns whether the automatic render flag is set
-  bool getRenderGeometry() const {return mRenderGeometry;}
+        //! Accumulated the total static torques applied at each joint by all dof's
+        Matrix staticJointTorques(bool useDynamicDofForce);
 
-  //! Returns a vector of all links associated with this robot
-  void getAllLinks(std::vector<DynamicBody *> &allLinkVec);
+        //! Returns the pre-defined approach direction for this robot
+        transf getApproachTran() const {
+            return approachTran;
+        }
 
-  //! Computes a smooth trajectory so that a given chain goes through a set of poses
-  void setChainEndTrajectory(std::vector<transf>& traj,int chainNum);
+        //! Tells us how far along the approach direction a given object is, within a certain limit
+        double getApproachDistance(Body *object, double maxDist);
 
-  //! Computes a trajectory that interpolates linearly between a start and end poses
-  void generateCartesianTrajectory(const transf &startTr, const transf &endTr, 
-								   std::vector<transf> &traj,
-								   double startVel, double endVel=0.0, double timeNeeded=-1.0);
+        //---------------------------Q_EMIT Q_SIGNALS-----------------------------------------
 
-  //! Accumulated the total static torques applied at each joint by all dof's
-  Matrix staticJointTorques(bool useDynamicDofForce);
-	
-  //! Returns the pre-defined approach direction for this robot
-  transf getApproachTran() const {return approachTran;}
+        //! Emits the configuration changed signal
+        void emitConfigChange() {
+            Q_EMIT configurationChanged();
+        }
+        //! Emits the user interaction start signal
+        void emitUserInteractionStart() {
+            Q_EMIT userInteractionStart();
+        }
+        //! Emits the user interaction ended signal
+        void emitUserInteractionEnd() {
+            Q_EMIT userInteractionEnd();
+        }
 
-  //! Tells us how far along the approach direction a given object is, within a certain limit
-  double getApproachDistance(Body *object, double maxDist);
-
-  //---------------------------Q_EMIT Q_SIGNALS-----------------------------------------
-
-  //! Emits the configuration changed signal
-  void emitConfigChange(){Q_EMIT configurationChanged();}
-  //! Emits the user interaction start signal
-  void emitUserInteractionStart(){Q_EMIT userInteractionStart();}
-  //! Emits the user interaction ended signal
-  void emitUserInteractionEnd(){Q_EMIT userInteractionEnd();}
-
-  static const double AUTO_GRASP_TIME_STEP;
+        static const double AUTO_GRASP_TIME_STEP;
 };
 
 /*! Informs the dofs of their new values in \a dofVals. Simply passes through
-	to the similar function of each dof
+    to the similar function of each dof
 */
-void Robot::updateDofVals(double *dofVals)
-{
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->updateVal(dofVals[d]);
-	}
+void Robot::updateDofVals(double *dofVals) {
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->updateVal(dofVals[d]);
+    }
 }
 
 /*! Gets the current joint values in \a jointVals. It is expected that
-	this vector is of size equal to the number of joints of this robot.
+    this vector is of size equal to the number of joints of this robot.
 */
-void Robot::getJointValues(double *jointVals) const
-{
-	for (int c=0; c<numChains; c++) {
-		chainVec[c]->getJointValues(jointVals);
-	}
+void Robot::getJointValues(double *jointVals) const {
+    for (int c = 0; c < numChains; c++) {
+        chainVec[c]->getJointValues(jointVals);
+    }
 }
 
-/*! Returns the closest distance between a joint value and its limit; positive 
-	if the  joint is inside its legal range and negative if it's outside
+/*! Returns the closest distance between a joint value and its limit; positive
+    if the  joint is inside its legal range and negative if it's outside
 */
-double Robot::jointLimitDist() const
-{
-	double dist, minDist = 1.0e10;
-	for (int c=0; c<numChains; c++) {
-		for (int j=0; j<chainVec[c]->getNumJoints(); j++) {
-			double val = chainVec[c]->getJoint(j)->getVal();
-			dist = std::min( chainVec[c]->getJoint(j)->getMax() - val, 
-							 val - chainVec[c]->getJoint(j)->getMin() );
-			minDist = std::min(dist, minDist);
-		}
-	}
-	return minDist;
+double Robot::jointLimitDist() const {
+    double dist, minDist = 1.0e10;
+    for (int c = 0; c < numChains; c++) {
+        for (int j = 0; j < chainVec[c]->getNumJoints(); j++) {
+            double val = chainVec[c]->getJoint(j)->getVal();
+            dist = std::min(chainVec[c]->getJoint(j)->getMax() - val,
+                            val - chainVec[c]->getJoint(j)->getMin());
+            minDist = std::min(dist, minDist);
+        }
+    }
+    return minDist;
 }
 
 /*! Sets the transform of the base link, the mount piece (if it exists), and tells each
-	kinematic chain to update the link poses, which also updates the pose of each 
-	attached robot. 
+    kinematic chain to update the link poses, which also updates the pose of each
+    attached robot.
 */
-void Robot::simpleSetTran(transf const& tr) {
+void Robot::simpleSetTran(transf const &tr) {
     base->setTran(tr);
     if (mountPiece) mountPiece->setTran(tr);
-    for (int f=0;f<numChains;f++) chainVec[f]->updateLinkPoses();
+    for (int f = 0; f < numChains; f++) chainVec[f]->updateLinkPoses();
 }
 
 /*! \a dofVals should point to a double array with a length at least equal to
     the number of DOF's of this robot.
 */
 void Robot::getDOFVals(double *dofVals) const {
-    for (int d=0;d<numDOF;d++) dofVals[d]=dofVec[d]->getVal();
+    for (int d = 0; d < numDOF; d++) dofVals[d] = dofVec[d]->getVal();
 }
 
 /*! The values of the DOFs that can be used for saving the current state
-	are not always the current values of the DOF's. This in not ideal, but
-	was necessary in the case of tha Barrett hand: when saving the current
-	state, more often we want the *breakaway* value of the DOF rather than
-	its current value. 
+    are not always the current values of the DOF's. This in not ideal, but
+    was necessary in the case of tha Barrett hand: when saving the current
+    state, more often we want the *breakaway* value of the DOF rather than
+    its current value.
 
-	Neither solution is ideal:
-	- if we later restore the state using the current value of the DOF, we
-	have lost breakaway information and that might result in a collision
-	- if we do it using the breakaway value, we will lose some contacts on
-	the distal link. However, these can usually be recovered using an 
-	autoGrasp(...).
+    Neither solution is ideal:
+    - if we later restore the state using the current value of the DOF, we
+    have lost breakaway information and that might result in a collision
+    - if we do it using the breakaway value, we will lose some contacts on
+    the distal link. However, these can usually be recovered using an
+    autoGrasp(...).
 
-	The correct way is to use writeDOFVals(...) and readDOFVals(...) which
-	save the entire state of the DOFs, including all breakaway information.
-	However, those functions work with QStrings, while we needed to save 
-	the state as one value per DOF for external reasons. Hence the need for
-	this hack-ish function.
+    The correct way is to use writeDOFVals(...) and readDOFVals(...) which
+    save the entire state of the DOFs, including all breakaway information.
+    However, those functions work with QStrings, while we needed to save
+    the state as one value per DOF for external reasons. Hence the need for
+    this hack-ish function.
 */
 void Robot::storeDOFVals(double *dofVals) const {
-    for (int d=0;d<numDOF;d++) dofVals[d]=dofVec[d]->getSaveVal();
+    for (int d = 0; d < numDOF; d++) dofVals[d] = dofVec[d]->getSaveVal();
 }
 
 /*! Forces a single dof to assume a current value. Gets the appropriate joint
-	values from the dofs, then forces the joints to that position and updates
-	the posture. Does NOT check for collisions
+    values from the dofs, then forces the joints to that position and updates
+    the posture. Does NOT check for collisions
 */
-void Robot::forceDOFVal(int dofNum,double val) {
-	double *jointVals = new double[numJoints];
-	getJointValues(jointVals);
-	dofVec[dofNum]->reset();
-	dofVec[dofNum]->accumulateMove(val, jointVals, NULL);
-	setJointValuesAndUpdate(jointVals);
-	dofVec[dofNum]->updateVal(val);
-	delete [] jointVals;
+void Robot::forceDOFVal(int dofNum, double val) {
+    double *jointVals = new double[numJoints];
+    getJointValues(jointVals);
+    dofVec[dofNum]->reset();
+    dofVec[dofNum]->accumulateMove(val, jointVals, NULL);
+    setJointValuesAndUpdate(jointVals);
+    dofVec[dofNum]->updateVal(val);
+    delete [] jointVals;
 }
 
-/*! Sets the values of the dofs of this robot to the values in the array 
-	\a dofVals. Then it updates the link poses, but collisions are NOT checked.
+/*! Sets the values of the dofs of this robot to the values in the array
+    \a dofVals. Then it updates the link poses, but collisions are NOT checked.
 */
 void Robot::forceDOFVals(double *dofVals) {
-	double *jointVals = new double[numJoints];
-	getJointValues(jointVals);
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->reset();
-		dofVec[d]->accumulateMove(dofVals[d], jointVals, NULL);
-	}
-	setJointValuesAndUpdate(jointVals);
-	updateDofVals(dofVals);
-	delete [] jointVals;
+    double *jointVals = new double[numJoints];
+    getJointValues(jointVals);
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->reset();
+        dofVec[d]->accumulateMove(dofVals[d], jointVals, NULL);
+    }
+    setJointValuesAndUpdate(jointVals);
+    updateDofVals(dofVals);
+    delete [] jointVals;
 }
 
 /*! Will set all DOF vals to their default values. */
-void Robot::forceDefaultDOFVals()
-{
-  std::vector<double> dofVals(numDOF, 0.0);
-  for (int d=0; d<numDOF; d++)
-  {
-    dofVals[d] = dofVec[d]->getDefaultValue();
-  }
-  forceDOFVals(&dofVals[0]);
+void Robot::forceDefaultDOFVals() {
+    std::vector<double> dofVals(numDOF, 0.0);
+    for (int d = 0; d < numDOF; d++) {
+        dofVals[d] = dofVec[d]->getDefaultValue();
+    }
+    forceDOFVals(&dofVals[0]);
 }
 
 /*! Asks each dof to update its value based on the joint values supplied in
-	\a jointVals 
+    \a jointVals
 */
 void Robot::updateDOFFromJoints(double *jointVals) {
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->updateFromJointValues(jointVals);
-	}
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->updateFromJointValues(jointVals);
+    }
 }
 
 /*! Returns true if all the dof values in \a dofVals are within their limits */
 bool Robot::checkDOFVals(double *dofVals) const {
-	  for (int d=0;d<numDOF;d++) {
-		  if ( dofVals[d] > dofVec[d]->getMax()) return false;
-		  if ( dofVals[d] < dofVec[d]->getMin()) return false;
-	  }
-	  return true;
+    for (int d = 0; d < numDOF; d++) {
+        if (dofVals[d] > dofVec[d]->getMax()) return false;
+        if (dofVals[d] < dofVec[d]->getMin()) return false;
+    }
+    return true;
 }
 
 /*! Clamps the dof values in \a dofVals to be within the dof limits. Returns true
-	if at least one the values in \a dofVals was within its limit before clamping
+    if at least one the values in \a dofVals was within its limit before clamping
 */
 bool Robot::checkSetDOFVals(double *dofVals) const {
-	  bool atLeastOneValid = false;
-	  for (int d=0;d<numDOF;d++) {
-		  if ( dofVals[d] > dofVec[d]->getMax()) {
-			  dofVals[d] = dofVec[d]->getMax();
-		  } else if ( dofVals[d] < dofVec[d]->getMin()) {
-			  dofVals[d] = dofVec[d]->getMin();
-		  }
-		  else atLeastOneValid = true;
-	  }
-	  return atLeastOneValid;
+    bool atLeastOneValid = false;
+    for (int d = 0; d < numDOF; d++) {
+        if (dofVals[d] > dofVec[d]->getMax()) {
+            dofVals[d] = dofVec[d]->getMax();
+        }
+        else if (dofVals[d] < dofVec[d]->getMin()) {
+            dofVals[d] = dofVec[d]->getMin();
+        }
+        else atLeastOneValid = true;
+    }
+    return atLeastOneValid;
 }
 
 
@@ -682,55 +752,63 @@ bool Robot::checkSetDOFVals(double *dofVals) const {
     a palm as the base link and one or more fingers, which are kinematic
     chains.  One instance of a grasp is associated with each hand, and it is
     usually analyzed each time contacts between the hand and the object to be
-    grasped change.  The hand class also provides an autograsp method which 
+    grasped change.  The hand class also provides an autograsp method which
     closes the fingers at fixed rates until further motion is prevented by
     contacts.
 
-	This class is more the results of legacy architecture than any conceptual 
-	differences. Arguably, any robot is also a "hand", especially since we allow
-	any robot to have multiple kinematic chains. It is possible that we will get rid
-	of the Hand class altogether at some point.
+    This class is more the results of legacy architecture than any conceptual
+    differences. Arguably, any robot is also a "hand", especially since we allow
+    any robot to have multiple kinematic chains. It is possible that we will get rid
+    of the Hand class altogether at some point.
 */
 class Hand : public Robot {
-  Q_OBJECT
+        Q_OBJECT
 
-protected:
-  //! A pointer to the grasp associated with this hand
-  Grasp *grasp;
+    protected:
+        //! A pointer to the grasp associated with this hand
+        Grasp *grasp;
 
-public:
-  //! Constructs the instance of the Grasp, then calls the Robot constructor
-  Hand(World *w,const char *name);
-  //! Also deletes the instance of the Grasp
-  virtual ~Hand();
+    public:
+        //! Constructs the instance of the Grasp, then calls the Robot constructor
+        Hand(World *w, const char *name);
+        //! Also deletes the instance of the Grasp
+        virtual ~Hand();
 
-  //! Clones this hand from another
-  virtual void cloneFrom(Hand *original);
+        //! Clones this hand from another
+        virtual void cloneFrom(Hand *original);
 
-  /*! Returns the number of fingers in the hand.  Fingers are just another name
-    for kinematic chains, so this is just a convenience function */
-  int getNumFingers() const {return numChains;}
+        /*! Returns the number of fingers in the hand.  Fingers are just another name
+            for kinematic chains, so this is just a convenience function */
+        int getNumFingers() const {
+            return numChains;
+        }
 
-  /*! Returns a pointer to the i-th kinematic chain. */
-  KinematicChain *getFinger(int i) const {return chainVec[i];}
+        /*! Returns a pointer to the i-th kinematic chain. */
+        KinematicChain *getFinger(int i) const {
+            return chainVec[i];
+        }
 
-  /*! Returns a pointer to the base link of the hand. */
-  Link *getPalm() const {return base;}
+        /*! Returns a pointer to the base link of the hand. */
+        Link *getPalm() const {
+            return base;
+        }
 
-  /*! Returns a pointer to the associated grasp object. */
-  Grasp *getGrasp() const {return grasp;}
+        /*! Returns a pointer to the associated grasp object. */
+        Grasp *getGrasp() const {
+            return grasp;
+        }
 
-  //! Closes all fingers in a direction pre-specified (usually in config file)
-  virtual bool autoGrasp(bool renderIt, double speedFactor = 1.0, bool stopAtContact = false);
+        //! Closes all fingers in a direction pre-specified (usually in config file)
+        virtual bool autoGrasp(bool renderIt, double speedFactor = 1.0, bool stopAtContact = false);
 
-  //! Opens the fingers in the opposite direction of \a autoGrasp
-  virtual bool quickOpen(double speedFactor = 0.1);
+        //! Opens the fingers in the opposite direction of \a autoGrasp
+        virtual bool quickOpen(double speedFactor = 0.1);
 
-  //! Moves the hand in the pre-specified approach direction until contact is made
-  virtual bool approachToContact(double moveDist, bool oneStep = true);
+        //! Moves the hand in the pre-specified approach direction until contact is made
+        virtual bool approachToContact(double moveDist, bool oneStep = true);
 
-  //! Moves the hand back until it is out of collision, then forward until a contact is made.
-  virtual bool findInitialContact(double moveDist);
+        //! Moves the hand back until it is out of collision, then forward until a contact is made.
+        virtual bool findInitialContact(double moveDist);
 };
 
 #define ROBOT_H

--- a/include/scanSimulator.h
+++ b/include/scanSimulator.h
@@ -34,84 +34,95 @@
 #undef DEBUG
 
 /*! A raw scan ray information, defining a ray (as horizontal and vertical
-	angle from the scanner reference position, and the distance along the 
-	ray that an object was hit.
+    angle from the scanner reference position, and the distance along the
+    ray that an object was hit.
 */
 struct RawScanPoint {
-	float hAngle,vAngle;
-	float dx, dy, dz;
-	float distance;
+    float hAngle, vAngle;
+    float dx, dy, dz;
+    float distance;
 };
 
 /*! A scan simulator can simulate a laser scanner scanning the GraspIt world.
-	The virtual scanner is placed at a position in the world and some scanning
-	parameters are set. It then uses Coin's ray intersection to simulate the
-	scan, and returns the resulting point cloud of whatever was in the GraspIt
-	world in its field of view. It can also return the "raw" scan data, with
-	each ray and the hit distance along the ray, rather than a point cloud.
+    The virtual scanner is placed at a position in the world and some scanning
+    parameters are set. It then uses Coin's ray intersection to simulate the
+    scan, and returns the resulting point cloud of whatever was in the GraspIt
+    world in its field of view. It can also return the "raw" scan data, with
+    each ray and the hit distance along the ray, rather than a point cloud.
 
-	The results can be returned either in GraspIt world coordinates, or in 
-	scanner coordinates.
+    The results can be returned either in GraspIt world coordinates, or in
+    scanner coordinates.
 */
 class ScanSimulator {
- public:
-	enum Type{SCANNER_COORDINATES,WORLD_COORDINATES};
+    public:
+        enum Type {SCANNER_COORDINATES, WORLD_COORDINATES};
         //! Convention for specifying the scanner's axes relative to the optical frame and "up"
         //! directions. Useful when specifying the scanner position as a transform, or when requesting
         //! the scan back in scanner coordinates.
-        enum AxesConvention{
-          //! positive Z is optical axis, Y is "down"
-          STEREO_CAMERA
+        enum AxesConvention {
+            //! positive Z is optical axis, Y is "down"
+            STEREO_CAMERA
         };
 
- private:
-	 //! The location of the scanner in the GraspIt world
-	position mPosition;
-	//! The orientation of the scanner, what it is aimed at
-	vec3 mDirection;
-	//! The "up" direction of the scanner
-	vec3 mUp;
-	//! The "horizontal" direction; together with "up" and "direction" forms a right-handed coord system.
-	vec3 mHorizDirection;
+    private:
+        //! The location of the scanner in the GraspIt world
+        position mPosition;
+        //! The orientation of the scanner, what it is aimed at
+        vec3 mDirection;
+        //! The "up" direction of the scanner
+        vec3 mUp;
+        //! The "horizontal" direction; together with "up" and "direction" forms a right-handed coord system.
+        vec3 mHorizDirection;
 
-	//! The scanner's transform in the GraspIt world
-	/*! Set so that the z axis is pointing "up" and the x axis id pointing
-		in the scanning direction.*/
-	transf mTran;
-	//! The inverse of the scanner tranforms, precomputed and stored to save time
-	transf mTranInv;
+        //! The scanner's transform in the GraspIt world
+        /*! Set so that the z axis is pointing "up" and the x axis id pointing
+            in the scanning direction.*/
+        transf mTran;
+        //! The inverse of the scanner tranforms, precomputed and stored to save time
+        transf mTranInv;
 
-	Type mType;
+        Type mType;
 
-	float mHMin, mHMax;
-	int mHLines; 
-	float mVMin, mVMax;
-	int mVLines;
+        float mHMin, mHMax;
+        int mHLines;
+        float mVMin, mVMax;
+        int mVLines;
 
-	bool shootRay(const vec3 &rayDirection, position &rayPoint);
- public:
-	ScanSimulator();
+        bool shootRay(const vec3 &rayDirection, position &rayPoint);
+    public:
+        ScanSimulator();
         void setPosition(transf tr, AxesConvention convention);
-	void setPosition(position p, vec3 optical_axis, vec3 up_axis, AxesConvention convention);
-	void setPosition(vec3 p, vec3 optical_axis, vec3 up_axis, AxesConvention convention){
-          position pp(p.x(), p.y(), p.z()); 
-          setPosition(pp, optical_axis, up_axis, convention);
+        void setPosition(position p, vec3 optical_axis, vec3 up_axis, AxesConvention convention);
+        void setPosition(vec3 p, vec3 optical_axis, vec3 up_axis, AxesConvention convention) {
+            position pp(p.x(), p.y(), p.z());
+            setPosition(pp, optical_axis, up_axis, convention);
         }
-	void getPosition(position &p, vec3 &optical_axis, vec3 &up_axis){
-		p = mPosition; optical_axis = mDirection; up_axis = mUp;
+        void getPosition(position &p, vec3 &optical_axis, vec3 &up_axis) {
+            p = mPosition;
+            optical_axis = mDirection;
+            up_axis = mUp;
         }
-	void setOptics( float hMin, float hMax, int hLines, 
-			float vMin, float vMax, int vLines) {
-		mHMin = hMin; mHMax = hMax; mHLines = hLines;
-		mVMin = vMin; mVMax = vMax; mVLines = vLines;}
-	void setType(Type t){mType=t;}
-	Type getType() const {return mType;}
-	void computeRayDirection(float hAngle, float vAngle, vec3 &rayDirection);
+        void setOptics(float hMin, float hMax, int hLines,
+                       float vMin, float vMax, int vLines) {
+            mHMin = hMin;
+            mHMax = hMax;
+            mHLines = hLines;
+            mVMin = vMin;
+            mVMax = vMax;
+            mVLines = vLines;
+        }
+        void setType(Type t) {
+            mType = t;
+        }
+        Type getType() const {
+            return mType;
+        }
+        void computeRayDirection(float hAngle, float vAngle, vec3 &rayDirection);
 
-	//! The main function for scanning. 
-	/*! Returns the full result as a point cloud and, if wanted 
-		(\a rawData is not NULL), also as raw data. */
-	void scan(std::vector<position> *cloud, std::vector<RawScanPoint> *rawData = NULL);
+        //! The main function for scanning.
+        /*! Returns the full result as a point cloud and, if wanted
+            (\a rawData is not NULL), also as raw data. */
+        void scan(std::vector<position> *cloud, std::vector<RawScanPoint> *rawData = NULL);
 };
 
 #endif

--- a/include/timer_calls.h
+++ b/include/timer_calls.h
@@ -24,17 +24,17 @@
 //######################################################################
 
 /*! This file implements the macros for reading and converting system time.
-  A total of six macros must be implemented:
+    A total of six macros must be implemented:
 
-  PROF_TIME_UNIT  - the data type for storing a time value
-  PROF_DURATION_UNIT - the data type for storing an interval or a duration
-  PROF_RESET_DURATION(DURATION) - resets a duration to zero
-  PROF_GET_TIME(TIME) - gets the current system time
-  PROF_ADD_DURATION(DURATION, START_TIME, END_TIME) - adds the interval between two time values to a duration
-  PROF_CONVERT_TO_MICROS(DURATION,DOUBLE) - converts a duration to microseconds
+    PROF_TIME_UNIT  - the data type for storing a time value
+    PROF_DURATION_UNIT - the data type for storing an interval or a duration
+    PROF_RESET_DURATION(DURATION) - resets a duration to zero
+    PROF_GET_TIME(TIME) - gets the current system time
+    PROF_ADD_DURATION(DURATION, START_TIME, END_TIME) - adds the interval between two time values to a duration
+    PROF_CONVERT_TO_MICROS(DURATION,DOUBLE) - converts a duration to microseconds
 
-  Conversion is separate from read time, since we don't want to do it every time we read time, but only
-  when we need to return it.
+    Conversion is separate from read time, since we don't want to do it every time we read time, but only
+    when we need to return it.
 */
 
 // ------------------------------------------- WINDOWS -----------------------------------------------
@@ -48,20 +48,20 @@
 #define PROF_TIME_UNIT unsigned __int64
 #define PROF_DURATION_UNIT unsigned __int64
 #define PROF_RESET_DURATION(DURATION) DURATION=0;
-#define PROF_ADD_DURATION(DURATION, START_TIME, END_TIME) DURATION += END_TIME - START_TIME; 
+#define PROF_ADD_DURATION(DURATION, START_TIME, END_TIME) DURATION += END_TIME - START_TIME;
 
 // Gets time in the highest resolution available to the CPU, about a nanosecond
-#define PROF_GET_TIME(TIME) LARGE_INTEGER tmp;			  \
-  QueryPerformanceCounter(&tmp);				  \
-  TIME = tmp.QuadPart;
+#define PROF_GET_TIME(TIME) LARGE_INTEGER tmp;            \
+    QueryPerformanceCounter(&tmp);                  \
+    TIME = tmp.QuadPart;
 #define PROF_CONVERT_TO_MICROS(DURATION,DOUBLE) DOUBLE = 1.0e6 * ((double)DURATION) / getProfiler().getCountsPerSec();
 
 /*
-// Gets time in units of 100 nanoseconds as 2 4-byte words
-#define PROF_GET_TIME(TIME)  FILETIME tmp;					\
-  GetSystemTimeAsFileTime(&tmp);					\
-  TIME = (static_cast<unsigned __int64>(tmp.dwHighDateTime) << 32) | tmp.dwLowDateTime;
-#define PROF_CONVERT_TO_MICROS(DURATION, DOUBLE) DOUBLE = 0.1 * DURATION;
+    // Gets time in units of 100 nanoseconds as 2 4-byte words
+    #define PROF_GET_TIME(TIME)  FILETIME tmp;                  \
+    GetSystemTimeAsFileTime(&tmp);                    \
+    TIME = (static_cast<unsigned __int64>(tmp.dwHighDateTime) << 32) | tmp.dwLowDateTime;
+    #define PROF_CONVERT_TO_MICROS(DURATION, DOUBLE) DOUBLE = 0.1 * DURATION;
 */
 
 // --------------------------------------------------------------------------------------------------
@@ -77,31 +77,31 @@
 #define PROF_DURATION_UNIT struct timeval
 #define PROF_RESET_DURATION(DURATION) DURATION.tv_sec = DURATION.tv_usec = 0;
 #define PROF_GET_TIME(TIME) gettimeofday(&TIME, NULL);
-#define PROF_ADD_DURATION(DURATION,START,END)	\
-  if (END.tv_usec < START.tv_usec) { \
-    int nsec = (START.tv_usec - END.tv_usec) / 1000000 + 1; \
-    START.tv_usec -= 1000000 * nsec; \
-    START.tv_sec += nsec; \
-  } \
-  if (END.tv_usec - START.tv_usec > 1000000) { \
-    int nsec = (END.tv_usec - START.tv_usec) / 1000000; \
-    START.tv_usec += 1000000 * nsec; \
-    START.tv_sec -= nsec; \
-  } \
-  DURATION.tv_sec += END.tv_sec - START.tv_sec; \
-  DURATION.tv_usec += END.tv_usec - START.tv_usec;
+#define PROF_ADD_DURATION(DURATION,START,END)   \
+    if (END.tv_usec < START.tv_usec) { \
+        int nsec = (START.tv_usec - END.tv_usec) / 1000000 + 1; \
+        START.tv_usec -= 1000000 * nsec; \
+        START.tv_sec += nsec; \
+    } \
+    if (END.tv_usec - START.tv_usec > 1000000) { \
+        int nsec = (END.tv_usec - START.tv_usec) / 1000000; \
+        START.tv_usec += 1000000 * nsec; \
+        START.tv_sec -= nsec; \
+    } \
+    DURATION.tv_sec += END.tv_sec - START.tv_sec; \
+    DURATION.tv_usec += END.tv_usec - START.tv_usec;
 #define PROF_CONVERT_TO_MICROS(DURATION,DOUBLE) DOUBLE = 1.0e6 * DURATION.tv_sec + DURATION.tv_usec;
 
 /*
-//version WITH ONLY ONE SECOND RESOLUTION
-#include <ctime>
-#include <sys/types.h>
+    //version WITH ONLY ONE SECOND RESOLUTION
+    #include <ctime>
+    #include <sys/types.h>
 
-#define PROF_TIME_UNIT u_int64_t
-#define PROF_DURATION_UNIT u_int64_t
-#define PROF_RESET_DURATION(STR) STR = 0;
-#define PROF_GET_TIME(STR) STR = time(NULL);
-#define PROF_ADD_DURATION(DURATION,START,END) DURATION += END - START; 
-#define PROF_CONVERT_TO_DOUBLE(DURATION,DOUBLE) DOUBLE = 1.0e6 * DURATION;
+    #define PROF_TIME_UNIT u_int64_t
+    #define PROF_DURATION_UNIT u_int64_t
+    #define PROF_RESET_DURATION(STR) STR = 0;
+    #define PROF_GET_TIME(STR) STR = time(NULL);
+    #define PROF_ADD_DURATION(DURATION,START,END) DURATION += END - START; 
+    #define PROF_CONVERT_TO_DOUBLE(DURATION,DOUBLE) DOUBLE = 1.0e6 * DURATION;
 */
 #endif

--- a/include/triangle.h
+++ b/include/triangle.h
@@ -32,59 +32,55 @@
 #include "mytools.h"
 /*! Very simple class, only holds 3 public vertices as positions */
 class Triangle {
-public:
-	position v1,v2,v3;
+    public:
+        position v1, v2, v3;
 
-	Triangle(const position &nv1, const position &nv2, const position &nv3) : v1(nv1), v2(nv2), v3(nv3) {}
-	Triangle(const Triangle &t) : v1(t.v1), v2(t.v2), v3(t.v3) {}
-	inline void applyTransform(const transf &t);
-	inline double area() const;
-	inline position centroid() const;
-	inline vec3 normal() const;
+        Triangle(const position &nv1, const position &nv2, const position &nv3) : v1(nv1), v2(nv2), v3(nv3) {}
+        Triangle(const Triangle &t) : v1(t.v1), v2(t.v2), v3(t.v3) {}
+        inline void applyTransform(const transf &t);
+        inline double area() const;
+        inline position centroid() const;
+        inline vec3 normal() const;
 
-	friend INLINE_RELEASE bool triangleIntersection(const Triangle &t1, const Triangle &t2);
+        friend INLINE_RELEASE bool triangleIntersection(const Triangle &t1, const Triangle &t2);
 };
 
-INLINE_RELEASE bool 
+INLINE_RELEASE bool
 triangleIntersection(const Triangle &t1, const Triangle &t2);
 
-INLINE_RELEASE position 
+INLINE_RELEASE position
 closestPtTriangle(const Triangle &t, const position &p);
 
 //! Returns the distance between the triangles as well as the two closest points on them
-INLINE_RELEASE double 
+INLINE_RELEASE double
 triangleTriangleDistanceSq(const Triangle &t1, const Triangle &t2,
- 						   position &p1, position &p2);
+                           position &p1, position &p2);
 
 //! Returns all the points on the two triangles separated by less than the threshold
 INLINE_RELEASE int
-triangleTriangleContact(const Triangle &t1, const Triangle &t2, double threshSq, 
-						std::vector< std::pair<position, position> >* contactPoints);
+triangleTriangleContact(const Triangle &t1, const Triangle &t2, double threshSq,
+                        std::vector< std::pair<position, position> > *contactPoints);
 
-double 
-Triangle::area() const
-{
-	return  0.5 * ((v2 - v1) * (v3 - v1)).len();
+double
+Triangle::area() const {
+    return  0.5 * ((v2 - v1) * (v3 - v1)).len();
 }
 
-vec3 
-Triangle::normal() const
-{
-	return normalise( (v2 - v1) * (v3 - v1) );
+vec3
+Triangle::normal() const {
+    return normalise((v2 - v1) * (v3 - v1));
 }
 
-position 
-Triangle::centroid() const
-{
-	return (1.0 / 3.0) * (v1 + v2 + v3);
+position
+Triangle::centroid() const {
+    return (1.0 / 3.0) * (v1 + v2 + v3);
 }
 
 void
-Triangle::applyTransform(const transf &t)
-{
-	v1 = v1*t;
-	v2 = v2*t;
-	v3 = v3*t;
+Triangle::applyTransform(const transf &t) {
+    v1 = v1 * t;
+    v2 = v2 * t;
+    v3 = v3 * t;
 }
 
 #ifdef GRASPIT_RELEASE

--- a/include/triangle_inl.h
+++ b/include/triangle_inl.h
@@ -24,130 +24,149 @@
 //######################################################################
 
 /*! \file
-	Triangle functions to be inlined during release compilation.
-	Do not put any of the necessary includes here, put them in both
-	triangle.h and triangle.cpp instead.
+    Triangle functions to be inlined during release compilation.
+    Do not put any of the necessary includes here, put them in both
+    triangle.h and triangle.cpp instead.
 */
 
-inline double gmax(double d1, double d2, double d3)
-{
-	double m = d1;
-	if (d2 > m) m = d2;
-	if (d3 > m) m = d3;
-	return m;
+inline double gmax(double d1, double d2, double d3) {
+    double m = d1;
+    if (d2 > m) m = d2;
+    if (d3 > m) m = d3;
+    return m;
 }
 
-inline double gmin(double d1, double d2, double d3)
-{
-	double m = d1;
-	if (d2 < m) m = d2;
-	if (d3 < m) m = d3;
-	return m;
+inline double gmin(double d1, double d2, double d3) {
+    double m = d1;
+    if (d2 < m) m = d2;
+    if (d3 < m) m = d3;
+    return m;
 }
 
 inline int
-project6(const vec3 &ax, 
-         const vec3 &p1, const vec3 &p2, const vec3 &p3, 
-         const vec3 &q1, const vec3 &q2, const vec3 &q3)
-{
-  double P1 = ax % p1;
-  double P2 = ax % p2;
-  double P3 = ax % p3;
-  double Q1 = ax % q1;
-  double Q2 = ax % q2;
-  double Q3 = ax % q3;
-  
-  double mx1 = gmax(P1, P2, P3);
-  double mn1 = gmin(P1, P2, P3);
-  double mx2 = gmax(Q1, Q2, Q3);
-  double mn2 = gmin(Q1, Q2, Q3);
+project6(const vec3 &ax,
+         const vec3 &p1, const vec3 &p2, const vec3 &p3,
+         const vec3 &q1, const vec3 &q2, const vec3 &q3) {
+    double P1 = ax % p1;
+    double P2 = ax % p2;
+    double P3 = ax % p3;
+    double Q1 = ax % q1;
+    double Q2 = ax % q2;
+    double Q3 = ax % q3;
 
-  if (mn1 > mx2) return 0;
-  if (mn2 > mx1) return 0;
-  return 1;
+    double mx1 = gmax(P1, P2, P3);
+    double mn1 = gmin(P1, P2, P3);
+    double mx2 = gmax(Q1, Q2, Q3);
+    double mn2 = gmin(Q1, Q2, Q3);
+
+    if (mn1 > mx2) return 0;
+    if (mn2 > mx1) return 0;
+    return 1;
 }
 
 inline
-bool triangleIntersection(const Triangle &t1, const Triangle &t2)
-{
-  vec3 p1, p2, p3;
-  vec3 q1, q2, q3;
-  vec3 e1, e2, e3;
-  vec3 f1, f2, f3;
-  vec3 g1, g2, g3;
-  vec3 h1, h2, h3;
-  vec3 n1, m1;
+bool triangleIntersection(const Triangle &t1, const Triangle &t2) {
+    vec3 p1, p2, p3;
+    vec3 q1, q2, q3;
+    vec3 e1, e2, e3;
+    vec3 f1, f2, f3;
+    vec3 g1, g2, g3;
+    vec3 h1, h2, h3;
+    vec3 n1, m1;
 
-  vec3 ef11, ef12, ef13;
-  vec3 ef21, ef22, ef23;
-  vec3 ef31, ef32, ef33;
-  
-  p1[0] = t1.v1[0] - t1.v1[0];  p1[1] = t1.v1[1] - t1.v1[1];  p1[2] = t1.v1[2] - t1.v1[2];
-  p2[0] = t1.v2[0] - t1.v1[0];  p2[1] = t1.v2[1] - t1.v1[1];  p2[2] = t1.v2[2] - t1.v1[2];
-  p3[0] = t1.v3[0] - t1.v1[0];  p3[1] = t1.v3[1] - t1.v1[1];  p3[2] = t1.v3[2] - t1.v1[2];
-  
-  q1[0] = t2.v1[0] - t1.v1[0];  q1[1] = t2.v1[1] - t1.v1[1];  q1[2] = t2.v1[2] - t1.v1[2];
-  q2[0] = t2.v2[0] - t1.v1[0];  q2[1] = t2.v2[1] - t1.v1[1];  q2[2] = t2.v2[2] - t1.v1[2];
-  q3[0] = t2.v3[0] - t1.v1[0];  q3[1] = t2.v3[1] - t1.v1[1];  q3[2] = t2.v3[2] - t1.v1[2];
-  
-  e1[0] = p2[0] - p1[0];  e1[1] = p2[1] - p1[1];  e1[2] = p2[2] - p1[2];
-  e2[0] = p3[0] - p2[0];  e2[1] = p3[1] - p2[1];  e2[2] = p3[2] - p2[2];
-  e3[0] = p1[0] - p3[0];  e3[1] = p1[1] - p3[1];  e3[2] = p1[2] - p3[2];
+    vec3 ef11, ef12, ef13;
+    vec3 ef21, ef22, ef23;
+    vec3 ef31, ef32, ef33;
 
-  f1[0] = q2[0] - q1[0];  f1[1] = q2[1] - q1[1];  f1[2] = q2[2] - q1[2];
-  f2[0] = q3[0] - q2[0];  f2[1] = q3[1] - q2[1];  f2[2] = q3[2] - q2[2];
-  f3[0] = q1[0] - q3[0];  f3[1] = q1[1] - q3[1];  f3[2] = q1[2] - q3[2];
-  
-  n1= e1 * e2;
-  m1= f1 * f2;
+    p1[0] = t1.v1[0] - t1.v1[0];
+    p1[1] = t1.v1[1] - t1.v1[1];
+    p1[2] = t1.v1[2] - t1.v1[2];
+    p2[0] = t1.v2[0] - t1.v1[0];
+    p2[1] = t1.v2[1] - t1.v1[1];
+    p2[2] = t1.v2[2] - t1.v1[2];
+    p3[0] = t1.v3[0] - t1.v1[0];
+    p3[1] = t1.v3[1] - t1.v1[1];
+    p3[2] = t1.v3[2] - t1.v1[2];
 
-  g1= e1 * n1;
-  g2= e2 * n1;
-  g3= e3 * n1;
-  h1= f1 * m1;
-  h2= f2 * m1;
-  h3= f3 * m1;
+    q1[0] = t2.v1[0] - t1.v1[0];
+    q1[1] = t2.v1[1] - t1.v1[1];
+    q1[2] = t2.v1[2] - t1.v1[2];
+    q2[0] = t2.v2[0] - t1.v1[0];
+    q2[1] = t2.v2[1] - t1.v1[1];
+    q2[2] = t2.v2[2] - t1.v1[2];
+    q3[0] = t2.v3[0] - t1.v1[0];
+    q3[1] = t2.v3[1] - t1.v1[1];
+    q3[2] = t2.v3[2] - t1.v1[2];
 
-  ef11= e1 * f1;
-  ef12= e1 * f2;
-  ef13= e1 * f3;
-  ef21= e2 * f1;
-  ef22= e2 * f2;
-  ef23= e2 * f3;
-  ef31= e3 * f1;
-  ef32= e3 * f2;
-  ef33= e3 * f3;
-  
-  // now begin the series of tests
+    e1[0] = p2[0] - p1[0];
+    e1[1] = p2[1] - p1[1];
+    e1[2] = p2[2] - p1[2];
+    e2[0] = p3[0] - p2[0];
+    e2[1] = p3[1] - p2[1];
+    e2[2] = p3[2] - p2[2];
+    e3[0] = p1[0] - p3[0];
+    e3[1] = p1[1] - p3[1];
+    e3[2] = p1[2] - p3[2];
 
-  if (!project6(n1, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(m1, p1, p2, p3, q1, q2, q3)) return 0;
-  
-  if (!project6(ef11, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef12, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef13, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef21, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef22, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef23, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef31, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef32, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(ef33, p1, p2, p3, q1, q2, q3)) return 0;
+    f1[0] = q2[0] - q1[0];
+    f1[1] = q2[1] - q1[1];
+    f1[2] = q2[2] - q1[2];
+    f2[0] = q3[0] - q2[0];
+    f2[1] = q3[1] - q2[1];
+    f2[2] = q3[2] - q2[2];
+    f3[0] = q1[0] - q3[0];
+    f3[1] = q1[1] - q3[1];
+    f3[2] = q1[2] - q3[2];
 
-  if (!project6(g1, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(g2, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(g3, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(h1, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(h2, p1, p2, p3, q1, q2, q3)) return 0;
-  if (!project6(h3, p1, p2, p3, q1, q2, q3)) return 0;
+    n1 = e1 * e2;
+    m1 = f1 * f2;
 
-  return 1;
+    g1 = e1 * n1;
+    g2 = e2 * n1;
+    g3 = e3 * n1;
+    h1 = f1 * m1;
+    h2 = f2 * m1;
+    h3 = f3 * m1;
+
+    ef11 = e1 * f1;
+    ef12 = e1 * f2;
+    ef13 = e1 * f3;
+    ef21 = e2 * f1;
+    ef22 = e2 * f2;
+    ef23 = e2 * f3;
+    ef31 = e3 * f1;
+    ef32 = e3 * f2;
+    ef33 = e3 * f3;
+
+    // now begin the series of tests
+
+    if (!project6(n1, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(m1, p1, p2, p3, q1, q2, q3)) return 0;
+
+    if (!project6(ef11, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef12, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef13, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef21, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef22, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef23, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef31, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef32, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(ef33, p1, p2, p3, q1, q2, q3)) return 0;
+
+    if (!project6(g1, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(g2, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(g3, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(h1, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(h2, p1, p2, p3, q1, q2, q3)) return 0;
+    if (!project6(h3, p1, p2, p3, q1, q2, q3)) return 0;
+
+    return 1;
 }
 
-/*! Code from REAL-TIME COLLISION DETECTION by Christer Ericson, 
-	published by Elsevier.
+/*! Code from REAL-TIME COLLISION DETECTION by Christer Ericson,
+    published by Elsevier.
 */
-position closestPtTriangle(const Triangle &t, const position &p)
-{
+position closestPtTriangle(const Triangle &t, const position &p) {
     // Check if P in vertex region outside t.v1
     vec3 ab = t.v2 - t.v1;
     vec3 ac = t.v3 - t.v1;
@@ -163,7 +182,7 @@ position closestPtTriangle(const Triangle &t, const position &p)
     if (d3 >= 0.0f && d4 <= d3) return t.v2; // barycentric coordinates (0,1,0)
 
     // Check if P in edge region of AB, if so return projection of P onto AB
-    double vc = d1*d4 - d3*d2;
+    double vc = d1 * d4 - d3 * d2;
     if (vc <= 0.0f && d1 >= 0.0f && d3 <= 0.0f) {
         double v = d1 / (d1 - d3);
         return t.v1 + v * ab; // barycentric coordinates (1-v,v,0)
@@ -176,14 +195,14 @@ position closestPtTriangle(const Triangle &t, const position &p)
     if (d6 >= 0.0f && d5 <= d6) return t.v3; // barycentric coordinates (0,0,1)
 
     // Check if P in edge region of AC, if so return projection of P onto AC
-    double vb = d5*d2 - d1*d6;
+    double vb = d5 * d2 - d1 * d6;
     if (vb <= 0.0f && d2 >= 0.0f && d6 <= 0.0f) {
         double w = d2 / (d2 - d6);
         return t.v1 + w * ac; // barycentric coordinates (1-w,0,w)
     }
 
     // Check if P in edge region of BC, if so return projection of P onto BC
-    double va = d3*d6 - d5*d4;
+    double va = d3 * d6 - d5 * d4;
     if (va <= 0.0f && (d4 - d3) >= 0.0f && (d5 - d6) >= 0.0f) {
         double w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
         return t.v2 + w * (t.v3 - t.v2); // barycentric coordinates (0,1-w,w)
@@ -203,21 +222,20 @@ inline double Clamp(double n, double min, double max) {
     return n;
 }
 
-/*! Code from REAL-TIME COLLISION DETECTION by Christer Ericson, 
-	published by Elsevier.
+/*! Code from REAL-TIME COLLISION DETECTION by Christer Ericson,
+    published by Elsevier.
 */
-inline double segmSegmDistanceSq(const position &p1, const position &q1, 
-								 const position &p2, const position &q2,
-								 position &c1, position &c2)
-{
-	double EPSILON = 1.0e-3;
+inline double segmSegmDistanceSq(const position &p1, const position &q1,
+                                 const position &p2, const position &q2,
+                                 position &c1, position &c2) {
+    double EPSILON = 1.0e-3;
     vec3 d1 = q1 - p1; // Direction vector of segment S1
     vec3 d2 = q2 - p2; // Direction vector of segment S2
     vec3 r = p1 - p2;
     double a = d1 % d1; // Squared length of segment S1, always nonnegative
     double e = d2 % d2; // Squared length of segment S2, always nonnegative
     double f = d2 % r;
-	double s, t;
+    double s, t;
 
     // Check if either or both segments degenerate into points
     if (a <= EPSILON && e <= EPSILON) {
@@ -232,26 +250,29 @@ inline double segmSegmDistanceSq(const position &p1, const position &q1,
         s = 0.0f;
         t = f / e; // s = 0 => t = (b*s + f) / e = f / e
         t = Clamp(t, 0.0f, 1.0f);
-    } else {
+    }
+    else {
         double c = d1 % r;
         if (e <= EPSILON) {
             // Second segment degenerates into a point
             t = 0.0f;
             s = Clamp(-c / a, 0.0f, 1.0f); // t = 0 => s = (b*t - c) / a = -c / a
-        } else {
+        }
+        else {
             // The general nondegenerate case starts here
             double b = d1 % d2;
-            double denom = a*e-b*b; // Always nonnegative
+            double denom = a * e - b * b; // Always nonnegative
 
             // If segments not parallel, compute closest point on L1 to L2, and
             // clamp to segment S1. Else pick arbitrary s (here 0)
             if (denom != 0.0f) {
-                s = Clamp((b*f - c*e) / denom, 0.0f, 1.0f);
-            } else s = 0.0f;
+                s = Clamp((b * f - c * e) / denom, 0.0f, 1.0f);
+            }
+            else s = 0.0f;
 
             // Compute point on L2 closest to S1(s) using
             // t = Dot((P1+D1*s)-P2,D2) / Dot(D2,D2) = (b*s + f) / e
-            t = (b*s + f) / e;
+            t = (b * s + f) / e;
 
             // If t in [0,1] done. Else clamp t, recompute s for the new value
             // of t using s = Dot((P2+D2*t)-P1,D1) / Dot(D1,D1)= (t*b - c) / a
@@ -259,7 +280,8 @@ inline double segmSegmDistanceSq(const position &p1, const position &q1,
             if (t < 0.0f) {
                 t = 0.0f;
                 s = Clamp(-c / a, 0.0f, 1.0f);
-            } else if (t > 1.0f) {
+            }
+            else if (t > 1.0f) {
                 t = 1.0f;
                 s = Clamp((b - c) / a, 0.0f, 1.0f);
             }
@@ -272,247 +294,259 @@ inline double segmSegmDistanceSq(const position &p1, const position &q1,
 }
 
 /*! Does all 6 vertex-face tests and all 9 edge-edge tests and adds to the report
-	all distinct pairs of resulting points separated by less than the threshold.
-	Returns the number of contact points, 0 if the triangles are not in contact
-	and -1 if the triangles are in collision.
+    all distinct pairs of resulting points separated by less than the threshold.
+    Returns the number of contact points, 0 if the triangles are not in contact
+    and -1 if the triangles are in collision.
 
-	I have not tested all the obscure cases, and it seems that more involved
-	collision detection engines put more intelligence into this. There might
-	be strange (or degenerate) pieces of geometry where this had an unexpected
-	result.
+    I have not tested all the obscure cases, and it seems that more involved
+    collision detection engines put more intelligence into this. There might
+    be strange (or degenerate) pieces of geometry where this had an unexpected
+    result.
 */
 int
-triangleTriangleContact(const Triangle &t1, const Triangle &t2, double threshSq, 
-						std::vector< std::pair<position, position> >* contactPoints)
-{
-	if (triangleIntersection(t1,t2)) return -1.0;
-	position p1, p2;
-	//vertices on triangle 2 and face on triangle 1
-	//--
-	p1 = closestPtTriangle(t1, t2.v1);
-	p2 = t2.v1;
-	if (((p2 - p1) % (p2 - p1)) < threshSq) {
-		contactPoints->push_back( std::pair<position, position>(p1,p2));
-	}
-	//--
-	p1 = closestPtTriangle(t1, t2.v2);
-	p2 = t2.v2;
-	if (((p2 - p1) % (p2 - p1)) < threshSq) {
-		contactPoints->push_back( std::pair<position, position>(p1,p2));
-	}
-	//--
-	p1 = closestPtTriangle(t1, t2.v3);
-	p2 = t2.v3;
-	if (((p2 - p1) % (p2 - p1)) < threshSq) {
-		contactPoints->push_back( std::pair<position, position>(p1,p2));
-	}
-	//vertices on triangle 1 and face on triangle 2
-	//if closest point on triangle 2 is a vertex, skip this pair as we have already done
-	//the vertices from triangle 2
-	p2 = closestPtTriangle(t2, t1.v1);
-	p1 = t1.v1;
-	if (((p2 - p1) % (p2 - p1)) < threshSq) {
-		if ( !(p2==t2.v1) && !(p2==t2.v2) && !(p2==t2.v3) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	p2 = closestPtTriangle(t2, t1.v2);
-	p1 = t1.v2;
-	if (((p2 - p1) % (p2 - p1)) < threshSq) {
-		if ( !(p2==t2.v1) && !(p2==t2.v2) && !(p2==t2.v3) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	p2 = closestPtTriangle(t2, t1.v3);
-	p1 = t1.v3;
-	if (((p2 - p1) % (p2 - p1)) < threshSq) {
-		if ( !(p2==t2.v1) && !(p2==t2.v2) && !(p2==t2.v3) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//------------------------------------------------------------------
+triangleTriangleContact(const Triangle &t1, const Triangle &t2, double threshSq,
+                        std::vector< std::pair<position, position> > *contactPoints) {
+    if (triangleIntersection(t1, t2)) return -1.0;
+    position p1, p2;
+    //vertices on triangle 2 and face on triangle 1
+    //--
+    p1 = closestPtTriangle(t1, t2.v1);
+    p2 = t2.v1;
+    if (((p2 - p1) % (p2 - p1)) < threshSq) {
+        contactPoints->push_back(std::pair<position, position>(p1, p2));
+    }
+    //--
+    p1 = closestPtTriangle(t1, t2.v2);
+    p2 = t2.v2;
+    if (((p2 - p1) % (p2 - p1)) < threshSq) {
+        contactPoints->push_back(std::pair<position, position>(p1, p2));
+    }
+    //--
+    p1 = closestPtTriangle(t1, t2.v3);
+    p2 = t2.v3;
+    if (((p2 - p1) % (p2 - p1)) < threshSq) {
+        contactPoints->push_back(std::pair<position, position>(p1, p2));
+    }
+    //vertices on triangle 1 and face on triangle 2
+    //if closest point on triangle 2 is a vertex, skip this pair as we have already done
+    //the vertices from triangle 2
+    p2 = closestPtTriangle(t2, t1.v1);
+    p1 = t1.v1;
+    if (((p2 - p1) % (p2 - p1)) < threshSq) {
+        if (!(p2 == t2.v1) && !(p2 == t2.v2) && !(p2 == t2.v3)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    p2 = closestPtTriangle(t2, t1.v2);
+    p1 = t1.v2;
+    if (((p2 - p1) % (p2 - p1)) < threshSq) {
+        if (!(p2 == t2.v1) && !(p2 == t2.v2) && !(p2 == t2.v3)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    p2 = closestPtTriangle(t2, t1.v3);
+    p1 = t1.v3;
+    if (((p2 - p1) % (p2 - p1)) < threshSq) {
+        if (!(p2 == t2.v1) && !(p2 == t2.v2) && !(p2 == t2.v3)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //------------------------------------------------------------------
 
-	//nine edge-edge tests
-	//if one of the closest points on an edge is actually a vertex, skip this pair
-	//as we have already done the vertex closest points
-	double d;
-	d = segmSegmDistanceSq(t1.v1, t1.v2, t2.v1, t2.v2, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v1) && !(p1==t1.v2) && !(p2==t2.v1) && !(p2==t2.v2) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	d = segmSegmDistanceSq(t1.v1, t1.v2, t2.v2, t2.v3, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v1) && !(p1==t1.v2) && !(p2==t2.v2) && !(p2==t2.v3) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	d = segmSegmDistanceSq(t1.v1, t1.v2, t2.v3, t2.v1, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v1) && !(p1==t1.v2) && !(p2==t2.v3) && !(p2==t2.v1) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//------------------
-	d = segmSegmDistanceSq(t1.v2, t1.v3, t2.v1, t2.v2, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v2) && !(p1==t1.v3) && !(p2==t2.v1) && !(p2==t2.v2) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	d = segmSegmDistanceSq(t1.v2, t1.v3, t2.v2, t2.v3, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v2) && !(p1==t1.v3) && !(p2==t2.v2) && !(p2==t2.v3) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	d = segmSegmDistanceSq(t1.v2, t1.v3, t2.v3, t2.v1, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v2) && !(p1==t1.v3) && !(p2==t2.v3) && !(p2==t2.v1) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//------------------
-	d = segmSegmDistanceSq(t1.v3, t1.v1, t2.v1, t2.v2, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v3) && !(p1==t1.v1) && !(p2==t2.v1) && !(p2==t2.v2) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	d = segmSegmDistanceSq(t1.v3, t1.v1, t2.v2, t2.v3, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v3) && !(p1==t1.v1) && !(p2==t2.v2) && !(p2==t2.v3) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	//--
-	d = segmSegmDistanceSq(t1.v3, t1.v1, t2.v3, t2.v1, p1, p2);
-	if (d < threshSq) {
-		if ( !(p1==t1.v3) && !(p1==t1.v1) && !(p2==t2.v3) && !(p2==t2.v1) ) {
-			contactPoints->push_back( std::pair<position, position>(p1,p2));
-		}
-	}
-	return contactPoints->size();
+    //nine edge-edge tests
+    //if one of the closest points on an edge is actually a vertex, skip this pair
+    //as we have already done the vertex closest points
+    double d;
+    d = segmSegmDistanceSq(t1.v1, t1.v2, t2.v1, t2.v2, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v1) && !(p1 == t1.v2) && !(p2 == t2.v1) && !(p2 == t2.v2)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    d = segmSegmDistanceSq(t1.v1, t1.v2, t2.v2, t2.v3, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v1) && !(p1 == t1.v2) && !(p2 == t2.v2) && !(p2 == t2.v3)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    d = segmSegmDistanceSq(t1.v1, t1.v2, t2.v3, t2.v1, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v1) && !(p1 == t1.v2) && !(p2 == t2.v3) && !(p2 == t2.v1)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //------------------
+    d = segmSegmDistanceSq(t1.v2, t1.v3, t2.v1, t2.v2, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v2) && !(p1 == t1.v3) && !(p2 == t2.v1) && !(p2 == t2.v2)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    d = segmSegmDistanceSq(t1.v2, t1.v3, t2.v2, t2.v3, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v2) && !(p1 == t1.v3) && !(p2 == t2.v2) && !(p2 == t2.v3)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    d = segmSegmDistanceSq(t1.v2, t1.v3, t2.v3, t2.v1, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v2) && !(p1 == t1.v3) && !(p2 == t2.v3) && !(p2 == t2.v1)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //------------------
+    d = segmSegmDistanceSq(t1.v3, t1.v1, t2.v1, t2.v2, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v3) && !(p1 == t1.v1) && !(p2 == t2.v1) && !(p2 == t2.v2)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    d = segmSegmDistanceSq(t1.v3, t1.v1, t2.v2, t2.v3, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v3) && !(p1 == t1.v1) && !(p2 == t2.v2) && !(p2 == t2.v3)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    //--
+    d = segmSegmDistanceSq(t1.v3, t1.v1, t2.v3, t2.v1, p1, p2);
+    if (d < threshSq) {
+        if (!(p1 == t1.v3) && !(p1 == t1.v1) && !(p2 == t2.v3) && !(p2 == t2.v1)) {
+            contactPoints->push_back(std::pair<position, position>(p1, p2));
+        }
+    }
+    return contactPoints->size();
 }
 
 double triangleTriangleDistanceSq(const Triangle &t1, const Triangle &t2,
-								  position &p1, position &p2)
-{
-	if (triangleIntersection(t1,t2)) return -1.0;
+                                  position &p1, position &p2) {
+    if (triangleIntersection(t1, t2)) return -1.0;
 
-	double dtmp, dmin;
-	position tmp1, tmp2;
-	//six vertex - face tests
-	//--
-	p1 = closestPtTriangle(t1, t2.v1);
-	p2 = t2.v1;
-	dmin = (p2 - p1) % (p2 - p1);
-	//--
-	tmp1 = closestPtTriangle(t1, t2.v2);
-	tmp2 = t2.v2;
-	dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	tmp1 = closestPtTriangle(t1, t2.v3);
-	tmp2 = t2.v3;
-	dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	tmp2 = closestPtTriangle(t2, t1.v1);
-	tmp1 = t1.v1;
-	dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	tmp2 = closestPtTriangle(t2, t1.v2);
-	tmp1 = t1.v2;
-	dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	tmp2 = closestPtTriangle(t2, t1.v3);
-	tmp1 = t1.v3;
-	dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//------------------------------------------------------------------
+    double dtmp, dmin;
+    position tmp1, tmp2;
+    //six vertex - face tests
+    //--
+    p1 = closestPtTriangle(t1, t2.v1);
+    p2 = t2.v1;
+    dmin = (p2 - p1) % (p2 - p1);
+    //--
+    tmp1 = closestPtTriangle(t1, t2.v2);
+    tmp2 = t2.v2;
+    dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    tmp1 = closestPtTriangle(t1, t2.v3);
+    tmp2 = t2.v3;
+    dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    tmp2 = closestPtTriangle(t2, t1.v1);
+    tmp1 = t1.v1;
+    dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    tmp2 = closestPtTriangle(t2, t1.v2);
+    tmp1 = t1.v2;
+    dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    tmp2 = closestPtTriangle(t2, t1.v3);
+    tmp1 = t1.v3;
+    dtmp = (tmp2 - tmp1) % (tmp2 - tmp1);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //------------------------------------------------------------------
 
-	//nine edge-edge tests
-	dtmp = segmSegmDistanceSq(t1.v1, t1.v2, t2.v1, t2.v2, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	dtmp = segmSegmDistanceSq(t1.v1, t1.v2, t2.v2, t2.v3, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	dtmp = segmSegmDistanceSq(t1.v1, t1.v2, t2.v3, t2.v1, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//-------------------------------
-	dtmp = segmSegmDistanceSq(t1.v2, t1.v3, t2.v1, t2.v2, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	dtmp = segmSegmDistanceSq(t1.v2, t1.v3, t2.v2, t2.v3, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	dtmp = segmSegmDistanceSq(t1.v2, t1.v3, t2.v3, t2.v1, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//-----------------------------------
-	dtmp = segmSegmDistanceSq(t1.v3, t1.v1, t2.v1, t2.v2, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	dtmp = segmSegmDistanceSq(t1.v3, t1.v1, t2.v2, t2.v3, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--
-	dtmp = segmSegmDistanceSq(t1.v3, t1.v1, t2.v3, t2.v1, tmp1, tmp2);
-	if (dtmp < dmin) {
-		dmin = dtmp;
-		p1 = tmp1; p2 = tmp2;
-	}
-	//--------
+    //nine edge-edge tests
+    dtmp = segmSegmDistanceSq(t1.v1, t1.v2, t2.v1, t2.v2, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    dtmp = segmSegmDistanceSq(t1.v1, t1.v2, t2.v2, t2.v3, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    dtmp = segmSegmDistanceSq(t1.v1, t1.v2, t2.v3, t2.v1, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //-------------------------------
+    dtmp = segmSegmDistanceSq(t1.v2, t1.v3, t2.v1, t2.v2, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    dtmp = segmSegmDistanceSq(t1.v2, t1.v3, t2.v2, t2.v3, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    dtmp = segmSegmDistanceSq(t1.v2, t1.v3, t2.v3, t2.v1, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //-----------------------------------
+    dtmp = segmSegmDistanceSq(t1.v3, t1.v1, t2.v1, t2.v2, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    dtmp = segmSegmDistanceSq(t1.v3, t1.v1, t2.v2, t2.v3, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--
+    dtmp = segmSegmDistanceSq(t1.v3, t1.v1, t2.v3, t2.v1, tmp1, tmp2);
+    if (dtmp < dmin) {
+        dmin = dtmp;
+        p1 = tmp1;
+        p2 = tmp2;
+    }
+    //--------
 
 
-	return dmin;
+    return dmin;
 }

--- a/include/world.h
+++ b/include/world.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the simulation world that controls interactions between the world elements
- */
+/*! \file
+    \brief Defines the simulation world that controls interactions between the world elements
+*/
 #ifndef WORLD_HXX
 
 #include <list>
@@ -69,7 +69,7 @@ typedef std::vector<CollisionData> CollisionReport;
 
 class CollisionInterface;
 class BoundingBox;
-class TiXmlElement; 
+class TiXmlElement;
 class SoGroup;
 class SoSeparator;
 class SoIdleSensor;
@@ -84,415 +84,486 @@ class SoSensor;
     the dynamic simulation of body motions within the world.  The state of
     a world may be written out to a simple text file which may be reloaded
     later.
- */
+*/
 class World : public QObject {
-  Q_OBJECT ;
+        Q_OBJECT ;
 
-protected:
-  //! Pointer to the IVmgr who controls the simulation
-  IVmgr *myIVmgr;
+    protected:
+        //! Pointer to the IVmgr who controls the simulation
+        IVmgr *myIVmgr;
 
-  //! Keeps track of the current simulation time.
-  double worldTime;
+        //! Keeps track of the current simulation time.
+        double worldTime;
 
-  //! A vector of pointers to ALL of the bodies in the world
-  std::vector<Body *> bodyVec;
+        //! A vector of pointers to ALL of the bodies in the world
+        std::vector<Body *> bodyVec;
 
-  //! A vector of pointers to the graspable bodies in the world
-  std::vector<GraspableBody *> GBVec;
+        //! A vector of pointers to the graspable bodies in the world
+        std::vector<GraspableBody *> GBVec;
 
-  //! A vector of pointers to the robots defined within this world
-  std::vector<Robot *> robotVec;        
+        //! A vector of pointers to the robots defined within this world
+        std::vector<Robot *> robotVec;
 
-  //! A vector of pointers to the hands defined within this world
-  std::vector<Hand *> handVec;
+        //! A vector of pointers to the hands defined within this world
+        std::vector<Hand *> handVec;
 
-  //! The number of bodies currently in this world
-  int numBodies;
+        //! The number of bodies currently in this world
+        int numBodies;
 
-  //! The number of graspable bodies currently in this world
-  int numGB;
+        //! The number of graspable bodies currently in this world
+        int numGB;
 
-  //! The number of robots currently in this world
-  int numRobots;
+        //! The number of robots currently in this world
+        int numRobots;
 
-  //! The number of hands currently in this world
-  int numHands;
+        //! The number of hands currently in this world
+        int numHands;
 
-  //! The number of currently selected elements
-  int numSelectedElements;
+        //! The number of currently selected elements
+        int numSelectedElements;
 
-  //! The number of currently selected body elements
-  int numSelectedBodyElements;
+        //! The number of currently selected body elements
+        int numSelectedBodyElements;
 
-  //! The number of currently selected body elements
-  int numSelectedRobotElements;
+        //! The number of currently selected body elements
+        int numSelectedRobotElements;
 
-  //! The number of currently selected bodies
-  int numSelectedBodies;
+        //! The number of currently selected bodies
+        int numSelectedBodies;
 
-  //! Keeps track of whether the world has been modified since the last save
-  bool modified;
+        //! Keeps track of whether the world has been modified since the last save
+        bool modified;
 
-  //! Keeps track of which hand is currently the focus of menu commands
-  Hand *currentHand;
+        //! Keeps track of which hand is currently the focus of menu commands
+        Hand *currentHand;
 
-  //! A list of pointers to the currently selected worldElements
-  std::list<WorldElement *> selectedElementList;
+        //! A list of pointers to the currently selected worldElements
+        std::list<WorldElement *> selectedElementList;
 
-  //! A vector of pointers to the currently selected bodies
-  std::vector<Body *> selectedBodyVec;
-  
-  //! keeps track is a tendon is selected or not
-  bool isTendonSelected;
+        //! A vector of pointers to the currently selected bodies
+        std::vector<Body *> selectedBodyVec;
 
-  //! pointer to selected tendon
-  Tendon* selectedTendon;
+        //! keeps track is a tendon is selected or not
+        bool isTendonSelected;
 
-  //! A flag to determine if collions checking is on or off
-  bool allCollisionsOFF;
+        //! pointer to selected tendon
+        Tendon *selectedTendon;
 
-  //! Turns on or off soft contacts, needs a switch in the Iv environment
-  bool softContactsON;
+        //! A flag to determine if collions checking is on or off
+        bool allCollisionsOFF;
 
-  //! A pointer to the collision detection instance
-  CollisionInterface *mCollisionInterface;
+        //! Turns on or off soft contacts, needs a switch in the Iv environment
+        bool softContactsON;
 
-  //! A pointer to the dynamics engine
-  DynamicsEngine *mDynamicsEngine;
+        //! A pointer to the collision detection instance
+        CollisionInterface *mCollisionInterface;
 
-  //! A pointer to the root of the world's Inventor scene graph
-  SoSeparator *IVRoot;
+        //! A pointer to the dynamics engine
+        DynamicsEngine *mDynamicsEngine;
 
-  //! The number of materials defined within this world
-  int numMaterials;
-  
-  //! A vector of strings, one for each material name
-  std::vector<QString> materialNames;
+        //! A pointer to the root of the world's Inventor scene graph
+        SoSeparator *IVRoot;
 
-  //! A numMaterials x numMaterials array of static coefficient of friction values
-  double **cofTable;
+        //! The number of materials defined within this world
+        int numMaterials;
 
-  //! A numMaterials x numMaterials array of kinetic coefficient of friction values
-  double **kcofTable;
+        //! A vector of strings, one for each material name
+        std::vector<QString> materialNames;
 
-  //! A flag to determine whether dynamics is currently being used or not
-  bool dynamicsOn;
+        //! A numMaterials x numMaterials array of static coefficient of friction values
+        double **cofTable;
 
-  //! A pointer to the Inventor idle sensor that is used when dynamics is on
-  SoIdleSensor *idleSensor;
+        //! A numMaterials x numMaterials array of kinetic coefficient of friction values
+        double **kcofTable;
 
-  //! The length of the default dynamics time step
-  double dynamicsTimeStep;  
+        //! A flag to determine whether dynamics is currently being used or not
+        bool dynamicsOn;
 
-  //! Reads the user preferences for the world settings.  Under
-  void readSettings();
+        //! A pointer to the Inventor idle sensor that is used when dynamics is on
+        SoIdleSensor *idleSensor;
 
-  //! Saves the user preferences for the world settings.  
-  void saveSettings();
+        //! The length of the default dynamics time step
+        double dynamicsTimeStep;
 
-  //! Static callback routine for the dynamic operations idle sensor.
-  static void dynamicsCB(void *data,SoSensor *sensor);
-  
-  friend class Body;
-  friend class DynamicBody;
-  friend class MainWindow;
+        //! Reads the user preferences for the world settings.  Under
+        void readSettings();
 
-Q_SIGNALS:
-  //! Signal that a dynamic step has been completed
-  void dynamicStepTaken();
+        //! Saves the user preferences for the world settings.
+        void saveSettings();
 
-  //! Signal a dynamics error has occured with an error string
-  void dynamicsError(const char *errMsg);
+        //! Static callback routine for the dynamic operations idle sensor.
+        static void dynamicsCB(void *data, SoSensor *sensor);
 
-  //! Signal that selections have changed
-  void selectionsChanged();
+        friend class Body;
+        friend class DynamicBody;
+        friend class MainWindow;
 
-  //! Signal that the number of world elements has changed
-  void numElementsChanged();
+    Q_SIGNALS:
+        //! Signal that a dynamic step has been completed
+        void dynamicStepTaken();
 
-  //! Signal that a hand was removed from the world
-  void handRemoved();
+        //! Signal a dynamics error has occured with an error string
+        void dynamicsError(const char *errMsg);
 
-  //! Signal that all grasps have been updated
-  void graspsUpdated();
+        //! Signal that selections have changed
+        void selectionsChanged();
 
-  //! Signal we want have changed the currently selected hand from within the code
-  void handSelectionChanged();
+        //! Signal that the number of world elements has changed
+        void numElementsChanged();
 
-  //! Signal that a tendon has been (de)selected
-  void tendonSelectionChanged();
+        //! Signal that a hand was removed from the world
+        void handRemoved();
 
-  //! Signal that the selected tendon's status has changed
-  void tendonDetailsChanged();
+        //! Signal that all grasps have been updated
+        void graspsUpdated();
 
-public:	
-  //! public constructor
-  World(QObject *parent=0,const char *name=0, IVmgr *mgr=NULL);
+        //! Signal we want have changed the currently selected hand from within the code
+        void handSelectionChanged();
 
-  //! Saves the current user settings in the registry and clears the world
-  ~World();
-  
-  //! Returns the number of bodies in this world
-  int getNumBodies() const {return numBodies;}
+        //! Signal that a tendon has been (de)selected
+        void tendonSelectionChanged();
 
-  //! Returns the number of graspable bodies in this world
-  int getNumGB() const {return numGB;}
+        //! Signal that the selected tendon's status has changed
+        void tendonDetailsChanged();
 
-  //! Returns the number of robots in this world
-  int getNumRobots() const {return numRobots;}
+    public:
+        //! public constructor
+        World(QObject *parent = 0, const char *name = 0, IVmgr *mgr = NULL);
 
-  //! Returns the number of hands in this world
-  int getNumHands() const {return numHands;}
+        //! Saves the current user settings in the registry and clears the world
+        ~World();
 
-  //! Returns the number of materials defined in this world
-  int getNumMaterials() const {return numMaterials;}
+        //! Returns the number of bodies in this world
+        int getNumBodies() const {
+            return numBodies;
+        }
 
-  //! Returns the material index of the material named by matName
-  int getMaterialIdx(const QString &matName) const; 
+        //! Returns the number of graspable bodies in this world
+        int getNumGB() const {
+            return numGB;
+        }
 
-  //! Returns the name of the material with index i 
-  QString getMaterialName(int i) const {return materialNames[i];}
+        //! Returns the number of robots in this world
+        int getNumRobots() const {
+            return numRobots;
+        }
+
+        //! Returns the number of hands in this world
+        int getNumHands() const {
+            return numHands;
+        }
+
+        //! Returns the number of materials defined in this world
+        int getNumMaterials() const {
+            return numMaterials;
+        }
+
+        //! Returns the material index of the material named by matName
+        int getMaterialIdx(const QString &matName) const;
+
+        //! Returns the name of the material with index i
+        QString getMaterialName(int i) const {
+            return materialNames[i];
+        }
+
+        //! Returns the number of selected body elements
+        int getNumSelectedBodyElements() const {
+            return numSelectedBodyElements;
+        }
+
+        //! Returns the number of selected robot elements
+        int getNumSelectedRobotElements() const {
+            return numSelectedRobotElements;
+        }
+
+        //! Returns the number of selected world elements
+        int getNumSelectedElements() const {
+            return numSelectedElements;
+        }
+
+        //! Returns the number of selected bodies
+        int getNumSelectedBodies() const {
+            return numSelectedBodies;
+        }
+
+        //! Returns a pointer to the i-th selected body in the world
+        Body *getSelectedBody(int i) const {
+            return selectedBodyVec[i];
+        }
+
+        //! returns the number of tendons in the currently selected hand
+        int getCurrentHandNumberTendons();
+
+        //! Returns the currently selected tendond
+        Tendon *getSelectedTendon() {
+            return selectedTendon;
+        }
+
+        //! returns the name of the i-th tendon of the currently selected hand
+        QString getSelectedHandTendonName(int i);
+
+        //! query whether a tendon is selected or not
+        bool queryTendonSelected() {
+            return isTendonSelected;
+        }
+
+        //! Set selected tendon
+        void selectTendon(Tendon *t);
+
+        //! Sets the selected tendon, receives an index into the selected hand's list of tendons
+        void selectTendon(int i);
+
+        //!deselect tendon
+        void deselectTendon();
+
+        //! Q_SIGNALS that a tendon has changed status, we need to update the tendon status bar
+        void tendonChange() {
+            Q_EMIT tendonDetailsChanged();
+        }
+
+        //! Returns the static coefficient of friction between two materials
+        double getCOF(int mat1, int mat2) {
+            return cofTable[mat1][mat2];
+        }
+
+        //! Returns the kinetic coefficient of friction between two materials
+        double getKCOF(int mat1, int mat2) {
+            return kcofTable[mat1][mat2];
+        }
+
+        //! Returns the current simulation time for this world
+        double getWorldTime() const {
+            return worldTime;
+        }
+
+        //! Returns the current simulation time reference for this world
+        double &getWorldTimeRef() {
+            return worldTime;
+        }
+
+        //! Returns the default timestep for this world
+        double getTimeStep() const {
+            return dynamicsTimeStep;
+        }
+
+        //! Returns whether this world has been modified since the last save.
+        bool wasModified() const {
+            return modified;
+        }
 
-  //! Returns the number of selected body elements 
-  int getNumSelectedBodyElements() const {return numSelectedBodyElements;}
-  
-  //! Returns the number of selected robot elements 
-  int getNumSelectedRobotElements() const {return numSelectedRobotElements;}
+        //! Returns the root of the Inventor scene graph for this world
+        SoSeparator *getIVRoot() const {
+            return IVRoot;
+        }
 
-  //! Returns the number of selected world elements 
-  int getNumSelectedElements() const {return numSelectedElements;}
+        //! Returns a pointer to the i-th body defined in this world
+        Body *getBody(int i) const {
+            return bodyVec[i];
+        }
 
-  //! Returns the number of selected bodies 
-  int getNumSelectedBodies() const {return numSelectedBodies;}
+        //! Returns a pointer to the i-th graspable body defined in this world
+        GraspableBody *getGB(int i) const {
+            return GBVec[i];
+        }
 
-  //! Returns a pointer to the i-th selected body in the world 
-  Body *getSelectedBody(int i) const {return selectedBodyVec[i];}
+        //! Returns a pointer to the i-th hand defined in this world
+        Hand *getHand(int i) const {
+            return handVec[i];
+        }
 
-  //! returns the number of tendons in the currently selected hand 
-  int getCurrentHandNumberTendons();
+        //! Returns a pointer to the i-th robot defined in this world
+        Robot *getRobot(int i) const {
+            return robotVec[i];
+        }
 
-  //! Returns the currently selected tendond 
-  Tendon* getSelectedTendon(){return selectedTendon;}
+        //! Returns whether the world element pointed to by e is currently selected or not
+        bool isSelected(WorldElement *e) const;
 
-  //! returns the name of the i-th tendon of the currently selected hand 
-  QString getSelectedHandTendonName(int i);
+        //! Returns a list of pointers to the currently selected world elements
+        const std::list<WorldElement *> &getSelectedElementList() const {
+            return selectedElementList;
+        }
 
-  //! query whether a tendon is selected or not 
-  bool queryTendonSelected(){return isTendonSelected;}
+        //! Returns a pointer to the hand that is the focus of menu commands etc.
+        Hand *getCurrentHand() const {
+            return currentHand;
+        }
 
-  //! Set selected tendon 
-  void selectTendon(Tendon *t);
+        //! Returns whether dynamics are currently running or not.
+        bool dynamicsAreOn() const {
+            return dynamicsOn;
+        }
 
-  //! Sets the selected tendon, receives an index into the selected hand's list of tendons 
-  void selectTendon(int i);
+        //! Returns whether  soft contacts are on
+        bool softContactsAreOn() {
+            return softContactsON;
+        }
 
-  //!deselect tendon 
-  void deselectTendon();
+        //! Sets all world settings to their original default values.
+        void setDefaults();
 
-  //! Q_SIGNALS that a tendon has changed status, we need to update the tendon status bar 
-  void tendonChange(){Q_EMIT tendonDetailsChanged();}
+        //! Sets the world modified flag.  Should be done when a change has since the last save.
+        void setModified() {
+            modified = true;
+        }
 
-  //! Returns the static coefficient of friction between two materials
-  double getCOF(int mat1,int mat2) {return cofTable[mat1][mat2];}
+        //! Loads the saved world from the file in filename.
+        int load(const QString &filename);
 
-  //! Returns the kinetic coefficient of friction between two materials
-  double getKCOF(int mat1,int mat2) {return kcofTable[mat1][mat2];}
+        //! Loads the saved world from the XML file in filename.
+        int loadFromXml(const TiXmlElement *root, QString rootPath);
 
-  //! Returns the current simulation time for this world 
-  double getWorldTime() const {return worldTime;}
+        //! Save the current state of the world to a file.
+        int save(const QString &filename);
 
-  //! Returns the current simulation time reference for this world
-  double& getWorldTimeRef() {return worldTime;}
+        //! Creates a new body of type \a bodyType, then calls the load routine of that body
+        Body *importBody(QString bodyType, QString filename);
 
-  //! Returns the default timestep for this world 
-  double getTimeStep() const {return dynamicsTimeStep;}
-  
-  //! Returns whether this world has been modified since the last save. 
-  bool wasModified() const {return modified;}
+        //! Creates a new body of type \a bodyType, then calls the loadFromXml routine of that body
+        Body *importBodyFromXml(QString bodyType, const TiXmlElement *child, QString rootPath);
 
-  //! Returns the root of the Inventor scene graph for this world 
-  SoSeparator *getIVRoot() const {return IVRoot;}
+        //! Adds an already populated body to the world, but not to collision detection system
+        void addBody(Body *body);
 
-  //! Returns a pointer to the i-th body defined in this world 
-  Body *getBody(int i) const {return bodyVec[i];}
+        //! Links are loaded in during the robot load method, but are added to the world with this routine
+        void addLink(Link *newLink);
 
-  //! Returns a pointer to the i-th graspable body defined in this world 
-  GraspableBody *getGB(int i) const {return GBVec[i];}
+        //! Called when the user selects a new hand from the drop down menu.
+        void setCurrentHand(Hand *hand) {
+            currentHand = hand;
+            Q_EMIT handSelectionChanged();
+        }
 
-  //! Returns a pointer to the i-th hand defined in this world 
-  Hand *getHand(int i) const {return handVec[i];}
+        //! Creates a robot, loads it from a file and adds it to the world
+        Robot *importRobot(QString filename);
 
-  //! Returns a pointer to the i-th robot defined in this world 
-  Robot *getRobot(int i) const {return robotVec[i];}
+        //! Adds an already populated robot to the world,and possibly to the scene graph
+        void addRobot(Robot *robot, bool addToScene = true);
 
-  //! Returns whether the world element pointed to by e is currently selected or not
-  bool isSelected(WorldElement *e) const;
+        //! Removes the robot pointed to by robot from the world, then deletes it.
+        void removeRobot(Robot *robot);
 
-  //! Returns a list of pointers to the currently selected world elements 
-  const std::list<WorldElement *>& getSelectedElementList() const {return selectedElementList;}
+        //! Creates a new dynamic body from the data in the body pointed to by b.
+        DynamicBody *makeBodyDynamic(Body *b, double mass);
 
-  //! Returns a pointer to the hand that is the focus of menu commands etc. 
-  Hand *getCurrentHand() const { return currentHand;}
+        //! Deselects all currently selected world elements.
+        void deselectAll();
 
-  //! Returns whether dynamics are currently running or not. 
-  bool dynamicsAreOn() const {return dynamicsOn;}
+        //! Adds the worldElement pointed to by e to the list of selected elements.
+        void selectElement(WorldElement *e);
 
-  //! Returns whether  soft contacts are on 
-  bool softContactsAreOn() { return softContactsON; }
+        //! Removes the worldElement pointed to by e from the list of selected elements.
+        void deselectElement(WorldElement *e);
 
-  //! Sets all world settings to their original default values. 
-  void setDefaults();
+        //! Removes the element pointed to by e from the world
+        void destroyElement(WorldElement *e, bool deleteElement = true);
 
-  //! Sets the world modified flag.  Should be done when a change has since the last save. 
-  void setModified() {modified = true;}
+        //! Turns the collision detection system on or off
+        void toggleAllCollisions(bool on);
 
-  //! Loads the saved world from the file in filename. 
-  int load(const QString &filename);
+        //! Toggle collisions for a world element (robot or body)
+        void toggleCollisions(bool on, WorldElement *e1, WorldElement *e2 = NULL);
 
-  //! Loads the saved world from the XML file in filename.
-  int loadFromXml(const TiXmlElement* root,QString rootPath);
+        //! Check if collisions are enabled for a world element (robot or body)
+        bool collisionsAreOff(WorldElement *e1 = NULL, WorldElement *e2 = NULL);
 
-  //! Save the current state of the world to a file.
-  int save(const QString &filename);
-  
-  //! Creates a new body of type \a bodyType, then calls the load routine of that body
-  Body *importBody(QString bodyType,QString filename);
+        //! Checks if collision between an entire robot and another element are on
+        bool robotCollisionsAreOff(Robot *r, WorldElement *e);
 
-  //! Creates a new body of type \a bodyType, then calls the loadFromXml routine of that body
-  Body *importBodyFromXml(QString bodyType, const TiXmlElement* child, QString rootPath);
+        //! Answers true if there are no collisions in the world, potentially involving a specified element.
+        bool noCollision(WorldElement *e = NULL);
 
-  //! Adds an already populated body to the world, but not to collision detection system
-  void addBody(Body *body);
+        //! Queries the collision detection system for a report of which pairs of bodies are colliding.
+        int getCollisionReport(CollisionReport *colReport, const std::vector<Body *> *interestList = NULL);
 
-  //! Links are loaded in during the robot load method, but are added to the world with this routine
-  void addLink(Link *newLink);
+        //! Returns the minimum distance in mm between the two bodies; deprecated, use version on world elements
+        // double getDist(Body *b1,Body *b2);
 
-  //! Called when the user selects a new hand from the drop down menu.
-  void setCurrentHand(Hand *hand) {currentHand = hand; Q_EMIT handSelectionChanged();}
+        //! Returns the minimum distance in mm between the two world elements
+        double getDist(WorldElement *e1, WorldElement *e2);
 
-  //! Creates a robot, loads it from a file and adds it to the world
-  Robot *importRobot(QString filename);
-	
-  //! Adds an already populated robot to the world,and possibly to the scene graph
-  void addRobot(Robot *robot, bool addToScene = true);
+        //! Returns the minimum distance in mm between the two bodies as well as the points on the bodies that are closest.
+        double getDist(Body *b1, Body *b2, position &p1, position &p2);
 
-  //! Removes the robot pointed to by robot from the world, then deletes it.
-  void removeRobot(Robot *robot);
+        //! Finds every contact occurring between the pairs of bodies listed in the colReport.
+        void findContacts(CollisionReport &colReport);
 
-  //! Creates a new dynamic body from the data in the body pointed to by b.
-  DynamicBody *makeBodyDynamic(Body *b, double mass);
+        //! Finds all contacts occurring on body b.
+        void findContacts(Body *b);
 
-  //! Deselects all currently selected world elements.
-  void deselectAll();
+        //! Finds all the contacts occuring in the world.
+        void findAllContacts();
 
-  //! Adds the worldElement pointed to by e to the list of selected elements.
-  void selectElement(WorldElement *e);
+        //! Sets up virtual contacts on all links at the closest points to a given body.
+        void findVirtualContacts(Hand *hand, Body *object);
 
-  //! Removes the worldElement pointed to by e from the list of selected elements.
-  void deselectElement(WorldElement *e);
+        //! Helper function that finds the closest point on a link to an object
+        ContactData findVirtualContact(Link *link, Body *object);
 
-  //! Removes the element pointed to by e from the world 
-  void destroyElement(WorldElement *e, bool deleteElement = true);
-  
-  //! Turns the collision detection system on or off
-  void toggleAllCollisions(bool on);
+        //! Returns the bounding boxes from the collision detection bounding box hierarchy of a body.
+        void getBvs(Body *b, int depth, std::vector<BoundingBox> *bvs);
 
-  //! Toggle collisions for a world element (robot or body)
-  void toggleCollisions(bool on, WorldElement *e1,WorldElement *e2=NULL);
+        //! Updates the grasp for any hand that has had contacts change since its grasp was last updated.
+        void updateGrasps();
 
-  //! Check if collisions are enabled for a world element (robot or body)
-  bool collisionsAreOff(WorldElement *e1=NULL, WorldElement *e2=NULL);
+        //! Resets the external wrench accumulator for all the dynamic bodies.
+        void resetDynamicWrenches();
 
-  //! Checks if collision between an entire robot and another element are on
-  bool robotCollisionsAreOff(Robot *r, WorldElement *e);
+        //! Starts the dynamic simulation for this world.
+        void turnOnDynamics();
 
-  //! Answers true if there are no collisions in the world, potentially involving a specified element.
-  bool noCollision(WorldElement *e=NULL);
+        //! Stops the dynamic simulation process.
+        void turnOffDynamics();
 
-  //! Queries the collision detection system for a report of which pairs of bodies are colliding.
-  int getCollisionReport(CollisionReport *colReport, const std::vector<Body*> *interestList = NULL);
+        //! Resets dynamic simulation. Clears the dynamic stack, fixes all robot bases
+        void resetDynamics();
 
-  //! Returns the minimum distance in mm between the two bodies; deprecated, use version on world elements
-  // double getDist(Body *b1,Body *b2);
+        //! One complete step of the dynamics simulation.
+        void stepDynamics();
 
-  //! Returns the minimum distance in mm between the two world elements
-  double getDist(WorldElement *e1, WorldElement *e2);
+        //! Moves all dynamic bodies based on their velocity and the length of the current timestep.
+        double moveDynamicBodies(double timeStep);
 
-  //! Returns the minimum distance in mm between the two bodies as well as the points on the bodies that are closest.
-  double getDist(Body *b1,Body *b2, position &p1, position &p2);
+        //! Calls the dynamics routine to build and solve the LCP to find the velocities of the bodies
+        int computeNewVelocities(double timeStep);
 
-  //! Finds every contact occurring between the pairs of bodies listed in the colReport.
-  void findContacts(CollisionReport &colReport);
+        //! Calls upon each dynamic body to save its current dynamic state to the top of its stack of states.
+        void pushDynamicState();
 
-  //! Finds all contacts occurring on body b.  
-  void findContacts(Body *b);
+        //! Restores the most recent dynamic state of each dynamic body by popping the state of each body's local stack.
+        void popDynamicState();
 
-  //! Finds all the contacts occuring in the world.
-  void findAllContacts();
+        //! Finds a region around a given point on a body through the collision detection system
+        void FindRegion(const Body *body, position point, vec3 normal, double radius,
+                        Neighborhood *neighborhood);
 
-  //! Sets up virtual contacts on all links at the closest points to a given body.
-  void findVirtualContacts(Hand *hand, Body *object);
+        //! Returns the collision interface being used
+        CollisionInterface *getCollisionInterface() {
+            return mCollisionInterface;
+        }
 
-  //! Helper function that finds the closest point on a link to an object
-  ContactData findVirtualContact(Link *link, Body* object);
+        //! Computes the distance between a point and a body
+        vec3 pointDistanceToBody(position p, Body *b, vec3 *normal = NULL);
 
-  //! Returns the bounding boxes from the collision detection bounding box hierarchy of a body.
-  void getBvs(Body *b, int depth, std::vector<BoundingBox> *bvs);
+        //! Adds back to the scene graph an element that has been removed
+        void addElementToSceneGraph(WorldElement *e);
+        //! Removes from the scene graph an element that is already part of this world
+        void removeElementFromSceneGraph(WorldElement *e);
 
-  //! Updates the grasp for any hand that has had contacts change since its grasp was last updated.
-  void updateGrasps();
+        //! Emits the signal that informs that grasps have been updated
+        void emitGraspsUpdated() {
+            Q_EMIT graspsUpdated();
+        }
 
-  //! Resets the external wrench accumulator for all the dynamic bodies.
-  void resetDynamicWrenches();
+        //! Emits the signal that dynamics error has occured with an error string
+        void emitdynamicsError(const char *errMsg) {
+            Q_EMIT dynamicsError(errMsg);
+        }
 
-  //! Starts the dynamic simulation for this world.
-  void turnOnDynamics();
-
-  //! Stops the dynamic simulation process.
-  void turnOffDynamics();
-
-  //! Resets dynamic simulation. Clears the dynamic stack, fixes all robot bases
-  void resetDynamics();
-
-  //! One complete step of the dynamics simulation. 
-  void stepDynamics();
-
-  //! Moves all dynamic bodies based on their velocity and the length of the current timestep.
-  double moveDynamicBodies(double timeStep);
-
-  //! Calls the dynamics routine to build and solve the LCP to find the velocities of the bodies
-  int computeNewVelocities(double timeStep);
-
-  //! Calls upon each dynamic body to save its current dynamic state to the top of its stack of states.
-  void pushDynamicState();
-
-  //! Restores the most recent dynamic state of each dynamic body by popping the state of each body's local stack.
-  void popDynamicState();
-
-  //! Finds a region around a given point on a body through the collision detection system
-  void FindRegion( const Body *body, position point, vec3 normal, double radius,
-	  			   Neighborhood *neighborhood);
-
-  //! Returns the collision interface being used
-  CollisionInterface *getCollisionInterface() {return mCollisionInterface;}
-
-  //! Computes the distance between a point and a body
-  vec3 pointDistanceToBody(position p, Body *b, vec3* normal = NULL);
-
-  //! Adds back to the scene graph an element that has been removed
-  void addElementToSceneGraph(WorldElement *e);
-  //! Removes from the scene graph an element that is already part of this world
-  void removeElementFromSceneGraph(WorldElement *e);
-
-  //! Emits the signal that informs that grasps have been updated
-  void emitGraspsUpdated(){Q_EMIT graspsUpdated();}
-
-  //! Emits the signal that dynamics error has occured with an error string
-  void emitdynamicsError(const char *errMsg){Q_EMIT dynamicsError(errMsg);}
-
-  //! Emits the Signal that a dynamic step has been completed
-  void emitDynamicStepTaken(){Q_EMIT dynamicStepTaken();}
+        //! Emits the Signal that a dynamic step has been completed
+        void emitDynamicStepTaken() {
+            Q_EMIT dynamicStepTaken();
+        }
 };
 
 #define WORLD_HXX

--- a/include/worldElement.h
+++ b/include/worldElement.h
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Defines the world element base class that is used for all robots and bodies.
- */
+/*! \file
+    \brief Defines the world element base class that is used for all robots and bodies.
+*/
 #ifndef WORLD_ELEMENT_H
 
 #include <vector>
@@ -46,114 +46,132 @@ class Body;
 /*!  A world element is either an individual body or a robot which is comprised
      of a collection of articulated bodies.  It serves as the common base class
      for these two types of elements.
-	 
-	 A WorldElement can not be initialized directly, but only by sub-classes.
+
+     A WorldElement can not be initialized directly, but only by sub-classes.
 */
-class WorldElement : public QObject{
-  Q_OBJECT  ;
-public:
-  //! Used to indicate moves should be made on one step, not broken down in small steps.
-  static const double ONE_STEP;
+class WorldElement : public QObject {
+        Q_OBJECT  ;
+    public:
+        //! Used to indicate moves should be made on one step, not broken down in small steps.
+        static const double ONE_STEP;
 
-private:
- //! Indicates whether any contacts have formed or been broken since the last time this was reset.
- bool contactsChangedFlag;
+    private:
+        //! Indicates whether any contacts have formed or been broken since the last time this was reset.
+        bool contactsChangedFlag;
 
-protected:
-  //! A pointer to the world that this element is a part of
-  World *myWorld;
+    protected:
+        //! A pointer to the world that this element is a part of
+        World *myWorld;
 
-  //! A pointer to the root of this element's Inventor scene graph
-  SoSeparator *IVRoot;
- 
-  //! Holds the file name associated with this element.  
-  /*! For bodies this is the geometry file, for robots its the configuration file.
-	  It is always stored relative to the GraspIt root, which is obtained from the
-	  GRASPIT environment variable.
-  */
-  QString myFilename;
+        //! A pointer to the root of this element's Inventor scene graph
+        SoSeparator *IVRoot;
 
-  //! Holds the name of this element
-  QString myName;
+        //! Holds the file name associated with this element.
+        /*! For bodies this is the geometry file, for robots its the configuration file.
+            It is always stored relative to the GraspIt root, which is obtained from the
+            GRASPIT environment variable.
+        */
+        QString myFilename;
 
-  //! Initializes and empty element belonging to a world
-  WorldElement(World *w,const char *name);
+        //! Holds the name of this element
+        QString myName;
 
-  //! Copy constructor
-  WorldElement(const WorldElement &e);
+        //! Initializes and empty element belonging to a world
+        WorldElement(World *w, const char *name);
 
-  //! Finds the moment of contacts between a collision and a collision-free position
-  virtual bool interpolateTo(transf lastTran, transf newTran, const CollisionReport &colReport);
+        //! Copy constructor
+        WorldElement(const WorldElement &e);
 
-  //! Moves element to a new location in one step; resolves collisions along the way
-  virtual bool jumpTo(transf newTran, CollisionReport *contactReport);
+        //! Finds the moment of contacts between a collision and a collision-free position
+        virtual bool interpolateTo(transf lastTran, transf newTran, const CollisionReport &colReport);
 
-  //! Adds all the bodies that make up this WorldElement to the given list of bodies
-  /*! This is implemented in both Body (which just adds itself) and Robot (which adds
-	  all of its links plus the base).
-  
-	  This is not ideal, as it automatically implies that any WorldElement is made 
-	  up of instances of the Body class, which actually inherits from WorldElement.
-	  However, this is true for both classes that, at this time, inherit from 
-	  WorldElement: the Body is obviously a Body itself, while the Robot is made up
-	  from a collection of Body instances (the links and the base).
-  */
-  virtual void getBodyList(std::vector<Body*> *bodies) = 0;
+        //! Moves element to a new location in one step; resolves collisions along the way
+        virtual bool jumpTo(transf newTran, CollisionReport *contactReport);
 
-public:
-  //! Currently, just a stub
-  virtual ~WorldElement();
+        //! Adds all the bodies that make up this WorldElement to the given list of bodies
+        /*! This is implemented in both Body (which just adds itself) and Robot (which adds
+            all of its links plus the base).
 
-  /*! Returns the world the element is a part of */
-  World *getWorld() const {return myWorld;}
+            This is not ideal, as it automatically implies that any WorldElement is made
+            up of instances of the Body class, which actually inherits from WorldElement.
+            However, this is true for both classes that, at this time, inherit from
+            WorldElement: the Body is obviously a Body itself, while the Robot is made up
+            from a collection of Body instances (the links and the base).
+        */
+        virtual void getBodyList(std::vector<Body *> *bodies) = 0;
 
-  /*! Returns a pointer to the root of this element's Inventor scene graph */
-  SoSeparator *getIVRoot() const {return IVRoot;}
+    public:
+        //! Currently, just a stub
+        virtual ~WorldElement();
 
-  /*! Returns the filename associated with this element */
-  QString getFilename() const {return myFilename;}
+        /*! Returns the world the element is a part of */
+        World *getWorld() const {
+            return myWorld;
+        }
 
-  /*! Returns the name of this element */
-  QString getName() const {return myName;}
+        /*! Returns a pointer to the root of this element's Inventor scene graph */
+        SoSeparator *getIVRoot() const {
+            return IVRoot;
+        }
 
-  //! Sets the name of this element
-  virtual void setName(QString newName){myName = newName;}
+        /*! Returns the filename associated with this element */
+        QString getFilename() const {
+            return myFilename;
+        }
 
-  //! Sets the filename of this element
-  virtual void setFilename(QString newName){myFilename = newName;}
+        /*! Returns the name of this element */
+        QString getName() const {
+            return myName;
+        }
 
-  /*! Returns the current pose of this element relative to the world frame.
-      This is a purely abstract function that is reimplemented in the robot
-      and body classes */
-  virtual const transf& getTran() const =0;
+        //! Sets the name of this element
+        virtual void setName(QString newName) {
+            myName = newName;
+        }
 
-  /*! Checks whether contacts on the element will prevent the element from 
-      making the motion described by the transform motion.  This is a purely
-      abstract function that is reimplemented in the robot and body classes */
-  virtual bool contactsPreventMotion(const transf& motion) const =0;
+        //! Sets the filename of this element
+        virtual void setFilename(QString newName) {
+            myFilename = newName;
+        }
 
-  /*! Returns the state of the contactsChanged flag. */
-  bool contactsChanged() const {return contactsChangedFlag;}
+        /*! Returns the current pose of this element relative to the world frame.
+            This is a purely abstract function that is reimplemented in the robot
+            and body classes */
+        virtual const transf &getTran() const = 0;
 
-  /*! This function is called whenever a contact is formed or broken on a body
-      or any body that is part of a robot.
-  */
-  virtual void setContactsChanged() {contactsChangedFlag=true;}
+        /*! Checks whether contacts on the element will prevent the element from
+            making the motion described by the transform motion.  This is a purely
+            abstract function that is reimplemented in the robot and body classes */
+        virtual bool contactsPreventMotion(const transf &motion) const = 0;
 
-  /*! This function is called after a grasp has been analyzed. */
-  virtual void resetContactsChanged() {contactsChangedFlag=false;}
+        /*! Returns the state of the contactsChanged flag. */
+        bool contactsChanged() const {
+            return contactsChangedFlag;
+        }
 
-  /*! Sets the current pose of the element with respect to the world frame.
-      This is a purely abstract function that is reimplemented in the robot and
-      body classes.
-  */
-  virtual int setTran(transf const& newTr)=0;
-  
-  //! Moves this element to a new location in small steps and resolves collisions along the way
-  virtual bool moveTo(transf &tr,double translStepSize,double rotStepSize);
+        /*! This function is called whenever a contact is formed or broken on a body
+            or any body that is part of a robot.
+        */
+        virtual void setContactsChanged() {
+            contactsChangedFlag = true;
+        }
 
-  //! Needed so that when processing the glove and flock we can access interpolateTo
-  friend class SensorInputDlg;
+        /*! This function is called after a grasp has been analyzed. */
+        virtual void resetContactsChanged() {
+            contactsChangedFlag = false;
+        }
+
+        /*! Sets the current pose of the element with respect to the world frame.
+            This is a purely abstract function that is reimplemented in the robot and
+            body classes.
+        */
+        virtual int setTran(transf const &newTr) = 0;
+
+        //! Moves this element to a new location in small steps and resolves collisions along the way
+        virtual bool moveTo(transf &tr, double translStepSize, double rotStepSize);
+
+        //! Needed so that when processing the glove and flock we can access interpolateTo
+        friend class SensorInputDlg;
 };
 
 

--- a/include/worldElementFactory.h
+++ b/include/worldElementFactory.h
@@ -34,56 +34,51 @@ class World;
 class WorldElement;
 
 //! Functor interface for creating world elements
-class WorldElementCreator
-{
-public:
-  virtual WorldElement* operator() (World* parent, const char* name) = 0;
-  virtual ~WorldElementCreator(){};
+class WorldElementCreator {
+    public:
+        virtual WorldElement *operator()(World *parent, const char *name) = 0;
+        virtual ~WorldElementCreator() {};
 };
 
 //! Templated implementation
 template <class E>
-class SimpleWorldElementCreator : public WorldElementCreator
-{
-public:
-  virtual WorldElement* operator() (World* parent, const char* name)
-  {
-    return new E(parent, name);
-  }
+class SimpleWorldElementCreator : public WorldElementCreator {
+    public:
+        virtual WorldElement *operator()(World *parent, const char *name) {
+            return new E(parent, name);
+        }
 };
 
 //! Factory class for creating WorldElements
 /*! Used to instantiate the right WorldElement based on a name, presumably read
-  from an .xml configuration file, such as a saved world or a robot definition.
+    from an .xml configuration file, such as a saved world or a robot definition.
 */
-class WorldElementFactory 
-{
-private:
-  //! Maps world element types to their creators
-  std::map<std::string, WorldElementCreator*> mCreators;
+class WorldElementFactory {
+    private:
+        //! Maps world element types to their creators
+        std::map<std::string, WorldElementCreator *> mCreators;
 
-public:  
-  //! Stub constructor
-  WorldElementFactory(){}
+    public:
+        //! Stub constructor
+        WorldElementFactory() {}
 
-  //! Cleans up, deletes all creators
-  ~WorldElementFactory();
+        //! Cleans up, deletes all creators
+        ~WorldElementFactory();
 
-  //! Instantiates an element based on the given type
-  WorldElement* createElement(std::string elementType, World *parent,const char *name);
+        //! Instantiates an element based on the given type
+        WorldElement *createElement(std::string elementType, World *parent, const char *name);
 
-  //! Registers a new world element creator for the given type
-  void registerCreator(std::string elementType, WorldElementCreator *creator);
+        //! Registers a new world element creator for the given type
+        void registerCreator(std::string elementType, WorldElementCreator *creator);
 
-  //! Registers creators for the built in element types. Called from the world constructor
-  static void registerBuiltinCreators();
+        //! Registers creators for the built in element types. Called from the world constructor
+        static void registerBuiltinCreators();
 };
 
 //! Returns the world element factory singleton
-inline WorldElementFactory& getWorldElementFactory()
-{
-  static WorldElementFactory wef;
-  return wef;
+inline WorldElementFactory &getWorldElementFactory() {
+    static WorldElementFactory wef;
+    return wef;
 }
 
 //! Convenience macro for registering a new class

--- a/src/SoArrow.cpp
+++ b/src/SoArrow.cpp
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: SoArrow.cpp,v 1.2 2009/03/25 22:10:03 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Implements an arrow node for Inventor/Coin.
+    \brief Implements an arrow node for Inventor/Coin.
 */
 
 #include <Inventor/misc/SoChildList.h>
@@ -46,210 +46,203 @@
 SO_NODE_SOURCE(SoArrow);
 
 /*!
-  Initializes the SoArrow class. This is a one-time
-  thing that is done after database initialization and before
-  any instance of this class is constructed.
+    Initializes the SoArrow class. This is a one-time
+    thing that is done after database initialization and before
+    any instance of this class is constructed.
 */
 void
-SoArrow::initClass()
-{
-   // Initialize type id variables
-   SO_NODE_INIT_CLASS(SoArrow, SoComplexShape, "SoComplexShape");
+SoArrow::initClass() {
+    // Initialize type id variables
+    SO_NODE_INIT_CLASS(SoArrow, SoComplexShape, "SoComplexShape");
 }
 
 /*!
-  Sets up default field values.
+    Sets up default field values.
 */
-SoArrow::SoArrow()
-{
+SoArrow::SoArrow() {
 
-  children = new SoChildList(this);
+    children = new SoChildList(this);
 
-   SO_NODE_CONSTRUCTOR(SoArrow);
-   SO_NODE_ADD_FIELD(arrowHeads,(END));
-   SO_NODE_ADD_FIELD(cylRadius, (0.5));
-   SO_NODE_ADD_FIELD(height,    (4.0));
-   SO_NODE_ADD_FIELD(coneHeight,(2.0));
-   SO_NODE_ADD_FIELD(coneRadius,(1.0));
+    SO_NODE_CONSTRUCTOR(SoArrow);
+    SO_NODE_ADD_FIELD(arrowHeads, (END));
+    SO_NODE_ADD_FIELD(cylRadius, (0.5));
+    SO_NODE_ADD_FIELD(height, (4.0));
+    SO_NODE_ADD_FIELD(coneHeight, (2.0));
+    SO_NODE_ADD_FIELD(coneRadius, (1.0));
 
-   // Set up static values and strings for the "arrowHeads"
-   // enumerated type field.
-   SO_NODE_DEFINE_ENUM_VALUE(Part, NONE);
-   SO_NODE_DEFINE_ENUM_VALUE(Part, BEGIN);
-   SO_NODE_DEFINE_ENUM_VALUE(Part, END);
-   SO_NODE_DEFINE_ENUM_VALUE(Part, BOTH);
+    // Set up static values and strings for the "arrowHeads"
+    // enumerated type field.
+    SO_NODE_DEFINE_ENUM_VALUE(Part, NONE);
+    SO_NODE_DEFINE_ENUM_VALUE(Part, BEGIN);
+    SO_NODE_DEFINE_ENUM_VALUE(Part, END);
+    SO_NODE_DEFINE_ENUM_VALUE(Part, BOTH);
 
-   // Copy static information for "arrowHeads" enumerated type field
-   // into this instance. 
-   SO_NODE_SET_SF_ENUM_TYPE(arrowHeads, Part);
+    // Copy static information for "arrowHeads" enumerated type field
+    // into this instance.
+    SO_NODE_SET_SF_ENUM_TYPE(arrowHeads, Part);
 }
 
 /*!
-  Deletes the child nodes that make up this node.
+    Deletes the child nodes that make up this node.
 */
 
-SoArrow::~SoArrow()
-{
-  delete children;
+SoArrow::~SoArrow() {
+    delete children;
 }
 
 /*!
-  Turns on a part of the arrow.
+    Turns on a part of the arrow.
 */
 void
-SoArrow::addPart(Part part)
-{
-   arrowHeads.setValue(arrowHeads.getValue() | part);
+SoArrow::addPart(Part part) {
+    arrowHeads.setValue(arrowHeads.getValue() | part);
 
-  if (HAS_PART(arrowHeads.getValue(),SoArrow::BEGIN)) {
-    calEngine->c.setValue(1);
-    beginSw->whichChild.setValue(SO_SWITCH_ALL);
-  }
-  else {
-    calEngine->c.setValue(0);
-    beginSw->whichChild.setValue(SO_SWITCH_NONE);
-  }
+    if (HAS_PART(arrowHeads.getValue(), SoArrow::BEGIN)) {
+        calEngine->c.setValue(1);
+        beginSw->whichChild.setValue(SO_SWITCH_ALL);
+    }
+    else {
+        calEngine->c.setValue(0);
+        beginSw->whichChild.setValue(SO_SWITCH_NONE);
+    }
 
-  if (HAS_PART(arrowHeads.getValue(),SoArrow::END)) {
-    calEngine->d.setValue(1);
-    endSw->whichChild.setValue(SO_SWITCH_ALL);
-  }
-  else {
-    calEngine->d.setValue(0);
-    endSw->whichChild.setValue(SO_SWITCH_NONE);
-  }
+    if (HAS_PART(arrowHeads.getValue(), SoArrow::END)) {
+        calEngine->d.setValue(1);
+        endSw->whichChild.setValue(SO_SWITCH_ALL);
+    }
+    else {
+        calEngine->d.setValue(0);
+        endSw->whichChild.setValue(SO_SWITCH_NONE);
+    }
 
 }
 
 /*!
-  Turns off a part of the arrow.
+    Turns off a part of the arrow.
 */
 void
-SoArrow::removePart(Part part)
-{
-   arrowHeads.setValue(arrowHeads.getValue() & ~part);
+SoArrow::removePart(Part part) {
+    arrowHeads.setValue(arrowHeads.getValue() & ~part);
 
-  if (HAS_PART(arrowHeads.getValue(),SoArrow::BEGIN)) {
-    calEngine->c.setValue(1);
-    beginSw->whichChild.setValue(SO_SWITCH_ALL);
-  }
-  else {
-    calEngine->c.setValue(0);
-    beginSw->whichChild.setValue(SO_SWITCH_NONE);
-  }
+    if (HAS_PART(arrowHeads.getValue(), SoArrow::BEGIN)) {
+        calEngine->c.setValue(1);
+        beginSw->whichChild.setValue(SO_SWITCH_ALL);
+    }
+    else {
+        calEngine->c.setValue(0);
+        beginSw->whichChild.setValue(SO_SWITCH_NONE);
+    }
 
-  if (HAS_PART(arrowHeads.getValue(),SoArrow::END)) {
-    calEngine->d.setValue(1);
-    endSw->whichChild.setValue(SO_SWITCH_ALL);
-  }
-  else {
-    calEngine->d.setValue(0);
-    endSw->whichChild.setValue(SO_SWITCH_NONE);
-  }
+    if (HAS_PART(arrowHeads.getValue(), SoArrow::END)) {
+        calEngine->d.setValue(1);
+        endSw->whichChild.setValue(SO_SWITCH_ALL);
+    }
+    else {
+        calEngine->d.setValue(0);
+        endSw->whichChild.setValue(SO_SWITCH_NONE);
+    }
 
 }
 
 /*!
-  Returns whether a given part is on or off.
+    Returns whether a given part is on or off.
 */
 SbBool
-SoArrow::hasPart(Part part) const
-{
-   return HAS_PART(arrowHeads.getValue(), part);
+SoArrow::hasPart(Part part) const {
+    return HAS_PART(arrowHeads.getValue(), part);
 }
 
 
-/*! 
-  This is called once to generate the child nodes that make up this
-  complex shape.  The child nodes consist of a cylinder, transforms, and
-  cones.  A calculator node caluculates the height of the cylinder from
-  the total height field and the height of any present arrowheads.
+/*!
+    This is called once to generate the child nodes that make up this
+    complex shape.  The child nodes consist of a cylinder, transforms, and
+    cones.  A calculator node caluculates the height of the cylinder from
+    the total height field and the height of any present arrowheads.
 */
 void
-SoArrow::generateChildren()
-{
-  // This should be called once, that means children
-  // doesn not have any children yet.
-  assert (children->getLength() == 0); 
+SoArrow::generateChildren() {
+    // This should be called once, that means children
+    // doesn not have any children yet.
+    assert(children->getLength() == 0);
 
-  // Construct the begin arrowhead
-  SoCone *cne = new SoCone;
-  cne->height.connectFrom(&coneHeight);
-  cne->bottomRadius.connectFrom(&coneRadius);
+    // Construct the begin arrowhead
+    SoCone *cne = new SoCone;
+    cne->height.connectFrom(&coneHeight);
+    cne->bottomRadius.connectFrom(&coneRadius);
 
-  SoTransform *beginTran = new SoTransform;
-  beginTran->rotation.setValue(SbVec3f(1,0,0),(float)M_PI);
-  
-  SoSeparator *beginSep = new SoSeparator;
-  beginSep->addChild(beginTran);
-  beginSep->addChild(cne);
-  beginSw = new SoSwitch;
-  beginSw->addChild(beginSep);
+    SoTransform *beginTran = new SoTransform;
+    beginTran->rotation.setValue(SbVec3f(1, 0, 0), (float)M_PI);
 
-  // Construct the end arrowhead
-  SoTranslation *endTran = new SoTranslation;
+    SoSeparator *beginSep = new SoSeparator;
+    beginSep->addChild(beginTran);
+    beginSep->addChild(cne);
+    beginSw = new SoSwitch;
+    beginSw->addChild(beginSep);
 
-  SoSeparator *endSep = new SoSeparator;
-  endSep->addChild(endTran);
-  endSep->addChild(cne);
-  endSw = new SoSwitch;
-  endSw->addChild(endSep);
+    // Construct the end arrowhead
+    SoTranslation *endTran = new SoTranslation;
 
-  // Move the arrowheads to the ends of the shaft
-  calEngine = new SoCalculator;
-  calEngine->a.connectFrom(&height);
-  calEngine->b.connectFrom(&coneHeight);
+    SoSeparator *endSep = new SoSeparator;
+    endSep->addChild(endTran);
+    endSep->addChild(cne);
+    endSw = new SoSwitch;
+    endSw->addChild(endSep);
 
-  if (HAS_PART(arrowHeads.getValue(),SoArrow::BEGIN)) {
-    calEngine->c.setValue(1);
-    beginSw->whichChild.setValue(SO_SWITCH_ALL);
-  }
-  else {
-    calEngine->c.setValue(0);
-    beginSw->whichChild.setValue(SO_SWITCH_NONE);
-  }
+    // Move the arrowheads to the ends of the shaft
+    calEngine = new SoCalculator;
+    calEngine->a.connectFrom(&height);
+    calEngine->b.connectFrom(&coneHeight);
 
-  if (HAS_PART(arrowHeads.getValue(),SoArrow::END)) {
-    calEngine->d.setValue(1);
-    endSw->whichChild.setValue(SO_SWITCH_ALL);
-  }
-  else {
-    calEngine->d.setValue(0);
-    endSw->whichChild.setValue(SO_SWITCH_NONE);
-  }
+    if (HAS_PART(arrowHeads.getValue(), SoArrow::BEGIN)) {
+        calEngine->c.setValue(1);
+        beginSw->whichChild.setValue(SO_SWITCH_ALL);
+    }
+    else {
+        calEngine->c.setValue(0);
+        beginSw->whichChild.setValue(SO_SWITCH_NONE);
+    }
 
-  // Calculate the height of the shaft
-  calEngine->expression.set1Value(0, "oa = a - c*b - d*b");
+    if (HAS_PART(arrowHeads.getValue(), SoArrow::END)) {
+        calEngine->d.setValue(1);
+        endSw->whichChild.setValue(SO_SWITCH_ALL);
+    }
+    else {
+        calEngine->d.setValue(0);
+        endSw->whichChild.setValue(SO_SWITCH_NONE);
+    }
 
-  // Compute the position where the begin cone needs to be moved to
-  calEngine->expression.set1Value(1, "oA = vec3f(0.0, b/2.0, 0.0)");
-  // Compute the position where the end cone needs to be moved to
-  calEngine->expression.set1Value(2, "oB = vec3f(0.0, a - b/2.0, 0.0)");
-  // Compute the position where the shaft needs to be moved to
-  calEngine->expression.set1Value(3, "oC = vec3f(0.0, oa/2.0 + c*b, 0.0)");
+    // Calculate the height of the shaft
+    calEngine->expression.set1Value(0, "oa = a - c*b - d*b");
 
-  beginTran->translation.connectFrom(&calEngine->oA);
-  endTran->translation.connectFrom(&calEngine->oB);
-  
-  SoCylinder *shaft = new SoCylinder;
-  shaft->radius.connectFrom(&cylRadius);
-  shaft->height.connectFrom(&calEngine->oa);
+    // Compute the position where the begin cone needs to be moved to
+    calEngine->expression.set1Value(1, "oA = vec3f(0.0, b/2.0, 0.0)");
+    // Compute the position where the end cone needs to be moved to
+    calEngine->expression.set1Value(2, "oB = vec3f(0.0, a - b/2.0, 0.0)");
+    // Compute the position where the shaft needs to be moved to
+    calEngine->expression.set1Value(3, "oC = vec3f(0.0, oa/2.0 + c*b, 0.0)");
 
-  SoTranslation *shaftTran = new SoTranslation;
-  shaftTran->translation.connectFrom(&calEngine->oC);
+    beginTran->translation.connectFrom(&calEngine->oA);
+    endTran->translation.connectFrom(&calEngine->oB);
 
-  SoSeparator *root = new SoSeparator;
-  root->addChild(beginSw);
-  root->addChild(endSw);
-  root->addChild(shaftTran);
-  root->addChild(shaft);
+    SoCylinder *shaft = new SoCylinder;
+    shaft->radius.connectFrom(&cylRadius);
+    shaft->height.connectFrom(&calEngine->oa);
 
-  children->append(root);
+    SoTranslation *shaftTran = new SoTranslation;
+    shaftTran->translation.connectFrom(&calEngine->oC);
+
+    SoSeparator *root = new SoSeparator;
+    root->addChild(beginSw);
+    root->addChild(endSw);
+    root->addChild(shaftTran);
+    root->addChild(shaft);
+
+    children->append(root);
 }
 
-  
 
-   
-  
+
+
+
 
 

--- a/src/SoComplexShape.cpp
+++ b/src/SoComplexShape.cpp
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: SoComplexShape.cpp,v 1.2 2009/03/25 22:10:03 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Implements a new abstract shape class for Inventor/Coin
+    \brief Implements a new abstract shape class for Inventor/Coin
 */
 
 #include <Inventor/misc/SoChildList.h>
@@ -44,219 +44,207 @@ SO_NODE_ABSTRACT_SOURCE(SoComplexShape);
 
 
 /*!
-  Initializes the SoComplexShape class. This is a one-time
-  thing that is done after database initialization and before
-  any instance of this class is constructed.
+    Initializes the SoComplexShape class. This is a one-time
+    thing that is done after database initialization and before
+    any instance of this class is constructed.
 */
 void
-SoComplexShape::initClass()
-{
-   // Initialize the run-time type variables
-   SO_NODE_INIT_ABSTRACT_CLASS(SoComplexShape, SoNode, "SoNode");
+SoComplexShape::initClass() {
+    // Initialize the run-time type variables
+    SO_NODE_INIT_ABSTRACT_CLASS(SoComplexShape, SoNode, "SoNode");
 
 }
 
 /*!
-  Generic constructor
+    Generic constructor
 */
-SoComplexShape::SoComplexShape()
-{
-   SO_NODE_CONSTRUCTOR(SoComplexShape);
+SoComplexShape::SoComplexShape() {
+    SO_NODE_CONSTRUCTOR(SoComplexShape);
 }
 
 
 /*!
-  Empty stub.
+    Empty stub.
 */
-SoComplexShape::~SoComplexShape()
-{
+SoComplexShape::~SoComplexShape() {
 }
 
 /*!
- Returns the children list.
+    Returns the children list.
 */
-SoChildList *SoComplexShape::getChildren() const
-{
-  return children;
+SoChildList *SoComplexShape::getChildren() const {
+    return children;
 }
 
 
 /*!
- Implements the SoGLRenderAction for the SoCoordinateAxis node.
+    Implements the SoGLRenderAction for the SoCoordinateAxis node.
 */
 void
-SoComplexShape::GLRender(SoGLRenderAction *action)
-{
-  SoComplexShape::doAction(action);
+SoComplexShape::GLRender(SoGLRenderAction *action) {
+    SoComplexShape::doAction(action);
 }
 
 /*!
- Generates triangles representing a SoComplexShape.
+    Generates triangles representing a SoComplexShape.
 */
 void
-SoComplexShape::callback(SoCallbackAction *action)
-{
-  SoComplexShape::doAction(action);
+SoComplexShape::callback(SoCallbackAction *action) {
+    SoComplexShape::doAction(action);
 }
 
 /*!
-  Enlarges the current bounding box by adding the bounding boxes of each
-  of this shape's children.
+    Enlarges the current bounding box by adding the bounding boxes of each
+    of this shape's children.
 */
 void
-SoComplexShape::getBoundingBox(SoGetBoundingBoxAction *action)
-{
-   SoComplexShape::doAction(action);
+SoComplexShape::getBoundingBox(SoGetBoundingBoxAction *action) {
+    SoComplexShape::doAction(action);
 }
 
 /*!
-  Passes the event on to each of the children of the complex shape.
+    Passes the event on to each of the children of the complex shape.
 */
 void
-SoComplexShape::handleEvent(SoHandleEventAction *action)
-{
-   SoComplexShape::doAction(action);
+SoComplexShape::handleEvent(SoHandleEventAction *action) {
+    SoComplexShape::doAction(action);
 }
 
 /*!
-  Passes the pick action on to each of the children of the complex shape.
+    Passes the pick action on to each of the children of the complex shape.
 */
 void
-SoComplexShape::pick(SoPickAction *action)
-{
-   SoComplexShape::doAction(action);
+SoComplexShape::pick(SoPickAction *action) {
+    SoComplexShape::doAction(action);
 }
 
 /*!
- This implements the traversal for the SoGetMatrixAction,
- which is handled a little differently: it does not traverse
- below the root node or tail of the path it is applied to.
- Therefore, we need to compute the matrix only if this group
- is in the middle of the current path chain or is off the path
- chain (since the only way this could be true is if the group
- is under a group that affects the chain).
+    This implements the traversal for the SoGetMatrixAction,
+    which is handled a little differently: it does not traverse
+    below the root node or tail of the path it is applied to.
+    Therefore, we need to compute the matrix only if this group
+    is in the middle of the current path chain or is off the path
+    chain (since the only way this could be true is if the group
+    is under a group that affects the chain).
 */
 void
-SoComplexShape::getMatrix(SoGetMatrixAction *action)
-{
-   int         numIndices;
-   const int   *indices;
+SoComplexShape::getMatrix(SoGetMatrixAction *action) {
+    int         numIndices;
+    const int   *indices;
 
-   // Use SoAction::getPathCode() to determine where this group
-   // is in relation to the path being applied to (if any). (see
-   // the comments in doAction() for details.)
-   switch (action->getPathCode(numIndices, indices)) {
+    // Use SoAction::getPathCode() to determine where this group
+    // is in relation to the path being applied to (if any). (see
+    // the comments in doAction() for details.)
+    switch (action->getPathCode(numIndices, indices)) {
 
-     case SoAction::NO_PATH:
-     case SoAction::BELOW_PATH:
-      // If there's no path, or we're off the end, do nothing
-      break;
+        case SoAction::NO_PATH:
+        case SoAction::BELOW_PATH:
+            // If there's no path, or we're off the end, do nothing
+            break;
 
-     case SoAction::OFF_PATH:
-     case SoAction::IN_PATH:
-      // If we are in the path chain or we affect nodes in the
-      // path chain, traverse the children
-      SoComplexShape::doAction(action);
-      break;
-   }
+        case SoAction::OFF_PATH:
+        case SoAction::IN_PATH:
+            // If we are in the path chain or we affect nodes in the
+            // path chain, traverse the children
+            SoComplexShape::doAction(action);
+            break;
+    }
 }
 
 
 /*!
- This implements typical action traversal for an SoComplexShape node
+    This implements typical action traversal for an SoComplexShape node
 */
 void
-SoComplexShape::doAction(SoAction *action)
-{
-  // Make sure all the children exist
-  if (children->getLength() == 0) generateChildren();
+SoComplexShape::doAction(SoAction *action) {
+    // Make sure all the children exist
+    if (children->getLength() == 0) generateChildren();
 
-   // SoAction has a method called "getPathCode()" that returns
-   // a code indicating how this node is related to the path(s)
-   // the action is being applied to. This code is one of the
-   // following:
-   //
-   // NO_PATH    = Not traversing a path (action was applied
-   //                to a node) 
-   // IN_PATH    = This node is in the path chain, but is not
-   //                the tail node
-   // BELOW_PATH = This node is the tail of the path chain or
-   //                is below the tail
-   // OFF_PATH   = This node is off to the left of some node in
-   //                the path chain
-   //
-   // If getPathCode() returns IN_PATH, it returns (in its two
-   // arguments) the indices of the next nodes in the paths.
-   // (Remember that an action can be applied to a list of
-   // paths.)
+    // SoAction has a method called "getPathCode()" that returns
+    // a code indicating how this node is related to the path(s)
+    // the action is being applied to. This code is one of the
+    // following:
+    //
+    // NO_PATH    = Not traversing a path (action was applied
+    //                to a node)
+    // IN_PATH    = This node is in the path chain, but is not
+    //                the tail node
+    // BELOW_PATH = This node is the tail of the path chain or
+    //                is below the tail
+    // OFF_PATH   = This node is off to the left of some node in
+    //                the path chain
+    //
+    // If getPathCode() returns IN_PATH, it returns (in its two
+    // arguments) the indices of the next nodes in the paths.
+    // (Remember that an action can be applied to a list of
+    // paths.)
 
-   // For the IN_PATH case, these will be set by getPathCode()
-   // to contain the number of child nodes that are in paths and
-   // the indices of those children, respectively. In the other
-   // cases, they are not meaningful.
-   int         numIndices;
-   const int   *indices;
+    // For the IN_PATH case, these will be set by getPathCode()
+    // to contain the number of child nodes that are in paths and
+    // the indices of those children, respectively. In the other
+    // cases, they are not meaningful.
+    int         numIndices;
+    const int   *indices;
 
-   // This will be set to the index of the last (rightmost)
-   // child to traverse
-   int         lastChildIndex;
+    // This will be set to the index of the last (rightmost)
+    // child to traverse
+    int         lastChildIndex;
 
-   // If this node is in a path, see which of our children are
-   // in paths, and traverse up to and including the rightmost
-   // of these nodes (the last one in the "indices" array).
-   if (action->getPathCode(numIndices, indices) ==
-       SoAction::IN_PATH)
-      lastChildIndex = indices[numIndices - 1];
+    // If this node is in a path, see which of our children are
+    // in paths, and traverse up to and including the rightmost
+    // of these nodes (the last one in the "indices" array).
+    if (action->getPathCode(numIndices, indices) ==
+            SoAction::IN_PATH)
+        lastChildIndex = indices[numIndices - 1];
 
-   // Otherwise, consider all of the children
-   else
-      lastChildIndex = children->getLength() - 1;
+    // Otherwise, consider all of the children
+    else
+        lastChildIndex = children->getLength() - 1;
 
-   // Now we are ready to traverse the children, skipping every
-   // other one. For the SoGetBoundingBoxAction, however, we
-   // have to do some extra work in between each pair of
-   // children - we have to make sure the center points get
-   // averaged correctly.
-   if (action->isOfType(
-            SoGetBoundingBoxAction::getClassTypeId())) {
-      SoGetBoundingBoxAction *bba =
-         (SoGetBoundingBoxAction *) action;
-      SbVec3f  totalCenter(0.0, 0.0, 0.0);
-      int      numCenters = 0;
+    // Now we are ready to traverse the children, skipping every
+    // other one. For the SoGetBoundingBoxAction, however, we
+    // have to do some extra work in between each pair of
+    // children - we have to make sure the center points get
+    // averaged correctly.
+    if (action->isOfType(
+                SoGetBoundingBoxAction::getClassTypeId())) {
+        SoGetBoundingBoxAction *bba =
+            (SoGetBoundingBoxAction *) action;
+        SbVec3f  totalCenter(0.0, 0.0, 0.0);
+        int      numCenters = 0;
 
-      for (int i = 0; i <= lastChildIndex; i++) {
-         children->traverse(bba, i);
+        for (int i = 0; i <= lastChildIndex; i++) {
+            children->traverse(bba, i);
 
-         // If the traversal set a center point in the action,
-         // add it to the total and reset for the next child.
-         if (bba->isCenterSet()) {
-            totalCenter += bba->getCenter();
-            numCenters++;
-            bba->resetCenter();
-         }
-      }
-      // Now, set the center to be the average. Since the
-      // centers were already transformed, there's no need to
-      // transform the average.
-      if (numCenters != 0)
-         bba->setCenter(totalCenter / (float)numCenters, FALSE);
-   }
+            // If the traversal set a center point in the action,
+            // add it to the total and reset for the next child.
+            if (bba->isCenterSet()) {
+                totalCenter += bba->getCenter();
+                numCenters++;
+                bba->resetCenter();
+            }
+        }
+        // Now, set the center to be the average. Since the
+        // centers were already transformed, there's no need to
+        // transform the average.
+        if (numCenters != 0)
+            bba->setCenter(totalCenter / (float)numCenters, FALSE);
+    }
 
-   // For all other actions, just traverse every child
-   else
-      for (int i = 0; i <= lastChildIndex; i++)
-         children->traverse(action, i);
+    // For all other actions, just traverse every child
+    else
+        for (int i = 0; i <= lastChildIndex; i++)
+            children->traverse(action, i);
 }
 
 
 /*!
- Copy function
+    Copy function
 */
-void SoComplexShape::copyContents(const SoFieldContainer *FC, 
-				  SbBool copyConnection)
-{
-  SoNode::copyContents(FC, copyConnection);
-  children = ((SoComplexShape *)FC)->children;
+void SoComplexShape::copyContents(const SoFieldContainer *FC,
+                                  SbBool copyConnection) {
+    SoNode::copyContents(FC, copyConnection);
+    children = ((SoComplexShape *)FC)->children;
 }
 
 

--- a/src/arch.cpp
+++ b/src/arch.cpp
@@ -19,7 +19,7 @@
 //
 // Author(s): Matei T. Ciocarlie
 //
-// $Id: 
+// $Id:
 //
 //######################################################################
 
@@ -40,184 +40,182 @@
 
 DynamicBody *rightBase;
 
-Body* createSupport(double size, double thickness, World *world)
-{
-	Body *body = new Body(world,"Support");
+Body *createSupport(double size, double thickness, World *world) {
+    Body *body = new Body(world, "Support");
 
-	//8 vertices
-	SbVec3f *points = new SbVec3f[8];
-	//6 faces, 5 indices for each (last is -1)
-//	int32_t *c = new int32_t[5*6];
+    //8 vertices
+    SbVec3f *points = new SbVec3f[8];
+    //6 faces, 5 indices for each (last is -1)
+    //  int32_t *c = new int32_t[5*6];
 
-	double z = thickness;
+    double z = thickness;
 
-	points[3].setValue( size, size, z);
-	points[2].setValue(-size, size, z);
-	points[1].setValue(-size,-size, z);
-	points[0].setValue( size,-size, z);
+    points[3].setValue(size, size, z);
+    points[2].setValue(-size, size, z);
+    points[1].setValue(-size, -size, z);
+    points[0].setValue(size, -size, z);
 
-	points[7].setValue( size, size,-z);
-	points[6].setValue(-size, size,-z);
-	points[5].setValue(-size,-size,-z);
-	points[4].setValue( size,-size,-z);
+    points[7].setValue(size, size, -z);
+    points[6].setValue(-size, size, -z);
+    points[5].setValue(-size, -size, -z);
+    points[4].setValue(size, -size, -z);
 
-	int32_t c[5*6] = { 3, 2, 1, 0, -1,
-					   4, 5, 6, 7, -1,
-					   1, 5, 4, 0, -1,
-					   2, 6, 5, 1, -1, 
-					   3, 7, 6, 2, -1, 
-					   4, 7, 3, 0, -1 };
+    int32_t c[5 * 6] = { 3, 2, 1, 0, -1,
+                         4, 5, 6, 7, -1,
+                         1, 5, 4, 0, -1,
+                         2, 6, 5, 1, -1,
+                         3, 7, 6, 2, -1,
+                         4, 7, 3, 0, -1
+                       };
 
-	SoCoordinate3 *coords = new SoCoordinate3;
-	coords->point.setValues( 0, 8, points );
-	SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
-	ifs->coordIndex.setValues(0, 5*6, c);
+    SoCoordinate3 *coords = new SoCoordinate3;
+    coords->point.setValues(0, 8, points);
+    SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
+    ifs->coordIndex.setValues(0, 5 * 6, c);
 
-	body->getIVGeomRoot()->addChild(coords);
-	body->getIVGeomRoot()->addChild(ifs);
-	body->setMaterial( world->getMaterialIdx("stone") );
-	body->addIVMat();
-	return body;
+    body->getIVGeomRoot()->addChild(coords);
+    body->getIVGeomRoot()->addChild(ifs);
+    body->setMaterial(world->getMaterialIdx("stone"));
+    body->addIVMat();
+    return body;
 }
 
 
-GraspableBody* create_block(double inner_radius, double outer_radius, double thickness, int n_blocks, World *world)
-{
-	double block_span = 3.14159 / n_blocks;
-	double theta = block_span / 2;
-	double radius = (inner_radius + outer_radius) / 2;
+GraspableBody *create_block(double inner_radius, double outer_radius, double thickness, int n_blocks, World *world) {
+    double block_span = 3.14159 / n_blocks;
+    double theta = block_span / 2;
+    double radius = (inner_radius + outer_radius) / 2;
 
-	double icx = inner_radius * cos(theta) - radius;
-	double icz = inner_radius * sin(theta);
+    double icx = inner_radius * cos(theta) - radius;
+    double icz = inner_radius * sin(theta);
 
-	double ocx = outer_radius * cos(theta) - radius;
-	double ocz = outer_radius * sin(theta);
+    double ocx = outer_radius * cos(theta) - radius;
+    double ocz = outer_radius * sin(theta);
 
-	double y = thickness / 2;
+    double y = thickness / 2;
 
-	GraspableBody *body = new GraspableBody(world,"Original Block");
+    GraspableBody *body = new GraspableBody(world, "Original Block");
 
-	//8 vertices
-	SbVec3f *points = new SbVec3f[8];
-	//6 faces, 5 indices for each (last is -1)
-//	int32_t *c = new int32_t[5*6];
+    //8 vertices
+    SbVec3f *points = new SbVec3f[8];
+    //6 faces, 5 indices for each (last is -1)
+    //  int32_t *c = new int32_t[5*6];
 
-	points[0].setValue( icx, y, -icz);
-	points[1].setValue( icx, y,  icz);
-	points[2].setValue( icx,-y,  icz);
-	points[3].setValue( icx,-y, -icz);
+    points[0].setValue(icx, y, -icz);
+    points[1].setValue(icx, y,  icz);
+    points[2].setValue(icx, -y,  icz);
+    points[3].setValue(icx, -y, -icz);
 
-	points[4].setValue( ocx, y, -ocz);
-	points[5].setValue( ocx, y,  ocz);
-	points[6].setValue( ocx,-y,  ocz);
-	points[7].setValue( ocx,-y, -ocz);
+    points[4].setValue(ocx, y, -ocz);
+    points[5].setValue(ocx, y,  ocz);
+    points[6].setValue(ocx, -y,  ocz);
+    points[7].setValue(ocx, -y, -ocz);
 
-	int32_t c[5*6] = { 3, 2, 1, 0, -1,
-					   4, 5, 6, 7, -1,
-					   1, 5, 4, 0, -1,
-					   2, 6, 5, 1, -1, 
-					   3, 7, 6, 2, -1, 
-					   4, 7, 3, 0, -1 };
+    int32_t c[5 * 6] = { 3, 2, 1, 0, -1,
+                         4, 5, 6, 7, -1,
+                         1, 5, 4, 0, -1,
+                         2, 6, 5, 1, -1,
+                         3, 7, 6, 2, -1,
+                         4, 7, 3, 0, -1
+                       };
 
-	SoCoordinate3 *coords = new SoCoordinate3;
-	coords->point.setValues( 0, 8, points );
-	SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
-	ifs->coordIndex.setValues(0, 5*6, c);
+    SoCoordinate3 *coords = new SoCoordinate3;
+    coords->point.setValues(0, 8, points);
+    SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
+    ifs->coordIndex.setValues(0, 5 * 6, c);
 
-	body->getIVGeomRoot()->addChild(coords);
-	body->getIVGeomRoot()->addChild(ifs);
-	body->setMaterial( world->getMaterialIdx("stone") );
-	body->addIVMat();
+    body->getIVGeomRoot()->addChild(coords);
+    body->getIVGeomRoot()->addChild(ifs);
+    body->setMaterial(world->getMaterialIdx("stone"));
+    body->addIVMat();
 
-	double density = 2 * 1.0e-3; //from john ochsendorf: 2000 kg / m3 converted to g / mm3
-	double volume = thickness * 0.5 * block_span * (outer_radius * outer_radius - inner_radius * inner_radius);
-	double mass = density * volume;
-	body->setMass(mass);
-	body->setMaxRadius(body->computeDefaultMaxRadius());
-	double I[9];
-	position CoG;
-	body->computeDefaultMassProp(CoG, I);
-	body->setCoG(CoG);
-	body->setInertiaMatrix(I);
-	fprintf(stderr,"Volume %f and mass %f\n",volume, mass);
+    double density = 2 * 1.0e-3; //from john ochsendorf: 2000 kg / m3 converted to g / mm3
+    double volume = thickness * 0.5 * block_span * (outer_radius * outer_radius - inner_radius * inner_radius);
+    double mass = density * volume;
+    body->setMass(mass);
+    body->setMaxRadius(body->computeDefaultMaxRadius());
+    double I[9];
+    position CoG;
+    body->computeDefaultMassProp(CoG, I);
+    body->setCoG(CoG);
+    body->setInertiaMatrix(I);
+    fprintf(stderr, "Volume %f and mass %f\n", volume, mass);
 
-	return body;
+    return body;
 }
 
-void create_arch(World *world, double inner_radius, double outer_radius, double thickness, int n_blocks, bool add_supports)
-{
-	fprintf(stderr,"Building arch: inner radius %f, outer radius %f, thickness %f, %d blocks, %d add_supports\n",
-					inner_radius, outer_radius, thickness, n_blocks, add_supports);
+void create_arch(World *world, double inner_radius, double outer_radius, double thickness, int n_blocks, bool add_supports) {
+    fprintf(stderr, "Building arch: inner radius %f, outer radius %f, thickness %f, %d blocks, %d add_supports\n",
+            inner_radius, outer_radius, thickness, n_blocks, add_supports);
 
-	GraspableBody* block = create_block(inner_radius, outer_radius, thickness, n_blocks, world);
-	//add the reference block to collision detection
-	block->addToIvc();
-	//but disable its collisions
-	world->toggleCollisions(false, block);
+    GraspableBody *block = create_block(inner_radius, outer_radius, thickness, n_blocks, world);
+    //add the reference block to collision detection
+    block->addToIvc();
+    //but disable its collisions
+    world->toggleCollisions(false, block);
 
-	transf blockTran,blockRot;
-	double block_span = 3.14159 / n_blocks;
-	double theta = block_span / 2;
-	double radius = (inner_radius + outer_radius) / 2;
-	for (int i=0; i<n_blocks; i++) {
-		QString name("Block "),id;
-		name.append(id.setNum(i));
-		GraspableBody *addBlock = new GraspableBody(world,name.latin1());
-		addBlock->cloneFrom(block); //this also adds it to collision detection!
-		world->addBody(addBlock);
+    transf blockTran, blockRot;
+    double block_span = 3.14159 / n_blocks;
+    double theta = block_span / 2;
+    double radius = (inner_radius + outer_radius) / 2;
+    for (int i = 0; i < n_blocks; i++) {
+        QString name("Block "), id;
+        name.append(id.setNum(i));
+        GraspableBody *addBlock = new GraspableBody(world, name.latin1());
+        addBlock->cloneFrom(block); //this also adds it to collision detection!
+        world->addBody(addBlock);
 
-		Quaternion r( theta*(2*i+1) , vec3(0,-1,0) );
-		//use radius + THRESHOLD so we don't have interpenetrating blocks due to numerical error
-		vec3 t( radius+0.1 , 0, 0);
+        Quaternion r(theta * (2 * i + 1) , vec3(0, -1, 0));
+        //use radius + THRESHOLD so we don't have interpenetrating blocks due to numerical error
+        vec3 t(radius + 0.1 , 0, 0);
 
-		blockRot.set(r, vec3(0,0,0) );
-		blockTran.set(Quaternion::IDENTITY, t);
+        blockRot.set(r, vec3(0, 0, 0));
+        blockTran.set(Quaternion::IDENTITY, t);
 
-		addBlock->setTran( blockTran * blockRot);
+        addBlock->setTran(blockTran * blockRot);
 
-		if (i==n_blocks-1)
-			rightBase = addBlock;
-	}
-	if (add_supports) {
-		Body* leftSupport = createSupport(0.9 * radius,50,world);
-		leftSupport->setName( QString("Left Support") );
-		Body* rightSupport = createSupport(0.9 * radius,50,world);
-		rightSupport->setName( QString("Right Support") );
+        if (i == n_blocks - 1)
+            rightBase = addBlock;
+    }
+    if (add_supports) {
+        Body *leftSupport = createSupport(0.9 * radius, 50, world);
+        leftSupport->setName(QString("Left Support"));
+        Body *rightSupport = createSupport(0.9 * radius, 50, world);
+        rightSupport->setName(QString("Right Support"));
 
-		leftSupport->addToIvc();
-		rightSupport->addToIvc();
+        leftSupport->addToIvc();
+        rightSupport->addToIvc();
 
-		vec3 t( radius+1, 0, -(50+Contact::THRESHOLD));
-		blockTran.set( Quaternion::IDENTITY, t);
-		leftSupport->setTran( blockTran );
-		world->addBody(leftSupport);
+        vec3 t(radius + 1, 0, -(50 + Contact::THRESHOLD));
+        blockTran.set(Quaternion::IDENTITY, t);
+        leftSupport->setTran(blockTran);
+        world->addBody(leftSupport);
 
-		t.set( -radius-1, 0, -(50+Contact::THRESHOLD));
-		blockTran.set( Quaternion::IDENTITY, t);
-		rightSupport->setTran( blockTran );
-		world->addBody(rightSupport);
-	}
+        t.set(-radius - 1, 0, -(50 + Contact::THRESHOLD));
+        blockTran.set(Quaternion::IDENTITY, t);
+        rightSupport->setTran(blockTran);
+        world->addBody(rightSupport);
+    }
 }
 
-void archSnapshot()
-{
-	static int steps = 0;
-/*
-	if (steps%5 == 0) {
-		QString fn( getenv("GRASPIT")+QString("/images/arch") );
-		QString n;
-		fn.append( n.setNum(steps) );
-		fn.append( ".jpg" );
-		graspItGUI->getIVmgr()->saveImage( fn );
-	}
-*/
-	if (steps%10 == 0) {
-		fprintf(stderr,"Set velocity\n");
-		double newVel[6];
-		for (int i=0; i<6; i++)
-			newVel[i] = rightBase->getVelocity()[i];
-		newVel[0] -= 100;
-		rightBase->setVelocity(newVel);
-	}
-	steps++;
+void archSnapshot() {
+    static int steps = 0;
+    /*
+        if (steps%5 == 0) {
+            QString fn( getenv("GRASPIT")+QString("/images/arch") );
+            QString n;
+            fn.append( n.setNum(steps) );
+            fn.append( ".jpg" );
+            graspItGUI->getIVmgr()->saveImage( fn );
+        }
+    */
+    if (steps % 10 == 0) {
+        fprintf(stderr, "Set velocity\n");
+        double newVel[6];
+        for (int i = 0; i < 6; i++)
+            newVel[i] = rightBase->getVelocity()[i];
+        newVel[0] -= 100;
+        rightBase->setVelocity(newVel);
+    }
+    steps++;
 }

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -24,7 +24,7 @@
 //######################################################################
 
 /*! \file
-  \brief Implements the body class hierarchy.
+    \brief Implements the body class hierarchy.
 */
 
 #include <cmath>
@@ -99,248 +99,252 @@ const float Body::CONE_HEIGHT = 20.0;
 double DynamicBody::defaultMass = 300.0;
 
 /*!
-  Constructs an empty body with its material set to invalid, and the
-  geometry pointer set to NULL.  Use \c load() to initialize the body from
-  a model file.
+    Constructs an empty body with its material set to invalid, and the
+    geometry pointer set to NULL.  Use \c load() to initialize the body from
+    a model file.
 */
-Body::Body(World *w,const char *name) : WorldElement(w,name)
-{
-	//defaults:
-	mIsElastic = false;
-	youngMod = -1;
-	
-	material = -1;
-	numContacts=0;
-	showFC = false;
-	showVC = false;
-	IVGeomRoot = NULL; IVTran = NULL; IVMat = NULL; IVContactIndicators=NULL;
-        IVScaleTran = NULL;
-        IVOffsetTran = NULL;
-	IVBVRoot = NULL;
-#ifdef GEOMETRY_LIB
-	IVPrimitiveRoot = NULL;
-#endif
-	mUsesFlock = false;
-	mBirdNumber = 0;
-	mRenderGeometry = true;
-	mGeometryFilename = "none";
+Body::Body(World *w, const char *name) : WorldElement(w, name) {
+    //defaults:
+    mIsElastic = false;
+    youngMod = -1;
 
-	initializeIV();
+    material = -1;
+    numContacts = 0;
+    showFC = false;
+    showVC = false;
+    IVGeomRoot = NULL;
+    IVTran = NULL;
+    IVMat = NULL;
+    IVContactIndicators = NULL;
+    IVScaleTran = NULL;
+    IVOffsetTran = NULL;
+    IVBVRoot = NULL;
+    #ifdef GEOMETRY_LIB
+    IVPrimitiveRoot = NULL;
+    #endif
+    mUsesFlock = false;
+    mBirdNumber = 0;
+    mRenderGeometry = true;
+    mGeometryFilename = "none";
+
+    initializeIV();
 }
 
 /*!
-  Copy constructor remains protected (should not be called by user)
+    Copy constructor remains protected (should not be called by user)
 */
-Body::Body(const Body &b) : WorldElement(b)
-{
-  mIsElastic = b.mIsElastic;
-  material = b.material;
-  youngMod = b.youngMod;
-  showFC = b.showFC;
-  mUsesFlock = b.mUsesFlock;
-  mRenderGeometry = true;
-  Tran = b.Tran;
+Body::Body(const Body &b) : WorldElement(b) {
+    mIsElastic = b.mIsElastic;
+    material = b.material;
+    youngMod = b.youngMod;
+    showFC = b.showFC;
+    mUsesFlock = b.mUsesFlock;
+    mRenderGeometry = true;
+    Tran = b.Tran;
 
-  IVRoot = b.IVRoot;
-  IVTran = b.IVTran;
-  IVContactIndicators = b.IVContactIndicators;
-#ifdef GEOMETRY_LIB
-  IVPrimitiveRoot = b.IVPrimitiveRoot;
-#endif
-  IVBVRoot = b.IVBVRoot;
-  IVGeomRoot = b.IVGeomRoot;
-  IVMat = b.IVMat;
-  mGeometryFilename = b.mGeometryFilename;
+    IVRoot = b.IVRoot;
+    IVTran = b.IVTran;
+    IVContactIndicators = b.IVContactIndicators;
+    #ifdef GEOMETRY_LIB
+    IVPrimitiveRoot = b.IVPrimitiveRoot;
+    #endif
+    IVBVRoot = b.IVBVRoot;
+    IVGeomRoot = b.IVGeomRoot;
+    IVMat = b.IVMat;
+    mGeometryFilename = b.mGeometryFilename;
 
-  createAxesGeometry();
+    createAxesGeometry();
 }
 
-/*! Breaks all contacts; it is up to the world to also remove it from 
-	the collision detection system or the scene graph. In general, do 
-	not delete bodies directly, but use World::removeElement(...)instead 
-	which can also delete them.
- */
-Body::~Body()
-{
-  breakContacts();
-  DBGP("Deleting Body: " << myName.latin1());
+/*! Breaks all contacts; it is up to the world to also remove it from
+    the collision detection system or the scene graph. In general, do
+    not delete bodies directly, but use World::removeElement(...)instead
+    which can also delete them.
+*/
+Body::~Body() {
+    breakContacts();
+    DBGP("Deleting Body: " << myName.latin1());
 }
 
 /*! Clones this body from an original. This means that the two bodies have independent
-	transform, materials, properties, etc, BUT they share the scene graph geometry and
-	the collision detection geometry. They can still be used for collision detection 
-	independently as they can have different transforms.
-	
-	WARNING: cloning mechanism is incomplete. If the original is deleted, the clone 
-	becomes unpredicateble and can cause the system to crash
+    transform, materials, properties, etc, BUT they share the scene graph geometry and
+    the collision detection geometry. They can still be used for collision detection
+    independently as they can have different transforms.
+
+    WARNING: cloning mechanism is incomplete. If the original is deleted, the clone
+    becomes unpredicateble and can cause the system to crash
 */
-void 
-Body::cloneFrom(const Body* original)
-{
-	mIsElastic = original->mIsElastic;
-	youngMod = original->youngMod;
-	material = original->material;
+void
+Body::cloneFrom(const Body *original) {
+    mIsElastic = original->mIsElastic;
+    youngMod = original->youngMod;
+    material = original->material;
 
-	//add virtual contacts
-	virtualContactList.clear();
-	std::list<Contact*> vc = original->getVirtualContacts();
-	std::list<Contact*>::iterator it;
-	for (it = vc.begin(); it!=vc.end(); it++) {
-		VirtualContact *newContact = new VirtualContact( (VirtualContact*)(*it) );
-		newContact->setBody(this);
-		addVirtualContact(newContact);
-	}
+    //add virtual contacts
+    virtualContactList.clear();
+    std::list<Contact *> vc = original->getVirtualContacts();
+    std::list<Contact *>::iterator it;
+    for (it = vc.begin(); it != vc.end(); it++) {
+        VirtualContact *newContact = new VirtualContact((VirtualContact *)(*it));
+        newContact->setBody(this);
+        addVirtualContact(newContact);
+    }
 
-	setRenderGeometry( original->getRenderGeometry() );
+    setRenderGeometry(original->getRenderGeometry());
 
-	int numGeomChildren = original->getIVGeomRoot()->getNumChildren();
-	//create a CLONE of all geometry 
-	for (int i=0; i<numGeomChildren; i++) {
-		IVGeomRoot->addChild( original->getIVGeomRoot()->getChild(i) );
-	}
+    int numGeomChildren = original->getIVGeomRoot()->getNumChildren();
+    //create a CLONE of all geometry
+    for (int i = 0; i < numGeomChildren; i++) {
+        IVGeomRoot->addChild(original->getIVGeomRoot()->getChild(i));
+    }
 
-	addIVMat(true);
+    addIVMat(true);
 
-	//add a CLONE to collision detection
-	cloneToIvc(original);
-	setTran(original->getTran());
+    //add a CLONE to collision detection
+    cloneToIvc(original);
+    setTran(original->getTran());
 }
 
 /*! Parses the root node of an XML structure containing information
-	for a body. It looks for all the relevant properties. Some of
-	the properties are optional and if they are not found, they will
-	be set to default values. Others will cause a failure if they
-	are not present.
+    for a body. It looks for all the relevant properties. Some of
+    the properties are optional and if they are not found, they will
+    be set to default values. Others will cause a failure if they
+    are not present.
 */
 int
-Body::loadFromXml(const TiXmlElement *root, QString rootPath)
-{
-	//material
-	const TiXmlElement* element = findXmlElement(root,"material");
-	QString valueStr;
-	if(element == NULL){
-		DBGA("No material type found; using default.");
-		material = myWorld->getMaterialIdx("wood");
-	} else {
-		valueStr = element->GetText();
-		if (!valueStr.isEmpty()) {
-			material = myWorld->getMaterialIdx(valueStr);
-			if (material==-1) {
-				QTWARNING("invalid material type in body file");
-				return FAILURE;
-			}
-		} else{
-			DBGA("No material type found; using default.");
-			material = myWorld->getMaterialIdx("wood");
-		}
-	}
+Body::loadFromXml(const TiXmlElement *root, QString rootPath) {
+    //material
+    const TiXmlElement *element = findXmlElement(root, "material");
+    QString valueStr;
+    if (element == NULL) {
+        DBGA("No material type found; using default.");
+        material = myWorld->getMaterialIdx("wood");
+    }
+    else {
+        valueStr = element->GetText();
+        if (!valueStr.isEmpty()) {
+            material = myWorld->getMaterialIdx(valueStr);
+            if (material == -1) {
+                QTWARNING("invalid material type in body file");
+                return FAILURE;
+            }
+        }
+        else {
+            DBGA("No material type found; using default.");
+            material = myWorld->getMaterialIdx("wood");
+        }
+    }
 
-	//Young's modulus
-	element = findXmlElement(root,"youngs");
-	if(element) {
-		valueStr = element->GetText();
-		youngMod = valueStr.toDouble();
-		if (youngMod <= 0) {
-			QTWARNING("invalid Young's modulus in body file");
-			return FAILURE;
-		}
-		mIsElastic = true;			
-	}
+    //Young's modulus
+    element = findXmlElement(root, "youngs");
+    if (element) {
+        valueStr = element->GetText();
+        youngMod = valueStr.toDouble();
+        if (youngMod <= 0) {
+            QTWARNING("invalid Young's modulus in body file");
+            return FAILURE;
+        }
+        mIsElastic = true;
+    }
 
-	//Use Flock of Birds
-	element = findXmlElement(root,"useFlockOfBirds");
-	if(element){
-		valueStr = element->GetText();
-		mBirdNumber = valueStr.toDouble();
-		mUsesFlock = true;
-		DBGA("Object using Flock of Birds sensor " << mBirdNumber);
-	}
+    //Use Flock of Birds
+    element = findXmlElement(root, "useFlockOfBirds");
+    if (element) {
+        valueStr = element->GetText();
+        mBirdNumber = valueStr.toDouble();
+        mUsesFlock = true;
+        DBGA("Object using Flock of Birds sensor " << mBirdNumber);
+    }
 
-	//load the geometry itself
-	element = findXmlElement(root,"geometryFile");
-	if (!element) {
-		QTWARNING("Geometry file information missing");
-		return FAILURE;
-	} else {
-		//the path in the file is relative to the body xml file
-		mGeometryFilename = element->GetText();
-		valueStr = rootPath + mGeometryFilename;
-		mGeometryFileType = element->Attribute("type");
-		//inventor is default
-		if (mGeometryFileType.isNull()||mGeometryFileType.isEmpty()) mGeometryFileType="Inventor";
-		int result;
-		if (mGeometryFileType=="Inventor") {
-			result = loadGeometryIV(valueStr);
-		} else if (mGeometryFileType=="off") {
-			result = loadGeometryOFF(valueStr);
-		} else if (mGeometryFileType=="ply") {
-			result = loadGeometryPLY(valueStr);
-		} else {
-			DBGA("Unknown geometry file type: " << mGeometryFileType.latin1());
-			result = FAILURE;
-		}
-		if (result == FAILURE) {
-			QTWARNING("Failed to open geometry file: " + valueStr);
-			return FAILURE;
-		}
-	}
-	
-	//scaling of the geometry
-        IVScaleTran = new SoTransform;
-        IVScaleTran->scaleFactor.setValue(1.0, 1.0, 1.0);
-	element = findXmlElement(root,"geometryScaling");
-	if (element) {
-	  valueStr = element->GetText();
-	  double scale = valueStr.toDouble();
-	  if (scale <= 0) {
-	    DBGA("Scale geometry: negative scale found");
-	    return FAILURE;
-	  }
-	  IVScaleTran->scaleFactor.setValue(scale, scale, scale);
-	}
-        IVGeomRoot->insertChild(IVScaleTran, 0);
+    //load the geometry itself
+    element = findXmlElement(root, "geometryFile");
+    if (!element) {
+        QTWARNING("Geometry file information missing");
+        return FAILURE;
+    }
+    else {
+        //the path in the file is relative to the body xml file
+        mGeometryFilename = element->GetText();
+        valueStr = rootPath + mGeometryFilename;
+        mGeometryFileType = element->Attribute("type");
+        //inventor is default
+        if (mGeometryFileType.isNull() || mGeometryFileType.isEmpty()) mGeometryFileType = "Inventor";
+        int result;
+        if (mGeometryFileType == "Inventor") {
+            result = loadGeometryIV(valueStr);
+        }
+        else if (mGeometryFileType == "off") {
+            result = loadGeometryOFF(valueStr);
+        }
+        else if (mGeometryFileType == "ply") {
+            result = loadGeometryPLY(valueStr);
+        }
+        else {
+            DBGA("Unknown geometry file type: " << mGeometryFileType.latin1());
+            result = FAILURE;
+        }
+        if (result == FAILURE) {
+            QTWARNING("Failed to open geometry file: " + valueStr);
+            return FAILURE;
+        }
+    }
 
-	//any offset to the geometry, inserted inside the geometry itself
-	//note that the offset gets added before the scale, so the offset is
-	//always expressed in graspit's units
-        IVOffsetTran = new SoTransform;
-        transf::IDENTITY.toSoTransform(IVOffsetTran);
-	element = findXmlElement(root,"geometryOffset");
-	if (element) {
-	  const TiXmlElement* transformElement = findXmlElement(element,"transform");
-	  if(!transformElement){
-	    DBGA("Geometry offset field missing transform information");
-	    return FAILURE;
-	  }
-	  transf offsetTran;
-	  if(!getTransform(transformElement, offsetTran)){
-	    DBGA("Geometry offset field: failed to parse transform");
-	    return FAILURE;
-	  }
-	  offsetTran.toSoTransform(IVOffsetTran);
-	}
-        IVGeomRoot->insertChild(IVOffsetTran, 0);
+    //scaling of the geometry
+    IVScaleTran = new SoTransform;
+    IVScaleTran->scaleFactor.setValue(1.0, 1.0, 1.0);
+    element = findXmlElement(root, "geometryScaling");
+    if (element) {
+        valueStr = element->GetText();
+        double scale = valueStr.toDouble();
+        if (scale <= 0) {
+            DBGA("Scale geometry: negative scale found");
+            return FAILURE;
+        }
+        IVScaleTran->scaleFactor.setValue(scale, scale, scale);
+    }
+    IVGeomRoot->insertChild(IVScaleTran, 0);
 
-	return SUCCESS;
+    //any offset to the geometry, inserted inside the geometry itself
+    //note that the offset gets added before the scale, so the offset is
+    //always expressed in graspit's units
+    IVOffsetTran = new SoTransform;
+    transf::IDENTITY.toSoTransform(IVOffsetTran);
+    element = findXmlElement(root, "geometryOffset");
+    if (element) {
+        const TiXmlElement *transformElement = findXmlElement(element, "transform");
+        if (!transformElement) {
+            DBGA("Geometry offset field missing transform information");
+            return FAILURE;
+        }
+        transf offsetTran;
+        if (!getTransform(transformElement, offsetTran)) {
+            DBGA("Geometry offset field: failed to parse transform");
+            return FAILURE;
+        }
+        offsetTran.toSoTransform(IVOffsetTran);
+    }
+    IVGeomRoot->insertChild(IVOffsetTran, 0);
+
+    return SUCCESS;
 }
 
 int
-Body::saveToXml(QTextStream& xml){
-	xml<<"\t\t\t<material>"<<myWorld->getMaterialName(material).latin1()<<"</material>"<<endl;
-	if(youngMod>0)
-		xml<<"\t\t\t<youngs>"<<youngMod<<"</youngs>"<<endl;
-	if(mUsesFlock){
-		xml<<"\t\t\t<useFlockOfBirds>"<<mBirdNumber<<"</useFlockOfBirds>"<<endl;
-	}
-	xml<<"\t\t\t<geometryFile type = \""<<mGeometryFileType.latin1()<<"\">"
-		<<mGeometryFilename.latin1()<<"</geometryFile>"<<endl;
-	return SUCCESS;
+Body::saveToXml(QTextStream &xml) {
+    xml << "\t\t\t<material>" << myWorld->getMaterialName(material).latin1() << "</material>" << endl;
+    if (youngMod > 0)
+        xml << "\t\t\t<youngs>" << youngMod << "</youngs>" << endl;
+    if (mUsesFlock) {
+        xml << "\t\t\t<useFlockOfBirds>" << mBirdNumber << "</useFlockOfBirds>" << endl;
+    }
+    xml << "\t\t\t<geometryFile type = \"" << mGeometryFileType.latin1() << "\">"
+        << mGeometryFilename.latin1() << "</geometryFile>" << endl;
+    return SUCCESS;
 }
 
 
 /*! Opens and loads a body information file.  \a filename is the complete path to
-    the body file, which should be in XML format (with a .xml extension) and can 
-    contain a number of Graspit-specific properties as XML tags, as well as a 
+    the body file, which should be in XML format (with a .xml extension) and can
+    contain a number of Graspit-specific properties as XML tags, as well as a
     pointer to a different file which contains the geometry itself.
 
     Alternatively, \a filename can also point directly to the geometry file.The
@@ -348,87 +352,89 @@ Body::saveToXml(QTextStream& xml){
     in which case GraspIt will use the default values for all the properties
     that normally come from the XML tags.
 */
-int 
-Body::load(const QString &filename)
-{
-	QString fileType = filename.section('.',-1,-1);
-	QString xmlFilename;
-	if (fileType == "xml"){
-		//the file itself is XML
-		xmlFilename = filename;
-	} else {
-		//file is geometry; use default XML file
-		DBGA("Loading geometry file with boilerplate XML file");
-		xmlFilename = QString(getenv("GRASPIT")) + QString("/models/objects/default.xml");
-	}
+int
+Body::load(const QString &filename) {
+    QString fileType = filename.section('.', -1, -1);
+    QString xmlFilename;
+    if (fileType == "xml") {
+        //the file itself is XML
+        xmlFilename = filename;
+    }
+    else {
+        //file is geometry; use default XML file
+        DBGA("Loading geometry file with boilerplate XML file");
+        xmlFilename = QString(getenv("GRASPIT")) + QString("/models/objects/default.xml");
+    }
 
 
-	myFilename = relativePath(filename, getenv("GRASPIT"));
-	if (myName.isEmpty() || myName == "unnamed") {
-		setName(filename.section('/',-1).section('.',0,0));
-	}
+    myFilename = relativePath(filename, getenv("GRASPIT"));
+    if (myName.isEmpty() || myName == "unnamed") {
+        setName(filename.section('/', -1).section('.', 0, 0));
+    }
 
-	//load the graspit specific information in XML format
-	TiXmlDocument doc(xmlFilename);
-	if(doc.LoadFile()==false){
-		QTWARNING("Could not open " + xmlFilename);
-		return FAILURE;
-	}
-	if (fileType != "xml") {
-		//make geometry point at the right thing
-		QString relFilename = relativePath(filename, QString(getenv("GRASPIT")) + 
-						   QString("/models/objects/"));
-		TiXmlElement * element = new TiXmlElement("geometryFile");
-		if (fileType=="iv" || fileType=="wrl") {
-			element->SetAttribute("type","Inventor");
-		} else if (fileType=="off") {
-			element->SetAttribute("type","off");
-		} else if (fileType=="ply") {
-			element->SetAttribute("type","ply");
-		}
-		TiXmlText * text = new TiXmlText( relFilename );
-		element->LinkEndChild(text);
-		doc.RootElement()->LinkEndChild(element);		
-	}
-	//the root path is the directory in which the xml file is placed
-	QString root = xmlFilename.section('/',0,-2,QString::SectionIncludeTrailingSep);
-	if (loadFromXml(doc.RootElement(), root) != SUCCESS) {
-		return FAILURE;
-	}
-	//add material for controlling transparency
-	addIVMat();
-	return SUCCESS;
+    //load the graspit specific information in XML format
+    TiXmlDocument doc(xmlFilename);
+    if (doc.LoadFile() == false) {
+        QTWARNING("Could not open " + xmlFilename);
+        return FAILURE;
+    }
+    if (fileType != "xml") {
+        //make geometry point at the right thing
+        QString relFilename = relativePath(filename, QString(getenv("GRASPIT")) +
+                                           QString("/models/objects/"));
+        TiXmlElement *element = new TiXmlElement("geometryFile");
+        if (fileType == "iv" || fileType == "wrl") {
+            element->SetAttribute("type", "Inventor");
+        }
+        else if (fileType == "off") {
+            element->SetAttribute("type", "off");
+        }
+        else if (fileType == "ply") {
+            element->SetAttribute("type", "ply");
+        }
+        TiXmlText *text = new TiXmlText(relFilename);
+        element->LinkEndChild(text);
+        doc.RootElement()->LinkEndChild(element);
+    }
+    //the root path is the directory in which the xml file is placed
+    QString root = xmlFilename.section('/', 0, -2, QString::SectionIncludeTrailingSep);
+    if (loadFromXml(doc.RootElement(), root) != SUCCESS) {
+        return FAILURE;
+    }
+    //add material for controlling transparency
+    addIVMat();
+    return SUCCESS;
 }
 
-/*! Loads only the geometry part of this object, without any other 
+/*! Loads only the geometry part of this object, without any other
     GraspIt specific information such as mass, material etc. The file
     must be in a format that is readable by Coin, which for now means
     either Inventor (.iv) or VRML.
 */
 int
-Body::loadGeometryIV(const QString &filename)
-{
-	SoInput myInput;
-	if (!myInput.openFile(filename.latin1())) {
-		QTWARNING("Could not open Inventor file " + filename);
-		return FAILURE;
-	}
+Body::loadGeometryIV(const QString &filename) {
+    SoInput myInput;
+    if (!myInput.openFile(filename.latin1())) {
+        QTWARNING("Could not open Inventor file " + filename);
+        return FAILURE;
+    }
 
-	//we will read the geometry from the file
-	SoGroup *fileGeomRoot;
-	if (myInput.isFileVRML2()) {
-		fileGeomRoot = SoDB::readAllVRML(&myInput);
-	} else {
-		fileGeomRoot = SoDB::readAll(&myInput);
-	}
-	myInput.closeFile();
-	if (fileGeomRoot == NULL) {
-		QTWARNING("A problem occurred while reading Inventor file" + filename);
-		return FAILURE;
-	}
-	//and add it to scene graph
-	IVGeomRoot->addChild(fileGeomRoot);
-	return SUCCESS;
+    //we will read the geometry from the file
+    SoGroup *fileGeomRoot;
+    if (myInput.isFileVRML2()) {
+        fileGeomRoot = SoDB::readAllVRML(&myInput);
+    }
+    else {
+        fileGeomRoot = SoDB::readAll(&myInput);
+    }
+    myInput.closeFile();
+    if (fileGeomRoot == NULL) {
+        QTWARNING("A problem occurred while reading Inventor file" + filename);
+        return FAILURE;
+    }
+    //and add it to scene graph
+    IVGeomRoot->addChild(fileGeomRoot);
+    return SUCCESS;
 }
 
 
@@ -443,818 +449,789 @@ using std::vector;
 
 //! Helper for loadGeometryOff
 /*! Strips off leading whitespace and comments */
-bool GetOffLine(ifstream* file, istringstream* line)
-{
-  string buffer;
-  if (!file->good()) return false;
-  getline(*file, buffer);
-  // remove comments and leading whitespace
-  buffer = buffer.substr(buffer.find_first_not_of(" \t\n\f\r"), 
-                         buffer.find_first_of("#"));
-  if (!buffer.empty()) {
-    line->clear();
-    line->str(buffer);
-    return true;
-  }
-  return GetOffLine(file, line);
+bool GetOffLine(ifstream *file, istringstream *line) {
+    string buffer;
+    if (!file->good()) return false;
+    getline(*file, buffer);
+    // remove comments and leading whitespace
+    buffer = buffer.substr(buffer.find_first_not_of(" \t\n\f\r"),
+                           buffer.find_first_of("#"));
+    if (!buffer.empty()) {
+        line->clear();
+        line->str(buffer);
+        return true;
+    }
+    return GetOffLine(file, line);
 }
 
 //! Helper for loadGeometryOFF
 int OFFReadFailure() {
-  DBGA("OFF reader failure");
-  return FAILURE;
+    DBGA("OFF reader failure");
+    return FAILURE;
 }
 
 
-/*! Loads the geometry of this object from an .off file. This was 
-	primarily created for loading models from the Princeton Shape 
-	Benchmark, allowing GraspIt to interact with the Columbia Grasp 
-	Database.
+/*! Loads the geometry of this object from an .off file. This was
+    primarily created for loading models from the Princeton Shape
+    Benchmark, allowing GraspIt to interact with the Columbia Grasp
+    Database.
 */
 int
-Body::loadGeometryOFF(const QString& filename) {
-  ifstream file(filename.toStdString().c_str());
-  istringstream line;
+Body::loadGeometryOFF(const QString &filename) {
+    ifstream file(filename.toStdString().c_str());
+    istringstream line;
 
-  // Skip the first line, which is always just "OFF"
-  if (!GetOffLine(&file, &line)) return OFFReadFailure();
-
-  // The header is the first line that isn't a comment (comments start with #)
-  // The header contains num_vertices and num_faces
-  if (!GetOffLine(&file, &line)) return OFFReadFailure();
-  long num_vertices, num_faces;
-  line >> num_vertices >> num_faces;
-  if (line.fail()) return OFFReadFailure();
-    
-  SbVec3f* vertices = new SbVec3f[num_vertices];
-  std::vector<int32_t> face_indices;
-  // Read vertices
-  for (long vertex = 0; vertex < num_vertices; ++vertex) {
+    // Skip the first line, which is always just "OFF"
     if (!GetOffLine(&file, &line)) return OFFReadFailure();
-    float x, y, z;
-    line >> x >> y >> z;
+
+    // The header is the first line that isn't a comment (comments start with #)
+    // The header contains num_vertices and num_faces
+    if (!GetOffLine(&file, &line)) return OFFReadFailure();
+    long num_vertices, num_faces;
+    line >> num_vertices >> num_faces;
     if (line.fail()) return OFFReadFailure();
- 	  vertices[vertex].setValue(x, y, z); 
-  }
-  // Read faces into a vector
-  for (long face = 0; face < num_faces; ++face) {
-    if (!GetOffLine(&file, &line)) return OFFReadFailure();
-    int num_points, vertex_index;
-    line >> num_points;
-    // Read the points
-    for (int point = 0; point < num_points; ++point) {
-      line >> vertex_index;
-      face_indices.push_back(vertex_index);
-      // Triangulate the face as we go with a triangle fan and save the 
+
+    SbVec3f *vertices = new SbVec3f[num_vertices];
+    std::vector<int32_t> face_indices;
+    // Read vertices
+    for (long vertex = 0; vertex < num_vertices; ++vertex) {
+        if (!GetOffLine(&file, &line)) return OFFReadFailure();
+        float x, y, z;
+        line >> x >> y >> z;
+        if (line.fail()) return OFFReadFailure();
+        vertices[vertex].setValue(x, y, z);
     }
-    if (line.fail()) return OFFReadFailure();
-    face_indices.push_back(SO_END_FACE_INDEX);
-  }
+    // Read faces into a vector
+    for (long face = 0; face < num_faces; ++face) {
+        if (!GetOffLine(&file, &line)) return OFFReadFailure();
+        int num_points, vertex_index;
+        line >> num_points;
+        // Read the points
+        for (int point = 0; point < num_points; ++point) {
+            line >> vertex_index;
+            face_indices.push_back(vertex_index);
+            // Triangulate the face as we go with a triangle fan and save the
+        }
+        if (line.fail()) return OFFReadFailure();
+        face_indices.push_back(SO_END_FACE_INDEX);
+    }
 
-	// Put everything into Coin geometry
-	SoCoordinate3* coords = new SoCoordinate3;
-	coords->point.setValues(0, num_vertices, vertices);
-	SoIndexedFaceSet* ifs = new SoIndexedFaceSet;
-	ifs->coordIndex.setValues(0, face_indices.size(), &(face_indices[0]));
-	this->IVGeomRoot->addChild(coords);
-	this->IVGeomRoot->addChild(ifs);
+    // Put everything into Coin geometry
+    SoCoordinate3 *coords = new SoCoordinate3;
+    coords->point.setValues(0, num_vertices, vertices);
+    SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
+    ifs->coordIndex.setValues(0, face_indices.size(), &(face_indices[0]));
+    this->IVGeomRoot->addChild(coords);
+    this->IVGeomRoot->addChild(ifs);
 
-	DBGA("OFF reader success");
-	return SUCCESS;
+    DBGA("OFF reader success");
+    return SUCCESS;
 }
 
 /*! Loads the geometry of this body from a .ply file.
     Uses ply loading code from ROS by Willow Garage, which in turn
     uses code from Greg Turk, Georgia Institute of Technology. PLY
-    loading seems to be fairly complex, as the ply format is very 
+    loading seems to be fairly complex, as the ply format is very
     extensible. Right now, this will only load vertices and triangles
     and nothing else, not even other types of faces. Could be extended
     in the future.
- */
-int
-Body::loadGeometryPLY(const QString& filename)
-{
-#ifndef PLY_READER
-	DBGA("PLY Reader not installed; can not read file");
-	return FAILURE;
-#else
-	PLYModelLoader loader;
-	std::vector<position> vertices;
-	std::vector<int> triangles;
-	if (loader.readFromFile(filename.toStdString(), vertices, triangles)) {
-		DBGA("PLY loader error");
-		return FAILURE;
-	}
-        return loadGeometryMemory(vertices, triangles);
-#endif
-}
-
-int 
-Body::loadGeometryMemory(const std::vector<position> &vertices, const std::vector<int> &triangles)
-{
-	int num_vertices = vertices.size();
-	SbVec3f* sbVertices = new SbVec3f[num_vertices];
-	for (size_t i=0; i<vertices.size(); i++) {
-		sbVertices[i].setValue(vertices[i].x(), vertices[i].y(), vertices[i].z());
-	}
-	SoCoordinate3* coords = new SoCoordinate3;
-	coords->point.setValues(0, num_vertices, sbVertices);
-	std::vector<int32_t> face_indices;
-	for (size_t i=0; i<triangles.size(); i++) {
-		face_indices.push_back(triangles[i]);
-		if (i%3==2) {
-			face_indices.push_back(SO_END_FACE_INDEX);
-		}
-	}					      
-	SoIndexedFaceSet* ifs = new SoIndexedFaceSet;
-	ifs->coordIndex.setValues(0, face_indices.size(), &(face_indices[0]));
-	this->IVGeomRoot->addChild(coords);
-	this->IVGeomRoot->addChild(ifs);
-	return SUCCESS;
-}
-
-/*! After the geometry has been set, this function adds a new Material 
-	node after any Material node already present so we can change the 
-	transparency of this object. Does not work on bodies loaded from 
-	VRML files, as they have different types of material nodes. I have
-	tried also searching for SoVRMLMaterial nodes, but the search fails
-	even if those nodes exist; I suppose that is a bug in Coin.
 */
-void 
-Body::addIVMat(bool clone)
-{
-	IVMat = new SoMaterial;
-	IVMat->diffuseColor.setIgnored(true);
-	IVMat->ambientColor.setIgnored(true);
-	IVMat->specularColor.setIgnored(true);
-	IVMat->emissiveColor.setIgnored(true);
-	IVMat->shininess.setIgnored(true);
+int
+Body::loadGeometryPLY(const QString &filename) {
+    #ifndef PLY_READER
+    DBGA("PLY Reader not installed; can not read file");
+    return FAILURE;
+    #else
+    PLYModelLoader loader;
+    std::vector<position> vertices;
+    std::vector<int> triangles;
+    if (loader.readFromFile(filename.toStdString(), vertices, triangles)) {
+        DBGA("PLY loader error");
+        return FAILURE;
+    }
+    return loadGeometryMemory(vertices, triangles);
+    #endif
+}
 
-	if (clone) {
-		//clone's IVMat really does nothing except die with the clone
-		IVGeomRoot->addChild(IVMat);		
-	} else {
-		SoSearchAction *sa = new SoSearchAction;
-		sa->setInterest(SoSearchAction::ALL);
-		sa->setType(SoMaterial::getClassTypeId());
-		sa->apply(IVGeomRoot);
-		
-		if (sa->getPaths().getLength() == 0) {
-			IVGeomRoot->insertChild(IVMat,0);
-		} else {
-			for (int i=0; i<sa->getPaths().getLength(); i++) {
-				SoGroup *g = (SoGroup *)sa->getPaths()[i]->getNodeFromTail(1);
-				if (((SoMaterial *)sa->getPaths()[i]->getTail())->transparency[0] == 0.0f) {
-					g->insertChild(IVMat,sa->getPaths()[i]->getIndexFromTail(0)+1);	
-				}
-			}
-		}
-		delete sa;
-	}
-	/*
-	FILE *fp = fopen("foo.txt","w");
-	SoOutput *so  = new SoOutput;
-	so->setFilePointer(fp);
-	SoWriteAction *swa = new SoWriteAction(so);
-	swa->apply(IVGeomRoot);
-	delete swa;
-	delete so;
-	fclose(fp);
-	*/
+int
+Body::loadGeometryMemory(const std::vector<position> &vertices, const std::vector<int> &triangles) {
+    int num_vertices = vertices.size();
+    SbVec3f *sbVertices = new SbVec3f[num_vertices];
+    for (size_t i = 0; i < vertices.size(); i++) {
+        sbVertices[i].setValue(vertices[i].x(), vertices[i].y(), vertices[i].z());
+    }
+    SoCoordinate3 *coords = new SoCoordinate3;
+    coords->point.setValues(0, num_vertices, sbVertices);
+    std::vector<int32_t> face_indices;
+    for (size_t i = 0; i < triangles.size(); i++) {
+        face_indices.push_back(triangles[i]);
+        if (i % 3 == 2) {
+            face_indices.push_back(SO_END_FACE_INDEX);
+        }
+    }
+    SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
+    ifs->coordIndex.setValues(0, face_indices.size(), &(face_indices[0]));
+    this->IVGeomRoot->addChild(coords);
+    this->IVGeomRoot->addChild(ifs);
+    return SUCCESS;
+}
+
+/*! After the geometry has been set, this function adds a new Material
+    node after any Material node already present so we can change the
+    transparency of this object. Does not work on bodies loaded from
+    VRML files, as they have different types of material nodes. I have
+    tried also searching for SoVRMLMaterial nodes, but the search fails
+    even if those nodes exist; I suppose that is a bug in Coin.
+*/
+void
+Body::addIVMat(bool clone) {
+    IVMat = new SoMaterial;
+    IVMat->diffuseColor.setIgnored(true);
+    IVMat->ambientColor.setIgnored(true);
+    IVMat->specularColor.setIgnored(true);
+    IVMat->emissiveColor.setIgnored(true);
+    IVMat->shininess.setIgnored(true);
+
+    if (clone) {
+        //clone's IVMat really does nothing except die with the clone
+        IVGeomRoot->addChild(IVMat);
+    }
+    else {
+        SoSearchAction *sa = new SoSearchAction;
+        sa->setInterest(SoSearchAction::ALL);
+        sa->setType(SoMaterial::getClassTypeId());
+        sa->apply(IVGeomRoot);
+
+        if (sa->getPaths().getLength() == 0) {
+            IVGeomRoot->insertChild(IVMat, 0);
+        }
+        else {
+            for (int i = 0; i < sa->getPaths().getLength(); i++) {
+                SoGroup *g = (SoGroup *)sa->getPaths()[i]->getNodeFromTail(1);
+                if (((SoMaterial *)sa->getPaths()[i]->getTail())->transparency[0] == 0.0f) {
+                    g->insertChild(IVMat, sa->getPaths()[i]->getIndexFromTail(0) + 1);
+                }
+            }
+        }
+        delete sa;
+    }
+    /*
+        FILE *fp = fopen("foo.txt","w");
+        SoOutput *so  = new SoOutput;
+        so->setFilePointer(fp);
+        SoWriteAction *swa = new SoWriteAction(so);
+        swa->apply(IVGeomRoot);
+        delete swa;
+        delete so;
+        fclose(fp);
+    */
 }
 
 /*! Adds the body to the world's collision detection system
 */
-void 
-Body::addToIvc(bool ExpectEmpty)
-{
-	myWorld->getCollisionInterface()->addBody(this, ExpectEmpty);
-	myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
+void
+Body::addToIvc(bool ExpectEmpty) {
+    myWorld->getCollisionInterface()->addBody(this, ExpectEmpty);
+    myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
 }
 
-/*!	Clones the original's body geometry for the world
-	collision detection system. The new body only gets 
-	its own IVC transform.
+/*! Clones the original's body geometry for the world
+    collision detection system. The new body only gets
+    its own IVC transform.
 */
-void 
-Body::cloneToIvc(const Body *original)
-{
-	myWorld->getCollisionInterface()->cloneBody(this, original);
-	myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
+void
+Body::cloneToIvc(const Body *original) {
+    myWorld->getCollisionInterface()->cloneBody(this, original);
+    myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
 }
 
 /*! Collision geometry gets updated which could be slow.
 */
-void Body::setGeometryScaling(double x, double y, double z)
-{
-  if (x<=0 || y<=0 || z<=0)
-  {
-    DBGA("Scale geometry: negative or zero scale found");
-    return;
-  }
-  IVScaleTran->scaleFactor.setValue(x, y, z);
-  myWorld->getCollisionInterface()->updateBodyGeometry(this);
+void Body::setGeometryScaling(double x, double y, double z) {
+    if (x <= 0 || y <= 0 || z <= 0) {
+        DBGA("Scale geometry: negative or zero scale found");
+        return;
+    }
+    IVScaleTran->scaleFactor.setValue(x, y, z);
+    myWorld->getCollisionInterface()->updateBodyGeometry(this);
 }
 
 /*! Collision geometry gets updated which could be slow.
 */
-void Body::setGeometryOffset(transf tr)
-{
-  tr.toSoTransform(IVOffsetTran);
-  myWorld->getCollisionInterface()->updateBodyGeometry(this);
+void Body::setGeometryOffset(transf tr) {
+    tr.toSoTransform(IVOffsetTran);
+    myWorld->getCollisionInterface()->updateBodyGeometry(this);
 }
 
-void 
-Body::setDefaultViewingParameters()
-{
-	showFC = false;
-	showVC = false;
-	setTransparency(0.0);	
+void
+Body::setDefaultViewingParameters() {
+    showFC = false;
+    showVC = false;
+    setTransparency(0.0);
 }
 
 /*! Initialized the empty scene graph structure that we will use
-	in the future to render this body
-*/
-void 
-Body::initializeIV()
-{
-	IVRoot = new SoSeparator;
-	IVTran = new SoTransform;
-	IVRoot->insertChild(IVTran,0);
-
-	//axes get added at the beginning, so they are not affected
-	//by what goes on in the other groups
-	createAxesGeometry();
-
-	IVContactIndicators = new SoSeparator;
-	IVRoot->addChild(IVContactIndicators);
-
-#ifdef GEOMETRY_LIB
-	IVPrimitiveRoot = new SoSeparator;
-	IVRoot->addChild(IVPrimitiveRoot);
-#endif
-
-	IVBVRoot = new SoSeparator;
-	IVRoot->addChild(IVBVRoot);
-
-	IVGeomRoot = new SoSeparator;
-	IVRoot->addChild(IVGeomRoot);
-}
-
-/*! Shows a bounding box hierarchy for this body. Used for 
-	debug purposes.
+    in the future to render this body
 */
 void
-Body::setBVGeometry(const std::vector<BoundingBox> &bvs)
-{
-	IVBVRoot->removeAllChildren();
-	int mark = 0;
-	for (int i=0; i<(int)bvs.size(); i++) {
-		SoSeparator *bvSep = new SoSeparator;
+Body::initializeIV() {
+    IVRoot = new SoSeparator;
+    IVTran = new SoTransform;
+    IVRoot->insertChild(IVTran, 0);
 
-		SoMaterial *bvMat = new SoMaterial;
-		bvSep->addChild(bvMat);
-		float r,g,b;
-		//random colors
-		r = ((float)rand()) / RAND_MAX;
-		g = ((float)rand()) / RAND_MAX;
-		b = ((float)rand()) / RAND_MAX;
+    //axes get added at the beginning, so they are not affected
+    //by what goes on in the other groups
+    createAxesGeometry();
 
-		//mark collisions	
-		if (bvs[i].mMark) {
-			mark++;
-			r = 0.8f; g=0.0f; b=0.0f;
-		} else {
-			r = g = b = 0.5f;
-		}
-		
-		bvMat->diffuseColor = SbColor(r,g,b);
-		bvMat->ambientColor = SbColor(r,g,b);
-		bvMat->transparency = 0.5;
+    IVContactIndicators = new SoSeparator;
+    IVRoot->addChild(IVContactIndicators);
 
-		SoTransform* bvTran = new SoTransform;
-		bvs[i].getTran().toSoTransform(bvTran);
-		bvSep->addChild(bvTran);
+    #ifdef GEOMETRY_LIB
+    IVPrimitiveRoot = new SoSeparator;
+    IVRoot->addChild(IVPrimitiveRoot);
+    #endif
 
-		
-		//a single cube for the entire box
-		SoCube *bvBox = new SoCube;
-		bvBox->width = 2 * bvs[i].halfSize.x();
-		bvBox->height = 2 * bvs[i].halfSize.y();
-		bvBox->depth = 2 * bvs[i].halfSize.z();
-		bvSep->addChild(bvBox);
-		
+    IVBVRoot = new SoSeparator;
+    IVRoot->addChild(IVBVRoot);
 
-		//2 cubes so we also see separarion plane
-		/*
-		SoCube *bvBox = new SoCube;
-		bvBox->width =		bvs[i].halfSize.x();
-		bvBox->height = 2 * bvs[i].halfSize.y();
-		bvBox->depth = 2 * bvs[i].halfSize.z();
-		SoTransform *halfCubeTran = new SoTransform;
-		halfCubeTran->translation.setValue(bvs[i].halfSize.x()/2.0, 0.0, 0.0);
-		bvSep->addChild(halfCubeTran);
-		bvSep->addChild(bvBox);
-		halfCubeTran = new SoTransform;
-		halfCubeTran->translation.setValue(-bvs[i].halfSize.x(), 0.0, 0.0);
-		bvSep->addChild(halfCubeTran);
-		bvSep->addChild(bvBox);
-		*/
+    IVGeomRoot = new SoSeparator;
+    IVRoot->addChild(IVGeomRoot);
+}
 
-		IVBVRoot->addChild(bvSep);
-	}
-	DBGA("Setting bv geom: " << bvs.size() << " boxes. Marked: " << mark);
+/*! Shows a bounding box hierarchy for this body. Used for
+    debug purposes.
+*/
+void
+Body::setBVGeometry(const std::vector<BoundingBox> &bvs) {
+    IVBVRoot->removeAllChildren();
+    int mark = 0;
+    for (int i = 0; i < (int)bvs.size(); i++) {
+        SoSeparator *bvSep = new SoSeparator;
+
+        SoMaterial *bvMat = new SoMaterial;
+        bvSep->addChild(bvMat);
+        float r, g, b;
+        //random colors
+        r = ((float)rand()) / RAND_MAX;
+        g = ((float)rand()) / RAND_MAX;
+        b = ((float)rand()) / RAND_MAX;
+
+        //mark collisions
+        if (bvs[i].mMark) {
+            mark++;
+            r = 0.8f;
+            g = 0.0f;
+            b = 0.0f;
+        }
+        else {
+            r = g = b = 0.5f;
+        }
+
+        bvMat->diffuseColor = SbColor(r, g, b);
+        bvMat->ambientColor = SbColor(r, g, b);
+        bvMat->transparency = 0.5;
+
+        SoTransform *bvTran = new SoTransform;
+        bvs[i].getTran().toSoTransform(bvTran);
+        bvSep->addChild(bvTran);
+
+
+        //a single cube for the entire box
+        SoCube *bvBox = new SoCube;
+        bvBox->width = 2 * bvs[i].halfSize.x();
+        bvBox->height = 2 * bvs[i].halfSize.y();
+        bvBox->depth = 2 * bvs[i].halfSize.z();
+        bvSep->addChild(bvBox);
+
+
+        //2 cubes so we also see separarion plane
+        /*
+            SoCube *bvBox = new SoCube;
+            bvBox->width =      bvs[i].halfSize.x();
+            bvBox->height = 2 * bvs[i].halfSize.y();
+            bvBox->depth = 2 * bvs[i].halfSize.z();
+            SoTransform *halfCubeTran = new SoTransform;
+            halfCubeTran->translation.setValue(bvs[i].halfSize.x()/2.0, 0.0, 0.0);
+            bvSep->addChild(halfCubeTran);
+            bvSep->addChild(bvBox);
+            halfCubeTran = new SoTransform;
+            halfCubeTran->translation.setValue(-bvs[i].halfSize.x(), 0.0, 0.0);
+            bvSep->addChild(halfCubeTran);
+            bvSep->addChild(bvBox);
+        */
+
+        IVBVRoot->addChild(bvSep);
+    }
+    DBGA("Setting bv geom: " << bvs.size() << " boxes. Marked: " << mark);
 }
 
 /*!
-  Returns the current transparency value for the body (between 0 and 1).
-  \sa setTransparency()
+    Returns the current transparency value for the body (between 0 and 1).
+    \sa setTransparency()
 */
 float
-Body::getTransparency() const
-{
-  return IVMat->transparency[0];
-}  
-  
-
-/*!
-  Set the current transparency value for the body.
-  \a t is a value between 0 and 1, where 0 is opaque, 1 is transparent.
-  \sa getTransparency()
-*/
-void
-Body::setTransparency(float t)
-{
-  IVMat->transparency = t;
-}
-
-  
-/*!
-  Set the current material of the body to mat
-  \sa getMaterial()
-*/
-void
-Body::setMaterial(int mat)
-{
-  std::list<Contact *>::iterator cp;
-
-  material = mat;
-  if (showFC || showVC) IVContactIndicators->removeAllChildren();
-
-  for (cp=contactList.begin();cp!=contactList.end();cp++) {
-    (*cp)->updateCof();
-    (*cp)->getMate()->updateCof();
-    (*cp)->getBody2()->redrawFrictionCones();
-  }
-  redrawFrictionCones();
+Body::getTransparency() const {
+    return IVMat->transparency[0];
 }
 
 
 /*!
-  Sets whether friction cones should be shown for this body.
+    Set the current transparency value for the body.
+    \a t is a value between 0 and 1, where 0 is opaque, 1 is transparent.
+    \sa getTransparency()
 */
 void
-Body::showFrictionCones(bool on, int vc)
-{
-  showFC = on;
-  if (vc==1) showVC = true;
-  else if (vc==2) showVC = false;
-  redrawFrictionCones();
+Body::setTransparency(float t) {
+    IVMat->transparency = t;
 }
 
 
 /*!
-  Recomputes all the friction cones on the body
+    Set the current material of the body to mat
+    \sa getMaterial()
 */
 void
-Body::redrawFrictionCones()
-{
-  std::list<Contact *>::iterator cp;
+Body::setMaterial(int mat) {
+    std::list<Contact *>::iterator cp;
 
-  IVContactIndicators->removeAllChildren();
-  if (showFC) {
-    for (cp=contactList.begin();cp!=contactList.end();cp++)
-		IVContactIndicators->addChild( (*cp)->getVisualIndicator() );
-  }
-  if (showVC) {
-	for (cp = virtualContactList.begin(); cp!=virtualContactList.end(); cp++)
-		IVContactIndicators->addChild( ( (VirtualContact*)(*cp) )->getVisualIndicator() );
-  }
+    material = mat;
+    if (showFC || showVC) IVContactIndicators->removeAllChildren();
+
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        (*cp)->updateCof();
+        (*cp)->getMate()->updateCof();
+        (*cp)->getBody2()->redrawFrictionCones();
+    }
+    redrawFrictionCones();
+}
+
+
+/*!
+    Sets whether friction cones should be shown for this body.
+*/
+void
+Body::showFrictionCones(bool on, int vc) {
+    showFC = on;
+    if (vc == 1) showVC = true;
+    else if (vc == 2) showVC = false;
+    redrawFrictionCones();
+}
+
+
+/*!
+    Recomputes all the friction cones on the body
+*/
+void
+Body::redrawFrictionCones() {
+    std::list<Contact *>::iterator cp;
+
+    IVContactIndicators->removeAllChildren();
+    if (showFC) {
+        for (cp = contactList.begin(); cp != contactList.end(); cp++)
+            IVContactIndicators->addChild((*cp)->getVisualIndicator());
+    }
+    if (showVC) {
+        for (cp = virtualContactList.begin(); cp != virtualContactList.end(); cp++)
+            IVContactIndicators->addChild(((VirtualContact *)(*cp))->getVisualIndicator());
+    }
 }
 
 /*! Sets whether a change of this body's transform should automatically
-	trigger a redraw. This seems to not always work...
+    trigger a redraw. This seems to not always work...
 */
 void
-Body::setRenderGeometry(bool s)
-{
-	assert(IVTran);
-	mRenderGeometry = s;
-	if (!s) {
-//		IVRoot->enableNotify(false);
-//		IVTran->enableNotify(false);
-//		IVMat->enableNotify(false);
-//		IVGeomRoot->enableNotify(false);
-//		IVContactIndicators->enableNotify(false);
-		IVTran->translation.enableNotify(false);
-		IVTran->rotation.enableNotify(false);
-	} else {
-//		IVRoot->enableNotify(true);
-//		IVTran->enableNotify(true);
-//		IVMat->enableNotify(true);
-//		IVGeomRoot->enableNotify(true);
-//		IVContactIndicators->enableNotify(true);
-		IVTran->translation.enableNotify(true);
-		IVTran->rotation.enableNotify(true);
-	}
-	
+Body::setRenderGeometry(bool s) {
+    assert(IVTran);
+    mRenderGeometry = s;
+    if (!s) {
+        //      IVRoot->enableNotify(false);
+        //      IVTran->enableNotify(false);
+        //      IVMat->enableNotify(false);
+        //      IVGeomRoot->enableNotify(false);
+        //      IVContactIndicators->enableNotify(false);
+        IVTran->translation.enableNotify(false);
+        IVTran->rotation.enableNotify(false);
+    }
+    else {
+        //      IVRoot->enableNotify(true);
+        //      IVTran->enableNotify(true);
+        //      IVMat->enableNotify(true);
+        //      IVGeomRoot->enableNotify(true);
+        //      IVContactIndicators->enableNotify(true);
+        IVTran->translation.enableNotify(true);
+        IVTran->rotation.enableNotify(true);
+    }
+
 }
 
 /*!
-  Sets the current world pose of the body to \a tr.  Collisions are not
-  checked.
+    Sets the current world pose of the body to \a tr.  Collisions are not
+    checked.
 */
 int
-Body::setTran(transf const &tr)
-{
-	if (tr == Tran) return SUCCESS;
-	breakContacts();
+Body::setTran(transf const &tr) {
+    if (tr == Tran) return SUCCESS;
+    breakContacts();
 
-	if (!myWorld->wasModified() && tr != Tran) {
-		myWorld->setModified();
-	}
-	Tran = tr;
-	myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
-	if (IVTran) {
-		Tran.toSoTransform(IVTran);
-	}
-	return SUCCESS;
+    if (!myWorld->wasModified() && tr != Tran) {
+        myWorld->setModified();
+    }
+    Tran = tr;
+    myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
+    if (IVTran) {
+        Tran.toSoTransform(IVTran);
+    }
+    return SUCCESS;
 }
 
- 
+
 /*!
-  Given a motion relative to body coordinates, this determines whether
-  the current contacts allow that motion.
+    Given a motion relative to body coordinates, this determines whether
+    the current contacts allow that motion.
 */
 bool
-Body::contactsPreventMotion(const transf& motion) const
-{
-  std::list<Contact *>::iterator cp;
-  std::list<Contact *> contactList;
+Body::contactsPreventMotion(const transf &motion) const {
+    std::list<Contact *>::iterator cp;
+    std::list<Contact *> contactList;
 
-  contactList = getContacts();
-  for (cp=contactList.begin();cp!=contactList.end();cp++) {
-    if ((*cp)->preventsMotion(motion)) {
-      return true;
+    contactList = getContacts();
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        if ((*cp)->preventsMotion(motion)) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 /*!
-  Breaks all contacts on the body, deleting entire contact list, and removes
-  all friction cones if necessary. Also clears the list of contacts from the
-  previous time step.
+    Breaks all contacts on the body, deleting entire contact list, and removes
+    all friction cones if necessary. Also clears the list of contacts from the
+    previous time step.
 */
 void
-Body::breakContacts()
-{
-	std::list<Contact *>::iterator cp;
+Body::breakContacts() {
+    std::list<Contact *>::iterator cp;
 
-	if (!contactList.empty()) {
-		setContactsChanged();
-		for (cp=contactList.begin();cp!=contactList.end();cp++) {
-			delete *cp; *cp = NULL;
-		}
-		contactList.clear();
-	}
-	numContacts = 0;
+    if (!contactList.empty()) {
+        setContactsChanged();
+        for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+            delete *cp;
+            *cp = NULL;
+        }
+        contactList.clear();
+    }
+    numContacts = 0;
 
-	for (cp = prevContactList.begin(); cp!=prevContactList.end(); cp++) {
-		if ( (*cp)->getMate() != NULL ) {
-			(*cp)->getMate()->setMate(NULL);
-		}
-		(*cp)->setMate(NULL);
-		delete *cp; *cp = NULL;
-	}
-	prevContactList.clear();
+    for (cp = prevContactList.begin(); cp != prevContactList.end(); cp++) {
+        if ((*cp)->getMate() != NULL) {
+            (*cp)->getMate()->setMate(NULL);
+        }
+        (*cp)->setMate(NULL);
+        delete *cp;
+        *cp = NULL;
+    }
+    prevContactList.clear();
 
-	if (showFC)
-		IVContactIndicators->removeAllChildren();
+    if (showFC)
+        IVContactIndicators->removeAllChildren();
 }
 
 /*! Load in all virtual contacts from file fn*/
 int
-Body::loadContactData(QString fn)
-{
-	FILE *fp = fopen(fn.latin1(), "r");
-	if (!fp) {
-		fprintf(stderr,"Could not open filename %s\n",fn.latin1());
-		return FAILURE;
-	}
-	int numContacts;
-	VirtualContactOnObject *newContact;
-	if(fscanf(fp,"%d",&numContacts) <= 0)
-		return FAILURE;
+Body::loadContactData(QString fn) {
+    FILE *fp = fopen(fn.latin1(), "r");
+    if (!fp) {
+        fprintf(stderr, "Could not open filename %s\n", fn.latin1());
+        return FAILURE;
+    }
+    int numContacts;
+    VirtualContactOnObject *newContact;
+    if (fscanf(fp, "%d", &numContacts) <= 0)
+        return FAILURE;
 
-	breakVirtualContacts();
-	for (int i=0; i<numContacts; i++) {
-		newContact = new VirtualContactOnObject();
-		newContact->readFromFile(fp);
-		newContact->setBody( this );
-		((Contact*)newContact)->computeWrenches();
-		addVirtualContact( newContact );//visualize the contact just read in
-	}
-	fclose(fp);
-	return SUCCESS;
+    breakVirtualContacts();
+    for (int i = 0; i < numContacts; i++) {
+        newContact = new VirtualContactOnObject();
+        newContact->readFromFile(fp);
+        newContact->setBody(this);
+        ((Contact *)newContact)->computeWrenches();
+        addVirtualContact(newContact);  //visualize the contact just read in
+    }
+    fclose(fp);
+    return SUCCESS;
 }
 /*! Removes all virtual contacts. This only removes the virtual contacts.
 */
 void
-Body::breakVirtualContacts()
-{
-	std::list<Contact *>::iterator cp;
-	for (cp = virtualContactList.begin(); cp!= virtualContactList.end(); cp++) {
-		delete *cp;
-	}
-	//this deletes all contact indicators, should be fixed..
-	if (showVC) {
-		IVContactIndicators->removeAllChildren();
-	}
-	virtualContactList.clear();
+Body::breakVirtualContacts() {
+    std::list<Contact *>::iterator cp;
+    for (cp = virtualContactList.begin(); cp != virtualContactList.end(); cp++) {
+        delete *cp;
+    }
+    //this deletes all contact indicators, should be fixed..
+    if (showVC) {
+        IVContactIndicators->removeAllChildren();
+    }
+    virtualContactList.clear();
 }
 
 /*!
-  Moves all contacts to the prevContactList and clears the contactList for new contacts
-  Old contacts from prevContactList are deleted.
+    Moves all contacts to the prevContactList and clears the contactList for new contacts
+    Old contacts from prevContactList are deleted.
 */
 void
-Body::resetContactList()
-{
-	std::list<Contact *>::iterator cp;
-	for (cp = prevContactList.begin(); cp!=prevContactList.end(); cp++) {
-		if ( (*cp)->getMate() != NULL ) {
-			(*cp)->getMate()->setMate(NULL);
-		}
-		(*cp)->setMate(NULL);
-		delete *cp; *cp = NULL;
-	}
-	prevContactList.clear();
-	if (!contactList.empty()) {
-		setContactsChanged();
-		for (cp=contactList.begin();cp!=contactList.end();cp++) {
-			prevContactList.push_back(*cp);
-		}
-		contactList.clear();
-	}
-	numContacts = 0;
-	if (showFC)
-		IVContactIndicators->removeAllChildren();
+Body::resetContactList() {
+    std::list<Contact *>::iterator cp;
+    for (cp = prevContactList.begin(); cp != prevContactList.end(); cp++) {
+        if ((*cp)->getMate() != NULL) {
+            (*cp)->getMate()->setMate(NULL);
+        }
+        (*cp)->setMate(NULL);
+        delete *cp;
+        *cp = NULL;
+    }
+    prevContactList.clear();
+    if (!contactList.empty()) {
+        setContactsChanged();
+        for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+            prevContactList.push_back(*cp);
+        }
+        contactList.clear();
+    }
+    numContacts = 0;
+    if (showFC)
+        IVContactIndicators->removeAllChildren();
 }
 
-/*! 
-  Adds contact \a c to the body's contact list.  Assumes the contact is not
-  already in the list.
-  \sa removeContact()
+/*!
+    Adds contact \a c to the body's contact list.  Assumes the contact is not
+    already in the list.
+    \sa removeContact()
 */
 void
-Body::addContact(Contact *c)
-{
-	setContactsChanged();
-	contactList.push_back(c);
-	numContacts++;
-	if (showFC) {
-		assert(IVContactIndicators->getNumChildren() > numContacts-2);
-		IVContactIndicators->insertChild( c->getVisualIndicator(), numContacts-1 );
-	}
+Body::addContact(Contact *c) {
+    setContactsChanged();
+    contactList.push_back(c);
+    numContacts++;
+    if (showFC) {
+        assert(IVContactIndicators->getNumChildren() > numContacts - 2);
+        IVContactIndicators->insertChild(c->getVisualIndicator(), numContacts - 1);
+    }
 }
 
 /*! The number of contacts on this body. If \a b is not null, it only counts
-	contacts against \a b. If it is null, is returns all contacts on this body,
-	regardless of who they are against.
+    contacts against \a b. If it is null, is returns all contacts on this body,
+    regardless of who they are against.
 */
-int 
-Body::getNumContacts(Body *b) const
-{
-	if (!b) return numContacts;
-	int c = 0;
-	std::list<Contact*>::const_iterator it;
-	for (it = contactList.begin(); it!=contactList.end(); it++) {
-		if ( (*it)->getBody2() == b) c++;
-	}
-	return c;
+int
+Body::getNumContacts(Body *b) const {
+    if (!b) return numContacts;
+    int c = 0;
+    std::list<Contact *>::const_iterator it;
+    for (it = contactList.begin(); it != contactList.end(); it++) {
+        if ((*it)->getBody2() == b) c++;
+    }
+    return c;
 }
 
 /*! Returns a list of the contacts on this body. if \a b is not NULL, it returns
-	only contacts against the body \a b. If \a b is NULL, it returns all the 
-	contacts.
+    only contacts against the body \a b. If \a b is NULL, it returns all the
+    contacts.
 */
-std::list<Contact*>
-Body::getContacts(Body *b) const
-{
-	if (!b) return contactList;
-	std::list<Contact*> contacts;
-	std::list<Contact*>::const_iterator it;
-	for (it = contactList.begin(); it!=contactList.end(); it++) {
-		if ( (*it)->getBody2() == b) contacts.push_back(*it);
-	}
-	return contacts;
+std::list<Contact *>
+Body::getContacts(Body *b) const {
+    if (!b) return contactList;
+    std::list<Contact *> contacts;
+    std::list<Contact *>::const_iterator it;
+    for (it = contactList.begin(); it != contactList.end(); it++) {
+        if ((*it)->getBody2() == b) contacts.push_back(*it);
+    }
+    return contacts;
 }
 
 /*! Adds a virtual contacts to this body */
 void
-Body::addVirtualContact(Contact *c)
-{
-	setContactsChanged();
-	virtualContactList.push_back(c);
-	if (showVC)
-		IVContactIndicators->addChild( c->getVisualIndicator() );
+Body::addVirtualContact(Contact *c) {
+    setContactsChanged();
+    virtualContactList.push_back(c);
+    if (showVC)
+        IVContactIndicators->addChild(c->getVisualIndicator());
 }
 
 /*!
-  Checks if this contact inherits some other contact from the prevContactList.
-  The check looks of contact points are close, normals agree and the second 
-  body is the same. If inheritance is found, some properites of the contact 
-  are passed from the previous contact to this one.
+    Checks if this contact inherits some other contact from the prevContactList.
+    The check looks of contact points are close, normals agree and the second
+    body is the same. If inheritance is found, some properites of the contact
+    are passed from the previous contact to this one.
 */
-Contact*
-Body::checkContactInheritance(Contact *c)
-{
-	std::list<Contact *>::iterator cp;
-	bool inheritance = false;
-	for (cp = prevContactList.begin(); cp != prevContactList.end(); cp++) {
-		if ( (*cp)->getBody1() != c->getBody1() )
-			continue;
-		if ( (*cp)->getBody2() != c->getBody2() )
-			continue;
-		vec3 d = (*cp)->getPosition() - c->getPosition();
-		if (d.len() > Contact::INHERITANCE_THRESHOLD )
-			continue;
-		vec3 n1 = (*cp)->getNormal();
-		vec3 n2 = c->getNormal();
-		double theta = n1 % n2;
-		if ( theta < Contact::INHERITANCE_ANGULAR_THRESHOLD )
-			continue;
-		inheritance = true;
-		break;
-	}
-	if (!inheritance)
-		return NULL;
-	return (*cp);
+Contact *
+Body::checkContactInheritance(Contact *c) {
+    std::list<Contact *>::iterator cp;
+    bool inheritance = false;
+    for (cp = prevContactList.begin(); cp != prevContactList.end(); cp++) {
+        if ((*cp)->getBody1() != c->getBody1())
+            continue;
+        if ((*cp)->getBody2() != c->getBody2())
+            continue;
+        vec3 d = (*cp)->getPosition() - c->getPosition();
+        if (d.len() > Contact::INHERITANCE_THRESHOLD)
+            continue;
+        vec3 n1 = (*cp)->getNormal();
+        vec3 n2 = c->getNormal();
+        double theta = n1 % n2;
+        if (theta < Contact::INHERITANCE_ANGULAR_THRESHOLD)
+            continue;
+        inheritance = true;
+        break;
+    }
+    if (!inheritance)
+        return NULL;
+    return (*cp);
 }
 
 
 /*!
-  Removes contact c from the body's contact list.  Assumes the contact is in the list.
-  \sa addContact() 
- */
+    Removes contact c from the body's contact list.  Assumes the contact is in the list.
+    \sa addContact()
+*/
 void
-Body::removeContact(Contact *c)
-{
-  int i;
-  std::list<Contact *>::iterator cp;
+Body::removeContact(Contact *c) {
+    int i;
+    std::list<Contact *>::iterator cp;
 
-  setContactsChanged();
+    setContactsChanged();
 
-  if (showFC) {
-    for (cp=contactList.begin(),i=0;cp!=contactList.end();cp++,i++)
-      if (*cp == c) {
-	    contactList.erase(cp);
-	    break;
-      }
-    IVContactIndicators->removeChild(i);
-  }
-  else contactList.remove(c);
+    if (showFC) {
+        for (cp = contactList.begin(), i = 0; cp != contactList.end(); cp++, i++)
+            if (*cp == c) {
+                contactList.erase(cp);
+                break;
+            }
+        IVContactIndicators->removeChild(i);
+    }
+    else contactList.remove(c);
 
-  delete c;
-  numContacts--;
+    delete c;
+    numContacts--;
 }
 
 /*!
-	Removes a contact c from the prevContactList
+    Removes a contact c from the prevContactList
 */
-void Body::removePrevContact(Contact *c)
-{
-	prevContactList.remove(c);
-	c->setMate(NULL);
-	delete c;
+void Body::removePrevContact(Contact *c) {
+    prevContactList.remove(c);
+    c->setMate(NULL);
+    delete c;
 }
 
 /*!
-  Output method for writing body data to a text world configuration file.
+    Output method for writing body data to a text world configuration file.
 */
-QTextStream&
-operator<<(QTextStream &os, const Body &b)
-{
-  os << b.myFilename << endl;
-  os << b.myWorld->getMaterialName(b.material) << endl;
-  return os;
+QTextStream &
+operator<<(QTextStream &os, const Body &b) {
+    os << b.myFilename << endl;
+    os << b.myWorld->getMaterialName(b.material) << endl;
+    return os;
 }
 
 
 /*! Helper callback for generating list of body triangles */
-void addTriangleCallBack(void* info, SoCallbackAction * action,
-						 const SoPrimitiveVertex * v1, 
-						 const SoPrimitiveVertex * v2, 
-						 const SoPrimitiveVertex * v3)
-{
-	std::vector<Triangle> *triangles = (std::vector<Triangle>*) info;
+void addTriangleCallBack(void *info, SoCallbackAction *action,
+                         const SoPrimitiveVertex *v1,
+                         const SoPrimitiveVertex *v2,
+                         const SoPrimitiveVertex *v3) {
+    std::vector<Triangle> *triangles = (std::vector<Triangle> *) info;
 
-	SbVec3f p1, p2, p3;
-	SbMatrix mm = action->getModelMatrix();
+    SbVec3f p1, p2, p3;
+    SbMatrix mm = action->getModelMatrix();
 
-	// Transform vertices (remember vertices are in the object space coordinates for each triangle)
-	mm.multVecMatrix( v1->getPoint(), p1 );
-	mm.multVecMatrix( v2->getPoint(), p2 );
-	mm.multVecMatrix( v3->getPoint(), p3 );
+    // Transform vertices (remember vertices are in the object space coordinates for each triangle)
+    mm.multVecMatrix(v1->getPoint(), p1);
+    mm.multVecMatrix(v2->getPoint(), p2);
+    mm.multVecMatrix(v3->getPoint(), p3);
 
-	// Don't add degenerate triangles!
-	if ((p1 == p2) || (p2 == p3) || (p1 == p3)) return;
+    // Don't add degenerate triangles!
+    if ((p1 == p2) || (p2 == p3) || (p1 == p3)) return;
 
-	position nv1(p1[0], p1[1], p1[2]);
-	position nv2(p2[0], p2[1], p2[2]);
-	position nv3(p3[0], p3[1], p3[2]);
-	Triangle newTri(nv1,nv2,nv3);
-	triangles->push_back( newTri );
+    position nv1(p1[0], p1[1], p1[2]);
+    position nv2(p2[0], p2[1], p2[2]);
+    position nv3(p3[0], p3[1], p3[2]);
+    Triangle newTri(nv1, nv2, nv3);
+    triangles->push_back(newTri);
 }
 
 /*! Helper callback for generating list of body vertices */
-void addVertexCallBack(void* info, SoCallbackAction * action, const SoPrimitiveVertex * v1)
-{
-	std::vector<position> *vertices = (std::vector<position>*) info;
-	SbVec3f p1;
-	SbMatrix mm = action->getModelMatrix();
-	// Transform vertex (remember vertices are in the object space coordinates for each triangle)
-	mm.multVecMatrix( v1->getPoint(), p1 );
-	position nv1(p1[0], p1[1], p1[2]);
-	vertices->push_back( nv1 );
+void addVertexCallBack(void *info, SoCallbackAction *action, const SoPrimitiveVertex *v1) {
+    std::vector<position> *vertices = (std::vector<position> *) info;
+    SbVec3f p1;
+    SbMatrix mm = action->getModelMatrix();
+    // Transform vertex (remember vertices are in the object space coordinates for each triangle)
+    mm.multVecMatrix(v1->getPoint(), p1);
+    position nv1(p1[0], p1[1], p1[2]);
+    vertices->push_back(nv1);
 }
 
 /*! Helper callback for generating list of body vertices */
-void addVerticesFromTriangleCallBack(void* info, SoCallbackAction * action,
-									 const SoPrimitiveVertex * v1, 
-									 const SoPrimitiveVertex * v2, 
-									 const SoPrimitiveVertex * v3)
-{
-	std::vector<position> *vertices = (std::vector<position>*) info;
-	SbVec3f p1, p2, p3;
-	SbMatrix mm = action->getModelMatrix();
-	// Transform vertices (remember vertices are in the object space coordinates for each triangle)
-	mm.multVecMatrix( v1->getPoint(), p1 );
-	mm.multVecMatrix( v2->getPoint(), p2 );
-	mm.multVecMatrix( v3->getPoint(), p3 );
-	vertices->push_back(position(p1[0], p1[1], p1[2]));
-	vertices->push_back(position(p2[0], p2[1], p2[2]));
-	vertices->push_back(position(p3[0], p3[1], p3[2]));
+void addVerticesFromTriangleCallBack(void *info, SoCallbackAction *action,
+                                     const SoPrimitiveVertex *v1,
+                                     const SoPrimitiveVertex *v2,
+                                     const SoPrimitiveVertex *v3) {
+    std::vector<position> *vertices = (std::vector<position> *) info;
+    SbVec3f p1, p2, p3;
+    SbMatrix mm = action->getModelMatrix();
+    // Transform vertices (remember vertices are in the object space coordinates for each triangle)
+    mm.multVecMatrix(v1->getPoint(), p1);
+    mm.multVecMatrix(v2->getPoint(), p2);
+    mm.multVecMatrix(v3->getPoint(), p3);
+    vertices->push_back(position(p1[0], p1[1], p1[2]));
+    vertices->push_back(position(p2[0], p2[1], p2[2]));
+    vertices->push_back(position(p3[0], p3[1], p3[2]));
 }
 
 /*! Returns all the triangle that make up the geometry of this body */
 void
-Body::getGeometryTriangles(std::vector<Triangle> *triangles) const
-{
-	SoCallbackAction ca;
-	ca.addTriangleCallback(SoShape::getClassTypeId(), addTriangleCallBack, triangles);
-	ca.apply(getIVGeomRoot());
+Body::getGeometryTriangles(std::vector<Triangle> *triangles) const {
+    SoCallbackAction ca;
+    ca.addTriangleCallback(SoShape::getClassTypeId(), addTriangleCallBack, triangles);
+    ca.apply(getIVGeomRoot());
 }
 
-/*!	Returns all the vertices that make up the geometry of this body. 
-	This function will return duplicates, as vertices are reported once 
-	for each triangle that they are part of
+/*! Returns all the vertices that make up the geometry of this body.
+    This function will return duplicates, as vertices are reported once
+    for each triangle that they are part of
 */
 void
-Body::getGeometryVertices(std::vector<position> *vertices) const
-{
-	SoCallbackAction ca;
-	//unfortunately, this does not work as triangle vertices are not considered points by Coin
-	//ca.addPointCallback(SoShape::getClassTypeId(), addVertexCallBack, vertices);
-	//we have to use a triangle callback which leads to duplication
-	ca.addTriangleCallback(SoShape::getClassTypeId(), addVerticesFromTriangleCallBack, vertices);
-	ca.apply(getIVGeomRoot());
+Body::getGeometryVertices(std::vector<position> *vertices) const {
+    SoCallbackAction ca;
+    //unfortunately, this does not work as triangle vertices are not considered points by Coin
+    //ca.addPointCallback(SoShape::getClassTypeId(), addVertexCallBack, vertices);
+    //we have to use a triangle callback which leads to duplication
+    ca.addTriangleCallback(SoShape::getClassTypeId(), addVerticesFromTriangleCallBack, vertices);
+    ca.apply(getIVGeomRoot());
 }
 
 /*! Creates the geometry of the axes which show this body's local
-	coordinate system. The axes are usually shown centered at the c.o.m
+    coordinate system. The axes are usually shown centered at the c.o.m
 */
-void Body::createAxesGeometry()
-{  
-  IVWorstCase = new SoSeparator;  
-  IVAxes = new SoSwitch;  
-  if (graspItGUI) {
-    SoSeparator *axesSep = new SoSeparator;
-    axesTranToCOG = new SoTranslation;
-    axesTranToCOG->translation.setValue(0,0,0);
-    axesSep->addChild(axesTranToCOG);
-    axesSep->addChild(IVWorstCase);
-    
-    axesScale = new SoScale;
-	axesScale->scaleFactor = SbVec3f(1,1,1);
-    axesSep->addChild(axesScale);
-    axesSep->addChild(graspItGUI->getIVmgr()->getPointers()->getChild(2));
-    IVAxes->addChild(axesSep);
-  }
-  if (!IVRoot) IVRoot = new SoSeparator;
+void Body::createAxesGeometry() {
+    IVWorstCase = new SoSeparator;
+    IVAxes = new SoSwitch;
+    if (graspItGUI) {
+        SoSeparator *axesSep = new SoSeparator;
+        axesTranToCOG = new SoTranslation;
+        axesTranToCOG->translation.setValue(0, 0, 0);
+        axesSep->addChild(axesTranToCOG);
+        axesSep->addChild(IVWorstCase);
 
-  IVRoot->addChild(IVAxes);
+        axesScale = new SoScale;
+        axesScale->scaleFactor = SbVec3f(1, 1, 1);
+        axesSep->addChild(axesScale);
+        axesSep->addChild(graspItGUI->getIVmgr()->getPointers()->getChild(2));
+        IVAxes->addChild(axesSep);
+    }
+    if (!IVRoot) IVRoot = new SoSeparator;
+
+    IVRoot->addChild(IVAxes);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1262,919 +1239,917 @@ void Body::createAxesGeometry()
 ///////////////////////////////////////////////////////////////////////////////
 
 /*!
-  If there is a dynamic joint connected to this body, it is deleted before the
-  body is destroyed.
+    If there is a dynamic joint connected to this body, it is deleted before the
+    body is destroyed.
 */
-DynamicBody::~DynamicBody()
-{
-  if (dynJoint) delete dynJoint;
+DynamicBody::~DynamicBody() {
+    if (dynJoint) delete dynJoint;
 }
 
 void
-DynamicBody::init()
-{
-  maxRadius = 0.0; mass = 0.0;
-  showAx = showDynCF = false;
-  fixed = false; dynJoint=NULL; dynamicsComputedFlag = false;
-  useDynamics = true;
-  bbox_min = vec3(-1e+6,-1e+6,-1e+6);
-  bbox_max = vec3(1e+6,1e+6,1e+6);
-  CoG.set(0.0,0.0,0.0);
-  for(int i=0; i<9; i++) {
-	  I[i] = 0.0;
-  }
-  resetDynamics();
+DynamicBody::init() {
+    maxRadius = 0.0;
+    mass = 0.0;
+    showAx = showDynCF = false;
+    fixed = false;
+    dynJoint = NULL;
+    dynamicsComputedFlag = false;
+    useDynamics = true;
+    bbox_min = vec3(-1e+6, -1e+6, -1e+6);
+    bbox_max = vec3(1e+6, 1e+6, 1e+6);
+    CoG.set(0.0, 0.0, 0.0);
+    for (int i = 0; i < 9; i++) {
+        I[i] = 0.0;
+    }
+    resetDynamics();
 }
 
 /*! Sets acceleration and velocity to 0 and the 7-dimensional
-	state vector to match the current transform (which includes
-	the position of the center of gravity.
+    state vector to match the current transform (which includes
+    the position of the center of gravity.
 */
 void
-DynamicBody::resetDynamics()
-{
-  resetExtWrenchAcc();
-  for (int i=0; i<6; i++) {
-    a[i] = 0.0;
-    v[i] = 0.0;
-  }
-  Quaternion quat = Tran.rotation();
-  vec3 cogOffset = quat * (CoG-position::ORIGIN);
-  q[0] = Tran.translation().x()+cogOffset.x();
-  q[1] = Tran.translation().y()+cogOffset.y();
-  q[2] = Tran.translation().z()+cogOffset.z();
-  q[3] = quat.w;
-  q[4] = quat.x;
-  q[5] = quat.y;
-  q[6] = quat.z;
+DynamicBody::resetDynamics() {
+    resetExtWrenchAcc();
+    for (int i = 0; i < 6; i++) {
+        a[i] = 0.0;
+        v[i] = 0.0;
+    }
+    Quaternion quat = Tran.rotation();
+    vec3 cogOffset = quat * (CoG - position::ORIGIN);
+    q[0] = Tran.translation().x() + cogOffset.x();
+    q[1] = Tran.translation().y() + cogOffset.y();
+    q[2] = Tran.translation().z() + cogOffset.z();
+    q[3] = quat.w;
+    q[4] = quat.x;
+    q[5] = quat.y;
+    q[6] = quat.z;
 }
 
 /*! Constructs an empty DynamicBody.  Use load() to initialize this class
-	from a model file, or cloneFrom to initialize from a different 
-	dynamic body.
+    from a model file, or cloneFrom to initialize from a different
+    dynamic body.
 */
-DynamicBody::DynamicBody(World *w, const char *name) : Body(w,name)
-{
-	init();
+DynamicBody::DynamicBody(World *w, const char *name) : Body(w, name) {
+    init();
 }
 
-/*! 
-  Creates a dynamic body from the basic body \a b.  Computes the mass
-  properties automatically assuming a mass of \a m and uniform mass
-  distribution.
+/*!
+    Creates a dynamic body from the basic body \a b.  Computes the mass
+    properties automatically assuming a mass of \a m and uniform mass
+    distribution.
 */
-DynamicBody::DynamicBody(const Body &b, double m) : Body(b)
-{
-  init();
-  position defCoG;
-  double defI[9];
-  computeDefaultMassProp(defCoG, defI);
-  setMass(m);
-  setCoG(defCoG);
-  setInertiaMatrix(defI);
-  setMaxRadius(computeDefaultMaxRadius());
-  //we need the effects of get tran on dynamics
-  setTran(b.getTran());
+DynamicBody::DynamicBody(const Body &b, double m) : Body(b) {
+    init();
+    position defCoG;
+    double defI[9];
+    computeDefaultMassProp(defCoG, defI);
+    setMass(m);
+    setCoG(defCoG);
+    setInertiaMatrix(defI);
+    setMaxRadius(computeDefaultMaxRadius());
+    //we need the effects of get tran on dynamics
+    setTran(b.getTran());
 }
 
 /*! Clones another dynamic body; all dynamic paramters are copied
-	over.
+    over.
 */
 void
-DynamicBody::cloneFrom(const DynamicBody *original)
-{
-	Body::cloneFrom(original);
-	setMass(original->mass);
-	setCoG(original->CoG);
-	setInertiaMatrix(original->I);
-	setMaxRadius(original->maxRadius);
-}
-
-int 
-DynamicBody::loadFromXml(const TiXmlElement *root, QString rootPath)
-{
-	if (Body::loadFromXml(root, rootPath)==FAILURE) {
-		return FAILURE;
-	}
-	double loadMass;
-	bool overrideI, overrideCog;
-	QString valueStr;
-
-	const TiXmlElement* element = findXmlElement(root, "mass");
-	if(element == NULL){
-		loadMass = defaultMass;
-		DBGA("Using default mass");
-	} else{
-		valueStr = element->GetText();
-		loadMass = valueStr.toDouble();
-		if (loadMass <= 0) {
-			QTWARNING("invalid mass in dynamic body file: " + myFilename);
-			return FAILURE;
-		}
-	}
-	element = findXmlElement(root, "cog");
-	position loadCog;
-	if(element == NULL){
-		overrideCog = false;
-	} else{
-		overrideCog = true;
-		valueStr = element->GetText();
-		valueStr = valueStr.simplifyWhiteSpace();
-		QStringList l;
-		l = QStringList::split(' ', valueStr.stripWhiteSpace());
-		if(l.count()!=3){
-			QTWARNING("Invalid Center of Gravity Input");
-			return FAILURE;
-		}		
-		double x,y,z;
-		x = l[0].toDouble();
-		y = l[1].toDouble();
-		z = l[2].toDouble();
-		loadCog = position(x,y,z);
-	}
-	double loadI[9];
-	element = findXmlElement(root, "inertia_matrix");
-	if(element == NULL){//set default inertia matrix
-		overrideI = false;
-	} else{
-		overrideI = true;
-		valueStr = element->GetText();
-		valueStr = valueStr.simplifyWhiteSpace();
-		QStringList l;
-		l = QStringList::split(' ', valueStr.stripWhiteSpace());
-		if(l.count()!=9){ //error
-			QTWARNING("Invalid Inertia Matrix Input");
-			return FAILURE;
-		}
-		loadI[0]=l[0].toDouble();
-		loadI[1]=l[1].toDouble();
-		loadI[2]=l[2].toDouble();
-		loadI[3]=l[3].toDouble();
-		loadI[4]=l[4].toDouble();
-		loadI[5]=l[5].toDouble();
-		loadI[6]=l[6].toDouble();
-		loadI[7]=l[7].toDouble();
-		loadI[8]=l[8].toDouble();
-	}
-	if (!overrideI || !overrideCog) {
-		position defaultCog;
-		double defaultI[9];
-		computeDefaultMassProp(defaultCog, defaultI);
-		if (!overrideI) {
-			memcpy(loadI, defaultI, 9*sizeof(double));
-			DBGA("Using default inertia matrix");
-		}
-		if (!overrideCog) {
-			loadCog = defaultCog;
-			DBGA("Using default center of gravity");
-		}
-	}
-	setMass(loadMass);
-	setCoG(loadCog);
-	setInertiaMatrix(loadI);
-	setMaxRadius(computeDefaultMaxRadius());
-	return SUCCESS;
-}
-
-/*! Computes both the center of gravity and the inertia matrix
-	automatically, based on the geometry of the object and then
-	sets them.
-*/
-void
-DynamicBody::setDefaultDynamicParameters()
-{
-	position defaultCog;
-	double defaultI[9];
-	computeDefaultMassProp(defaultCog, defaultI);
-	setCoG(defaultCog);
-	setInertiaMatrix(defaultI);
+DynamicBody::cloneFrom(const DynamicBody *original) {
+    Body::cloneFrom(original);
+    setMass(original->mass);
+    setCoG(original->CoG);
+    setInertiaMatrix(original->I);
+    setMaxRadius(original->maxRadius);
 }
 
 int
-DynamicBody::saveToXml(QTextStream &xml){
-	if(Body::saveToXml(xml)!=SUCCESS)  return FAILURE;
-	xml<<"\t\t\t<mass>"<<mass<<"</mass>"<<endl;
-	xml<<"\t\t\t<cog>"<<CoG.x()<<" "<<CoG.y()<<" "<<CoG.z()<<"</cog>"<<endl;
-	xml<<"\t\t\t<inertia_matrix>";
-	for(int i=0;i<9;i++){
-		xml<<I[i];
-		if(i!=8)
-			xml<<" ";
-	}
-	xml<<"</inertia_matrix>"<<endl;
-	return SUCCESS;
+DynamicBody::loadFromXml(const TiXmlElement *root, QString rootPath) {
+    if (Body::loadFromXml(root, rootPath) == FAILURE) {
+        return FAILURE;
+    }
+    double loadMass;
+    bool overrideI, overrideCog;
+    QString valueStr;
+
+    const TiXmlElement *element = findXmlElement(root, "mass");
+    if (element == NULL) {
+        loadMass = defaultMass;
+        DBGA("Using default mass");
+    }
+    else {
+        valueStr = element->GetText();
+        loadMass = valueStr.toDouble();
+        if (loadMass <= 0) {
+            QTWARNING("invalid mass in dynamic body file: " + myFilename);
+            return FAILURE;
+        }
+    }
+    element = findXmlElement(root, "cog");
+    position loadCog;
+    if (element == NULL) {
+        overrideCog = false;
+    }
+    else {
+        overrideCog = true;
+        valueStr = element->GetText();
+        valueStr = valueStr.simplifyWhiteSpace();
+        QStringList l;
+        l = QStringList::split(' ', valueStr.stripWhiteSpace());
+        if (l.count() != 3) {
+            QTWARNING("Invalid Center of Gravity Input");
+            return FAILURE;
+        }
+        double x, y, z;
+        x = l[0].toDouble();
+        y = l[1].toDouble();
+        z = l[2].toDouble();
+        loadCog = position(x, y, z);
+    }
+    double loadI[9];
+    element = findXmlElement(root, "inertia_matrix");
+    if (element == NULL) { //set default inertia matrix
+        overrideI = false;
+    }
+    else {
+        overrideI = true;
+        valueStr = element->GetText();
+        valueStr = valueStr.simplifyWhiteSpace();
+        QStringList l;
+        l = QStringList::split(' ', valueStr.stripWhiteSpace());
+        if (l.count() != 9) { //error
+            QTWARNING("Invalid Inertia Matrix Input");
+            return FAILURE;
+        }
+        loadI[0] = l[0].toDouble();
+        loadI[1] = l[1].toDouble();
+        loadI[2] = l[2].toDouble();
+        loadI[3] = l[3].toDouble();
+        loadI[4] = l[4].toDouble();
+        loadI[5] = l[5].toDouble();
+        loadI[6] = l[6].toDouble();
+        loadI[7] = l[7].toDouble();
+        loadI[8] = l[8].toDouble();
+    }
+    if (!overrideI || !overrideCog) {
+        position defaultCog;
+        double defaultI[9];
+        computeDefaultMassProp(defaultCog, defaultI);
+        if (!overrideI) {
+            memcpy(loadI, defaultI, 9 * sizeof(double));
+            DBGA("Using default inertia matrix");
+        }
+        if (!overrideCog) {
+            loadCog = defaultCog;
+            DBGA("Using default center of gravity");
+        }
+    }
+    setMass(loadMass);
+    setCoG(loadCog);
+    setInertiaMatrix(loadI);
+    setMaxRadius(computeDefaultMaxRadius());
+    return SUCCESS;
 }
-/*! Also has to reset dynamics since the current state has to be changed
-	to match the new CoG.
+
+/*! Computes both the center of gravity and the inertia matrix
+    automatically, based on the geometry of the object and then
+    sets them.
 */
 void
-DynamicBody::setCoG(const position &newCoG)
-{
-	CoG = newCoG;  
-	resetDynamics();
-	//use this to display axes at the CoG
-	//axesTranToCOG->translation.setValue(CoG.x(), CoG.y(), CoG.z());
+DynamicBody::setDefaultDynamicParameters() {
+    position defaultCog;
+    double defaultI[9];
+    computeDefaultMassProp(defaultCog, defaultI);
+    setCoG(defaultCog);
+    setInertiaMatrix(defaultI);
+}
 
-	//use this to display axes at body origin
-	axesTranToCOG->translation.setValue(0,0,0);
+int
+DynamicBody::saveToXml(QTextStream &xml) {
+    if (Body::saveToXml(xml) != SUCCESS)  return FAILURE;
+    xml << "\t\t\t<mass>" << mass << "</mass>" << endl;
+    xml << "\t\t\t<cog>" << CoG.x() << " " << CoG.y() << " " << CoG.z() << "</cog>" << endl;
+    xml << "\t\t\t<inertia_matrix>";
+    for (int i = 0; i < 9; i++) {
+        xml << I[i];
+        if (i != 8)
+            xml << " ";
+    }
+    xml << "</inertia_matrix>" << endl;
+    return SUCCESS;
+}
+/*! Also has to reset dynamics since the current state has to be changed
+    to match the new CoG.
+*/
+void
+DynamicBody::setCoG(const position &newCoG) {
+    CoG = newCoG;
+    resetDynamics();
+    //use this to display axes at the CoG
+    //axesTranToCOG->translation.setValue(CoG.x(), CoG.y(), CoG.z());
+
+    //use this to display axes at body origin
+    axesTranToCOG->translation.setValue(0, 0, 0);
 }
 
 /*! The max radius can be thought of as the largest distance from the center
-	of gravity to the edge of the object.
+    of gravity to the edge of the object.
 */
 void
-DynamicBody::setMaxRadius(double maxRad)
-{
-	maxRadius = maxRad;
-	axesScale->scaleFactor = SbVec3f(maxRadius / AXES_SCALE, maxRadius / AXES_SCALE, maxRadius / AXES_SCALE);
+DynamicBody::setMaxRadius(double maxRad) {
+    maxRadius = maxRad;
+    axesScale->scaleFactor = SbVec3f(maxRadius / AXES_SCALE, maxRadius / AXES_SCALE, maxRadius / AXES_SCALE);
 }
 
 void
-DynamicBody::setInertiaMatrix(const double *newI)
-{
-	memcpy(I, newI, 9*sizeof(double));
+DynamicBody::setInertiaMatrix(const double *newI) {
+    memcpy(I, newI, 9 * sizeof(double));
 }
 
 double
-DynamicBody::computeDefaultMaxRadius()
-{
-	std::vector<position> vertices;
-	getGeometryVertices(&vertices);
-	if (vertices.empty()) {
-		DBGA("No vertices found when computing maxRadius!");
-	}
-	double maxRad = 0.0;
-	for (int i=0; i<(int)vertices.size(); i++) {
-		double tmpRadius = (CoG - vertices[i]).len();
-		if (tmpRadius > maxRad) maxRad = tmpRadius;
-	}
-	return maxRad;
+DynamicBody::computeDefaultMaxRadius() {
+    std::vector<position> vertices;
+    getGeometryVertices(&vertices);
+    if (vertices.empty()) {
+        DBGA("No vertices found when computing maxRadius!");
+    }
+    double maxRad = 0.0;
+    for (int i = 0; i < (int)vertices.size(); i++) {
+        double tmpRadius = (CoG - vertices[i]).len();
+        if (tmpRadius > maxRad) maxRad = tmpRadius;
+    }
+    return maxRad;
 }
 
 /*!
-  Support routine for computing body mass properties.  This code is
-  adapted from code written by Brian Mirtich.
+    Support routine for computing body mass properties.  This code is
+    adapted from code written by Brian Mirtich.
 */
 void
-DynamicBody::compProjectionIntegrals(FACE &f, int A, int B)
-{
-  double a0, a1, da;
-  double b0, b1, db;
-  double a0_2, a0_3, a0_4, b0_2, b0_3, b0_4;
-  double a1_2, a1_3, b1_2, b1_3;
-  double C1, Ca, Caa, Caaa, Cb, Cbb, Cbbb;
-  double Cab, Kab, Caab, Kaab, Cabb, Kabb;
-  int i;
+DynamicBody::compProjectionIntegrals(FACE &f, int A, int B) {
+    double a0, a1, da;
+    double b0, b1, db;
+    double a0_2, a0_3, a0_4, b0_2, b0_3, b0_4;
+    double a1_2, a1_3, b1_2, b1_3;
+    double C1, Ca, Caa, Caaa, Cb, Cbb, Cbbb;
+    double Cab, Kab, Caab, Kaab, Cabb, Kabb;
+    int i;
 
-  P1 = Pa = Pb = Paa = Pab = Pbb = Paaa = Paab = Pabb = Pbbb = 0.0;
+    P1 = Pa = Pb = Paa = Pab = Pbb = Paaa = Paab = Pabb = Pbbb = 0.0;
 
-  for (i = 0; i < 3; i++) {
-    a0 = f.verts[i][A];
-    b0 = f.verts[i][B];
-    a1 = f.verts[(i+1) % 3][A];
-    b1 = f.verts[(i+1) % 3][B];
-    da = a1 - a0;
-    db = b1 - b0;
-    a0_2 = a0 * a0; a0_3 = a0_2 * a0; a0_4 = a0_3 * a0;
-    b0_2 = b0 * b0; b0_3 = b0_2 * b0; b0_4 = b0_3 * b0;
-    a1_2 = a1 * a1; a1_3 = a1_2 * a1; 
-    b1_2 = b1 * b1; b1_3 = b1_2 * b1;
+    for (i = 0; i < 3; i++) {
+        a0 = f.verts[i][A];
+        b0 = f.verts[i][B];
+        a1 = f.verts[(i + 1) % 3][A];
+        b1 = f.verts[(i + 1) % 3][B];
+        da = a1 - a0;
+        db = b1 - b0;
+        a0_2 = a0 * a0;
+        a0_3 = a0_2 * a0;
+        a0_4 = a0_3 * a0;
+        b0_2 = b0 * b0;
+        b0_3 = b0_2 * b0;
+        b0_4 = b0_3 * b0;
+        a1_2 = a1 * a1;
+        a1_3 = a1_2 * a1;
+        b1_2 = b1 * b1;
+        b1_3 = b1_2 * b1;
 
-    C1 = a1 + a0;
-    Ca = a1*C1 + a0_2; Caa = a1*Ca + a0_3; Caaa = a1*Caa + a0_4;
-    Cb = b1*(b1 + b0) + b0_2; Cbb = b1*Cb + b0_3; Cbbb = b1*Cbb + b0_4;
-    Cab = 3*a1_2 + 2*a1*a0 + a0_2; Kab = a1_2 + 2*a1*a0 + 3*a0_2;
-    Caab = a0*Cab + 4*a1_3; Kaab = a1*Kab + 4*a0_3;
-    Cabb = 4*b1_3 + 3*b1_2*b0 + 2*b1*b0_2 + b0_3;
-    Kabb = b1_3 + 2*b1_2*b0 + 3*b1*b0_2 + 4*b0_3;
+        C1 = a1 + a0;
+        Ca = a1 * C1 + a0_2;
+        Caa = a1 * Ca + a0_3;
+        Caaa = a1 * Caa + a0_4;
+        Cb = b1 * (b1 + b0) + b0_2;
+        Cbb = b1 * Cb + b0_3;
+        Cbbb = b1 * Cbb + b0_4;
+        Cab = 3 * a1_2 + 2 * a1 * a0 + a0_2;
+        Kab = a1_2 + 2 * a1 * a0 + 3 * a0_2;
+        Caab = a0 * Cab + 4 * a1_3;
+        Kaab = a1 * Kab + 4 * a0_3;
+        Cabb = 4 * b1_3 + 3 * b1_2 * b0 + 2 * b1 * b0_2 + b0_3;
+        Kabb = b1_3 + 2 * b1_2 * b0 + 3 * b1 * b0_2 + 4 * b0_3;
 
-    P1 += db*C1;
-    Pa += db*Ca;
-    Paa += db*Caa;
-    Paaa += db*Caaa;
-    Pb += da*Cb;
-    Pbb += da*Cbb;
-    Pbbb += da*Cbbb;
-    Pab += db*(b1*Cab + b0*Kab);
-    Paab += db*(b1*Caab + b0*Kaab);
-    Pabb += da*(a1*Cabb + a0*Kabb);
-  }
+        P1 += db * C1;
+        Pa += db * Ca;
+        Paa += db * Caa;
+        Paaa += db * Caaa;
+        Pb += da * Cb;
+        Pbb += da * Cbb;
+        Pbbb += da * Cbbb;
+        Pab += db * (b1 * Cab + b0 * Kab);
+        Paab += db * (b1 * Caab + b0 * Kaab);
+        Pabb += da * (a1 * Cabb + a0 * Kabb);
+    }
 
-  P1 /= 2.0;
-  Pa /= 6.0;
-  Paa /= 12.0;
-  Paaa /= 20.0;
-  Pb /= -6.0;
-  Pbb /= -12.0;
-  Pbbb /= -20.0;
-  Pab /= 24.0;
-  Paab /= 60.0;
-  Pabb /= -60.0;
+    P1 /= 2.0;
+    Pa /= 6.0;
+    Paa /= 12.0;
+    Paaa /= 20.0;
+    Pb /= -6.0;
+    Pbb /= -12.0;
+    Pbbb /= -20.0;
+    Pab /= 24.0;
+    Paab /= 60.0;
+    Pabb /= -60.0;
 }
 
 /*!
-  Support routine for computing body mass properties.  This code is
-  adapted from code written by Brian Mirtich.
+    Support routine for computing body mass properties.  This code is
+    adapted from code written by Brian Mirtich.
 */
 void
-DynamicBody::compFaceIntegrals(FACE &f,int A, int B, int C)
-{
-  double *n, w;
-  double k1, k2, k3, k4;
+DynamicBody::compFaceIntegrals(FACE &f, int A, int B, int C) {
+    double *n, w;
+    double k1, k2, k3, k4;
 
-  compProjectionIntegrals(f,A,B);
+    compProjectionIntegrals(f, A, B);
 
-  w = f.w;
-  n = f.norm;
-  k1 = 1 / n[C]; k2 = k1 * k1; k3 = k2 * k1; k4 = k3 * k1;
+    w = f.w;
+    n = f.norm;
+    k1 = 1 / n[C];
+    k2 = k1 * k1;
+    k3 = k2 * k1;
+    k4 = k3 * k1;
 
-  Fa = k1 * Pa;
-  Fb = k1 * Pb;
-  Fc = -k2 * (n[A]*Pa + n[B]*Pb + w*P1);
+    Fa = k1 * Pa;
+    Fb = k1 * Pb;
+    Fc = -k2 * (n[A] * Pa + n[B] * Pb + w * P1);
 
-  Faa = k1 * Paa;
-  Fbb = k1 * Pbb;
-  Fcc = k3 * (SQR(n[A])*Paa + 2*n[A]*n[B]*Pab + SQR(n[B])*Pbb
-	 + w*(2*(n[A]*Pa + n[B]*Pb) + w*P1));
+    Faa = k1 * Paa;
+    Fbb = k1 * Pbb;
+    Fcc = k3 * (SQR(n[A]) * Paa + 2 * n[A] * n[B] * Pab + SQR(n[B]) * Pbb
+                + w * (2 * (n[A] * Pa + n[B] * Pb) + w * P1));
 
-  Faaa = k1 * Paaa;
-  Fbbb = k1 * Pbbb;
-  Fccc = -k4 * (CUBE(n[A])*Paaa + 3*SQR(n[A])*n[B]*Paab 
-	   + 3*n[A]*SQR(n[B])*Pabb + CUBE(n[B])*Pbbb
-	   + 3*w*(SQR(n[A])*Paa + 2*n[A]*n[B]*Pab + SQR(n[B])*Pbb)
-	   + w*w*(3*(n[A]*Pa + n[B]*Pb) + w*P1));
+    Faaa = k1 * Paaa;
+    Fbbb = k1 * Pbbb;
+    Fccc = -k4 * (CUBE(n[A]) * Paaa + 3 * SQR(n[A]) * n[B] * Paab
+                  + 3 * n[A] * SQR(n[B]) * Pabb + CUBE(n[B]) * Pbbb
+                  + 3 * w * (SQR(n[A]) * Paa + 2 * n[A] * n[B] * Pab + SQR(n[B]) * Pbb)
+                  + w * w * (3 * (n[A] * Pa + n[B] * Pb) + w * P1));
 
-  Faab = k1 * Paab;
-  Fbbc = -k2 * (n[A]*Pabb + n[B]*Pbbb + w*Pbb);
-  Fcca = k3 * (SQR(n[A])*Paaa + 2*n[A]*n[B]*Paab + SQR(n[B])*Pabb
-	 + w*(2*(n[A]*Paa + n[B]*Pab) + w*Pa));
+    Faab = k1 * Paab;
+    Fbbc = -k2 * (n[A] * Pabb + n[B] * Pbbb + w * Pbb);
+    Fcca = k3 * (SQR(n[A]) * Paaa + 2 * n[A] * n[B] * Paab + SQR(n[B]) * Pabb
+                 + w * (2 * (n[A] * Paa + n[B] * Pab) + w * Pa));
 }
 
 /*! Helper function that uses code by Brian Mirtich to compute the center of
-	gravity and the inertia matrix for a list of triangles. Returns FAILURE
-	if the computation fails, and some degenerate values are returned.
+    gravity and the inertia matrix for a list of triangles. Returns FAILURE
+    if the computation fails, and some degenerate values are returned.
 */
-int 
-DynamicBody::computeDefaultInertiaMatrix(std::vector<Triangle> &triangles, double *defaultI)
-{
-  FACE f;
-  double dx1,dy1,dz1,dx2,dy2,dz2;
-  double nx, ny, nz,len;
-  int i,A,B,C;
-  double r[3], v1[3], v2[3], v3[3];
-  double density;
+int
+DynamicBody::computeDefaultInertiaMatrix(std::vector<Triangle> &triangles, double *defaultI) {
+    FACE f;
+    double dx1, dy1, dz1, dx2, dy2, dz2;
+    double nx, ny, nz, len;
+    int i, A, B, C;
+    double r[3], v1[3], v2[3], v3[3];
+    double density;
 
-  f.verts[0] = v1;
-  f.verts[1] = v2;
-  f.verts[2] = v3;
+    f.verts[0] = v1;
+    f.verts[1] = v2;
+    f.verts[2] = v3;
 
-  // volume integrals
-  double T0, T1[3], T2[3], TP[3];
+    // volume integrals
+    double T0, T1[3], T2[3], TP[3];
 
-  T0 = T1[0] = T1[1] = T1[2] 
-     = T2[0] = T2[1] = T2[2] 
-     = TP[0] = TP[1] = TP[2] = 0;
+    T0 = T1[0] = T1[1] = T1[2]
+                         = T2[0] = T2[1] = T2[2]
+                                           = TP[0] = TP[1] = TP[2] = 0;
 
 
-  for (i = 0; i < (int)triangles.size(); i++) {
-	triangles[i].v1.get(v1);
-	triangles[i].v2.get(v2);
-	triangles[i].v3.get(v3);
+    for (i = 0; i < (int)triangles.size(); i++) {
+        triangles[i].v1.get(v1);
+        triangles[i].v2.get(v2);
+        triangles[i].v3.get(v3);
 
-	dx1 = f.verts[1][0] - f.verts[0][0];
-    dy1 = f.verts[1][1] - f.verts[0][1];
-    dz1 = f.verts[1][2] - f.verts[0][2];
-    dx2 = f.verts[2][0] - f.verts[1][0];
-    dy2 = f.verts[2][1] - f.verts[1][1];
-    dz2 = f.verts[2][2] - f.verts[1][2];
-    nx = dy1 * dz2 - dy2 * dz1;
-    ny = dz1 * dx2 - dz2 * dx1;
-    nz = dx1 * dy2 - dx2 * dy1;
-    len = sqrt(nx * nx + ny * ny + nz * nz);
+        dx1 = f.verts[1][0] - f.verts[0][0];
+        dy1 = f.verts[1][1] - f.verts[0][1];
+        dz1 = f.verts[1][2] - f.verts[0][2];
+        dx2 = f.verts[2][0] - f.verts[1][0];
+        dy2 = f.verts[2][1] - f.verts[1][1];
+        dz2 = f.verts[2][2] - f.verts[1][2];
+        nx = dy1 * dz2 - dy2 * dz1;
+        ny = dz1 * dx2 - dz2 * dx1;
+        nz = dx1 * dy2 - dx2 * dy1;
+        len = sqrt(nx * nx + ny * ny + nz * nz);
 
-    f.norm[0] = nx / len;
-    f.norm[1] = ny / len;
-    f.norm[2] = nz / len;
-    f.w = - f.norm[0] * f.verts[0][0]
-           - f.norm[1] * f.verts[0][1]
-           - f.norm[2] * f.verts[0][2];
+        f.norm[0] = nx / len;
+        f.norm[1] = ny / len;
+        f.norm[2] = nz / len;
+        f.w = - f.norm[0] * f.verts[0][0]
+              - f.norm[1] * f.verts[0][1]
+              - f.norm[2] * f.verts[0][2];
 
-    nx = fabs(f.norm[0]);
-    ny = fabs(f.norm[1]);
-    nz = fabs(f.norm[2]);
-    if (nx > ny && nx > nz) C = 0;
-    else C = (ny > nz) ? 1 : 2;
-    A = (C + 1) % 3;
-    B = (A + 1) % 3;
+        nx = fabs(f.norm[0]);
+        ny = fabs(f.norm[1]);
+        nz = fabs(f.norm[2]);
+        if (nx > ny && nx > nz) C = 0;
+        else C = (ny > nz) ? 1 : 2;
+        A = (C + 1) % 3;
+        B = (A + 1) % 3;
 
-    compFaceIntegrals(f,A,B,C);
+        compFaceIntegrals(f, A, B, C);
 
-    T0 += f.norm[0] * ((A == 0) ? Fa : ((B == 0) ? Fb : Fc));
+        T0 += f.norm[0] * ((A == 0) ? Fa : ((B == 0) ? Fb : Fc));
 
-    T1[A] += f.norm[A] * Faa;
-    T1[B] += f.norm[B] * Fbb;
-    T1[C] += f.norm[C] * Fcc;
-    T2[A] += f.norm[A] * Faaa;
-    T2[B] += f.norm[B] * Fbbb;
-    T2[C] += f.norm[C] * Fccc;
-    TP[A] += f.norm[A] * Faab;
-    TP[B] += f.norm[B] * Fbbc;
-    TP[C] += f.norm[C] * Fcca;
-  }
+        T1[A] += f.norm[A] * Faa;
+        T1[B] += f.norm[B] * Fbb;
+        T1[C] += f.norm[C] * Fcc;
+        T2[A] += f.norm[A] * Faaa;
+        T2[B] += f.norm[B] * Fbbb;
+        T2[C] += f.norm[C] * Fccc;
+        TP[A] += f.norm[A] * Faab;
+        TP[B] += f.norm[B] * Fbbc;
+        TP[C] += f.norm[C] * Fcca;
+    }
 
-  T1[0] /= 2; T1[1] /= 2; T1[2] /= 2;
-  T2[0] /= 3; T2[1] /= 3; T2[2] /= 3;
-  TP[0] /= 2; TP[1] /= 2; TP[2] /= 2;
+    T1[0] /= 2;
+    T1[1] /= 2;
+    T1[2] /= 2;
+    T2[0] /= 3;
+    T2[1] /= 3;
+    T2[2] /= 3;
+    TP[0] /= 2;
+    TP[1] /= 2;
+    TP[2] /= 2;
 
-  r[0] = T1[0] / T0;
-  r[1] = T1[1] / T0;
-  r[2] = T1[2] / T0;
+    r[0] = T1[0] / T0;
+    r[1] = T1[1] / T0;
+    r[2] = T1[2] / T0;
 
-  DBGP("COM: " << r[0] << " " << r[1] << " " << r[2]);
+    DBGP("COM: " << r[0] << " " << r[1] << " " << r[2]);
 
-  //default values in case of failure
-  for (int i=0; i<9; i++) {
-	  defaultI[i] = 0.0;
-  }
-  defaultI[0] = defaultI[3] = defaultI[6] = 1.0;
+    //default values in case of failure
+    for (int i = 0; i < 9; i++) {
+        defaultI[i] = 0.0;
+    }
+    defaultI[0] = defaultI[3] = defaultI[6] = 1.0;
 
-  //sanity checks
-  if (r[0] != r[0]) return FAILURE;
-  if (r[1] != r[1]) return FAILURE;
-  if (r[2] != r[2]) return FAILURE;
-  if (fabs(T0) < 1.0e-5) return FAILURE;
-  if ( fabs(r[0]) > 5.0e2 || fabs(r[1]) > 5.0e2 || fabs(r[2]) > 5.0e2 ) {
-	  return FAILURE;
-  }
+    //sanity checks
+    if (r[0] != r[0]) return FAILURE;
+    if (r[1] != r[1]) return FAILURE;
+    if (r[2] != r[2]) return FAILURE;
+    if (fabs(T0) < 1.0e-5) return FAILURE;
+    if (fabs(r[0]) > 5.0e2 || fabs(r[1]) > 5.0e2 || fabs(r[2]) > 5.0e2) {
+        return FAILURE;
+    }
 
-  //assume unity mass
-  density = 1.0 / T0;
+    //assume unity mass
+    density = 1.0 / T0;
 
-  /* compute inertia tensor */
-  defaultI[0] = density * (T2[1] + T2[2]);
-  defaultI[4] = density * (T2[2] + T2[0]);
-  defaultI[8] = density * (T2[0] + T2[1]);
-  defaultI[1] = defaultI[3] = - density * TP[0];
-  defaultI[5] = defaultI[7] = - density * TP[1];
-  defaultI[6] = defaultI[2] = - density * TP[2];
+    /* compute inertia tensor */
+    defaultI[0] = density * (T2[1] + T2[2]);
+    defaultI[4] = density * (T2[2] + T2[0]);
+    defaultI[8] = density * (T2[0] + T2[1]);
+    defaultI[1] = defaultI[3] = - density * TP[0];
+    defaultI[5] = defaultI[7] = - density * TP[1];
+    defaultI[6] = defaultI[2] = - density * TP[2];
 
-  /* translate inertia tensor to center of mass */
-  defaultI[0] -= (r[1]*r[1] + r[2]*r[2]);
-  defaultI[4] -= (r[2]*r[2] + r[0]*r[0]);
-  defaultI[8] -= (r[0]*r[0] + r[1]*r[1]);
-  defaultI[1] = defaultI[3] += r[0] * r[1]; 
-  defaultI[5] = defaultI[7] += r[1] * r[2]; 
-  defaultI[6] = defaultI[2] += r[2] * r[0]; 
-  return SUCCESS;
+    /* translate inertia tensor to center of mass */
+    defaultI[0] -= (r[1] * r[1] + r[2] * r[2]);
+    defaultI[4] -= (r[2] * r[2] + r[0] * r[0]);
+    defaultI[8] -= (r[0] * r[0] + r[1] * r[1]);
+    defaultI[1] = defaultI[3] += r[0] * r[1];
+    defaultI[5] = defaultI[7] += r[1] * r[2];
+    defaultI[6] = defaultI[2] += r[2] * r[0];
+    return SUCCESS;
 }
 
 /*! Helper function for computing cog and inertia matrix. Integrates
-	a pointwise function over the surface of a triangle using 7-point
-	Gaussian integration.
+    a pointwise function over the surface of a triangle using 7-point
+    Gaussian integration.
 */
 template <class IntegrableFunction>
-float Gaussian7Integrate(const Triangle& triangle, IntegrableFunction integrable_function) {
-  // Setup
-  static const float terms[8] = {
-	0.333333333333333333333333333333333f,
-	0.79742698535308732239802527616971f,
-	0.10128650732345633880098736191512f,
-	0.059715871789769820459117580973143f,
-	0.47014206410511508977044120951345f,
-	0.225f,
-	0.12593918054482715259568394550018f,
-	0.13239415278850618073764938783315f};
-	  
-  static const float barycentric_weights[7][3] = {
-    {terms[0], terms[0], terms[0]}, 
-    {terms[1], terms[2], terms[2]}, 
-    {terms[2], terms[1], terms[2]}, 
-    {terms[2], terms[2], terms[1]}, 
-    {terms[3], terms[4], terms[4]}, 
-    {terms[4], terms[3], terms[4]}, 
-    {terms[4], terms[4], terms[3]}}; 
-  static const float sample_weights[7] = {
-    terms[5], terms[6], terms[6], terms[6], 
-    terms[7], terms[7], terms[7]};
-	// Calculate the integration sample points
-  float integration_samples[7][3] = {{0}};
-	const position* vertices[3] = {&(triangle.v1), &(triangle.v2), &(triangle.v3)};
-	for(int sample_num = 0; sample_num < 7; ++sample_num) {
-		float* sample = integration_samples[sample_num];
-		const float* barycentric_weight = barycentric_weights[sample_num];
-		for (int vertex_num = 0; vertex_num < 3; ++vertex_num) {
-			const position& vertex = *(vertices[vertex_num]);
-			for (int coord = 0; coord < 3; ++coord) {
-				sample[coord] += vertex[coord] * barycentric_weight[vertex_num];
-			}
-		}
-	}
-  // Integration
-  float result = 0;
-  for (int sample = 0; sample < 7; ++sample){
-    result += integrable_function(integration_samples[sample]) * sample_weights[sample];
-   }
-  return result * triangle.area();
-} 
+float Gaussian7Integrate(const Triangle &triangle, IntegrableFunction integrable_function) {
+    // Setup
+    static const float terms[8] = {
+        0.333333333333333333333333333333333f,
+        0.79742698535308732239802527616971f,
+        0.10128650732345633880098736191512f,
+        0.059715871789769820459117580973143f,
+        0.47014206410511508977044120951345f,
+        0.225f,
+        0.12593918054482715259568394550018f,
+        0.13239415278850618073764938783315f
+    };
+
+    static const float barycentric_weights[7][3] = {
+        {terms[0], terms[0], terms[0]},
+        {terms[1], terms[2], terms[2]},
+        {terms[2], terms[1], terms[2]},
+        {terms[2], terms[2], terms[1]},
+        {terms[3], terms[4], terms[4]},
+        {terms[4], terms[3], terms[4]},
+        {terms[4], terms[4], terms[3]}
+    };
+    static const float sample_weights[7] = {
+        terms[5], terms[6], terms[6], terms[6],
+        terms[7], terms[7], terms[7]
+    };
+    // Calculate the integration sample points
+    float integration_samples[7][3] = {{0}};
+    const position *vertices[3] = {&(triangle.v1), &(triangle.v2), &(triangle.v3)};
+    for (int sample_num = 0; sample_num < 7; ++sample_num) {
+        float *sample = integration_samples[sample_num];
+        const float *barycentric_weight = barycentric_weights[sample_num];
+        for (int vertex_num = 0; vertex_num < 3; ++vertex_num) {
+            const position &vertex = *(vertices[vertex_num]);
+            for (int coord = 0; coord < 3; ++coord) {
+                sample[coord] += vertex[coord] * barycentric_weight[vertex_num];
+            }
+        }
+    }
+    // Integration
+    float result = 0;
+    for (int sample = 0; sample < 7; ++sample) {
+        result += integrable_function(integration_samples[sample]) * sample_weights[sample];
+    }
+    return result * triangle.area();
+}
 
 //! Integrable functor for computing triangle area
 struct GetCoord {
-  int coord;
-  template <class T> float operator()(const T vertex) const { return vertex[coord]; }
+    int coord;
+    template <class T> float operator()(const T vertex) const {
+        return vertex[coord];
+    }
 };
 
 //! Integrable functor for computing the covariance matrix
 struct GetCovar {
-  int coord_a, coord_b;
-  float mean_a, mean_b;
-  template <class T> float operator()(const T vertex) const { 
-	  return (vertex[coord_a] - mean_a) * (vertex[coord_b] - mean_b); 
-  }
+    int coord_a, coord_b;
+    float mean_a, mean_b;
+    template <class T> float operator()(const T vertex) const {
+        return (vertex[coord_a] - mean_a) * (vertex[coord_b] - mean_b);
+    }
 };
 
 /*! A different version for computing the cog of an object based
-	on the surface triangles. Used as a fallback when the other
-	version fails. Courtesy of Corey Goldfeder.
+    on the surface triangles. Used as a fallback when the other
+    version fails. Courtesy of Corey Goldfeder.
 */
 int
-computeDefaultCoG(std::vector<Triangle> &triangles, position &defaultCoG)
-{
-  // Figure out the center of mass consistent with how it was done in the CGDB
-  double center_of_mass[3] = {0, 0, 0};
-  // First we need the total area of the mesh
-  float total_area = 0;
-  for (std::vector<Triangle>::const_iterator triangle = triangles.begin();
-       triangle != triangles.end(); ++triangle) {
-    total_area += triangle->area();
-  }
-
-  if (total_area != 0) {
-    // Compute the (weighted by area) means of x, y, and z
-    float means[3] = {0};
-    // set up local class representing function to integrate
-    GetCoord get_coord;
-    for(unsigned i = 0; i < 3; ++i) {
-      get_coord.coord = i;
-      for (std::vector<Triangle>::const_iterator triangle = triangles.begin();
-          triangle != triangles.end(); ++triangle) {
-         means[i] += Gaussian7Integrate(*triangle, get_coord);
-      }
-    }
-    for (int i = 0; i < 3; ++i) center_of_mass[i] = means[i] / total_area;
-
-	// Get the covariance
-    float covars[3][3] = {{0}};
-    GetCovar get_covar;
-    for(unsigned a = 0; a < 3; ++a) {
-      for(unsigned b = a; b < 3; ++b) {
-        get_covar.coord_a = a;
-        get_covar.coord_b = b;
-		get_covar.mean_a = center_of_mass[a];
-		get_covar.mean_b = center_of_mass[b];
-        for (std::vector<Triangle>::const_iterator triangle = triangles.begin();
+computeDefaultCoG(std::vector<Triangle> &triangles, position &defaultCoG) {
+    // Figure out the center of mass consistent with how it was done in the CGDB
+    double center_of_mass[3] = {0, 0, 0};
+    // First we need the total area of the mesh
+    float total_area = 0;
+    for (std::vector<Triangle>::const_iterator triangle = triangles.begin();
             triangle != triangles.end(); ++triangle) {
-          covars[b][a] += Gaussian7Integrate(*triangle, get_covar);
+        total_area += triangle->area();
+    }
+
+    if (total_area != 0) {
+        // Compute the (weighted by area) means of x, y, and z
+        float means[3] = {0};
+        // set up local class representing function to integrate
+        GetCoord get_coord;
+        for (unsigned i = 0; i < 3; ++i) {
+            get_coord.coord = i;
+            for (std::vector<Triangle>::const_iterator triangle = triangles.begin();
+                    triangle != triangles.end(); ++triangle) {
+                means[i] += Gaussian7Integrate(*triangle, get_coord);
+            }
         }
-      }
-	}
-	defaultCoG.set(center_of_mass);
-	return SUCCESS;
-  } else {
-	  defaultCoG.set(0,0,0);
- 	  return FAILURE;
-  }
+        for (int i = 0; i < 3; ++i) center_of_mass[i] = means[i] / total_area;
+
+        // Get the covariance
+        float covars[3][3] = {{0}};
+        GetCovar get_covar;
+        for (unsigned a = 0; a < 3; ++a) {
+            for (unsigned b = a; b < 3; ++b) {
+                get_covar.coord_a = a;
+                get_covar.coord_b = b;
+                get_covar.mean_a = center_of_mass[a];
+                get_covar.mean_b = center_of_mass[b];
+                for (std::vector<Triangle>::const_iterator triangle = triangles.begin();
+                        triangle != triangles.end(); ++triangle) {
+                    covars[b][a] += Gaussian7Integrate(*triangle, get_covar);
+                }
+            }
+        }
+        defaultCoG.set(center_of_mass);
+        return SUCCESS;
+    }
+    else {
+        defaultCoG.set(0, 0, 0);
+        return FAILURE;
+    }
 }
 /*!
-  Given a list of the body vertices, and the number of triangles, this
-  computes the center of gravity and inertia matrix by assuming a uniform
-  mass distribution.
+    Given a list of the body vertices, and the number of triangles, this
+    computes the center of gravity and inertia matrix by assuming a uniform
+    mass distribution.
 */
 void
-DynamicBody::computeDefaultMassProp(position &defaultCoG, double *defaultI)
-{
-  std::vector<Triangle> triangles;
-  getGeometryTriangles(&triangles);
-  if (triangles.empty()) {
-	 DBGA("No triangles found when computing mass properties!");
-	 defaultCoG.set(0,0,0);
-	 return;
-  }
-  if (computeDefaultInertiaMatrix(triangles, defaultI) == FAILURE) {
-	DBGA("Failed to compute inertia matrix based on geometry; using identity");
-  }
-  for(int i=0; i<3; i++) {
-	DBGP(defaultI[3*i] << " " << defaultI[3*i+1] << " " << defaultI[3*i+2]);
-  }
-  computeDefaultCoG(triangles, defaultCoG);
+DynamicBody::computeDefaultMassProp(position &defaultCoG, double *defaultI) {
+    std::vector<Triangle> triangles;
+    getGeometryTriangles(&triangles);
+    if (triangles.empty()) {
+        DBGA("No triangles found when computing mass properties!");
+        defaultCoG.set(0, 0, 0);
+        return;
+    }
+    if (computeDefaultInertiaMatrix(triangles, defaultI) == FAILURE) {
+        DBGA("Failed to compute inertia matrix based on geometry; using identity");
+    }
+    for (int i = 0; i < 3; i++) {
+        DBGP(defaultI[3 * i] << " " << defaultI[3 * i + 1] << " " << defaultI[3 * i + 2]);
+    }
+    computeDefaultCoG(triangles, defaultCoG);
 }
 
-void 
-DynamicBody::setDefaultViewingParameters()
-{
-	Body::setDefaultViewingParameters();
-	showAx = false;
-}
-
-/*!
-  Changes the state of the Inventor switch node controlling whether the
-  coordinate axes on the body are visible
-*/
 void
-DynamicBody::showAxes(bool on)
-{
-  DBGP("Show axes: " << on);
-  if (on) IVAxes->whichChild = 0;
-  else IVAxes->whichChild = -1;
-  showAx = on;
-}
-
-/*!
-  Sets whether dynamic contact forces should be drawn during dynamic
-  simulation.
-*/
-void
-DynamicBody::showDynContactForces(bool on)
-{
-  showDynCF = on;
-}
-
-
-/*!
-  Resets the external wrench accumulator to 0.
-*/
-void
-DynamicBody::resetExtWrenchAcc()
-{
-  extWrenchAcc[0] = extWrenchAcc[1] = extWrenchAcc[2] = 0.0;
-  extWrenchAcc[3] = extWrenchAcc[4] = extWrenchAcc[5] = 0.0;
+DynamicBody::setDefaultViewingParameters() {
+    Body::setDefaultViewingParameters();
+    showAx = false;
 }
 
 /*!
-  Adds \a extW to the external wrench accumulator.
+    Changes the state of the Inventor switch node controlling whether the
+    coordinate axes on the body are visible
 */
 void
-DynamicBody::addExtWrench(double *extW){
-  extWrenchAcc[0] += extW[0];
-  extWrenchAcc[1] += extW[1];
-  extWrenchAcc[2] += extW[2];
-  extWrenchAcc[3] += extW[3];
-  extWrenchAcc[4] += extW[4];
-  extWrenchAcc[5] += extW[5];
+DynamicBody::showAxes(bool on) {
+    DBGP("Show axes: " << on);
+    if (on) IVAxes->whichChild = 0;
+    else IVAxes->whichChild = -1;
+    showAx = on;
 }
 
-/*! 
-   Adds a force expressed in world coordinates, to the external force
-   accumulator for this body.
+/*!
+    Sets whether dynamic contact forces should be drawn during dynamic
+    simulation.
 */
 void
-DynamicBody::addForce(vec3 force)
-{
-  extWrenchAcc[0] += force[0];
-  extWrenchAcc[1] += force[1];
-  extWrenchAcc[2] += force[2];
+DynamicBody::showDynContactForces(bool on) {
+    showDynCF = on;
+}
+
+
+/*!
+    Resets the external wrench accumulator to 0.
+*/
+void
+DynamicBody::resetExtWrenchAcc() {
+    extWrenchAcc[0] = extWrenchAcc[1] = extWrenchAcc[2] = 0.0;
+    extWrenchAcc[3] = extWrenchAcc[4] = extWrenchAcc[5] = 0.0;
+}
+
+/*!
+    Adds \a extW to the external wrench accumulator.
+*/
+void
+DynamicBody::addExtWrench(double *extW) {
+    extWrenchAcc[0] += extW[0];
+    extWrenchAcc[1] += extW[1];
+    extWrenchAcc[2] += extW[2];
+    extWrenchAcc[3] += extW[3];
+    extWrenchAcc[4] += extW[4];
+    extWrenchAcc[5] += extW[5];
+}
+
+/*!
+    Adds a force expressed in world coordinates, to the external force
+    accumulator for this body.
+*/
+void
+DynamicBody::addForce(vec3 force) {
+    extWrenchAcc[0] += force[0];
+    extWrenchAcc[1] += force[1];
+    extWrenchAcc[2] += force[2];
 
 }
 
 /*!
-  Adds a torque expressed in world coordinates, to the external force
-  accumulator for this body.
- */
+    Adds a torque expressed in world coordinates, to the external force
+    accumulator for this body.
+*/
 void
-DynamicBody::addTorque(vec3 torque)
-{
-  extWrenchAcc[3] += torque[0];
-  extWrenchAcc[4] += torque[1];
-  extWrenchAcc[5] += torque[2];
-  DBGP("Adding torque "<< torque);
+DynamicBody::addTorque(vec3 torque) {
+    extWrenchAcc[3] += torque[0];
+    extWrenchAcc[4] += torque[1];
+    extWrenchAcc[5] += torque[2];
+    DBGP("Adding torque " << torque);
 }
 
 /*
-  Adds a torque expressed in body coordinates, to the external force
-  accumulator for this body.
+    Adds a torque expressed in body coordinates, to the external force
+    accumulator for this body.
 */
 void
-DynamicBody::addRelTorque(vec3 torque)
-{
-  vec3 worldTorque;
-  DBGP("Adding rel torque "<< torque);
-  worldTorque = Tran.rotation() * torque;
-  extWrenchAcc[3] += worldTorque[0];
-  extWrenchAcc[4] += worldTorque[1];
-  extWrenchAcc[5] += worldTorque[2];
-  DBGP("     world torque "<< worldTorque);
-}
-
-
-/*! 
-   Adds a force expressed in world coordinates at a position also expressed
-   world coordinates. This force and the computed torque are added to the
-   external force accumulator for this body.
-*/
-void
-DynamicBody::addForceAtPos(vec3 force,position pos)
-{
-  vec3 worldTorque;
-  vec3 worldPos;
-  worldPos = (pos - CoG * Tran);
-
-  worldTorque = worldPos * force;
-  extWrenchAcc[0] += force[0];
-  extWrenchAcc[1] += force[1];
-  extWrenchAcc[2] += force[2];
-
-  extWrenchAcc[3] += worldTorque[0];
-  extWrenchAcc[4] += worldTorque[1];
-  extWrenchAcc[5] += worldTorque[2];
+DynamicBody::addRelTorque(vec3 torque) {
+    vec3 worldTorque;
+    DBGP("Adding rel torque " << torque);
+    worldTorque = Tran.rotation() * torque;
+    extWrenchAcc[3] += worldTorque[0];
+    extWrenchAcc[4] += worldTorque[1];
+    extWrenchAcc[5] += worldTorque[2];
+    DBGP("     world torque " << worldTorque);
 }
 
 
 /*!
-  Adds a force expressed in body coordinates at a position also expressed
-  body coordinates. This force and the computed torque are added to the
-  external force accumulator for this body.
+    Adds a force expressed in world coordinates at a position also expressed
+    world coordinates. This force and the computed torque are added to the
+    external force accumulator for this body.
 */
 void
-DynamicBody::addForceAtRelPos(vec3 force,position pos)
-{
-  vec3 worldForce;
-  vec3 worldTorque;
+DynamicBody::addForceAtPos(vec3 force, position pos) {
+    vec3 worldTorque;
+    vec3 worldPos;
+    worldPos = (pos - CoG * Tran);
 
-  worldForce = Tran.rotation() * force;
-  worldTorque = Tran.rotation() * ((pos - CoG) * force);
-  extWrenchAcc[0] += worldForce[0];
-  extWrenchAcc[1] += worldForce[1];
-  extWrenchAcc[2] += worldForce[2];
+    worldTorque = worldPos * force;
+    extWrenchAcc[0] += force[0];
+    extWrenchAcc[1] += force[1];
+    extWrenchAcc[2] += force[2];
 
-  extWrenchAcc[3] += worldTorque[0];
-  extWrenchAcc[4] += worldTorque[1];
-  extWrenchAcc[5] += worldTorque[2];
-  DBGP("Adding rel force "<< force << " at " << pos);
-  DBGP("    world torque "<< worldTorque << " worldForce " << worldForce);
+    extWrenchAcc[3] += worldTorque[0];
+    extWrenchAcc[4] += worldTorque[1];
+    extWrenchAcc[5] += worldTorque[2];
+}
+
+
+/*!
+    Adds a force expressed in body coordinates at a position also expressed
+    body coordinates. This force and the computed torque are added to the
+    external force accumulator for this body.
+*/
+void
+DynamicBody::addForceAtRelPos(vec3 force, position pos) {
+    vec3 worldForce;
+    vec3 worldTorque;
+
+    worldForce = Tran.rotation() * force;
+    worldTorque = Tran.rotation() * ((pos - CoG) * force);
+    extWrenchAcc[0] += worldForce[0];
+    extWrenchAcc[1] += worldForce[1];
+    extWrenchAcc[2] += worldForce[2];
+
+    extWrenchAcc[3] += worldTorque[0];
+    extWrenchAcc[4] += worldTorque[1];
+    extWrenchAcc[5] += worldTorque[2];
+    DBGP("Adding rel force " << force << " at " << pos);
+    DBGP("    world torque " << worldTorque << " worldForce " << worldForce);
 }
 
 // Let the dynamics routine take care of breaking the contacts
-bool 
-DynamicBody::setPos(const double *new_q)
-{
-	double norm;
-	// is the object within its permissable area?
-	if (new_q[0] < bbox_min.x() || new_q[0] > bbox_max.x()) return false;
-	if (new_q[1] < bbox_min.y() || new_q[1] > bbox_max.y()) return false;
-	if (new_q[2] < bbox_min.z() || new_q[2] > bbox_max.z()) return false;
-  
-	memcpy(q,new_q,7*sizeof(double));
+bool
+DynamicBody::setPos(const double *new_q) {
+    double norm;
+    // is the object within its permissable area?
+    if (new_q[0] < bbox_min.x() || new_q[0] > bbox_max.x()) return false;
+    if (new_q[1] < bbox_min.y() || new_q[1] > bbox_max.y()) return false;
+    if (new_q[2] < bbox_min.z() || new_q[2] > bbox_max.z()) return false;
 
-	// normalize the quaternion
-	norm = sqrt(q[3]*q[3]+q[4]*q[4]+q[5]*q[5]+q[6]*q[6]);
-	q[3] /= norm;
-	q[4] /= norm;
-	q[5] /= norm;
-	q[6] /= norm;
-	Quaternion rot(q[3],q[4],q[5],q[6]);
-	vec3 cogOffset = rot * (CoG-position::ORIGIN);
-	transf tr = transf(rot,vec3(q[0],q[1],q[2])-cogOffset);
+    memcpy(q, new_q, 7 * sizeof(double));
 
-	Tran = tr;
-	Tran.toSoTransform(IVTran);
-	myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
-	
-	return true;
+    // normalize the quaternion
+    norm = sqrt(q[3] * q[3] + q[4] * q[4] + q[5] * q[5] + q[6] * q[6]);
+    q[3] /= norm;
+    q[4] /= norm;
+    q[5] /= norm;
+    q[6] /= norm;
+    Quaternion rot(q[3], q[4], q[5], q[6]);
+    vec3 cogOffset = rot * (CoG - position::ORIGIN);
+    transf tr = transf(rot, vec3(q[0], q[1], q[2]) - cogOffset);
+
+    Tran = tr;
+    Tran.toSoTransform(IVTran);
+    myWorld->getCollisionInterface()->setBodyTransform(this, Tran);
+
+    return true;
 }
 
 /*!
-  Save the current dynamic state of the body.
-  May soon be replaced by pushState().
+    Save the current dynamic state of the body.
+    May soon be replaced by pushState().
 */
 void
-DynamicBody::markState()
-{
-  memcpy(markedQ,q,7*sizeof(double));
-  memcpy(markedV,v,6*sizeof(double));
+DynamicBody::markState() {
+    memcpy(markedQ, q, 7 * sizeof(double));
+    memcpy(markedV, v, 6 * sizeof(double));
 }
 
 /*!
-  Restore the marked dynamic state of the body.
-  May soon be replaced by popState().
+    Restore the marked dynamic state of the body.
+    May soon be replaced by popState().
 */
 void
-DynamicBody::returnToMarkedState()
-{
-  memcpy(v,markedV,6*sizeof(double));
-  setPos(markedQ);
-}
-
-/*! 
-  Push the current dynamic state of the body onto a local stack.
-*/
-void
-DynamicBody::pushState()
-{
-  double *tmp = new double[7];
-  memcpy(tmp,q,7*sizeof(double));
-  qStack.push_back(tmp);
-
-  tmp = new double[6];
-  memcpy(tmp,v,6*sizeof(double));
-  vStack.push_back(tmp);  
+DynamicBody::returnToMarkedState() {
+    memcpy(v, markedV, 6 * sizeof(double));
+    setPos(markedQ);
 }
 
 /*!
-  Pop the current dynamic state of the body from a local stack.
+    Push the current dynamic state of the body onto a local stack.
+*/
+void
+DynamicBody::pushState() {
+    double *tmp = new double[7];
+    memcpy(tmp, q, 7 * sizeof(double));
+    qStack.push_back(tmp);
+
+    tmp = new double[6];
+    memcpy(tmp, v, 6 * sizeof(double));
+    vStack.push_back(tmp);
+}
+
+/*!
+    Pop the current dynamic state of the body from a local stack.
 */
 bool
-DynamicBody::popState()
-{
-	if (qStack.empty()) {
-		DBGA("Pop state failed: stack empty");
-		return false;
-	}
-	memcpy(v,vStack.back(),6*sizeof(double));
-	setPos(qStack.back());
+DynamicBody::popState() {
+    if (qStack.empty()) {
+        DBGA("Pop state failed: stack empty");
+        return false;
+    }
+    memcpy(v, vStack.back(), 6 * sizeof(double));
+    setPos(qStack.back());
 
-	// don't pop off the first saved state.
-	if (++qStack.begin() != qStack.end()) {
-		delete [] vStack.back();
-		delete [] qStack.back();
-		vStack.pop_back(); 
-		qStack.pop_back();
-		return true;
-	} else {
-		return false;
+    // don't pop off the first saved state.
+    if (++qStack.begin() != qStack.end()) {
+        delete [] vStack.back();
+        delete [] qStack.back();
+        vStack.pop_back();
+        qStack.pop_back();
+        return true;
+    }
+    else {
+        return false;
     }
 }
 
 void
-DynamicBody::clearState()
-{
-	//we don't actually change the state of the object, just clear
-	//the stack. For some reason we leave the last state in.
-	if (qStack.empty()) return;
-	while (++qStack.begin() != qStack.end()) {
-		delete [] vStack.back();
-		delete [] qStack.back();
-		vStack.pop_back(); 
-		qStack.pop_back();
-	}
+DynamicBody::clearState() {
+    //we don't actually change the state of the object, just clear
+    //the stack. For some reason we leave the last state in.
+    if (qStack.empty()) return;
+    while (++qStack.begin() != qStack.end()) {
+        delete [] vStack.back();
+        delete [] qStack.back();
+        vStack.pop_back();
+        qStack.pop_back();
+    }
 }
 /*!
-  Calls Body::setTran then updates the dynamic state of the body.
+    Calls Body::setTran then updates the dynamic state of the body.
 */
 int
-DynamicBody::setTran(transf const& tr)
-{
-  if (tr == Tran) return SUCCESS;
-  if (Body::setTran(tr) == FAILURE) return FAILURE;
-  Quaternion quat = Tran.rotation();
-  vec3 cogOffset = quat * (CoG-position::ORIGIN);
-  q[0] = Tran.translation().x()+cogOffset.x();
-  q[1] = Tran.translation().y()+cogOffset.y();
-  q[2] = Tran.translation().z()+cogOffset.z();
-  q[3] = quat.w;
-  q[4] = quat.x;
-  q[5] = quat.y;
-  q[6] = quat.z;  
-  if (fixed) {
-	  if (!dynJoint->getPrevLink()) {
-		  //if the previous link of the dynamic joint is NULL this means
-		  //the body is fixed to the current position in the world
-		  //we need to update that position
-		  fix();
-	  }
-  }
-  return SUCCESS;
+DynamicBody::setTran(transf const &tr) {
+    if (tr == Tran) return SUCCESS;
+    if (Body::setTran(tr) == FAILURE) return FAILURE;
+    Quaternion quat = Tran.rotation();
+    vec3 cogOffset = quat * (CoG - position::ORIGIN);
+    q[0] = Tran.translation().x() + cogOffset.x();
+    q[1] = Tran.translation().y() + cogOffset.y();
+    q[2] = Tran.translation().z() + cogOffset.z();
+    q[3] = quat.w;
+    q[4] = quat.x;
+    q[5] = quat.y;
+    q[6] = quat.z;
+    if (fixed) {
+        if (!dynJoint->getPrevLink()) {
+            //if the previous link of the dynamic joint is NULL this means
+            //the body is fixed to the current position in the world
+            //we need to update that position
+            fix();
+        }
+    }
+    return SUCCESS;
 }
 
 /*!
-  Fixes the body so that it does not move during dynamic simulation.  This
-  is done by addind a fixed dynamic joint that will constrain all 6 body
-  velocities to 0.
+    Fixes the body so that it does not move during dynamic simulation.  This
+    is done by addind a fixed dynamic joint that will constrain all 6 body
+    velocities to 0.
 */
 void
-DynamicBody::fix()
-{
-  fixed = true;
-  setDynJoint(new FixedDynJoint(NULL,this,Tran));
+DynamicBody::fix() {
+    fixed = true;
+    setDynJoint(new FixedDynJoint(NULL, this, Tran));
 }
 
 /*!
-  Removes the fixed dynamic joint so the body is free to move again during
-  dynamic simulation.
+    Removes the fixed dynamic joint so the body is free to move again during
+    dynamic simulation.
 */
 void
-DynamicBody::unfix()
-{
-  fixed = false;
-  setDynJoint(NULL);
+DynamicBody::unfix() {
+    fixed = false;
+    setDynJoint(NULL);
 }
 
 /*!
-  Sets the dynamic joint connected to this body to \a dj.
+    Sets the dynamic joint connected to this body to \a dj.
 */
 void
-DynamicBody::setDynJoint(DynJoint *dj)
-{
-  if (dynJoint) delete dynJoint;
-  dynJoint = dj;
+DynamicBody::setDynJoint(DynJoint *dj) {
+    if (dynJoint) delete dynJoint;
+    dynJoint = dj;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2182,80 +2157,77 @@ DynamicBody::setDynJoint(DynJoint *dj)
 ///////////////////////////////////////////////////////////////////////////////
 
 /*
-  Initializes a robot link.  \a r is the pointer to the robot that owns
-  this link, \a c is the index of the chain this link is in, and \a l is
-  the link number of this link within that chain.
+    Initializes a robot link.  \a r is the pointer to the robot that owns
+    this link, \a c is the index of the chain this link is in, and \a l is
+    the link number of this link within that chain.
 */
-Link::Link(Robot *r,int c, int l,World *w,const char *name) : DynamicBody(w,name)
-{
-  owner = r; chainNum = c; linkNum = l; showVC = false; showFC = false;
+Link::Link(Robot *r, int c, int l, World *w, const char *name) : DynamicBody(w, name) {
+    owner = r;
+    chainNum = c;
+    linkNum = l;
+    showVC = false;
+    showFC = false;
 }
 
 
 /*
-  Stub destructor.
+    Stub destructor.
 */
-Link::~Link()
-{
+Link::~Link() {
 }
 
 
 /*!
-  Sets BOTH the worldElement's AND the robot's \a contactsChanged flag.
+    Sets BOTH the worldElement's AND the robot's \a contactsChanged flag.
 */
 void
-Link::setContactsChanged()
-{
-  WorldElement::setContactsChanged();
-  owner->setContactsChanged();
+Link::setContactsChanged() {
+    WorldElement::setContactsChanged();
+    owner->setContactsChanged();
 }
 /*!
-	This acts like contactPreventMotion, except in the case of a link belonging to a robot.
-	In this case, contact against another link of the same robot does not prevent motion,
-	as we assume the entire robot is moving.
+    This acts like contactPreventMotion, except in the case of a link belonging to a robot.
+    In this case, contact against another link of the same robot does not prevent motion,
+    as we assume the entire robot is moving.
 */
 bool
-Link::externalContactsPreventMotion(const transf& motion)
-{
-	std::list<Contact *>::iterator cp;
-	std::list<Contact *> contactList;
+Link::externalContactsPreventMotion(const transf &motion) {
+    std::list<Contact *>::iterator cp;
+    std::list<Contact *> contactList;
 
-	contactList = getContacts();
-	for (cp=contactList.begin();cp!=contactList.end();cp++) {
-		if ( (*cp)->getBody2()->getOwner() == getOwner() )
-			continue;
-		if ((*cp)->preventsMotion(motion)) {
-			return true;
-		}
-	}
-  return false;
+    contactList = getContacts();
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        if ((*cp)->getBody2()->getOwner() == getOwner())
+            continue;
+        if ((*cp)->preventsMotion(motion)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /*! By convention, in GraspIt! each link's origin is located at the next joint in the chain */
 position
-Link::getDistalJointLocation()
-{
-	return position(0,0,0);
+Link::getDistalJointLocation() {
+    return position(0, 0, 0);
 }
 
 /*! The translation component of the previous joint transform gives me the location of that joint
-	in this joint's coordinate system */
+    in this joint's coordinate system */
 position
-Link::getProximalJointLocation()
-{
-	int jointNum = owner->getChain(chainNum)->getLastJoint(linkNum);
-	Joint *j = owner->getChain(chainNum)->getJoint(jointNum);
-	vec3 p = j->getTran().inverse().translation();
-	return position( p.x(), p.y(), p.z() );
+Link::getProximalJointLocation() {
+    int jointNum = owner->getChain(chainNum)->getLastJoint(linkNum);
+    Joint *j = owner->getChain(chainNum)->getJoint(jointNum);
+    vec3 p = j->getTran().inverse().translation();
+    return position(p.x(), p.y(), p.z());
 }
 
 vec3
-Link::getProximalJointAxis()
-{
-	int jointNum = owner->getChain(chainNum)->getLastJoint(linkNum);
-	Joint *j = owner->getChain(chainNum)->getJoint(jointNum);
-	vec3 r = vec3(0,0,1) * j->getTran().inverse();
-	return r;
+Link::getProximalJointAxis() {
+    int jointNum = owner->getChain(chainNum)->getLastJoint(linkNum);
+    Joint *j = owner->getChain(chainNum)->getJoint(jointNum);
+    vec3 r = vec3(0, 0, 1) * j->getTran().inverse();
+    return r;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2263,47 +2235,42 @@ Link::getProximalJointAxis()
 ///////////////////////////////////////////////////////////////////////////////
 
 /*
-  Stub constructor.
+    Stub constructor.
 */
-GraspableBody::GraspableBody(World *w,const char *name) : DynamicBody(w,name)
-{
-#ifdef CGDB_ENABLED
-	mGraspitDBModel = NULL;
-#endif
+GraspableBody::GraspableBody(World *w, const char *name) : DynamicBody(w, name) {
+    #ifdef CGDB_ENABLED
+    mGraspitDBModel = NULL;
+    #endif
 }
 
 /*
-  Stub destructor.
+    Stub destructor.
 */
-GraspableBody::~GraspableBody()
-{
+GraspableBody::~GraspableBody() {
 
 }
 
 /*! Shows friction cones and axes, and sets transparency to 0.4 */
-void 
-GraspableBody::setDefaultViewingParameters()
-{
-	showFC = true;
-	showVC = true;
-	showAxes(true);
-	setTransparency(0.4f);
+void
+GraspableBody::setDefaultViewingParameters() {
+    showFC = true;
+    showVC = true;
+    showAxes(true);
+    setTransparency(0.4f);
 }
 
 /*! Probably not needed, just calls super*/
 void
-GraspableBody::cloneFrom(const GraspableBody *original) 
-{
-	DynamicBody::cloneFrom(original);
-	setDefaultViewingParameters();
+GraspableBody::cloneFrom(const GraspableBody *original) {
+    DynamicBody::cloneFrom(original);
+    setDefaultViewingParameters();
 }
 
 /*!
-  Output method for writing body data to a text world configuration file
+    Output method for writing body data to a text world configuration file
 */
-QTextStream&
-operator<<(QTextStream &os, const GraspableBody &gb)
-{
-  os << gb.myFilename << endl;
-  return os;
+QTextStream &
+operator<<(QTextStream &os, const GraspableBody &gb) {
+    os << gb.myFilename << endl;
+    return os;
 }

--- a/src/contact.cpp
+++ b/src/contact.cpp
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: contact.cpp,v 1.56 2009/08/14 18:09:43 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Implements the contact class
- */
+/*! \file
+    \brief Implements the contact class
+*/
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -60,582 +60,563 @@ const double Contact::INHERITANCE_THRESHOLD = 1;
 const double Contact::INHERITANCE_ANGULAR_THRESHOLD = 0.984; //cosine of 10 degrees
 
 /*!
-  Initializes a new contact on body \a b1.  The other contacting body is \a b2.
-  The contact position \a pos and the contact normal \a norm are expressed
-  in local body \a b1 coordinates.
+    Initializes a new contact on body \a b1.  The other contacting body is \a b2.
+    The contact position \a pos and the contact normal \a norm are expressed
+    in local body \a b1 coordinates.
 */
-Contact::Contact(Body *b1, Body *b2, position pos, vec3 norm)
-{
-  body1 = b1;
-  body2 = b2;
-  mate = NULL;
-  wrench = NULL;
-  body1Tran = b1->getTran();
-  body2Tran = b2->getTran();
-  
-  updateCof();
-  normal = normalise(norm);
-  loc = pos;
-  vec3 tangentX,tangentY;
+Contact::Contact(Body *b1, Body *b2, position pos, vec3 norm) {
+    body1 = b1;
+    body2 = b2;
+    mate = NULL;
+    wrench = NULL;
+    body1Tran = b1->getTran();
+    body2Tran = b2->getTran();
 
-  if (fabs(normal % vec3(1,0,0)) > 1.0 - MACHINE_ZERO) {
-    tangentX = normalise(normal * vec3(0,0,1));
-  } else {
-    tangentX = normalise(normal * vec3(1,0,0));
-  }
-  tangentY = normalise(normal * tangentX);  
-  frame = coordinate_transf(loc,tangentX,tangentY);			 
-  coneMat = NULL;
-  prevBetas = NULL;
-  inheritanceInfo = false;
-  for (int i=0; i<6; i++) {
-	  dynamicForce[i] = 0;
-  }
+    updateCof();
+    normal = normalise(norm);
+    loc = pos;
+    vec3 tangentX, tangentY;
+
+    if (fabs(normal % vec3(1, 0, 0)) > 1.0 - MACHINE_ZERO) {
+        tangentX = normalise(normal * vec3(0, 0, 1));
+    }
+    else {
+        tangentX = normalise(normal * vec3(1, 0, 0));
+    }
+    tangentY = normalise(normal * tangentX);
+    frame = coordinate_transf(loc, tangentX, tangentY);
+    coneMat = NULL;
+    prevBetas = NULL;
+    inheritanceInfo = false;
+    for (int i = 0; i < 6; i++) {
+        dynamicForce[i] = 0;
+    }
 }
 
 /*!
-  Deletes contact basis vectors, optimal force coefficients, and
-  friction cone boundary wrenches.  If the contact has an undeleted mate,
-  it removes the mate's connection to this contact, and removes the mate
-  contact from the other body (thus deleting it).
+    Deletes contact basis vectors, optimal force coefficients, and
+    friction cone boundary wrenches.  If the contact has an undeleted mate,
+    it removes the mate's connection to this contact, and removes the mate
+    contact from the other body (thus deleting it).
 */
-Contact::~Contact()
-{
-  if (optimalCoeffs) delete [] optimalCoeffs;
-  if (wrench) delete [] wrench;
-  if (prevBetas) delete [] prevBetas;
+Contact::~Contact() {
+    if (optimalCoeffs) delete [] optimalCoeffs;
+    if (wrench) delete [] wrench;
+    if (prevBetas) delete [] prevBetas;
 
-  if (mate) {
-    mate->setMate(NULL);
-    body2->removeContact(mate);
-  }
-  DBGP("Contact deleted");
+    if (mate) {
+        mate->setMate(NULL);
+        body2->removeContact(mate);
+    }
+    DBGP("Contact deleted");
 }
 
-/*! Friction edges contain "normalised" friction information: just the 
-	frictional component, and without reference to normal force or coeff
-	of friction (c.o.f.). They only care about the relationship between 
-	frictional components.
-	
-	To get an actual wrench that can be applied at the contact, we must add
-	normal force (normalised here to 1N) and take into account the relationship
-	btw normal force and c.o.f.
+/*! Friction edges contain "normalised" friction information: just the
+    frictional component, and without reference to normal force or coeff
+    of friction (c.o.f.). They only care about the relationship between
+    frictional components.
+
+    To get an actual wrench that can be applied at the contact, we must add
+    normal force (normalised here to 1N) and take into account the relationship
+    btw normal force and c.o.f.
 */
-void Contact::wrenchFromFrictionEdge(double *edge, const vec3 &radius, Wrench *wr)
-{
-	vec3 tangentX = frame.affine().row(0);
-	vec3 tangentY = frame.affine().row(1);
+void Contact::wrenchFromFrictionEdge(double *edge, const vec3 &radius, Wrench *wr) {
+    vec3 tangentX = frame.affine().row(0);
+    vec3 tangentY = frame.affine().row(1);
 
-	GraspableBody *object = (GraspableBody *)body1;
+    GraspableBody *object = (GraspableBody *)body1;
 
-	//max friction is normal_force_magnitude (which is 1) * coeff_of_friction 
-	//possible friction for this wrench is (friction_edge * max_friction) in the X and Y direction of the contact
-	vec3 forceVec = normal + (tangentX*cof*edge[0])+ (tangentY*cof*edge[1]);
-	
-	//max torque is contact_radius * normal_force_magnitude (which is 1) * coeff_of_friction
-	//possible torque for this wrench is (friction_edge * max_torque) in the direction of the contact normal
-	//the contact_radius coefficient is already taken into account in the friction_edge
-	vec3 torqueVec = ( (radius*forceVec) + normal*cof*edge[5] )/object->getMaxRadius();
-	
-	wr->torque = torqueVec;
-	wr->force = forceVec;
+    //max friction is normal_force_magnitude (which is 1) * coeff_of_friction
+    //possible friction for this wrench is (friction_edge * max_friction) in the X and Y direction of the contact
+    vec3 forceVec = normal + (tangentX * cof * edge[0]) + (tangentY * cof * edge[1]);
+
+    //max torque is contact_radius * normal_force_magnitude (which is 1) * coeff_of_friction
+    //possible torque for this wrench is (friction_edge * max_torque) in the direction of the contact normal
+    //the contact_radius coefficient is already taken into account in the friction_edge
+    vec3 torqueVec = ((radius * forceVec) + normal * cof * edge[5]) / object->getMaxRadius();
+
+    wr->torque = torqueVec;
+    wr->force = forceVec;
 }
 
 /*! Takes the information about pure friction at this contact, contained in the
-	frictionEdges, and adds normal force and the effect of coeff of friction
-	to obtain actual wrenches that can be applied at this contact. Essentially
-	builds the Contact Wrench Space based on the friction information and
-	(normalized) contact forces. See wrenchFromFrictionEdge for details.  
+    frictionEdges, and adds normal force and the effect of coeff of friction
+    to obtain actual wrenches that can be applied at this contact. Essentially
+    builds the Contact Wrench Space based on the friction information and
+    (normalized) contact forces. See wrenchFromFrictionEdge for details.
 */
-void Contact::computeWrenches()
-{
-  DBGP("COMPUTING WRENCHES");
+void Contact::computeWrenches() {
+    DBGP("COMPUTING WRENCHES");
 
-  if (wrench) delete [] wrench;
-  //one wrench for each vector
-  numFCWrenches = numFrictionEdges;
-  wrench = new Wrench[numFCWrenches];
+    if (wrench) delete [] wrench;
+    //one wrench for each vector
+    numFCWrenches = numFrictionEdges;
+    wrench = new Wrench[numFCWrenches];
 
-  vec3 radius = loc - ((GraspableBody*)body1)->getCoG();
-  for (int i=0;i<numFCWrenches;i++) {
-	  wrenchFromFrictionEdge( &frictionEdges[6*i], radius, &wrench[i] );
-	}
+    vec3 radius = loc - ((GraspableBody *)body1)->getCoG();
+    for (int i = 0; i < numFCWrenches; i++) {
+        wrenchFromFrictionEdge(&frictionEdges[6 * i], radius, &wrench[i]);
+    }
 }
 
 
-/*! Sets up the friction edges of this contact using an ellipsoid 
-	approximation. This is convenience function, as friction edges can
-	be set in many ways. However, we currently use PCWF and SFC models
-	which are both cases of linearized ellipsoids, so this function
-	can be used for both.
-	
-	Consider a 3D friction ellipsoid, where the first two dimensions are
-	tangential frictional force (along X and Y) and the third is frictional
-	torque (along Z). This function samples this ellipsoid at \a numLatitudes
-	latitudes contained in \a phi[]; at each latitude l it takes \a numDirs[l] 
-	equally spaced discrete samples. Each of those samples becomes a friction
-	edge, after it is converted to the full 6D space by filling in the other
-	dimensions with zeroes.
- */
+/*! Sets up the friction edges of this contact using an ellipsoid
+    approximation. This is convenience function, as friction edges can
+    be set in many ways. However, we currently use PCWF and SFC models
+    which are both cases of linearized ellipsoids, so this function
+    can be used for both.
+
+    Consider a 3D friction ellipsoid, where the first two dimensions are
+    tangential frictional force (along X and Y) and the third is frictional
+    torque (along Z). This function samples this ellipsoid at \a numLatitudes
+    latitudes contained in \a phi[]; at each latitude l it takes \a numDirs[l]
+    equally spaced discrete samples. Each of those samples becomes a friction
+    edge, after it is converted to the full 6D space by filling in the other
+    dimensions with zeroes.
+*/
 int
-Contact::setUpFrictionEllipsoid(int numLatitudes, int numDirs[], double phi[], double eccen[])
-{
-	numFrictionEdges = 0;
-	for (int i=0;i<numLatitudes;i++) {
-		numFrictionEdges += numDirs[i];
-	}
-	if (numFrictionEdges > MAX_FRICTION_EDGES) return FAILURE;
-	prevBetas = new double[numFrictionEdges];
+Contact::setUpFrictionEllipsoid(int numLatitudes, int numDirs[], double phi[], double eccen[]) {
+    numFrictionEdges = 0;
+    for (int i = 0; i < numLatitudes; i++) {
+        numFrictionEdges += numDirs[i];
+    }
+    if (numFrictionEdges > MAX_FRICTION_EDGES) return FAILURE;
+    prevBetas = new double[numFrictionEdges];
 
-	int col = 0;
-	for (int i=0;i<numLatitudes;i++) {
-		double cosphi = cos(phi[i]);
-		double sinphi = sin(phi[i]);
-		for (int j=0;j<numDirs[i];j++) {
-			double theta = j * 2*M_PI/numDirs[i];
-      
-			double num = cos(theta)*cosphi;
-			double denom = num*num/(eccen[0]*eccen[0]);
-			num = sin(theta)*cosphi;
-			denom += num*num/(eccen[1]*eccen[1]);
-			num = sinphi;
-			denom += num*num/(eccen[2]*eccen[2]);
-			denom = sqrt(denom);
+    int col = 0;
+    for (int i = 0; i < numLatitudes; i++) {
+        double cosphi = cos(phi[i]);
+        double sinphi = sin(phi[i]);
+        for (int j = 0; j < numDirs[i]; j++) {
+            double theta = j * 2 * M_PI / numDirs[i];
 
-			frictionEdges[col*6]   = cos(theta)*cosphi/denom;
-			frictionEdges[col*6+1] = sin(theta)*cosphi/denom;
-			frictionEdges[col*6+2] = 0;
-			frictionEdges[col*6+3] = 0;
-			frictionEdges[col*6+4] = 0;
-			frictionEdges[col*6+5] = sinphi/denom;
-			col++;
-		}    
-	}
-	return SUCCESS;
+            double num = cos(theta) * cosphi;
+            double denom = num * num / (eccen[0] * eccen[0]);
+            num = sin(theta) * cosphi;
+            denom += num * num / (eccen[1] * eccen[1]);
+            num = sinphi;
+            denom += num * num / (eccen[2] * eccen[2]);
+            denom = sqrt(denom);
+
+            frictionEdges[col * 6]   = cos(theta) * cosphi / denom;
+            frictionEdges[col * 6 + 1] = sin(theta) * cosphi / denom;
+            frictionEdges[col * 6 + 2] = 0;
+            frictionEdges[col * 6 + 3] = 0;
+            frictionEdges[col * 6 + 4] = 0;
+            frictionEdges[col * 6 + 5] = sinphi / denom;
+            col++;
+        }
+    }
+    return SUCCESS;
 }
 
 /*! Assembles a friction constraint matrix for this contact that can be used in
-	an LCP. This matrix is of the form [-mu 1 1 ... 1] with a 1 for each friction
-	edge. This is used in a constraint as F * beta <= 0, saying that the sum of
-	friction edge amplitudes (thus friction force) must be less than normal force 
-	times friction coefficient.
+    an LCP. This matrix is of the form [-mu 1 1 ... 1] with a 1 for each friction
+    edge. This is used in a constraint as F * beta <= 0, saying that the sum of
+    friction edge amplitudes (thus friction force) must be less than normal force
+    times friction coefficient.
 */
-Matrix 
-Contact::frictionConstraintsMatrix() const
-{
-	Matrix F(1, 1+numFrictionEdges);
-	F.setAllElements(1.0);
-	F.elem(0,0) = -1.0 * getCof();
-	return F;
+Matrix
+Contact::frictionConstraintsMatrix() const {
+    Matrix F(1, 1 + numFrictionEdges);
+    F.setAllElements(1.0);
+    F.elem(0, 0) = -1.0 * getCof();
+    return F;
 }
 
 /*! Returns the matric that relates friction edge amplitudes to friction force. That
-	matrix is of the form [n D] where n is the contact normal and D has as columns
-	the friction edges. The computations are done in local contact coordinate system
-	(contact normal along the z axis).
+    matrix is of the form [n D] where n is the contact normal and D has as columns
+    the friction edges. The computations are done in local contact coordinate system
+    (contact normal along the z axis).
 */
-Matrix 
-Contact::frictionForceMatrix() const
-{
-	Matrix Rfi(6, numFrictionEdges + 1);
-	//the column for the normal force;
-	//in local contact coordinates the normal always points in the z direction
-	Rfi.elem(0,0) = Rfi.elem(1,0) = 0.0; Rfi.elem(2,0) = 1.0;
-	Rfi.elem(3,0) = Rfi.elem(4,0) = Rfi.elem(5,0) = 0.0;
-	//the columns for the friction edges
-	for(int edge=0; edge<numFrictionEdges; edge++) {
-		for(int i=0; i<6; i++) {
-			Rfi.elem(i, edge+1) = frictionEdges[6*edge+i];
-		}
-	}
-	//flip the sign of Rfi to get contact pointing in the right direction
-	Rfi.multiply(-1.0);
-	return Rfi;
+Matrix
+Contact::frictionForceMatrix() const {
+    Matrix Rfi(6, numFrictionEdges + 1);
+    //the column for the normal force;
+    //in local contact coordinates the normal always points in the z direction
+    Rfi.elem(0, 0) = Rfi.elem(1, 0) = 0.0;
+    Rfi.elem(2, 0) = 1.0;
+    Rfi.elem(3, 0) = Rfi.elem(4, 0) = Rfi.elem(5, 0) = 0.0;
+    //the columns for the friction edges
+    for (int edge = 0; edge < numFrictionEdges; edge++) {
+        for (int i = 0; i < 6; i++) {
+            Rfi.elem(i, edge + 1) = frictionEdges[6 * edge + i];
+        }
+    }
+    //flip the sign of Rfi to get contact pointing in the right direction
+    Rfi.multiply(-1.0);
+    return Rfi;
 }
 
 /*! Creates the individual force matrices for all contacts in the list using
-	frictionConstraintMatrix() then assembles them in block diagonal form.
+    frictionConstraintMatrix() then assembles them in block diagonal form.
 */
 Matrix
-Contact::frictionForceBlockMatrix(const std::list<Contact*> &contacts)
-{
-	if (contacts.empty()) {
-		return Matrix(0,0);
-	}
-	std::list<Matrix*> blocks;
-	std::list<Contact*>::const_iterator it;
-	for (it=contacts.begin(); it!=contacts.end(); it++) {
-		blocks.push_back( new Matrix((*it)->frictionForceMatrix()) );
-	}
-	Matrix Rf(Matrix::BLOCKDIAG<Matrix>(&blocks));
-	while (!blocks.empty()) {
-		delete blocks.back();
-		blocks.pop_back();
-	}
-	return Rf;
+Contact::frictionForceBlockMatrix(const std::list<Contact *> &contacts) {
+    if (contacts.empty()) {
+        return Matrix(0, 0);
+    }
+    std::list<Matrix *> blocks;
+    std::list<Contact *>::const_iterator it;
+    for (it = contacts.begin(); it != contacts.end(); it++) {
+        blocks.push_back(new Matrix((*it)->frictionForceMatrix()));
+    }
+    Matrix Rf(Matrix::BLOCKDIAG<Matrix>(&blocks));
+    while (!blocks.empty()) {
+        delete blocks.back();
+        blocks.pop_back();
+    }
+    return Rf;
 }
 
 /*! Creates the friction constraint matrices of all contacts in the list using
-	Contact::frictionConstraintMatrix(), then assembles all the matrices in 
-	block diagonal form.
+    Contact::frictionConstraintMatrix(), then assembles all the matrices in
+    block diagonal form.
 */
-Matrix 
-Contact::frictionConstraintsBlockMatrix(const std::list<Contact*> &contacts)
-{
-	if (contacts.empty()) {
-		return Matrix(0,0);
-	}
-	std::list<Matrix*> blocks;
-	std::list<Contact*>::const_iterator it;
-	for (it=contacts.begin(); it!=contacts.end(); it++) {
-		blocks.push_back( new Matrix((*it)->frictionConstraintsMatrix()) );
-	}
-	Matrix blockF(Matrix::BLOCKDIAG<Matrix>(&blocks));
-	while (!blocks.empty()) {
-		delete blocks.back();
-		blocks.pop_back();
-	}
-	return blockF;
+Matrix
+Contact::frictionConstraintsBlockMatrix(const std::list<Contact *> &contacts) {
+    if (contacts.empty()) {
+        return Matrix(0, 0);
+    }
+    std::list<Matrix *> blocks;
+    std::list<Contact *>::const_iterator it;
+    for (it = contacts.begin(); it != contacts.end(); it++) {
+        blocks.push_back(new Matrix((*it)->frictionConstraintsMatrix()));
+    }
+    Matrix blockF(Matrix::BLOCKDIAG<Matrix>(&blocks));
+    while (!blocks.empty()) {
+        delete blocks.back();
+        blocks.pop_back();
+    }
+    return blockF;
 }
 
 /*! Creates a line vector that, when multiplied by a vector of contact wrench
-	amplitudes returns the sum of the normal components. Therefore, it has 1
-	in the positions corresponding to normal force amplitudes and 0 in the
-	positions corresponding to friction wrench amplitudes.
+    amplitudes returns the sum of the normal components. Therefore, it has 1
+    in the positions corresponding to normal force amplitudes and 0 in the
+    positions corresponding to friction wrench amplitudes.
 */
-Matrix 
-Contact::normalForceSumMatrix(const std::list<Contact*> &contacts)
-{
-	if (contacts.empty()) {
-		return Matrix(0,0);
-	}
-	std::list<Matrix*> blocks;
-	std::list<Contact*>::const_iterator it;
-	for (it=contacts.begin(); it!=contacts.end(); it++) {
-		blocks.push_back( new Matrix(Matrix::ZEROES<Matrix>(1, (*it)->numFrictionEdges+1)) );
-		blocks.back()->elem(0,0) = 1.0;
-	}
-	Matrix blockF(Matrix::BLOCKROW<Matrix>(&blocks));
-	while (!blocks.empty()) {
-		delete blocks.back();
-		blocks.pop_back();
-	}
-	return blockF;
+Matrix
+Contact::normalForceSumMatrix(const std::list<Contact *> &contacts) {
+    if (contacts.empty()) {
+        return Matrix(0, 0);
+    }
+    std::list<Matrix *> blocks;
+    std::list<Contact *>::const_iterator it;
+    for (it = contacts.begin(); it != contacts.end(); it++) {
+        blocks.push_back(new Matrix(Matrix::ZEROES<Matrix>(1, (*it)->numFrictionEdges + 1)));
+        blocks.back()->elem(0, 0) = 1.0;
+    }
+    Matrix blockF(Matrix::BLOCKROW<Matrix>(&blocks));
+    while (!blocks.empty()) {
+        delete blocks.back();
+        blocks.pop_back();
+    }
+    return blockF;
 }
 
 /*! The matrix, when multiplied with a wrench applied at this contact will give the
-	resultant wrench applied on the other body in contact (thus computed relative
-	to that object's center of mass), expressed in world coordinates.
+    resultant wrench applied on the other body in contact (thus computed relative
+    to that object's center of mass), expressed in world coordinates.
 
-	The matrix looks like this:
-	| R 0 |
-	|CR R |
-	Where R is the 3x3 rotation matrix between the coordinate systems and C also 
-	contains the cross product matrix that depends on the translation between them.	
+    The matrix looks like this:
+    | R 0 |
+    |CR R |
+    Where R is the 3x3 rotation matrix between the coordinate systems and C also
+    contains the cross product matrix that depends on the translation between them.
 */
-Matrix 
-Contact::localToWorldWrenchMatrix() const
-{
-	Matrix Ro(Matrix::ZEROES<Matrix>(6,6));
-	transf contactTran = getContactFrame() * getBody1()->getTran();
-	Matrix Rot( Matrix::ROTATION(contactTran.affine()) );
-	//the force transform is simple, just the matrix that changes coord. systems
-	Ro.copySubMatrix(0, 0, Rot);
-	Ro.copySubMatrix(3, 3, Rot);
-	//for torque we also multiply by a cross product matrix
-	vec3 worldLocation = contactTran.translation();
-	vec3 cog = getBody2()->getTran().translation();
-	mat3 C; C.setCrossProductMatrix(worldLocation - cog); 
-	Matrix CR(3,3);
-	matrixMultiply(Matrix::ROTATION(C.transpose()), Rot, CR);
-	//also scale by object max radius so we get same units as force
-	//and optimization does not favor torque over force
-	double scale = 1.0;
-	if (getBody2()->isA("GraspableBody")) {
-		scale = scale / static_cast<GraspableBody*>(getBody2())->getMaxRadius();
-	}
-	CR.multiply(scale);
-	Ro.copySubMatrix(3, 0, CR);
-	return Ro;
+Matrix
+Contact::localToWorldWrenchMatrix() const {
+    Matrix Ro(Matrix::ZEROES<Matrix>(6, 6));
+    transf contactTran = getContactFrame() * getBody1()->getTran();
+    Matrix Rot(Matrix::ROTATION(contactTran.affine()));
+    //the force transform is simple, just the matrix that changes coord. systems
+    Ro.copySubMatrix(0, 0, Rot);
+    Ro.copySubMatrix(3, 3, Rot);
+    //for torque we also multiply by a cross product matrix
+    vec3 worldLocation = contactTran.translation();
+    vec3 cog = getBody2()->getTran().translation();
+    mat3 C;
+    C.setCrossProductMatrix(worldLocation - cog);
+    Matrix CR(3, 3);
+    matrixMultiply(Matrix::ROTATION(C.transpose()), Rot, CR);
+    //also scale by object max radius so we get same units as force
+    //and optimization does not favor torque over force
+    double scale = 1.0;
+    if (getBody2()->isA("GraspableBody")) {
+        scale = scale / static_cast<GraspableBody *>(getBody2())->getMaxRadius();
+    }
+    CR.multiply(scale);
+    Ro.copySubMatrix(3, 0, CR);
+    return Ro;
 }
 
 /*! Assembles together the localToWorldWrenchMatrix for all the contacts in the list
-	in block diagonal form.
+    in block diagonal form.
 */
-Matrix 
-Contact::localToWorldWrenchBlockMatrix(const std::list<Contact*> &contacts)
-{
-	if (contacts.empty()) {
-		return Matrix(0,0);
-	}
-	std::list<Matrix*> blocks;
-	std::list<Contact*>::const_iterator it;
-	for (it=contacts.begin(); it!=contacts.end(); it++) {
-		blocks.push_back( new Matrix((*it)->localToWorldWrenchMatrix()) );
-	}
-	Matrix Ro(Matrix::BLOCKDIAG<Matrix>(&blocks));
-	while (!blocks.empty()) {
-		delete blocks.back();
-		blocks.pop_back();
-	}
-	return Ro;
+Matrix
+Contact::localToWorldWrenchBlockMatrix(const std::list<Contact *> &contacts) {
+    if (contacts.empty()) {
+        return Matrix(0, 0);
+    }
+    std::list<Matrix *> blocks;
+    std::list<Contact *>::const_iterator it;
+    for (it = contacts.begin(); it != contacts.end(); it++) {
+        blocks.push_back(new Matrix((*it)->localToWorldWrenchMatrix()));
+    }
+    Matrix Ro(Matrix::BLOCKDIAG<Matrix>(&blocks));
+    while (!blocks.empty()) {
+        delete blocks.back();
+        blocks.pop_back();
+    }
+    return Ro;
 }
 
 /*!
-  First computes the new location of the contact point using the motion
-  transform (expressed with respect to the body coordinate frame).  If the
-  dot product of the contact point motion vector and the contact normal is
-  less than zero, then the contact prevents this motion.
+    First computes the new location of the contact point using the motion
+    transform (expressed with respect to the body coordinate frame).  If the
+    dot product of the contact point motion vector and the contact normal is
+    less than zero, then the contact prevents this motion.
 */
-bool Contact::preventsMotion(const transf& motion) const
-{  
-  if ( (loc*motion - loc) % normal < -MACHINE_ZERO) return true;
-  return false;
+bool Contact::preventsMotion(const transf &motion) const {
+    if ((loc * motion - loc) % normal < -MACHINE_ZERO) return true;
+    return false;
 }
 
 
 /*!
-  Recomputes the COF for this contact.  This is called when the material of
-  one of the two bodies is changed.
+    Recomputes the COF for this contact.  This is called when the material of
+    one of the two bodies is changed.
 */
 void
-Contact::updateCof()
-{
-  cof = body1->getWorld()->getCOF(body1->getMaterial(),body2->getMaterial());
-  kcof = body1->getWorld()->getKCOF(body1->getMaterial(),body2->getMaterial());
-  body1->setContactsChanged();
-  body2->setContactsChanged();
+Contact::updateCof() {
+    cof = body1->getWorld()->getCOF(body1->getMaterial(), body2->getMaterial());
+    kcof = body1->getWorld()->getKCOF(body1->getMaterial(), body2->getMaterial());
+    body1->setContactsChanged();
+    body2->setContactsChanged();
 }
 
 /*!
-  Returns the correct coefficient of friction for this contact.  If either
-  body is dynamic, and the relative velocity between them is greater than
-  1.0 mm/sec (should be made a parameter), then it returns the kinetic COF,
-  otherwise it returns the static COF.
+    Returns the correct coefficient of friction for this contact.  If either
+    body is dynamic, and the relative velocity between them is greater than
+    1.0 mm/sec (should be made a parameter), then it returns the kinetic COF,
+    otherwise it returns the static COF.
 */
 double
-Contact::getCof() const
-{
-  DynamicBody *db;
-  vec3 radius,vel1(vec3::ZERO),vel2(vec3::ZERO),rotvel;
+Contact::getCof() const {
+    DynamicBody *db;
+    vec3 radius, vel1(vec3::ZERO), vel2(vec3::ZERO), rotvel;
 
-  if (body1->isDynamic()) {
-    db = (DynamicBody *)body1;
-    radius = db->getTran().rotation() * (loc - db->getCoG());
-    vel1.set(db->getVelocity()[0],db->getVelocity()[1],db->getVelocity()[2]);
-    rotvel.set(db->getVelocity()[3],db->getVelocity()[4],db->getVelocity()[5]);
-    vel1 += radius * rotvel;
-  }
-  if (body2->isDynamic()) {
-    db = (DynamicBody *)body2;
-    radius = db->getTran().rotation() * (mate->loc - db->getCoG());
-    vel2.set(db->getVelocity()[0],db->getVelocity()[1],db->getVelocity()[2]);
-    rotvel.set(db->getVelocity()[3],db->getVelocity()[4],db->getVelocity()[5]);
-    vel2 += radius * rotvel;
-  }
-  if ((vel1 - vel2).len() > 1.0) {
-    DBGP("SLIDING!");
-    return kcof;
-  }
-  else return cof;
+    if (body1->isDynamic()) {
+        db = (DynamicBody *)body1;
+        radius = db->getTran().rotation() * (loc - db->getCoG());
+        vel1.set(db->getVelocity()[0], db->getVelocity()[1], db->getVelocity()[2]);
+        rotvel.set(db->getVelocity()[3], db->getVelocity()[4], db->getVelocity()[5]);
+        vel1 += radius * rotvel;
+    }
+    if (body2->isDynamic()) {
+        db = (DynamicBody *)body2;
+        radius = db->getTran().rotation() * (mate->loc - db->getCoG());
+        vel2.set(db->getVelocity()[0], db->getVelocity()[1], db->getVelocity()[2]);
+        rotvel.set(db->getVelocity()[3], db->getVelocity()[4], db->getVelocity()[5]);
+        vel2 += radius * rotvel;
+    }
+    if ((vel1 - vel2).len() > 1.0) {
+        DBGP("SLIDING!");
+        return kcof;
+    }
+    else return cof;
 }
 
 /*!
-  When the grasp force optimization completes it calls this routine to set
-  this contact's optimal force.  This force is a compromise between minimizing
-  internal grasp forces and how close the force is to the boundary of the
-  friction cone, or starting to slip.
+    When the grasp force optimization completes it calls this routine to set
+    this contact's optimal force.  This force is a compromise between minimizing
+    internal grasp forces and how close the force is to the boundary of the
+    friction cone, or starting to slip.
 */
 void
-Contact::setContactForce (double *optmx)
-{
-  for (int i=0;i<contactDim;i++)
-    optimalCoeffs[i] = optmx[i];
+Contact::setContactForce(double *optmx) {
+    for (int i = 0; i < contactDim; i++)
+        optimalCoeffs[i] = optmx[i];
 }
 
 /*!
-  Each body has a thin layer around it that is Contact::THRESHOLD mm thick, and
-  when another body is within that layer, the two bodies are in contact.
-  During dynamic simulation, contacts provide constraints to prevent the two
-  bodies from interpenetrating.  However, the constraint is a velocity
-  constraint not a position one, so errors in position due to numerical issues
-  can occur.  If the two bodies get closer than half the contact threshold,
-  we correct this specifying a constraint error in the dynamics, which will
-  serve to move the bodies apart.  This routine returns the distance that
-  two bodies have violated that halfway constraint.
+    Each body has a thin layer around it that is Contact::THRESHOLD mm thick, and
+    when another body is within that layer, the two bodies are in contact.
+    During dynamic simulation, contacts provide constraints to prevent the two
+    bodies from interpenetrating.  However, the constraint is a velocity
+    constraint not a position one, so errors in position due to numerical issues
+    can occur.  If the two bodies get closer than half the contact threshold,
+    we correct this specifying a constraint error in the dynamics, which will
+    serve to move the bodies apart.  This routine returns the distance that
+    two bodies have violated that halfway constraint.
 */
 double
-Contact::getConstraintError()
-{
-	transf cf = frame * body1->getTran();
-	transf cf2 = mate->getContactFrame() * body2->getTran();
-	return MAX(0.0,Contact::THRESHOLD/2.0 - (cf.translation() - cf2.translation()).len());
+Contact::getConstraintError() {
+    transf cf = frame * body1->getTran();
+    transf cf2 = mate->getContactFrame() * body2->getTran();
+    return MAX(0.0, Contact::THRESHOLD / 2.0 - (cf.translation() - cf2.translation()).len());
 }
 
-/*! Attempts to save some information from a previously computed dynamics 
-	time step. The contact \a c is from the previous time step, but has been 
-	determined to be close enough to this one that it is probably the same
-	contact, having slightly evolved over a time step.
+/*! Attempts to save some information from a previously computed dynamics
+    time step. The contact \a c is from the previous time step, but has been
+    determined to be close enough to this one that it is probably the same
+    contact, having slightly evolved over a time step.
 */
 void
-Contact::inherit(Contact *c)
-{
-	inheritanceInfo = true;
-	setLCPInfo( c->getPrevCn(), c->getPrevLambda(), c->getPrevBetas() );
-	/*
-	if (!coneMat || !c->coneMat) {
-		return;
-	}
-	coneR = c->coneR;
-	coneG = c->coneG;
-	coneB = c->coneB;
-	coneMat->diffuseColor = SbColor( coneR, coneG, coneB);
-	coneMat->ambientColor = SbColor( coneR, coneG, coneB);
-	coneMat->emissiveColor = SbColor( coneR, coneG, coneB);
-	*/
+Contact::inherit(Contact *c) {
+    inheritanceInfo = true;
+    setLCPInfo(c->getPrevCn(), c->getPrevLambda(), c->getPrevBetas());
+    /*
+        if (!coneMat || !c->coneMat) {
+        return;
+        }
+        coneR = c->coneR;
+        coneG = c->coneG;
+        coneB = c->coneB;
+        coneMat->diffuseColor = SbColor( coneR, coneG, coneB);
+        coneMat->ambientColor = SbColor( coneR, coneG, coneB);
+        coneMat->emissiveColor = SbColor( coneR, coneG, coneB);
+    */
 }
 
 void
-Contact::setLCPInfo(double cn, double l, double *betas)
-{
-	prevCn = cn;
-	prevLambda = l;
-	for (int i=0; i<numFrictionEdges; i++) {
-		prevBetas[i] = betas[i];
-	}
-	//lambda is the LCP paramter that indicates contact slip
-	if (l>0) mSlip = true;
-	else mSlip = false;
+Contact::setLCPInfo(double cn, double l, double *betas) {
+    prevCn = cn;
+    prevLambda = l;
+    for (int i = 0; i < numFrictionEdges; i++) {
+        prevBetas[i] = betas[i];
+    }
+    //lambda is the LCP paramter that indicates contact slip
+    if (l > 0) mSlip = true;
+    else mSlip = false;
 }
 
 ///////////////////////////////////////////
 // Point contact
 ///////////////////////////////////////////
 
-PointContact::PointContact(Body *b1,Body *b2,position pos, vec3 norm) : 
-				Contact( b1, b2, pos, norm )
-{
-	//we should really have another class for the FL contact
-	if (cof == 0.0) {
-		frictionType = FL;
-		contactDim = 1;
-		lmiDim = 1;
-	} else {
-		frictionType = PCWF;
-		contactDim = 3;
-		lmiDim = 3;
-	}
-	optimalCoeffs = new double[contactDim]; 
-	setUpFrictionEdges();
+PointContact::PointContact(Body *b1, Body *b2, position pos, vec3 norm) :
+    Contact(b1, b2, pos, norm) {
+    //we should really have another class for the FL contact
+    if (cof == 0.0) {
+        frictionType = FL;
+        contactDim = 1;
+        lmiDim = 1;
+    }
+    else {
+        frictionType = PCWF;
+        contactDim = 3;
+        lmiDim = 3;
+    }
+    optimalCoeffs = new double[contactDim];
+    setUpFrictionEdges();
 }
 
-PointContact::~PointContact()
-{
+PointContact::~PointContact() {
 }
 
 /*! Set up friction as a linearized circle; a PCWF can only have friction
-	forces (no torques) in the tangential plane of the contact. When normal
-	force will be added later, the friction circle becomes the more 
-	familiar contact cone.
+    forces (no torques) in the tangential plane of the contact. When normal
+    force will be added later, the friction circle becomes the more
+    familiar contact cone.
 */
-int PointContact::setUpFrictionEdges(bool dynamicsOn)
-{
+int PointContact::setUpFrictionEdges(bool dynamicsOn) {
 
-	if (dynamicsOn) {
-		//we don't really need to update anything; friction edges for point contacts do not change
-		//during dynamic simulation
-		return 0;
-	}
-	double eccen[3] = {1,1,1};
-	int numDirs[1] = {8};
-	double phi[1] = {0.0};
-	return setUpFrictionEllipsoid(1,numDirs,phi,eccen); 
+    if (dynamicsOn) {
+        //we don't really need to update anything; friction edges for point contacts do not change
+        //during dynamic simulation
+        return 0;
+    }
+    double eccen[3] = {1, 1, 1};
+    int numDirs[1] = {8};
+    double phi[1] = {0.0};
+    return setUpFrictionEllipsoid(1, numDirs, phi, eccen);
 }
 
 /*! Return a visual indicator showing the contact cone */
-SoSeparator* 
-PointContact::getVisualIndicator()
-{
-	double height,alpha,cof;
-	SoSeparator *cne;
-	SoTransform *tran;
-	SoIndexedFaceSet *ifs;
-	SoCoordinate3 *coords;
+SoSeparator *
+PointContact::getVisualIndicator() {
+    double height, alpha, cof;
+    SoSeparator *cne;
+    SoTransform *tran;
+    SoIndexedFaceSet *ifs;
+    SoCoordinate3 *coords;
 
-	SbVec3f *points = new SbVec3f[numFrictionEdges+1];
-	int32_t *cIndex = new int32_t[5*numFrictionEdges+1];
-	int i;
+    SbVec3f *points = new SbVec3f[numFrictionEdges + 1];
+    int32_t *cIndex = new int32_t[5 * numFrictionEdges + 1];
+    int i;
 
-	points[0].setValue(0,0,0);
+    points[0].setValue(0, 0, 0);
 
-	//this is now a member of the class so no need to declare it here
-	coneMat = new SoMaterial;  
+    //this is now a member of the class so no need to declare it here
+    coneMat = new SoMaterial;
 
-    coneMat->diffuseColor = SbColor(0.8f,0.0f,0.0f);
-    coneMat->ambientColor = SbColor(0.2f,0.0f,0.0f);
-    coneMat->emissiveColor = SbColor(0.4f,0.0f,0.0f);
-/*
-	coneR = ((float)rand())/RAND_MAX;
-	coneG = ((float)rand())/RAND_MAX;
-	coneB = ((float)rand())/RAND_MAX;
+    coneMat->diffuseColor = SbColor(0.8f, 0.0f, 0.0f);
+    coneMat->ambientColor = SbColor(0.2f, 0.0f, 0.0f);
+    coneMat->emissiveColor = SbColor(0.4f, 0.0f, 0.0f);
+    /*
+        coneR = ((float)rand())/RAND_MAX;
+        coneG = ((float)rand())/RAND_MAX;
+        coneB = ((float)rand())/RAND_MAX;
 
-	coneMat->diffuseColor = SbColor(coneR, coneG, coneB);
-	coneMat->ambientColor = SbColor(coneR, coneG, coneB);
-	coneMat->emissiveColor = SbColor(coneR, coneG, coneB);
-*/
+        coneMat->diffuseColor = SbColor(coneR, coneG, coneB);
+        coneMat->ambientColor = SbColor(coneR, coneG, coneB);
+        coneMat->emissiveColor = SbColor(coneR, coneG, coneB);
+    */
     coneMat->transparency = 0.8f;
 
-    SoMaterial* zaxisMat = new SoMaterial;  
-    zaxisMat->diffuseColor = SbColor(0,0,0);
-    zaxisMat->ambientColor = SbColor(0,0,0);
+    SoMaterial *zaxisMat = new SoMaterial;
+    zaxisMat->diffuseColor = SbColor(0, 0, 0);
+    zaxisMat->ambientColor = SbColor(0, 0, 0);
 
-	cof = getCof();
+    cof = getCof();
 
-	height = Body::CONE_HEIGHT;
-	cne = new SoSeparator;
-	coords = new SoCoordinate3;
-	ifs = new SoIndexedFaceSet;
-	tran = new SoTransform;
-  
-	alpha = 0.0;
-	for (i=0;i<numFrictionEdges;i++) {
-		points[i+1].setValue(cos(alpha)*cof,sin(alpha)*cof,1.0);
-		points[i+1] *= height;
-		cIndex[4*i] = 0;
-		cIndex[4*i+1] = (i+2 <= numFrictionEdges ? i+2 : 1);
-		cIndex[4*i+2] =  i+1;
-		cIndex[4*i+3] = -1;
-		cIndex[4*numFrictionEdges+i] = i+1;
-		alpha += 2.0*M_PI/numFrictionEdges;
-	}
-	cIndex[5*numFrictionEdges] = -1;
-  
-	coords->point.setValues(0,numFrictionEdges+1,points);
-	ifs->coordIndex.setValues(0,5*numFrictionEdges+1,cIndex);
-	delete [] points;
-	delete [] cIndex;
+    height = Body::CONE_HEIGHT;
+    cne = new SoSeparator;
+    coords = new SoCoordinate3;
+    ifs = new SoIndexedFaceSet;
+    tran = new SoTransform;
 
-	getContactFrame().toSoTransform(tran);
-  
-	SoCylinder *zaxisCyl = new SoCylinder;
-	zaxisCyl->radius = 0.05f;
-	zaxisCyl->height = height;
-  
-	SoTransform *zaxisTran = new SoTransform;
-	zaxisTran->translation.setValue(0,0,height/2.0);
-	zaxisTran->rotation.setValue(SbVec3f(1,0,0),(float)M_PI/2.0f);
-  
-	SoSeparator *zaxisSep = new SoSeparator;
-	zaxisSep->addChild(zaxisTran);
-	zaxisSep->addChild(zaxisMat);
-	zaxisSep->addChild(zaxisCyl);
-  
-	cne->addChild(tran);
-	cne->addChild(zaxisSep);
-	cne->addChild(coneMat);
-	cne->addChild(coords);
-	cne->addChild(ifs);
-	return cne;
+    alpha = 0.0;
+    for (i = 0; i < numFrictionEdges; i++) {
+        points[i + 1].setValue(cos(alpha)*cof, sin(alpha)*cof, 1.0);
+        points[i + 1] *= height;
+        cIndex[4 * i] = 0;
+        cIndex[4 * i + 1] = (i + 2 <= numFrictionEdges ? i + 2 : 1);
+        cIndex[4 * i + 2] =  i + 1;
+        cIndex[4 * i + 3] = -1;
+        cIndex[4 * numFrictionEdges + i] = i + 1;
+        alpha += 2.0 * M_PI / numFrictionEdges;
+    }
+    cIndex[5 * numFrictionEdges] = -1;
+
+    coords->point.setValues(0, numFrictionEdges + 1, points);
+    ifs->coordIndex.setValues(0, 5 * numFrictionEdges + 1, cIndex);
+    delete [] points;
+    delete [] cIndex;
+
+    getContactFrame().toSoTransform(tran);
+
+    SoCylinder *zaxisCyl = new SoCylinder;
+    zaxisCyl->radius = 0.05f;
+    zaxisCyl->height = height;
+
+    SoTransform *zaxisTran = new SoTransform;
+    zaxisTran->translation.setValue(0, 0, height / 2.0);
+    zaxisTran->rotation.setValue(SbVec3f(1, 0, 0), (float)M_PI / 2.0f);
+
+    SoSeparator *zaxisSep = new SoSeparator;
+    zaxisSep->addChild(zaxisTran);
+    zaxisSep->addChild(zaxisMat);
+    zaxisSep->addChild(zaxisCyl);
+
+    cne->addChild(tran);
+    cne->addChild(zaxisSep);
+    cne->addChild(coneMat);
+    cne->addChild(coords);
+    cne->addChild(ifs);
+    return cne;
 }
 
 //////////////////////////////////////////////////////////
@@ -643,480 +624,473 @@ PointContact::getVisualIndicator()
 //////////////////////////////////////////////////////////
 
 /*! Does not set up friction edges yet; we need to wait until the mate of
-	this contact is also defined because we will need its own analytical
-	surface before we can come up with friction edges.
+    this contact is also defined because we will need its own analytical
+    surface before we can come up with friction edges.
 */
-SoftContact::SoftContact( Body *b1, Body *b2, position pos, vec3 norm,
-						 Neighborhood *bn ) : Contact(b1, b2, pos, norm)
-{ 
-	frictionType = SFCL;
-	contactDim = 4;
-	lmiDim = 4;
-	optimalCoeffs = new double[contactDim]; 
+SoftContact::SoftContact(Body *b1, Body *b2, position pos, vec3 norm,
+                         Neighborhood *bn) : Contact(b1, b2, pos, norm) {
+    frictionType = SFCL;
+    contactDim = 4;
+    lmiDim = 4;
+    optimalCoeffs = new double[contactDim];
 
-	bodyNghbd =  new vec3[ (int) bn->size() ];
-	Neighborhood::iterator itr;
-	int i = 0;
-	vec3 temp;
-	
-	for( itr = bn->begin(); itr != bn->end(); itr++ ) {
-		temp.set(itr->x(), itr->y(), itr->z());
-		//places bodyNghbd in frame of contact with the z-axis pointing out
-		//bodyNghbd[i] = frame.affine().inverse() * ( temp - frame.translation() );
-		position posit;
-		posit = position( temp.toSbVec3f() ) * frame.inverse();
-		bodyNghbd[i] = vec3( posit.toSbVec3f() );
-		i++;
-	}
-	numPts = (int) bn->size();
-	majorAxis = 0.0;
-	minorAxis = 0.0;
-	relPhi = 0.0;
-	a = 0; b = 0; c = 0;
-	r1 = 0; r2 = 0;
-	r1prime = 0; r2prime = 0;
+    bodyNghbd =  new vec3[(int) bn->size() ];
+    Neighborhood::iterator itr;
+    int i = 0;
+    vec3 temp;
 
-	FitPoints();
+    for (itr = bn->begin(); itr != bn->end(); itr++) {
+        temp.set(itr->x(), itr->y(), itr->z());
+        //places bodyNghbd in frame of contact with the z-axis pointing out
+        //bodyNghbd[i] = frame.affine().inverse() * ( temp - frame.translation() );
+        position posit;
+        posit = position(temp.toSbVec3f()) * frame.inverse();
+        bodyNghbd[i] = vec3(posit.toSbVec3f());
+        i++;
+    }
+    numPts = (int) bn->size();
+    majorAxis = 0.0;
+    minorAxis = 0.0;
+    relPhi = 0.0;
+    a = 0;
+    b = 0;
+    c = 0;
+    r1 = 0;
+    r2 = 0;
+    r1prime = 0;
+    r2prime = 0;
 
-	//setUpFrictionEdges();
-	//wait to set these up until other contact is made
+    FitPoints();
+
+    //setUpFrictionEdges();
+    //wait to set these up until other contact is made
 }
 
-SoftContact::~SoftContact()
-{
-	delete[]bodyNghbd;
+SoftContact::~SoftContact() {
+    delete[]bodyNghbd;
 }
 
 /*! Sets up friction edges as a 3D friction ellipsoid. All the computations for
-	fitting analytical surfaces to the two bodies should already have been 
-	completed.
+    fitting analytical surfaces to the two bodies should already have been
+    completed.
 */
-int SoftContact::setUpFrictionEdges(bool dynamicsOn )
-{
-	if( !getMate() ) {
-		fprintf(stderr,"Trying to set up friction edges for a contact with no mate!!\n");
-		return 1;
-	}
+int SoftContact::setUpFrictionEdges(bool dynamicsOn) {
+    if (!getMate()) {
+        fprintf(stderr, "Trying to set up friction edges for a contact with no mate!!\n");
+        return 1;
+    }
 
-	DBGP("Setting up SOFT contact friction edges");
-	double eccen[3];
+    DBGP("Setting up SOFT contact friction edges");
+    double eccen[3];
 
-	// magnitude of tangential friction
-	eccen[0]=1;
-	eccen[1]=1;
-	// magnitude of max frictional torque
-	double torquedivN;
+    // magnitude of tangential friction
+    eccen[0] = 1;
+    eccen[1] = 1;
+    // magnitude of max frictional torque
+    double torquedivN;
 
-	// relative radii of curvature at the contact
-	CalcRprimes();
+    // relative radii of curvature at the contact
+    CalcRprimes();
 
-	if (!dynamicsOn) {
-		// if dynamics are not on, compute it based on some random applied force
-		torquedivN = CalcContact_Mattress( 5 );
-		eccen[2] = torquedivN*1000;
-	} else {
-		// if dynamics are on, compute it based on the applied force reported by the LCP
-		double nForce = dynamicForce[2];
-		//need to figure out what all the numbers in the dynamic force mean
-		//I think it is a wrench, and hope it is in the contacts coordinate frame
-		//and that the units are in newtons, chekc dynamics.cpp iterateDynamics where
-		//it is created
-		torquedivN = CalcContact_Mattress( nForce );
-		eccen[2] = torquedivN*1000;
-	}
+    if (!dynamicsOn) {
+        // if dynamics are not on, compute it based on some random applied force
+        torquedivN = CalcContact_Mattress(5);
+        eccen[2] = torquedivN * 1000;
+    }
+    else {
+        // if dynamics are on, compute it based on the applied force reported by the LCP
+        double nForce = dynamicForce[2];
+        //need to figure out what all the numbers in the dynamic force mean
+        //I think it is a wrench, and hope it is in the contacts coordinate frame
+        //and that the units are in newtons, chekc dynamics.cpp iterateDynamics where
+        //it is created
+        torquedivN = CalcContact_Mattress(nForce);
+        eccen[2] = torquedivN * 1000;
+    }
 
-	//various possible approximations for the friction ellipsoid
+    //various possible approximations for the friction ellipsoid
 
-	/*
-	int numDirs[9] = {1,3,5,7,8,7,5,3,1};
-	double phi[9] = {M_PI_2, M_PI_2*0.6, M_PI_2*0.3, M_PI_2*0.15, 0.0,
+    /*
+        int numDirs[9] = {1,3,5,7,8,7,5,3,1};
+        double phi[9] = {M_PI_2, M_PI_2*0.6, M_PI_2*0.3, M_PI_2*0.15, 0.0,
                      -M_PI_2*0.15, -M_PI_2*0.3, -M_PI_2*0.6, -M_PI_2};
-	return Contact::setUpFrictionEdges(9,numDirs,phi,eccen);
-	*/
+        return Contact::setUpFrictionEdges(9,numDirs,phi,eccen);
+    */
 
-	/*
-	int numDirs[9] = {1,8,8,8,8,8,8,8,1};
-	double phi[9] = {M_PI_2, M_PI_2*0.66, M_PI_2*0.33, M_PI_2*0.165, 0.0,
-				  -M_PI_2*0.165, -M_PI_2*0.33, -M_PI_2*0.66, -M_PI_2};
-	return Contact::setUpFrictionEdges(9,numDirs,phi,eccen);
-	*/
-	
-	int numDirs[5] = {1,5,8,5,1};
-	double phi[5] = {M_PI_2, M_PI_2*0.50, 0.0, -M_PI_2*0.50, -M_PI_2};
-	return Contact::setUpFrictionEllipsoid( 5, numDirs, phi, eccen );
+    /*
+        int numDirs[9] = {1,8,8,8,8,8,8,8,1};
+        double phi[9] = {M_PI_2, M_PI_2*0.66, M_PI_2*0.33, M_PI_2*0.165, 0.0,
+                  -M_PI_2*0.165, -M_PI_2*0.33, -M_PI_2*0.66, -M_PI_2};
+        return Contact::setUpFrictionEdges(9,numDirs,phi,eccen);
+    */
+
+    int numDirs[5] = {1, 5, 8, 5, 1};
+    double phi[5] = {M_PI_2, M_PI_2 * 0.50, 0.0, -M_PI_2 * 0.50, -M_PI_2};
+    return Contact::setUpFrictionEllipsoid(5, numDirs, phi, eccen);
 }
 
 /*! The Soft Contact version of computeWrenches can also take into
-	account the fact that a soft contact can generate some moments in
-	the plane of the contacts. It creates wrenches like the regular
-	contact, but multiple times, moving the location of the force around
-	the area of contact. Currently disabled.
- */
-void SoftContact::computeWrenches()
-{
-	bool approxPlaneMoments = false;
+    account the fact that a soft contact can generate some moments in
+    the plane of the contacts. It creates wrenches like the regular
+    contact, but multiple times, moving the location of the force around
+    the area of contact. Currently disabled.
+*/
+void SoftContact::computeWrenches() {
+    bool approxPlaneMoments = false;
 
-	if (!approxPlaneMoments) {
-		Contact::computeWrenches();
-		return;
-	}
+    if (!approxPlaneMoments) {
+        Contact::computeWrenches();
+        return;
+    }
 
-	//for now we hard-code 4 possible locations for the contact
-	//on 4 points around the perimeter of the ellipse
+    //for now we hard-code 4 possible locations for the contact
+    //on 4 points around the perimeter of the ellipse
 
-	//we also approximate the ellipse with a circle of radius sqrt(majorAxis * minorAxis) 
-	//because for now we don't really compute the direction of the major axis
+    //we also approximate the ellipse with a circle of radius sqrt(majorAxis * minorAxis)
+    //because for now we don't really compute the direction of the major axis
 
-	//when we do, we will have to transform the tangents by:
-	// - the transform that aligns it with the major radius of the paraboloid
-	// - the transform that further moves that to the major axis of the contact ellipse
+    //when we do, we will have to transform the tangents by:
+    // - the transform that aligns it with the major radius of the paraboloid
+    // - the transform that further moves that to the major axis of the contact ellipse
 
-	if (wrench) delete [] wrench;
-	numFCWrenches = 4 * numFrictionEdges;
-	wrench = new Wrench[numFCWrenches];
+    if (wrench) delete [] wrench;
+    numFCWrenches = 4 * numFrictionEdges;
+    wrench = new Wrench[numFCWrenches];
 
-	vec3 tangentX = frame.affine().row(0);
-	vec3 tangentY = frame.affine().row(1);
-	
-	vec3 radius;
-	vec3 baseRadius = loc - ((GraspableBody*)body1)->getCoG();
+    vec3 tangentX = frame.affine().row(0);
+    vec3 tangentY = frame.affine().row(1);
 
-	float a,b;
-	a = b = 1000 * sqrt(majorAxis * minorAxis); //also convert to milimeters
-	a = b = 1000 * std::max(majorAxis, minorAxis);
+    vec3 radius;
+    vec3 baseRadius = loc - ((GraspableBody *)body1)->getCoG();
 
-	DBGA("Soft contact size: " << a);
+    float a, b;
+    a = b = 1000 * sqrt(majorAxis * minorAxis); //also convert to milimeters
+    a = b = 1000 * std::max(majorAxis, minorAxis);
 
-	for (int i=0;i<numFrictionEdges;i++) {
-		radius = baseRadius + ( a * tangentX );
-		wrenchFromFrictionEdge( &frictionEdges[6*i], radius, &wrench[4*i+0] );
+    DBGA("Soft contact size: " << a);
 
-		radius = baseRadius - ( a * tangentX );
-		wrenchFromFrictionEdge( &frictionEdges[6*i], radius, &wrench[4*i+1] );
+    for (int i = 0; i < numFrictionEdges; i++) {
+        radius = baseRadius + (a * tangentX);
+        wrenchFromFrictionEdge(&frictionEdges[6 * i], radius, &wrench[4 * i + 0]);
 
-		radius = baseRadius + ( b * tangentY );
-		wrenchFromFrictionEdge( &frictionEdges[6*i], radius, &wrench[4*i+2] );
+        radius = baseRadius - (a * tangentX);
+        wrenchFromFrictionEdge(&frictionEdges[6 * i], radius, &wrench[4 * i + 1]);
 
-		radius = baseRadius - ( b * tangentY );
-		wrenchFromFrictionEdge( &frictionEdges[6*i], radius, &wrench[4*i+3] );
-	}
-	DBGA("Soft wrenches computed");
+        radius = baseRadius + (b * tangentY);
+        wrenchFromFrictionEdge(&frictionEdges[6 * i], radius, &wrench[4 * i + 2]);
+
+        radius = baseRadius - (b * tangentY);
+        wrenchFromFrictionEdge(&frictionEdges[6 * i], radius, &wrench[4 * i + 3]);
+    }
+    DBGA("Soft wrenches computed");
 }
 
 /*! Computes an analytical surface of the form ax^2 + bx + c in a small patch
-	around the contact on body1. The fit is in the local body1 coordinate 
-	system.
+    around the contact on body1. The fit is in the local body1 coordinate
+    system.
 */
-void SoftContact::FitPoints( )
-{
-	double *coeffs = new double [3];
-	FitParaboloid( bodyNghbd, numPts, coeffs );
+void SoftContact::FitPoints() {
+    double *coeffs = new double [3];
+    FitParaboloid(bodyNghbd, numPts, coeffs);
 
-	a = coeffs[0];
-	b = coeffs[1];
-	c = coeffs[2];
+    a = coeffs[0];
+    b = coeffs[1];
+    c = coeffs[2];
 
-	RotateParaboloid( coeffs, &r1, &r2, &fitRot, &fitRotAngle );
-	DBGP(getBody1()->getName().latin1() << ": " << "a=" << a << " b=" << b << " c=" <<c);
-	DBGP("r1=" << r1 << " r2=" <<r2);
+    RotateParaboloid(coeffs, &r1, &r2, &fitRot, &fitRotAngle);
+    DBGP(getBody1()->getName().latin1() << ": " << "a=" << a << " b=" << b << " c=" << c);
+    DBGP("r1=" << r1 << " r2=" << r2);
 }
 
-/*! Calculates the angle betwen the main radius curvature on body1 and the 
-	main radius of curvature on body 2.
+/*! Calculates the angle betwen the main radius curvature on body1 and the
+    main radius of curvature on body 2.
 */
-int SoftContact::CalcRelPhi( )
-{
-	vec3 temp, t;
-	vec3 R11, R12;		//directions of relative curvatures in world frame
+int SoftContact::CalcRelPhi() {
+    vec3 temp, t;
+    vec3 R11, R12;      //directions of relative curvatures in world frame
 
-	temp.set( 1, 0 , 0);
-	t = fitRot * temp;
-	R11 = t * frame;
-	R11 = R11 * body1->getTran();
+    temp.set(1, 0 , 0);
+    t = fitRot * temp;
+    R11 = t * frame;
+    R11 = R11 * body1->getTran();
 
-	temp.set( 1, 0 , 0);
-	t = ((SoftContact *)getMate())->fitRot * temp;
-	R12 = t * ((SoftContact *)getMate())->frame;
-	R12 = R12 * body2->getTran();
+    temp.set(1, 0 , 0);
+    t = ((SoftContact *)getMate())->fitRot * temp;
+    R12 = t * ((SoftContact *)getMate())->frame;
+    R12 = R12 * body2->getTran();
 
-	relPhi = acos( (R11%R12)/(R11.len()*R12.len()) );
-	((SoftContact *)getMate())->relPhi = relPhi ;
+    relPhi = acos((R11 % R12) / (R11.len() * R12.len()));
+    ((SoftContact *)getMate())->relPhi = relPhi ;
 
-	//fprintf( stderr, "Rel Phi   %f", relPhi );
-	return 0;	
+    //fprintf( stderr, "Rel Phi   %f", relPhi );
+    return 0;
 }
 
 /*! Calculates the relative radii of curvature of the contact, using the
-	radii of curvature of both bodies and the angle between them. 
-	See Johnson, Contact Mechanics Chapter 4 page 85 for calculations.
+    radii of curvature of both bodies and the angle between them.
+    See Johnson, Contact Mechanics Chapter 4 page 85 for calculations.
 */
-int SoftContact::CalcRprimes()
-{
-	if( !(getMate()) ) {
-		DBGA("Contact doesn't have mate, not calculating curvature...");
-		return 1;
-	}
+int SoftContact::CalcRprimes() {
+    if (!(getMate())) {
+        DBGA("Contact doesn't have mate, not calculating curvature...");
+        return 1;
+    }
 
-	SoftContact *m = (SoftContact *)getMate();
+    SoftContact *m = (SoftContact *)getMate();
 
-	CalcRelPhi();
+    CalcRelPhi();
 
-	DBGP("Body 1" << getBody1()->getName().latin1() << " Body 2 " << m->getBody1()->getName().latin1());
+    DBGP("Body 1" << getBody1()->getName().latin1() << " Body 2 " << m->getBody1()->getName().latin1());
 
-	//the less than zero curvature is for flat objects
-	//1/r goes to zero for flat objects because the curvature
-	//is infinite
-	double x,y,w,z;
-	if( r1 < 0.0 )
-		w = 0.0;
-	else
-		w = 1/r1;
+    //the less than zero curvature is for flat objects
+    //1/r goes to zero for flat objects because the curvature
+    //is infinite
+    double x, y, w, z;
+    if (r1 < 0.0)
+        w = 0.0;
+    else
+        w = 1 / r1;
 
-	if( r2 < 0.0 )
-		x = 0.0;
-	else
-		x = 1/r2;	
+    if (r2 < 0.0)
+        x = 0.0;
+    else
+        x = 1 / r2;
 
-	if( m->r1 < 0.0 )
-		y = 0.0;
-	else
-		y = 1/m->r1;
+    if (m->r1 < 0.0)
+        y = 0.0;
+    else
+        y = 1 / m->r1;
 
-	if( m->r2 < 0.0 )
-		z = 0.0;
-	else
-		z = 1/m->r2;
+    if (m->r2 < 0.0)
+        z = 0.0;
+    else
+        z = 1 / m->r2;
 
-	DBGP("x: " << x << " y: " << y << " w: " << w << " z: " << z);
+    DBGP("x: " << x << " y: " << y << " w: " << w << " z: " << z);
 
-	double ApB = 0.5*( w + x + y + z );
+    double ApB = 0.5 * (w + x + y + z);
 
-	DBGP("Apb: " << ApB);
+    DBGP("Apb: " << ApB);
 
-	double AmB = 0.5*sqrt( (w - x)*(w - x) + (y - z)*(y - z) +
-					2*cos(2*relPhi)*(w - x)*(y - z) );
+    double AmB = 0.5 * sqrt((w - x) * (w - x) + (y - z) * (y - z) +
+                            2 * cos(2 * relPhi) * (w - x) * (y - z));
 
-	DBGP("Amb: " << AmB << " relPhi: " << relPhi);
+    DBGP("Amb: " << AmB << " relPhi: " << relPhi);
 
-	if( AmB > ApB ) {
-		printf( "Invalid relative curvature, ending calculation...\n" );
-		return 1;
-	}
+    if (AmB > ApB) {
+        printf("Invalid relative curvature, ending calculation...\n");
+        return 1;
+    }
 
-	//by definition r1prime >= r2prime
-	if (ApB + AmB != 0)
-		r1prime = 1/( ApB + AmB );
-	else
-		r1prime = -1.0;
+    //by definition r1prime >= r2prime
+    if (ApB + AmB != 0)
+        r1prime = 1 / (ApB + AmB);
+    else
+        r1prime = -1.0;
 
-	if( ApB == AmB)
-		r2prime = -1.0;
-	else
-		r2prime = 1/(ApB - AmB );
+    if (ApB == AmB)
+        r2prime = -1.0;
+    else
+        r2prime = 1 / (ApB - AmB);
 
-	m->r1prime = r1prime;
-	m->r2prime = r2prime;
+    m->r1prime = r1prime;
+    m->r2prime = r2prime;
 
-	//fprintf(stderr,"original: %f %f and %f %f\n",r1,r2,m->r1, m->r2);
-	//fprintf(stderr,"Relative radii: %f %f equiv: %f\n",r1prime, r2prime, sqrt(r1prime*r2prime) );
-	return 0;
+    //fprintf(stderr,"original: %f %f and %f %f\n",r1,r2,m->r1, m->r2);
+    //fprintf(stderr,"Relative radii: %f %f equiv: %f\n",r1prime, r2prime, sqrt(r1prime*r2prime) );
+    return 0;
 }
 
-/*! Calculates the axes of the ellipse of contact using the mattress 
-	model and a given normal force (for dynamics its the normal component 
-	of the dynamic contact force). Sets major axis and minor axis.
-	Returns the max torque available.
-	See Contact Mechanics, KL Johnson Chapter 4
+/*! Calculates the axes of the ellipse of contact using the mattress
+    model and a given normal force (for dynamics its the normal component
+    of the dynamic contact force). Sets major axis and minor axis.
+    Returns the max torque available.
+    See Contact Mechanics, KL Johnson Chapter 4
 */
-double SoftContact::CalcContact_Mattress( double nForce )
-{
-	if (r1prime < 0) {
-		DBGP("Degenerate soft contact");
-		r1prime = 20;
-	}
-	if (r2prime < 0) {
-		DBGP("Degenerate soft contact");
-		r2prime = 20;
-	}
-		
-	//hardwired height of mattress = 3.0 mm
-	//r primes are in mm
-	double h = 0.003;
-	double delta = sqrt( nForce*h/(MAX(body1->getYoungs(), body2->getYoungs())
-									* M_PI * sqrt(r1prime*0.001*r2prime*0.001)) ); //meters
+double SoftContact::CalcContact_Mattress(double nForce) {
+    if (r1prime < 0) {
+        DBGP("Degenerate soft contact");
+        r1prime = 20;
+    }
+    if (r2prime < 0) {
+        DBGP("Degenerate soft contact");
+        r2prime = 20;
+    }
 
-	majorAxis = sqrt( 2*delta*r1prime*0.001 ); //meters
-	minorAxis = sqrt( 2*delta*r2prime*0.001 ); 
-	DBGP("Axes: " << majorAxis << " " << minorAxis);
-	//axes are given in meters!!!!
-	//rprimes and the radii of curvature are calculated in mm
+    //hardwired height of mattress = 3.0 mm
+    //r primes are in mm
+    double h = 0.003;
+    double delta = sqrt(nForce * h / (MAX(body1->getYoungs(), body2->getYoungs())
+                                      * M_PI * sqrt(r1prime * 0.001 * r2prime * 0.001))); //meters
 
-	SoftContact *m = (SoftContact *)getMate();
-	m->majorAxis = majorAxis;
-	m->minorAxis = minorAxis;
+    majorAxis = sqrt(2 * delta * r1prime * 0.001); //meters
+    minorAxis = sqrt(2 * delta * r2prime * 0.001);
+    DBGP("Axes: " << majorAxis << " " << minorAxis);
+    //axes are given in meters!!!!
+    //rprimes and the radii of curvature are calculated in mm
 
-	//returns max available torque proportional to given normal force
-	//max torque=*K/h*mu*4*pi*(ab)^1.5/15 where a and b are 
-	//the axis of the contact ellipse
-	//this just returns the max torque divided by the normal force times mu
-	//which is 8sqrt(ab)/15
-	//the pressure distrib is K*delta/h/2*pi*ab
+    SoftContact *m = (SoftContact *)getMate();
+    m->majorAxis = majorAxis;
+    m->minorAxis = minorAxis;
 
-	//std::cerr<<"Ma ma "<< majorAxis << minorAxis << "\n";
+    //returns max available torque proportional to given normal force
+    //max torque=*K/h*mu*4*pi*(ab)^1.5/15 where a and b are
+    //the axis of the contact ellipse
+    //this just returns the max torque divided by the normal force times mu
+    //which is 8sqrt(ab)/15
+    //the pressure distrib is K*delta/h/2*pi*ab
 
-	return 8*sqrt( majorAxis*minorAxis )/15;	//in meters
+    //std::cerr<<"Ma ma "<< majorAxis << minorAxis << "\n";
+
+    return 8 * sqrt(majorAxis * minorAxis) / 15; //in meters
 }
 
 /*! Gets the visual indicator as a small patch of the fit analytical surface
-	around the body. Also places a small arrow indicating the direction of
-	the main radius of curvature computed for the body.
+    around the body. Also places a small arrow indicating the direction of
+    the main radius of curvature computed for the body.
 */
-SoSeparator* SoftContact::getVisualIndicator()
-{
-        double height;
-	SoSeparator *cne;
-	SoTransform *tran;
-	SoCoordinate3 *coords;
-	cne = new SoSeparator;
+SoSeparator *SoftContact::getVisualIndicator() {
+    double height;
+    SoSeparator *cne;
+    SoTransform *tran;
+    SoCoordinate3 *coords;
+    cne = new SoSeparator;
 
-	int sampling_n = 10, sampling_m = 10;
-	//double sampleSize_n = 2, sampleSize_m = 1;
-	//double sampleSize_n = (4.0 * majorAxis * 1000) / (2.0 * sampling_n);
-	//double sampleSize_m = (4.0 * minorAxis * 1000) / (2.0 * sampling_m);
+    int sampling_n = 10, sampling_m = 10;
+    //double sampleSize_n = 2, sampleSize_m = 1;
+    //double sampleSize_n = (4.0 * majorAxis * 1000) / (2.0 * sampling_n);
+    //double sampleSize_m = (4.0 * minorAxis * 1000) / (2.0 * sampling_m);
 
-	double sampleSize_n = 0.7;
-	double sampleSize_m = 0.7;
+    double sampleSize_n = 0.7;
+    double sampleSize_m = 0.7;
 
 
-	DBGP("Major " << majorAxis << " minor " << minorAxis);
-	
-	//points runs left to right and then up to down in the grid
-	SbVec3f *points = new SbVec3f[(2*sampling_n + 1)*(2*sampling_m + 1) ];
+    DBGP("Major " << majorAxis << " minor " << minorAxis);
 
-	coneMat = new SoMaterial;
-	coneMat->diffuseColor = SbColor(0.8f,0.0f,0.0f);
-	coneMat->ambientColor = SbColor(0.2f,0.0f,0.0f);
-	coneMat->emissiveColor = SbColor(0.4f,0.0f,0.0f);
-	coneMat->transparency = 0.8f;
+    //points runs left to right and then up to down in the grid
+    SbVec3f *points = new SbVec3f[(2 * sampling_n + 1) * (2 * sampling_m + 1) ];
 
-	SoMaterial* zaxisMat = new SoMaterial;  
-	zaxisMat->diffuseColor = SbColor(0,0,0);
-	zaxisMat->ambientColor = SbColor(0,0,0);
+    coneMat = new SoMaterial;
+    coneMat->diffuseColor = SbColor(0.8f, 0.0f, 0.0f);
+    coneMat->ambientColor = SbColor(0.2f, 0.0f, 0.0f);
+    coneMat->emissiveColor = SbColor(0.4f, 0.0f, 0.0f);
+    coneMat->transparency = 0.8f;
 
-	height = Body::CONE_HEIGHT;
+    SoMaterial *zaxisMat = new SoMaterial;
+    zaxisMat->diffuseColor = SbColor(0, 0, 0);
+    zaxisMat->ambientColor = SbColor(0, 0, 0);
 
-	tran = new SoTransform;  
-	getContactFrame().toSoTransform(tran);
+    height = Body::CONE_HEIGHT;
 
-	SoCylinder *zaxisCyl = new SoCylinder;
-	zaxisCyl->radius = 0.05f;
-	zaxisCyl->height = 0.2 * height;
-  
-	SoTransform *zaxisTran = new SoTransform;
-	zaxisTran->translation.setValue(0,0,0.2 * height/2.0);
-	zaxisTran->rotation.setValue(SbVec3f(1,0,0),(float)M_PI/2.0f);
-  
-	SoSeparator *zaxisSep = new SoSeparator;
-	zaxisSep->addChild(zaxisTran);
-	zaxisSep->addChild(zaxisMat);
-	zaxisSep->addChild(zaxisCyl);
+    tran = new SoTransform;
+    getContactFrame().toSoTransform(tran);
 
-	int n_squares = 2 * sampling_n * 2 *sampling_m;
-	int32_t *cIndex = new int32_t[5*n_squares];
+    SoCylinder *zaxisCyl = new SoCylinder;
+    zaxisCyl->radius = 0.05f;
+    zaxisCyl->height = 0.2 * height;
 
-	int count = 0;
-	int count_sq = 0;
-	for( int i = -sampling_n; i <= sampling_n; i++ )
-	{
-		for( int j = -sampling_m; j <= sampling_m; j++ )
-		{
-			double x = i*sampleSize_n;
-			double y = j*sampleSize_m;
-			//double z = a*x*x + b*y*y + c*x*y;
-			double z = 0;
-			if (r1 > 0) z+= x*x*1.0/(2*r1);
-			if (r2 > 0) z+= y*y*1.0/(2*r2);
-			points[ count ].setValue( x, y, z );
-			if (x>0 && y == 0){
-				points[count].setValue(x,y,z+0.4);
-			}
+    SoTransform *zaxisTran = new SoTransform;
+    zaxisTran->translation.setValue(0, 0, 0.2 * height / 2.0);
+    zaxisTran->rotation.setValue(SbVec3f(1, 0, 0), (float)M_PI / 2.0f);
 
-			if ( i > -sampling_n && j > -sampling_m)
-			{
-				cIndex[5*count_sq + 0] = count - (2*sampling_m + 1);
-				cIndex[5*count_sq + 1] = count - (2*sampling_m + 1) - 1;
-				cIndex[5*count_sq + 2] = count - 1;
-				cIndex[5*count_sq + 3] = count;
-				cIndex[5*count_sq + 4] = -1;
-				count_sq++;
-			}
-			count++;
-		}
-	}
-	if (count != (2*sampling_n + 1)*(2*sampling_m + 1) || count_sq != n_squares)
-		exit(0);
+    SoSeparator *zaxisSep = new SoSeparator;
+    zaxisSep->addChild(zaxisTran);
+    zaxisSep->addChild(zaxisMat);
+    zaxisSep->addChild(zaxisCyl);
 
-	coords = new SoCoordinate3;
-	coords->point.setValues( 0, count, points );
+    int n_squares = 2 * sampling_n * 2 * sampling_m;
+    int32_t *cIndex = new int32_t[5 * n_squares];
 
-	SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
-	ifs->coordIndex.setValues(0, 5*n_squares, cIndex);
+    int count = 0;
+    int count_sq = 0;
+    for (int i = -sampling_n; i <= sampling_n; i++) {
+        for (int j = -sampling_m; j <= sampling_m; j++) {
+            double x = i * sampleSize_n;
+            double y = j * sampleSize_m;
+            //double z = a*x*x + b*y*y + c*x*y;
+            double z = 0;
+            if (r1 > 0) z += x * x * 1.0 / (2 * r1);
+            if (r2 > 0) z += y * y * 1.0 / (2 * r2);
+            points[ count ].setValue(x, y, z);
+            if (x > 0 && y == 0) {
+                points[count].setValue(x, y, z + 0.4);
+            }
 
-	//neighborhood is in frame of contact, so add contact transform first
-	cne->addChild(tran);
-/*
-	SoMaterial* sphereMat = new SoMaterial;  
-	sphereMat->diffuseColor = SbColor(1,1,0);
-	sphereMat->ambientColor = SbColor(1,1,0);
-	cne->addChild(sphereMat);
-	for (int i=0; i<numPts; i++)
-	{
-		SoSphere* sphere = new SoSphere;
-		sphere->radius = 0.5;
-		SoTransform* sphereTran = new SoTransform;
-		sphereTran->translation.setValue( bodyNghbd[i].x(), bodyNghbd[i].y(), bodyNghbd[i].z() );
-		SoSeparator* sep = new SoSeparator;
-		sep->addChild(sphereTran);
-		sep->addChild(sphere);
-		cne->addChild(sep);
-	}
-*/
+            if (i > -sampling_n && j > -sampling_m) {
+                cIndex[5 * count_sq + 0] = count - (2 * sampling_m + 1);
+                cIndex[5 * count_sq + 1] = count - (2 * sampling_m + 1) - 1;
+                cIndex[5 * count_sq + 2] = count - 1;
+                cIndex[5 * count_sq + 3] = count;
+                cIndex[5 * count_sq + 4] = -1;
+                count_sq++;
+            }
+            count++;
+        }
+    }
+    if (count != (2 * sampling_n + 1) * (2 * sampling_m + 1) || count_sq != n_squares)
+        exit(0);
 
-	cne->addChild(zaxisSep);
+    coords = new SoCoordinate3;
+    coords->point.setValues(0, count, points);
 
-	//this angle gets us from the contact frame to the frame in which the paraboloid is defined by just
-	//two parameters, r1 and r2
-	SoTransform* axisAlignTran = new SoTransform;  
-	axisAlignTran->rotation.setValue(SbVec3f(0,0,1), -fitRotAngle);
-	cne->addChild(axisAlignTran);
+    SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
+    ifs->coordIndex.setValues(0, 5 * n_squares, cIndex);
 
-	cne->addChild(coneMat);
-	cne->addChild(coords);
-	cne->addChild(ifs);
+    //neighborhood is in frame of contact, so add contact transform first
+    cne->addChild(tran);
+    /*
+        SoMaterial* sphereMat = new SoMaterial;
+        sphereMat->diffuseColor = SbColor(1,1,0);
+        sphereMat->ambientColor = SbColor(1,1,0);
+        cne->addChild(sphereMat);
+        for (int i=0; i<numPts; i++)
+        {
+            SoSphere* sphere = new SoSphere;
+            sphere->radius = 0.5;
+            SoTransform* sphereTran = new SoTransform;
+            sphereTran->translation.setValue( bodyNghbd[i].x(), bodyNghbd[i].y(), bodyNghbd[i].z() );
+            SoSeparator* sep = new SoSeparator;
+            sep->addChild(sphereTran);
+            sep->addChild(sphere);
+            cne->addChild(sep);
+        }
+    */
 
-	//add an arrow in the direction of the major axis of the contact ellipse
-	//this is the angle between the major axis of the two paraboloids. it is used to compute the
-	//magnitude of the major axis of the contact ellipse
-	//but for now we don't compute the direction of the contact ellipse!
-	SoTransform* phiAlignTran = new SoTransform;  
-	phiAlignTran->rotation.setValue(SbVec3f(0,0,1), relPhi);
-	cne->addChild(phiAlignTran);
+    cne->addChild(zaxisSep);
 
-	SoCylinder *xaxisCyl = new SoCylinder;
-	xaxisCyl->radius = 0.05f;
-	xaxisCyl->height = height / 2.0;
-  
-	SoTransform *xaxisTran = new SoTransform;
-	xaxisTran->translation.setValue(height/4.0, 0.0, 0.0);
-	xaxisTran->rotation.setValue(SbVec3f(0,0,1),-(float)M_PI/2.0f);
-  
-	SoSeparator *xaxisSep = new SoSeparator;
-	xaxisSep->addChild(xaxisTran);
-	xaxisSep->addChild(zaxisMat);
-	xaxisSep->addChild(xaxisCyl);
+    //this angle gets us from the contact frame to the frame in which the paraboloid is defined by just
+    //two parameters, r1 and r2
+    SoTransform *axisAlignTran = new SoTransform;
+    axisAlignTran->rotation.setValue(SbVec3f(0, 0, 1), -fitRotAngle);
+    cne->addChild(axisAlignTran);
 
-	//cne->addChild(xaxisSep);
-	return cne;
+    cne->addChild(coneMat);
+    cne->addChild(coords);
+    cne->addChild(ifs);
+
+    //add an arrow in the direction of the major axis of the contact ellipse
+    //this is the angle between the major axis of the two paraboloids. it is used to compute the
+    //magnitude of the major axis of the contact ellipse
+    //but for now we don't compute the direction of the contact ellipse!
+    SoTransform *phiAlignTran = new SoTransform;
+    phiAlignTran->rotation.setValue(SbVec3f(0, 0, 1), relPhi);
+    cne->addChild(phiAlignTran);
+
+    SoCylinder *xaxisCyl = new SoCylinder;
+    xaxisCyl->radius = 0.05f;
+    xaxisCyl->height = height / 2.0;
+
+    SoTransform *xaxisTran = new SoTransform;
+    xaxisTran->translation.setValue(height / 4.0, 0.0, 0.0);
+    xaxisTran->rotation.setValue(SbVec3f(0, 0, 1), -(float)M_PI / 2.0f);
+
+    SoSeparator *xaxisSep = new SoSeparator;
+    xaxisSep->addChild(xaxisTran);
+    xaxisSep->addChild(zaxisMat);
+    xaxisSep->addChild(xaxisCyl);
+
+    //cne->addChild(xaxisSep);
+    return cne;
 }
 
 ///////////////////////////////////////////
@@ -1124,602 +1098,583 @@ SoSeparator* SoftContact::getVisualIndicator()
 ///////////////////////////////////////////
 
 /*! Initializes an empty (and for now unusable) contact. Sets it
-	as its own mate, which is the distinctive sign of a virtual
-	contact.
+    as its own mate, which is the distinctive sign of a virtual
+    contact.
 */
 void
-VirtualContact::init()
-{
-	mFingerNum = -2;
-	mLinkNum = 0;
-	mZaxisMat = NULL;
-	mWorldInd = NULL;
-	mate = this;
-	body1 = NULL;
-	body2 = NULL;
+VirtualContact::init() {
+    mFingerNum = -2;
+    mLinkNum = 0;
+    mZaxisMat = NULL;
+    mWorldInd = NULL;
+    mate = this;
+    body1 = NULL;
+    body2 = NULL;
 }
 
-/*! Just calls the super and then calls init to give default values 
-	to the virtual contact specific parameters.
+/*! Just calls the super and then calls init to give default values
+    to the virtual contact specific parameters.
 */
-VirtualContact::VirtualContact() : Contact()
-{
-	init();
+VirtualContact::VirtualContact() : Contact() {
+    init();
 }
 
 /*! Copies the location, friction edges, and coefficients of the \a original.
-	This should really use a super's copy constructor, but we never wrote
-	one. Does not copy the wrenches; the new contact needs to build them
-	itself from the friction edges.
+    This should really use a super's copy constructor, but we never wrote
+    one. Does not copy the wrenches; the new contact needs to build them
+    itself from the friction edges.
 */
-VirtualContact::VirtualContact(const VirtualContact *original) : Contact()
-{
-	init();
-	mFingerNum = original->mFingerNum;
-	mLinkNum = original->mLinkNum;
-	//copy friction edges
-	//this should really be done by a Contact copy constructor
-	numFrictionEdges = original->numFrictionEdges;
-	memcpy( frictionEdges, original->frictionEdges, 6 * numFrictionEdges * sizeof(double) );
-	//wrenches are not copied; this contact should build them itself
-	loc = original->loc;
-	frame = original->frame;
-	normal = original->normal;
-	cof = original->cof;	
-	body1 = original->body1;
-	body2 = original->body2;
+VirtualContact::VirtualContact(const VirtualContact *original) : Contact() {
+    init();
+    mFingerNum = original->mFingerNum;
+    mLinkNum = original->mLinkNum;
+    //copy friction edges
+    //this should really be done by a Contact copy constructor
+    numFrictionEdges = original->numFrictionEdges;
+    memcpy(frictionEdges, original->frictionEdges, 6 * numFrictionEdges * sizeof(double));
+    //wrenches are not copied; this contact should build them itself
+    loc = original->loc;
+    frame = original->frame;
+    normal = original->normal;
+    cof = original->cof;
+    body1 = original->body1;
+    body2 = original->body2;
 }
 
-/*! When copying from a regular contact, we must be careful because the	
-	normal of a virtual contact points outwards, whereas the normal of a 
-	trasitional contact points inwards.
+/*! When copying from a regular contact, we must be careful because the
+    normal of a virtual contact points outwards, whereas the normal of a
+    trasitional contact points inwards.
 */
-VirtualContact::VirtualContact(int f, int l, Contact *original) : Contact()
-{
-	init();
-	mFingerNum = f;
-	mLinkNum = l;
+VirtualContact::VirtualContact(int f, int l, Contact *original) : Contact() {
+    init();
+    mFingerNum = f;
+    mLinkNum = l;
 
-	numFrictionEdges = original->numFrictionEdges;
-	memcpy( frictionEdges, original->frictionEdges, 6 * numFrictionEdges * sizeof(double) );
-	cof = original->cof;
+    numFrictionEdges = original->numFrictionEdges;
+    memcpy(frictionEdges, original->frictionEdges, 6 * numFrictionEdges * sizeof(double));
+    cof = original->cof;
 
-	loc = original->loc;
-	frame = original->frame;
-	//we now rotate the frame so that the normal points outwards, as the contact on the object would
-	Quaternion q(3.14159, vec3(1,0,0));
-	transf newRot(q, vec3(0,0,0) );
-	frame = newRot * frame;
-	normal = -1 * original->normal;
-	body1 = original->body1;
-	body2 = original->body2;
+    loc = original->loc;
+    frame = original->frame;
+    //we now rotate the frame so that the normal points outwards, as the contact on the object would
+    Quaternion q(3.14159, vec3(1, 0, 0));
+    transf newRot(q, vec3(0, 0, 0));
+    frame = newRot * frame;
+    normal = -1 * original->normal;
+    body1 = original->body1;
+    body2 = original->body2;
 }
 
-/*! Just sets the mate to NULL and let the super destructor 
-	take care of the rest.
+/*! Just sets the mate to NULL and let the super destructor
+    take care of the rest.
 */
-VirtualContact::~VirtualContact()
-{
-	mate = NULL;
+VirtualContact::~VirtualContact() {
+    mate = NULL;
 }
 
 /*! Sets the frame, location and normal, but does not do anything with the friction edges.
- */
-void VirtualContact::changeFrame(transf tr)
-{
-  frame = tr;
-  loc = position(tr.translation().toSbVec3f());
-  normal = vec3(0,0,1) * tr;
+*/
+void VirtualContact::changeFrame(transf tr) {
+    frame = tr;
+    loc = position(tr.translation().toSbVec3f());
+    normal = vec3(0, 0, 1) * tr;
 }
 
 position
-VirtualContact::getWorldLocation()
-{
-	return loc * body1->getTran();
+VirtualContact::getWorldLocation() {
+    return loc * body1->getTran();
 }
 
 vec3
-VirtualContact::getWorldNormal()
-{
-	return normal * body1->getTran();
+VirtualContact::getWorldNormal() {
+    return normal * body1->getTran();
 }
 
 /*! The virtual contact, for now, does not compute its own friction
-	edges, but just inherits them from the regular contact that it 
-	starts from. Alternatively, if it loaded from a file, it reads
-	them in from the file.
-	
-	In the future, this hierarchy needs to be better engineered.
+    edges, but just inherits them from the regular contact that it
+    starts from. Alternatively, if it loaded from a file, it reads
+    them in from the file.
+
+    In the future, this hierarchy needs to be better engineered.
 */
 int
-VirtualContact::setUpFrictionEdges(bool dynamicsOn)
-{
-	dynamicsOn = dynamicsOn;
-	return 1;
+VirtualContact::setUpFrictionEdges(bool dynamicsOn) {
+    dynamicsOn = dynamicsOn;
+    return 1;
 }
 
-/*!	This computes the wrenches of the virtual contact as used for grasp 
-	quality computations. The important aspect to take into account is 
-	wether we are using an object or not.
-	
-	If we are using an object, we assume that contact centroid and maxradius 
-	have already been set to match those of the	object (hopefully, the grasp 
-	has done this). Also, the force applied be the contact is scaled by a 
-	function of the distance between the contact and the actual object.
-	
-	If there is no object, we assume that contact centroid and maxradius 
-	have been preset dependign only on the set of virtual contacts that 
-	make up the grasp (again, we hope the grasp has done this). There is no 
-	scaling involved, all forces are handled normally as if the contact was 
-	actually on the object.
+/*! This computes the wrenches of the virtual contact as used for grasp
+    quality computations. The important aspect to take into account is
+    wether we are using an object or not.
+
+    If we are using an object, we assume that contact centroid and maxradius
+    have already been set to match those of the object (hopefully, the grasp
+    has done this). Also, the force applied be the contact is scaled by a
+    function of the distance between the contact and the actual object.
+
+    If there is no object, we assume that contact centroid and maxradius
+    have been preset dependign only on the set of virtual contacts that
+    make up the grasp (again, we hope the grasp has done this). There is no
+    scaling involved, all forces are handled normally as if the contact was
+    actually on the object.
 */
 void
-VirtualContact::computeWrenches(bool useObjectData, bool simplify)
-{
-	int i;
-	//double alpha;
-	vec3 radius, forceVec,torqueVec,tangentX,tangentY;
+VirtualContact::computeWrenches(bool useObjectData, bool simplify) {
+    int i;
+    //double alpha;
+    vec3 radius, forceVec, torqueVec, tangentX, tangentY;
 
-	//we need everything to be wrt world coordinates
-	position worldLoc;
-	vec3 worldNormal;
+    //we need everything to be wrt world coordinates
+    position worldLoc;
+    vec3 worldNormal;
 
-	if (!useObjectData) {	
-		worldLoc = getWorldLocation();
-		worldNormal = getWorldNormal();
-		transf worldFrame = frame * body1->getTran();
-		tangentX = worldFrame.affine().row(0);
-		tangentY = worldFrame.affine().row(1);
-	} else {
-//		LOOK AT VIRTUAL CONTACT ON THE HAND
-		worldLoc = getWorldLocation();
-		worldNormal = getWorldNormal();
-		tangentX = vec3(0,1,0) * worldNormal;
-		tangentX = normalise(tangentX);
-		tangentY = worldNormal * tangentX;
-	}
+    if (!useObjectData) {
+        worldLoc = getWorldLocation();
+        worldNormal = getWorldNormal();
+        transf worldFrame = frame * body1->getTran();
+        tangentX = worldFrame.affine().row(0);
+        tangentY = worldFrame.affine().row(1);
+    }
+    else {
+        //      LOOK AT VIRTUAL CONTACT ON THE HAND
+        worldLoc = getWorldLocation();
+        worldNormal = getWorldNormal();
+        tangentX = vec3(0, 1, 0) * worldNormal;
+        tangentX = normalise(tangentX);
+        tangentY = worldNormal * tangentX;
+    }
 
-	//mCenter needs to be already set to object cog if needed as such
-	radius = worldLoc - mCenter;
-	if (wrench) delete [] wrench;
+    //mCenter needs to be already set to object cog if needed as such
+    radius = worldLoc - mCenter;
+    if (wrench) delete [] wrench;
 
-	if (simplify) {
-		numFCWrenches = 1; //this is hack-ish, should be fixed
-		wrench = new Wrench[1];
-		wrench[0].force = worldNormal;
-		wrench[0].torque = (radius*worldNormal) / mMaxRadius;
-		return;
-	}
+    if (simplify) {
+        numFCWrenches = 1; //this is hack-ish, should be fixed
+        wrench = new Wrench[1];
+        wrench[0].force = worldNormal;
+        wrench[0].torque = (radius * worldNormal) / mMaxRadius;
+        return;
+    }
 
-	numFCWrenches = numFrictionEdges;
-	wrench = new Wrench[numFrictionEdges];
+    numFCWrenches = numFrictionEdges;
+    wrench = new Wrench[numFrictionEdges];
 
-	//SHOULD SET UP COEFFICIENT BASED ON MATERIALS!
-	for (i=0;i<numFCWrenches;i++) {
-		forceVec = worldNormal + (tangentX*cof*frictionEdges[6*i])+ (tangentY*cof*frictionEdges[6*i+1]);
-		//max friction is normal_force_magnitude (which is 1) * coeff_of_friction 
-		//possible friction for this wrench is (friction_edge * max_friction) in the X and Y direction of the contact
+    //SHOULD SET UP COEFFICIENT BASED ON MATERIALS!
+    for (i = 0; i < numFCWrenches; i++) {
+        forceVec = worldNormal + (tangentX * cof * frictionEdges[6 * i]) + (tangentY * cof * frictionEdges[6 * i + 1]);
+        //max friction is normal_force_magnitude (which is 1) * coeff_of_friction
+        //possible friction for this wrench is (friction_edge * max_friction) in the X and Y direction of the contact
 
-		wrench[i].force = forceVec;
+        wrench[i].force = forceVec;
 
-		wrench[i].torque = ( (radius*forceVec) + worldNormal*cof*frictionEdges[6*i+5] )/mMaxRadius;
-		//max torque is contact_radius * normal_force_magnitude (which is 1) * coeff_of_friction
-		//possible torque for this wrench is (friction_edge * max_torque) in the direction of the contact normal
-		//the contact_radius coefficient is already taken into account in the friction_edge
-	}
+        wrench[i].torque = ((radius * forceVec) + worldNormal * cof * frictionEdges[6 * i + 5]) / mMaxRadius;
+        //max torque is contact_radius * normal_force_magnitude (which is 1) * coeff_of_friction
+        //possible torque for this wrench is (friction_edge * max_torque) in the direction of the contact normal
+        //the contact_radius coefficient is already taken into account in the friction_edge
+    }
 }
 
-/*!	Scales the force vector based on how distant the VirtualContact 
-	is from the actual object. The intuition is as follows: we do not 
-	want Grasp Quality to be a step function depending wether a contact 
-	is on of off the surface of the object. Ratherm we want it smooth so 
-	we allow a VirtualContact to contribute to GQ even if it's a bit off the
-	surface of the object.
+/*! Scales the force vector based on how distant the VirtualContact
+    is from the actual object. The intuition is as follows: we do not
+    want Grasp Quality to be a step function depending wether a contact
+    is on of off the surface of the object. Ratherm we want it smooth so
+    we allow a VirtualContact to contribute to GQ even if it's a bit off the
+    surface of the object.
 */
 void
-VirtualContact::scaleWrenches(double factor)
-{
-	int i;
-	for (i=0; i<numFCWrenches; i++) {
-		wrench[i].force = factor * wrench[i].force;
-		wrench[i].torque = factor * wrench[i].torque;
-	}
+VirtualContact::scaleWrenches(double factor) {
+    int i;
+    for (i = 0; i < numFCWrenches; i++) {
+        wrench[i].force = factor * wrench[i].force;
+        wrench[i].torque = factor * wrench[i].torque;
+    }
 }
 
-/*!	Gives us a visual indicator of what this contact looks like, 
-	in WORLD COORDINATES. Since this contact has to be transformed 
-	to world coordinates for the sake of grasp analysis, this allows 
-	us to be sure that the transformation makes sense.
-	
-	It assumes WRENCHES have been computed.
+/*! Gives us a visual indicator of what this contact looks like,
+    in WORLD COORDINATES. Since this contact has to be transformed
+    to world coordinates for the sake of grasp analysis, this allows
+    us to be sure that the transformation makes sense.
+
+    It assumes WRENCHES have been computed.
 */
 void
-VirtualContact::getWorldIndicator(bool useObjectData)
-{
-	vec3 forceVec;
-	position worldLoc;
+VirtualContact::getWorldIndicator(bool useObjectData) {
+    vec3 forceVec;
+    position worldLoc;
 
-	if (!useObjectData) {
-		worldLoc = getWorldLocation();
-	} else {
-		vec3 objDist;
-		getObjectDistanceAndNormal(body2, &objDist, NULL);
-		worldLoc = getWorldLocation() + objDist;
-	}
+    if (!useObjectData) {
+        worldLoc = getWorldLocation();
+    }
+    else {
+        vec3 objDist;
+        getObjectDistanceAndNormal(body2, &objDist, NULL);
+        worldLoc = getWorldLocation() + objDist;
+    }
 
-	SoTransform* tran = new SoTransform;  
-	SbMatrix tr;
-	tr.setTranslate( worldLoc.toSbVec3f() );
-	tran->setMatrix( tr );
-  
-	SbVec3f *points = (SbVec3f*)calloc(numFCWrenches+1, sizeof(SbVec3f) );
-	int32_t *cIndex = (int32_t*)calloc(4*numFCWrenches, sizeof(int32_t) );
+    SoTransform *tran = new SoTransform;
+    SbMatrix tr;
+    tr.setTranslate(worldLoc.toSbVec3f());
+    tran->setMatrix(tr);
 
-	points[0].setValue(0,0,0);
+    SbVec3f *points = (SbVec3f *)calloc(numFCWrenches + 1, sizeof(SbVec3f));
+    int32_t *cIndex = (int32_t *)calloc(4 * numFCWrenches, sizeof(int32_t));
 
-	for (int i=0;i<numFCWrenches;i++) {
-		//if ( wrench[i].torque.len() != 0 ) continue;
-		forceVec = wrench[i].force;
-		forceVec = Body::CONE_HEIGHT * forceVec;
-		points[i+1].setValue( forceVec.x(), forceVec.y(), forceVec.z() );
-		cIndex[4*i] = 0;
-		cIndex[4*i+1] = i + 2;
-		if ( i == numFCWrenches-1) cIndex[4*i+1] = 1;
-		cIndex[4*i+2] = i + 1;
-		cIndex[4*i+3] = -1;
-	}
+    points[0].setValue(0, 0, 0);
 
-	SoCoordinate3* coords = new SoCoordinate3;
-	SoIndexedFaceSet* ifs = new SoIndexedFaceSet;
-	coords->point.setValues(0,numFCWrenches+1,points);
-	ifs->coordIndex.setValues(0,4*numFCWrenches,cIndex);
-	free(points);
-	free(cIndex);
+    for (int i = 0; i < numFCWrenches; i++) {
+        //if ( wrench[i].torque.len() != 0 ) continue;
+        forceVec = wrench[i].force;
+        forceVec = Body::CONE_HEIGHT * forceVec;
+        points[i + 1].setValue(forceVec.x(), forceVec.y(), forceVec.z());
+        cIndex[4 * i] = 0;
+        cIndex[4 * i + 1] = i + 2;
+        if (i == numFCWrenches - 1) cIndex[4 * i + 1] = 1;
+        cIndex[4 * i + 2] = i + 1;
+        cIndex[4 * i + 3] = -1;
+    }
 
-	SoMaterial *coneMat = new SoMaterial;  
-    coneMat->diffuseColor = SbColor(0.0f,0.0f,0.8f);
-    coneMat->ambientColor = SbColor(0.0f,0.0f,0.2f);
-    coneMat->emissiveColor = SbColor(0.0f,0.0f,0.4f);
+    SoCoordinate3 *coords = new SoCoordinate3;
+    SoIndexedFaceSet *ifs = new SoIndexedFaceSet;
+    coords->point.setValues(0, numFCWrenches + 1, points);
+    ifs->coordIndex.setValues(0, 4 * numFCWrenches, cIndex);
+    free(points);
+    free(cIndex);
 
-	if (mWorldInd) {
-		body1->getWorld()->getIVRoot()->removeChild(mWorldInd);
-	}
+    SoMaterial *coneMat = new SoMaterial;
+    coneMat->diffuseColor = SbColor(0.0f, 0.0f, 0.8f);
+    coneMat->ambientColor = SbColor(0.0f, 0.0f, 0.2f);
+    coneMat->emissiveColor = SbColor(0.0f, 0.0f, 0.4f);
 
-	mWorldInd = new SoSeparator;
-	mWorldInd->addChild(tran);
-	mWorldInd->addChild(coneMat);
-	mWorldInd->addChild(coords);
-	mWorldInd->addChild(ifs);
-	body1->getWorld()->getIVRoot()->addChild(mWorldInd);
+    if (mWorldInd) {
+        body1->getWorld()->getIVRoot()->removeChild(mWorldInd);
+    }
 
-	/*
-	SoSeparator* cSep = new SoSeparator;
-	tr.setTranslate( mCenter.toSbVec3f() );
-	tran = new SoTransform;
-	tran->setMatrix( tr );
-	cSep->addChild(tran);
-	SoSphere* cSphere = new SoSphere();
-	cSphere->radius = 5;
-	cSep->addChild(cSphere);
-	body1->getWorld()->getIVRoot()->addChild(cSep);
-	*/
+    mWorldInd = new SoSeparator;
+    mWorldInd->addChild(tran);
+    mWorldInd->addChild(coneMat);
+    mWorldInd->addChild(coords);
+    mWorldInd->addChild(ifs);
+    body1->getWorld()->getIVRoot()->addChild(mWorldInd);
+
+    /*
+        SoSeparator* cSep = new SoSeparator;
+        tr.setTranslate( mCenter.toSbVec3f() );
+        tran = new SoTransform;
+        tran->setMatrix( tr );
+        cSep->addChild(tran);
+        SoSphere* cSphere = new SoSphere();
+        cSphere->radius = 5;
+        cSep->addChild(cSphere);
+        body1->getWorld()->getIVRoot()->addChild(cSep);
+    */
 }
 
-SoSeparator* 
-VirtualContact::getVisualIndicator()
-{
-	SoTransform *tran;
+SoSeparator *
+VirtualContact::getVisualIndicator() {
+    SoTransform *tran;
 
-	//this one is a member variable so we can change color if we want to "mark" the contact
-	if (!mZaxisMat) {
-		mZaxisMat = new SoMaterial;
-		mZaxisMat->ref();
-	}
-	mZaxisMat->diffuseColor = SbColor(0.8f,0,0);
-	mZaxisMat->ambientColor = SbColor(0.8f,0,0);
+    //this one is a member variable so we can change color if we want to "mark" the contact
+    if (!mZaxisMat) {
+        mZaxisMat = new SoMaterial;
+        mZaxisMat->ref();
+    }
+    mZaxisMat->diffuseColor = SbColor(0.8f, 0, 0);
+    mZaxisMat->ambientColor = SbColor(0.8f, 0, 0);
 
-	tran = new SoTransform;  
-	getContactFrame().toSoTransform(tran);
-  
-	SoCylinder *zaxisCyl = new SoCylinder;
-	zaxisCyl->radius = 0.2f;
-	zaxisCyl->height = Body::CONE_HEIGHT;
+    tran = new SoTransform;
+    getContactFrame().toSoTransform(tran);
 
-	SoSphere *zaxisSphere = new SoSphere;
-	zaxisSphere->radius = 3.0f;
-  
-	SoTransform *zaxisTran = new SoTransform;
-	zaxisTran->translation.setValue(0,0,Body::CONE_HEIGHT/2.0);
-//	zaxisTran->translation.setValue(0,0,2.0);
-	zaxisTran->rotation.setValue(SbVec3f(1,0,0),(float)M_PI/2.0f);
-  
-	SoSeparator *zaxisSep = new SoSeparator;
-	zaxisSep->addChild(zaxisTran);
-	zaxisSep->addChild(mZaxisMat);
-	zaxisSep->addChild(zaxisCyl);
-//	zaxisSep->addChild(zaxisSphere);
+    SoCylinder *zaxisCyl = new SoCylinder;
+    zaxisCyl->radius = 0.2f;
+    zaxisCyl->height = Body::CONE_HEIGHT;
 
-	SoSeparator* cne = new SoSeparator;
-	cne->addChild(tran);
-	cne->addChild(zaxisSep);
-	return cne;
+    SoSphere *zaxisSphere = new SoSphere;
+    zaxisSphere->radius = 3.0f;
+
+    SoTransform *zaxisTran = new SoTransform;
+    zaxisTran->translation.setValue(0, 0, Body::CONE_HEIGHT / 2.0);
+    //  zaxisTran->translation.setValue(0,0,2.0);
+    zaxisTran->rotation.setValue(SbVec3f(1, 0, 0), (float)M_PI / 2.0f);
+
+    SoSeparator *zaxisSep = new SoSeparator;
+    zaxisSep->addChild(zaxisTran);
+    zaxisSep->addChild(mZaxisMat);
+    zaxisSep->addChild(zaxisCyl);
+    //  zaxisSep->addChild(zaxisSphere);
+
+    SoSeparator *cne = new SoSeparator;
+    cne->addChild(tran);
+    cne->addChild(zaxisSep);
+    return cne;
 }
 
 /*! Changes the color of the visual indicator from red to blue
-	if this contact is to be "marked".
+    if this contact is to be "marked".
 */
 void
-VirtualContact::mark(bool m)
-{
-	if (!mZaxisMat) return;
-	if (m) {
-		mZaxisMat->diffuseColor = SbColor(0,0,0.8f);
-		mZaxisMat->ambientColor = SbColor(0,0,0.8f);
-	} else {
-		mZaxisMat->diffuseColor = SbColor(0.8f,0,0);
-		mZaxisMat->ambientColor = SbColor(0.8f,0,0);
-	}
+VirtualContact::mark(bool m) {
+    if (!mZaxisMat) return;
+    if (m) {
+        mZaxisMat->diffuseColor = SbColor(0, 0, 0.8f);
+        mZaxisMat->ambientColor = SbColor(0, 0, 0.8f);
+    }
+    else {
+        mZaxisMat->diffuseColor = SbColor(0.8f, 0, 0);
+        mZaxisMat->ambientColor = SbColor(0.8f, 0, 0);
+    }
 }
 
-/*! Saves all the info needed for this contact (what body and link 
-	it's on, location, normal, friction edges and coefficient) to
-	a file.
+/*! Saves all the info needed for this contact (what body and link
+    it's on, location, normal, friction edges and coefficient) to
+    a file.
 */
 void
-VirtualContact::writeToFile(FILE *fp)
-{
-	//finger and link number
-	fprintf(fp,"%d %d\n",mFingerNum, mLinkNum);
+VirtualContact::writeToFile(FILE *fp) {
+    //finger and link number
+    fprintf(fp, "%d %d\n", mFingerNum, mLinkNum);
 
-	//numFrictionEdges
-	fprintf(fp,"%d\n",numFrictionEdges);
+    //numFrictionEdges
+    fprintf(fp, "%d\n", numFrictionEdges);
 
-	//frictionEdges
-	for (int i=0; i<numFrictionEdges; i++) {
-		for (int j=0; j<6; j++)
-			fprintf(fp,"%f ",frictionEdges[6*i+j]);
-		fprintf(fp,"\n");
-	}
+    //frictionEdges
+    for (int i = 0; i < numFrictionEdges; i++) {
+        for (int j = 0; j < 6; j++)
+            fprintf(fp, "%f ", frictionEdges[6 * i + j]);
+        fprintf(fp, "\n");
+    }
 
-	//loc
-	fprintf(fp,"%f %f %f\n",loc.x(), loc.y(), loc.z());
+    //loc
+    fprintf(fp, "%f %f %f\n", loc.x(), loc.y(), loc.z());
 
-	//frame
-	Quaternion q = frame.rotation();
-	vec3 t = frame.translation();
-	fprintf(fp,"%f %f %f %f\n",q.w,q.x,q.y,q.z);
-	fprintf(fp,"%f %f %f\n",t.x(), t.y(), t.z());
+    //frame
+    Quaternion q = frame.rotation();
+    vec3 t = frame.translation();
+    fprintf(fp, "%f %f %f %f\n", q.w, q.x, q.y, q.z);
+    fprintf(fp, "%f %f %f\n", t.x(), t.y(), t.z());
 
-	//normal
-	fprintf(fp,"%f %f %f\n",normal.x(), normal.y(), normal.z());
+    //normal
+    fprintf(fp, "%f %f %f\n", normal.x(), normal.y(), normal.z());
 
-	//cof
-	fprintf(fp,"%f\n",cof);
+    //cof
+    fprintf(fp, "%f\n", cof);
 }
 
 /*! Loads all the info for this contact from a file previously written
-	by VirtualContact::writeToFile(...)
+    by VirtualContact::writeToFile(...)
 */
 void
-VirtualContact::readFromFile(FILE *fp)
-{
-	float v,x,y,z;
+VirtualContact::readFromFile(FILE *fp) {
+    float v, x, y, z;
 
-	//finger and link number
-	if ( fscanf(fp,"%d %d",&mFingerNum, &mLinkNum) <= 0){
-	  DBGA("VirtualContact::readFromFile - Failed to read fingernumber or link number");
-	  return;
-	}
-	//numFrictionEdges
-	if (fscanf(fp,"%d",&numFrictionEdges) <= 0){
-	    DBGA("VirtualContact::readFromFile - Failed to read number of virtual contacts");
-	    return;
-	  }
+    //finger and link number
+    if (fscanf(fp, "%d %d", &mFingerNum, &mLinkNum) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read fingernumber or link number");
+        return;
+    }
+    //numFrictionEdges
+    if (fscanf(fp, "%d", &numFrictionEdges) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read number of virtual contacts");
+        return;
+    }
 
-	//frictionEdges
-	for (int i=0; i<numFrictionEdges; i++) {
-		for (int j=0; j<6; j++) {
-		  if(fscanf(fp,"%f",&v) <= 0){
-		    DBGA("VirtualContact::readFromFile - Failed to read number of friction edges");
-		    return;
-		  };
-			frictionEdges[6*i+j] = v;
-		}
-	}
+    //frictionEdges
+    for (int i = 0; i < numFrictionEdges; i++) {
+        for (int j = 0; j < 6; j++) {
+            if (fscanf(fp, "%f", &v) <= 0) {
+                DBGA("VirtualContact::readFromFile - Failed to read number of friction edges");
+                return;
+            };
+            frictionEdges[6 * i + j] = v;
+        }
+    }
 
-	//loc
-	if(fscanf(fp,"%f %f %f",&x, &y, &z) <= 0){
-	 DBGA("VirtualContact::readFromFile - Failed to read virtual contact location");
-	 return;
-	}
-	loc = position(x,y,z);
+    //loc
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read virtual contact location");
+        return;
+    }
+    loc = position(x, y, z);
 
-	//frame
-	Quaternion q;
-	vec3 t;
-	if(fscanf(fp,"%f %f %f %f",&v,&x,&y,&z) <= 0) {
-	  DBGA("VirtualContact::readFromFile - Failed to read virtual contact frame orientation");
-	}
-	q.set(v,x,y,z);
-	if(fscanf(fp,"%f %f %f",&x, &y, &z) <= 0) {
-	 DBGA("VirtualContact::readFromFile - Failed to read virtual contact frame location");
-	} 
+    //frame
+    Quaternion q;
+    vec3 t;
+    if (fscanf(fp, "%f %f %f %f", &v, &x, &y, &z) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read virtual contact frame orientation");
+    }
+    q.set(v, x, y, z);
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read virtual contact frame location");
+    }
 
-	t.set(x,y,z);
-	frame.set(q,t);
+    t.set(x, y, z);
+    frame.set(q, t);
 
-	//normal
-	if( fscanf(fp,"%f %f %f",&x, &y, &z) <= 0){
-	 DBGA("VirtualContact::readFromFile - Failed to read virtual contact normal");
-	 return;
-	}
-	normal.set(x,y,z);
+    //normal
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read virtual contact normal");
+        return;
+    }
+    normal.set(x, y, z);
 
-	//cof
-	if( fscanf(fp,"%f",&v) <= 0){ 
-	DBGA("VirtualContact::readFromFile - Failed to read virtual contact friction");
-	return;
-	}
-	cof = v;
+    //cof
+    if (fscanf(fp, "%f", &v) <= 0) {
+        DBGA("VirtualContact::readFromFile - Failed to read virtual contact friction");
+        return;
+    }
+    cof = v;
 }
 
 /*! Sets objDistance to be the vector from the contact to the closest
-	point on the given body. Sets objNormal to be the object surface normal
-	at that point.
+    point on the given body. Sets objNormal to be the object surface normal
+    at that point.
 */
 void
-VirtualContact::getObjectDistanceAndNormal(Body *body, vec3 *objDistance, vec3 *objNormal)
-{
-	position loc = getWorldLocation();
-	*objDistance = body->getWorld()->pointDistanceToBody(loc, body, objNormal);
+VirtualContact::getObjectDistanceAndNormal(Body *body, vec3 *objDistance, vec3 *objNormal) {
+    position loc = getWorldLocation();
+    *objDistance = body->getWorld()->pointDistanceToBody(loc, body, objNormal);
 }
 
 
-VirtualContactOnObject::VirtualContactOnObject()
-{
-	wrench = NULL;
-	body2 = NULL;
-	mate = this;
-	prevBetas = NULL;
+VirtualContactOnObject::VirtualContactOnObject() {
+    wrench = NULL;
+    body2 = NULL;
+    mate = this;
+    prevBetas = NULL;
 }
 
-VirtualContactOnObject::~VirtualContactOnObject()
-{
+VirtualContactOnObject::~VirtualContactOnObject() {
 }
 
 void
-VirtualContactOnObject::readFromFile(FILE *fp)
-{
-	float w,x,y,z;
+VirtualContactOnObject::readFromFile(FILE *fp) {
+    float w, x, y, z;
 
-	//numFCVectors
-	if(fscanf(fp,"%d",&numFrictionEdges) <= 0) {
-	  DBGA("VirtualContactOnObject::readFromFile - Failed to read number of friction vectors");
-	  return; 
-	}
+    //numFCVectors
+    if (fscanf(fp, "%d", &numFrictionEdges) <= 0) {
+        DBGA("VirtualContactOnObject::readFromFile - Failed to read number of friction vectors");
+        return;
+    }
 
-	//frictionEdges
-	for (int i=0; i<numFrictionEdges; i++) {
-		for (int j=0; j<6; j++) {
-		  if (fscanf(fp,"%f",&w) <= 0) {
-		    DBGA("VirtualContactOnObject::readFromFile - Failed to read number of friction edges");
-		    return; 
-		  }
-		    
-			frictionEdges[6*i+j] = w;
-		}
-	}
-	fprintf(stderr,"\n<frictionEdges scanned successfully>"); // for test
+    //frictionEdges
+    for (int i = 0; i < numFrictionEdges; i++) {
+        for (int j = 0; j < 6; j++) {
+            if (fscanf(fp, "%f", &w) <= 0) {
+                DBGA("VirtualContactOnObject::readFromFile - Failed to read number of friction edges");
+                return;
+            }
 
-	// (w,x,y,z) is already a quaternion, if you want to do frame rotate v rad along a vector (x,y,z),
-	//you can use q(v,vec(x,y,z))
-	Quaternion q;
-	vec3 t;
-	if(fscanf(fp,"%f %f %f %f",&w,&x,&y,&z) <= 0) {
-	  DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact location");
-	  return;
-	}
-	
+            frictionEdges[6 * i + j] = w;
+        }
+    }
+    fprintf(stderr, "\n<frictionEdges scanned successfully>"); // for test
 
-	q.set(w,x,y,z);
-	if(fscanf(fp,"%f %f %f",&x, &y, &z) <= 0) {
-	  DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact orientation");
-	  return;
-	}
-	
-	t.set(x,y,z);
-	loc = position(x,y,z);
-	frame.set(q,t);
+    // (w,x,y,z) is already a quaternion, if you want to do frame rotate v rad along a vector (x,y,z),
+    //you can use q(v,vec(x,y,z))
+    Quaternion q;
+    vec3 t;
+    if (fscanf(fp, "%f %f %f %f", &w, &x, &y, &z) <= 0) {
+        DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact location");
+        return;
+    }
 
-	//normal
-	if(fscanf(fp,"%f %f %f",&x, &y, &z) <= 0) {
-	  DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact normal");
-	  return;
-	}
 
-	normal.set(x,y,z);
+    q.set(w, x, y, z);
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact orientation");
+        return;
+    }
 
-	//cof
-	if(fscanf(fp,"%f",&w) <= 0) {
-	  DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact normal");
-	  return;
-	}
-	cof = w;
+    t.set(x, y, z);
+    loc = position(x, y, z);
+    frame.set(q, t);
+
+    //normal
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact normal");
+        return;
+    }
+
+    normal.set(x, y, z);
+
+    //cof
+    if (fscanf(fp, "%f", &w) <= 0) {
+        DBGA("VirtualContactOnObject::readFromFile - Failed to read virtual contact normal");
+        return;
+    }
+    cof = w;
 }
 
 #ifdef ARIZONA_PROJECT_ENABLED
 void
-VirtualContactOnObject::readFromRawData(ArizonaRawExp* are, QString file, int index, bool flipNormal)
-{
-	
-	float v;
-	FILE *fp = fopen(file.latin1(), "r");
-	if (!fp) {
-		fprintf(stderr,"Could not open filename %s\n",file.latin1());
-		return;
-	}
+VirtualContactOnObject::readFromRawData(ArizonaRawExp *are, QString file, int index, bool flipNormal) {
 
-	//numFCVectors
-	if(fscanf(fp,"%d",&numFrictionEdges) <= 0) {
-	  DBGA("VirtualContactOnObject::readFromRawData - Failed to read virtual contact orientation");
-	  return; 
-	}
+    float v;
+    FILE *fp = fopen(file.latin1(), "r");
+    if (!fp) {
+        fprintf(stderr, "Could not open filename %s\n", file.latin1());
+        return;
+    }
 
-	//frictionEdges
-	for (int i=0; i<numFrictionEdges; i++) {
-		for (int j=0; j<6; j++) {
-		  if(fscanf(fp,"%f",&v) <= 0) 
-		    {
-		      DBGA("VirtualContactOnObject::readFromRawData - Failed to read number of friction edges for virtual contacts");
-		      return; 
-		    }
-		  frictionEdges[6*i+j] = v;
-		}
-	}
+    //numFCVectors
+    if (fscanf(fp, "%d", &numFrictionEdges) <= 0) {
+        DBGA("VirtualContactOnObject::readFromRawData - Failed to read virtual contact orientation");
+        return;
+    }
 
-	Quaternion q;
-	vec3 t;
-	q = are->getQuaternion(index);
-	t = are->getContact(index);
-	loc = position(t.x(),t.y(),t.z());
-	frame.set(q,t);
+    //frictionEdges
+    for (int i = 0; i < numFrictionEdges; i++) {
+        for (int j = 0; j < 6; j++) {
+            if (fscanf(fp, "%f", &v) <= 0) {
+                DBGA("VirtualContactOnObject::readFromRawData - Failed to read number of friction edges for virtual contacts");
+                return;
+            }
+            frictionEdges[6 * i + j] = v;
+        }
+    }
 
-	//normal
-	normal = are->getNormal(index);
-	if(flipNormal){
-		std::cout << "flipped normal" << std::endl;
-		normal = - normal;
-	}
+    Quaternion q;
+    vec3 t;
+    q = are->getQuaternion(index);
+    t = are->getContact(index);
+    loc = position(t.x(), t.y(), t.z());
+    frame.set(q, t);
 
-	//cof, need further consideration
-	cof = 0.5;
+    //normal
+    normal = are->getNormal(index);
+    if (flipNormal) {
+        std::cout << "flipped normal" << std::endl;
+        normal = - normal;
+    }
 
-	fclose(fp);
-	
+    //cof, need further consideration
+    cof = 0.5;
+
+    fclose(fp);
+
 }
 #endif
 
 void
-VirtualContactOnObject::writeToFile(FILE *fp){
-	//numFrictionEdges
-	fprintf(fp,"%d\n",numFrictionEdges);
+VirtualContactOnObject::writeToFile(FILE *fp) {
+    //numFrictionEdges
+    fprintf(fp, "%d\n", numFrictionEdges);
 
-	//frictionEdges
-	for (int i=0; i<numFrictionEdges; i++) {
-		for (int j=0; j<6; j++)
-			fprintf(fp,"%f ",frictionEdges[6*i+j]);
-		fprintf(fp,"\n");
-	}
+    //frictionEdges
+    for (int i = 0; i < numFrictionEdges; i++) {
+        for (int j = 0; j < 6; j++)
+            fprintf(fp, "%f ", frictionEdges[6 * i + j]);
+        fprintf(fp, "\n");
+    }
 
-	//frame
-	Quaternion q = frame.rotation();
-	vec3 t = frame.translation();
-	fprintf(fp,"%f %f %f %f\n",q.w,q.x,q.y,q.z);
-	fprintf(fp,"%f %f %f\n",t.x(), t.y(), t.z());
+    //frame
+    Quaternion q = frame.rotation();
+    vec3 t = frame.translation();
+    fprintf(fp, "%f %f %f %f\n", q.w, q.x, q.y, q.z);
+    fprintf(fp, "%f %f %f\n", t.x(), t.y(), t.z());
 
-	//normal
-	fprintf(fp,"%f %f %f\n",normal.x(), normal.y(), normal.z());
+    //normal
+    fprintf(fp, "%f %f %f\n", normal.x(), normal.y(), normal.z());
 
-	//cof
-	fprintf(fp,"%f\n",cof);
+    //cof
+    fprintf(fp, "%f\n", cof);
 }

--- a/src/contactSetting.cpp
+++ b/src/contactSetting.cpp
@@ -34,260 +34,259 @@
 //#define GRASPITDBG
 #include "debug.h"
 
-double 
-contactDistance(Body* body1, Body* body2, ContactData &cp)
-{
-	position b1_pos(cp.b1_pos), b2_pos(cp.b2_pos);
-	b1_pos = b1_pos * body1->getTran();
-	b2_pos = b2_pos * body2->getTran();
-	vec3 dist_vec = (b1_pos-b2_pos);
-	return dist_vec.len();
+double
+contactDistance(Body *body1, Body *body2, ContactData &cp) {
+    position b1_pos(cp.b1_pos), b2_pos(cp.b2_pos);
+    b1_pos = b1_pos * body1->getTran();
+    b2_pos = b2_pos * body2->getTran();
+    vec3 dist_vec = (b1_pos - b2_pos);
+    return dist_vec.len();
 }
 
-/*	
-	Attempt to check if the normals of the contact are well defined by looking at the distance between the bodies.
-*/	
-bool 
-checkContactNormals(Body *b1, Body *b2, ContactData *c)
-{
-	bool r = true;
-	vec3 n1(c->b1_normal);
-	vec3 n2(c->b2_normal);
-	n1 = n1 * b1->getTran();
-	n2 = n2 * b2->getTran();
+/*
+    Attempt to check if the normals of the contact are well defined by looking at the distance between the bodies.
+*/
+bool
+checkContactNormals(Body *b1, Body *b2, ContactData *c) {
+    bool r = true;
+    vec3 n1(c->b1_normal);
+    vec3 n2(c->b2_normal);
+    n1 = n1 * b1->getTran();
+    n2 = n2 * b2->getTran();
 
-	position p1(c->b1_pos);
-	position p2(c->b2_pos);
-	p1 = p1 * b1->getTran();
-	p2 = p2 * b2->getTran();
+    position p1(c->b1_pos);
+    position p2(c->b2_pos);
+    p1 = p1 * b1->getTran();
+    p2 = p2 * b2->getTran();
 
-	vec3 d = p2 - p1;
-	if ( d % n1 > 0) {
-		r = false;
-		for (int i=0; i<3; i++) {
-			c->b1_normal[i] = -c->b1_normal[i];
-		}
-	}
-	if ( d % n2 < 0) {
-		r = false;
-		for (int i=0; i<3; i++) {
-			c->b2_normal[i] = - c->b2_normal[i];
-		}
-	}
-	return r;
+    vec3 d = p2 - p1;
+    if (d % n1 > 0) {
+        r = false;
+        for (int i = 0; i < 3; i++) {
+            c->b1_normal[i] = -c->b1_normal[i];
+        }
+    }
+    if (d % n2 < 0) {
+        r = false;
+        for (int i = 0; i < 3; i++) {
+            c->b2_normal[i] = - c->b2_normal[i];
+        }
+    }
+    return r;
 }
 
 bool neighborhoodsOverlap(const Neighborhood &n1, const Neighborhood &n2) {
-	// both neighborhoods are assumed to be in the same frame 
-	Neighborhood::const_iterator it1, it2;
-	for (it1 = n1.begin(); it1!=n1.end(); it1++)
-		for (it2 = n2.begin(); it2 != n2.end(); it2++) {
-			if ( *it1 == *it2 )
-				return true;
-		}
-	return false;
+    // both neighborhoods are assumed to be in the same frame
+    Neighborhood::const_iterator it1, it2;
+    for (it1 = n1.begin(); it1 != n1.end(); it1++)
+        for (it2 = n2.begin(); it2 != n2.end(); it2++) {
+            if (*it1 == *it2)
+                return true;
+        }
+    return false;
 }
 
-void mergeNeighborhoods(Neighborhood &n1, Neighborhood &n2)
-{
-	Neighborhood::iterator it1, it2;
-	bool present;
-	for (it2 = n2.begin(); it2 != n2.end(); it2++) {
-		present = false;
-		for (it1 = n1.begin(); it1 != n1.end(); it1++) {
-			if ( *it1 == *it2 ) {
-				present = true;
-				break;
-			}
-		}
-		if (!present) {
-			n1.push_back( *it2 );
-		}
-	}
+void mergeNeighborhoods(Neighborhood &n1, Neighborhood &n2) {
+    Neighborhood::iterator it1, it2;
+    bool present;
+    for (it2 = n2.begin(); it2 != n2.end(); it2++) {
+        present = false;
+        for (it1 = n1.begin(); it1 != n1.end(); it1++) {
+            if (*it1 == *it2) {
+                present = true;
+                break;
+            }
+        }
+        if (!present) {
+            n1.push_back(*it2);
+        }
+    }
 }
 
-/*! For elastic bodies, calculates the contact neighborhoods and puts 
-	them in the contact set. Not done for rigid contacts.
+/*! For elastic bodies, calculates the contact neighborhoods and puts
+    them in the contact set. Not done for rigid contacts.
 */
-void findSoftNeighborhoods( Body *body1, Body *body2, ContactReport &contactSet )
-{
-	ContactReport::iterator itr;
+void findSoftNeighborhoods(Body *body1, Body *body2, ContactReport &contactSet) {
+    ContactReport::iterator itr;
 
-	for( itr = contactSet.begin(); itr != contactSet.end(); itr++ )	{
-		DBGP("Contact finding regions:");
-		//right now, findregion assumes point is in body frame
-		//the units for the threshold and the radius should be in mm, NOT cm
+    for (itr = contactSet.begin(); itr != contactSet.end(); itr++)  {
+        DBGP("Contact finding regions:");
+        //right now, findregion assumes point is in body frame
+        //the units for the threshold and the radius should be in mm, NOT cm
 
-		//The input radius is proportional to the fourth root of the youngs mod/depth of mattress
-		//(units for Youngs Mod and mattress depth are in Pa and meters)
-		//This gives a radius around 6 mm, for rubber with youngs = 1.5E6 and h = 3E-3which is reasonable
+        //The input radius is proportional to the fourth root of the youngs mod/depth of mattress
+        //(units for Youngs Mod and mattress depth are in Pa and meters)
+        //This gives a radius around 6 mm, for rubber with youngs = 1.5E6 and h = 3E-3which is reasonable
 
-		double rad = pow( 1/(MAX( body1->getYoungs(), body2->getYoungs() )), 0.333 ) * 1000.0 * 0.4;
-		//the 0.4 is a fudge factor for the time being
+        double rad = pow(1 / (MAX(body1->getYoungs(), body2->getYoungs())), 0.333) * 1000.0 * 0.4;
+        //the 0.4 is a fudge factor for the time being
 
-		//hack to ensure that the fit is at least resonable
-		if( rad <= 3.0 && rad >= 10.0 )	rad = 5.0;
+        //hack to ensure that the fit is at least resonable
+        if (rad <= 3.0 && rad >= 10.0)  rad = 5.0;
 
-		body1->getWorld()->FindRegion( body1, itr->b1_pos, itr->b1_normal, rad, &(itr->nghbd1) );
-		DBGP("Neighborhood on body1 has " << itr->nghbd1.size() << " points");
-		body2->getWorld()->FindRegion( body2, itr->b2_pos, itr->b2_normal, rad, &(itr->nghbd2) );
-		DBGP("Neighborhood on body2 has " << itr->nghbd2.size() << " points");
-	}
+        body1->getWorld()->FindRegion(body1, itr->b1_pos, itr->b1_normal, rad, &(itr->nghbd1));
+        DBGP("Neighborhood on body1 has " << itr->nghbd1.size() << " points");
+        body2->getWorld()->FindRegion(body2, itr->b2_pos, itr->b2_normal, rad, &(itr->nghbd2));
+        DBGP("Neighborhood on body2 has " << itr->nghbd2.size() << " points");
+    }
 }
 
-/*! For elastic objects, if we have two contacts close to each other 
-	we assume they are actually part of the same contact. This function 
-	checks for overlapping neighborhoods and merges them.
+/*! For elastic objects, if we have two contacts close to each other
+    we assume they are actually part of the same contact. This function
+    checks for overlapping neighborhoods and merges them.
 */
 void
-mergeSoftNeighborhoods(Body *body1, Body *body2, ContactReport &contactSet)
-{
-	bool mergePerformed = true;
+mergeSoftNeighborhoods(Body *body1, Body *body2, ContactReport &contactSet) {
+    bool mergePerformed = true;
 
-	ContactReport::iterator refContact, otherContact;
+    ContactReport::iterator refContact, otherContact;
 
-	while (mergePerformed) {
-		mergePerformed = false;
-		//check each contact agains each other contact
-		for (refContact=contactSet.begin(); refContact!=contactSet.end(); refContact++) {
-			for (otherContact = contactSet.begin(); otherContact != contactSet.end(); otherContact++) {
-				if (otherContact == refContact)	continue;
+    while (mergePerformed) {
+        mergePerformed = false;
+        //check each contact agains each other contact
+        for (refContact = contactSet.begin(); refContact != contactSet.end(); refContact++) {
+            for (otherContact = contactSet.begin(); otherContact != contactSet.end(); otherContact++) {
+                if (otherContact == refContact) continue;
 
-				//this arbitrarily checks only the neighborhoods on body1
-				if ( neighborhoodsOverlap(refContact->nghbd1, otherContact->nghbd1) ) {
-					DBGP("Overlap found");
-					// this should be improved; it keeps the closest contact but merges neighborhoods
-					// ideally it should keep the closest contact and RECALCULATE the neighborhoods
-					if ( contactDistance(body1, body2, *refContact) < contactDistance(body1, body2, *otherContact) ) {
-						mergeNeighborhoods( refContact->nghbd1, otherContact->nghbd1 );
-						mergeNeighborhoods( refContact->nghbd2, otherContact->nghbd2 );
-						contactSet.erase( otherContact );
-					} else {
-						mergeNeighborhoods( otherContact->nghbd1, refContact->nghbd1 );
-						mergeNeighborhoods( otherContact->nghbd2, refContact->nghbd2 );
-						contactSet.erase( refContact );
-					}
-					mergePerformed = true;
-					break;
-				} else {
-					DBGP("Overlap not found");
-				}
-			}
-			//if we have a merge, restart operation
-			if (mergePerformed)
-				break;
-		}
-	}
+                //this arbitrarily checks only the neighborhoods on body1
+                if (neighborhoodsOverlap(refContact->nghbd1, otherContact->nghbd1)) {
+                    DBGP("Overlap found");
+                    // this should be improved; it keeps the closest contact but merges neighborhoods
+                    // ideally it should keep the closest contact and RECALCULATE the neighborhoods
+                    if (contactDistance(body1, body2, *refContact) < contactDistance(body1, body2, *otherContact)) {
+                        mergeNeighborhoods(refContact->nghbd1, otherContact->nghbd1);
+                        mergeNeighborhoods(refContact->nghbd2, otherContact->nghbd2);
+                        contactSet.erase(otherContact);
+                    }
+                    else {
+                        mergeNeighborhoods(otherContact->nghbd1, refContact->nghbd1);
+                        mergeNeighborhoods(otherContact->nghbd2, refContact->nghbd2);
+                        contactSet.erase(refContact);
+                    }
+                    mergePerformed = true;
+                    break;
+                }
+                else {
+                    DBGP("Overlap not found");
+                }
+            }
+            //if we have a merge, restart operation
+            if (mergePerformed)
+                break;
+        }
+    }
 }
 
 /*!
-  Takes pointers to the two bodies in contact, and the set of contacts returned
-  from the collision detection system, and adds a contact to each body for each
-  contact in the set.
- */
+    Takes pointers to the two bodies in contact, and the set of contacts returned
+    from the collision detection system, and adds a contact to each body for each
+    contact in the set.
+*/
 void
-addContacts(Body *body1, Body *body2, ContactReport &contactSet, bool softContactsOn )
-{
-	ContactReport::iterator cp;
-	Contact *c1,*c2;
-	int i;
+addContacts(Body *body1, Body *body2, ContactReport &contactSet, bool softContactsOn) {
+    ContactReport::iterator cp;
+    Contact *c1, *c2;
+    int i;
 
-	if ( softContactsOn && ( body1->isElastic() || body2->isElastic() ) ) {
-		findSoftNeighborhoods( body1, body2, contactSet);
-		DBGP("Before merge: " << contactSet.size());
-		mergeSoftNeighborhoods( body1, body2, contactSet);
-		DBGP("After merge: " << contactSet.size());
-	}
+    if (softContactsOn && (body1->isElastic() || body2->isElastic())) {
+        findSoftNeighborhoods(body1, body2, contactSet);
+        DBGP("Before merge: " << contactSet.size());
+        mergeSoftNeighborhoods(body1, body2, contactSet);
+        DBGP("After merge: " << contactSet.size());
+    }
 
-	for (i=0,cp=contactSet.begin();cp!=contactSet.end();cp++,i++) {
+    for (i = 0, cp = contactSet.begin(); cp != contactSet.end(); cp++, i++) {
 
-		DBGP( body1->getName().latin1() << " - " << body2->getName().latin1() << " contact: " <<
-		cp->b1_pos << " " <<  cp->b1_normal );
+        DBGP(body1->getName().latin1() << " - " << body2->getName().latin1() << " contact: " <<
+             cp->b1_pos << " " <<  cp->b1_normal);
 
-		//this is an attempt to check if the contact normals point in the right direction
-		//based on the distance between the bodies. It is meant to help with bad geometry with ill-defined
-		//normals. Can be removed completely - should never come up for good geometry
-		if (! checkContactNormals(body1, body2, &(*cp)) ) {
-			DBGP("Wrong normals detected!");
-		}
-		if ( softContactsOn && ( body1->isElastic() || body2->isElastic() ) ) {
-			c1 = new SoftContact( body1, body2, cp->b1_pos, cp->b1_normal, &(cp->nghbd1) );
-			c2 = new SoftContact( body2, body1, cp->b2_pos, cp->b2_normal, &(cp->nghbd2) );
-			c1->setMate(c2);
-			c2->setMate(c1);
+        //this is an attempt to check if the contact normals point in the right direction
+        //based on the distance between the bodies. It is meant to help with bad geometry with ill-defined
+        //normals. Can be removed completely - should never come up for good geometry
+        if (! checkContactNormals(body1, body2, &(*cp))) {
+            DBGP("Wrong normals detected!");
+        }
+        if (softContactsOn && (body1->isElastic() || body2->isElastic())) {
+            c1 = new SoftContact(body1, body2, cp->b1_pos, cp->b1_normal, &(cp->nghbd1));
+            c2 = new SoftContact(body2, body1, cp->b2_pos, cp->b2_normal, &(cp->nghbd2));
+            c1->setMate(c2);
+            c2->setMate(c1);
 
-			((SoftContact *)c1)->setUpFrictionEdges();
-			((SoftContact *)c2)->setUpFrictionEdges();
-		} else {
-			c1 = new PointContact(body1,body2,cp->b1_pos,cp->b1_normal);
-			c2 = new PointContact(body2,body1,cp->b2_pos,cp->b2_normal);
-			c1->setMate(c2);
-			c2->setMate(c1);
-		}
+            ((SoftContact *)c1)->setUpFrictionEdges();
+            ((SoftContact *)c2)->setUpFrictionEdges();
+        }
+        else {
+            c1 = new PointContact(body1, body2, cp->b1_pos, cp->b1_normal);
+            c2 = new PointContact(body2, body1, cp->b2_pos, cp->b2_normal);
+            c1->setMate(c2);
+            c2->setMate(c1);
+        }
 
-		body1->addContact(c1);
-		body2->addContact(c2);
+        body1->addContact(c1);
+        body2->addContact(c2);
 
-		//check if the new contacts inherit two contacts from previous time step
-		//if so, remove ancestors so nobody else inherits them
-		Contact *ancestor = body1->checkContactInheritance(c1);
-		if (ancestor) {
-			c1->inherit(ancestor);
-			if (!ancestor->getMate()) 
-				fprintf(stderr,"No mate for inherited contact!!\n");
-			else
-				c2->inherit(ancestor->getMate());
-			//careful: this also deletes the removed contact so remove the mate first
-			if (ancestor->getMate()) body2->removePrevContact( ancestor->getMate() );
-			body1->removePrevContact( ancestor );
-		} else {
-			ancestor = body2->checkContactInheritance(c2);
-			if (ancestor){
-				if (!ancestor->getMate())
-					fprintf(stderr,"No mate for inherited contact!!\n");
-				else		
-					c1->inherit(ancestor->getMate());
-				c2->inherit(ancestor);
-				if (ancestor->getMate()) body1->removePrevContact( ancestor->getMate() );
-				body2->removePrevContact( ancestor );
-			} else {
-//				fprintf(stderr,"New contact between %s and %s\n",body1->getName().latin1(), body2->getName().latin1() );
-			}
-		}
-	}
+        //check if the new contacts inherit two contacts from previous time step
+        //if so, remove ancestors so nobody else inherits them
+        Contact *ancestor = body1->checkContactInheritance(c1);
+        if (ancestor) {
+            c1->inherit(ancestor);
+            if (!ancestor->getMate())
+                fprintf(stderr, "No mate for inherited contact!!\n");
+            else
+                c2->inherit(ancestor->getMate());
+            //careful: this also deletes the removed contact so remove the mate first
+            if (ancestor->getMate()) body2->removePrevContact(ancestor->getMate());
+            body1->removePrevContact(ancestor);
+        }
+        else {
+            ancestor = body2->checkContactInheritance(c2);
+            if (ancestor) {
+                if (!ancestor->getMate())
+                    fprintf(stderr, "No mate for inherited contact!!\n");
+                else
+                    c1->inherit(ancestor->getMate());
+                c2->inherit(ancestor);
+                if (ancestor->getMate()) body1->removePrevContact(ancestor->getMate());
+                body2->removePrevContact(ancestor);
+            }
+            else {
+                //              fprintf(stderr,"New contact between %s and %s\n",body1->getName().latin1(), body2->getName().latin1() );
+            }
+        }
+    }
 }
 
 /*! Adds a virtual contact on the body \a body1, which is assumed to
-	be the \a l-th link on the \a f-th finger of a robot. Works by
-	first creating a traditional contact, then converting it to a 
-	virtual contact.
-	
-	The whole VirtualContact scheme is in bad need of an overhaul.
+    be the \a l-th link on the \a f-th finger of a robot. Works by
+    first creating a traditional contact, then converting it to a
+    virtual contact.
+
+    The whole VirtualContact scheme is in bad need of an overhaul.
 */
 void
-addVirtualContacts(Body *body1, int f, int l, Body *body2, ContactReport &contactSet, 
-				   bool softContactsOn )
-{
-	if ( softContactsOn && body1->isElastic() )	{
-		findSoftNeighborhoods( body1, body2, contactSet );
-		mergeSoftNeighborhoods(body1, body2, contactSet);
-	}
+addVirtualContacts(Body *body1, int f, int l, Body *body2, ContactReport &contactSet,
+                   bool softContactsOn) {
+    if (softContactsOn && body1->isElastic())  {
+        findSoftNeighborhoods(body1, body2, contactSet);
+        mergeSoftNeighborhoods(body1, body2, contactSet);
+    }
 
-	ContactReport::iterator cp;
-	for (cp=contactSet.begin(); cp!=contactSet.end(); cp++) {
-		Contact *c1;
-		if ( softContactsOn && body1->isElastic() )	{
-			c1 = new SoftContact( body1, body2, cp->b1_pos, cp->b1_normal, &(cp->nghbd1) );
-			c1->setMate(NULL);
-			((SoftContact *)c1)->setUpFrictionEdges();
-		} else {
-			c1 = new PointContact(body1, body2, cp->b1_pos, cp->b1_normal);
-			c1->setMate(NULL);
-		}
-		
-		VirtualContact *vc = new VirtualContact(f, l, c1);
-		vc->setBody(body1);
-		body1->addVirtualContact(vc);
-		delete c1;
-	}
+    ContactReport::iterator cp;
+    for (cp = contactSet.begin(); cp != contactSet.end(); cp++) {
+        Contact *c1;
+        if (softContactsOn && body1->isElastic())  {
+            c1 = new SoftContact(body1, body2, cp->b1_pos, cp->b1_normal, &(cp->nghbd1));
+            c1->setMate(NULL);
+            ((SoftContact *)c1)->setUpFrictionEdges();
+        }
+        else {
+            c1 = new PointContact(body1, body2, cp->b1_pos, cp->b1_normal);
+            c1->setMate(NULL);
+        }
+
+        VirtualContact *vc = new VirtualContact(f, l, c1);
+        vc->setBody(body1);
+        body1->addVirtualContact(vc);
+        delete c1;
+    }
 }

--- a/src/dlfcn-win32.cpp
+++ b/src/dlfcn-win32.cpp
@@ -1,324 +1,305 @@
 /*
- * dlfcn-win32
- * Copyright (c) 2007 Ramiro Polla
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- */
+    dlfcn-win32
+    Copyright (c) 2007 Ramiro Polla
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dlfcn-win32.h"
 
-/* Note:
- * MSDN says these functions are not thread-safe. We make no efforts to have
- * any kind of thread safety.
- */
+/*  Note:
+    MSDN says these functions are not thread-safe. We make no efforts to have
+    any kind of thread safety.
+*/
 
 typedef struct global_object {
-  HMODULE hModule;
-  struct global_object *previous;
-  struct global_object *next;
+    HMODULE hModule;
+    struct global_object *previous;
+    struct global_object *next;
 } global_object;
 
 static global_object first_object;
 
 /* These functions implement a double linked list for the global objects. */
-static global_object *global_search( HMODULE hModule )
-{
-  global_object *pobject;
+static global_object *global_search(HMODULE hModule) {
+    global_object *pobject;
 
-  if( hModule == NULL )
+    if (hModule == NULL)
+        return NULL;
+
+    for (pobject = &first_object; pobject ; pobject = pobject->next)
+        if (pobject->hModule == hModule)
+            return pobject;
+
     return NULL;
-
-  for( pobject = &first_object; pobject ; pobject = pobject->next )
-    if( pobject->hModule == hModule )
-      return pobject;
-
-  return NULL;
 }
 
-static void global_add( HMODULE hModule )
-{
-  global_object *pobject;
-  global_object *nobject;
+static void global_add(HMODULE hModule) {
+    global_object *pobject;
+    global_object *nobject;
 
-  if( hModule == NULL )
-    return;
+    if (hModule == NULL)
+        return;
 
-  pobject = global_search( hModule );
+    pobject = global_search(hModule);
 
-  /* Do not add object again if it's already on the list */
-  if( pobject )
-    return;
+    /* Do not add object again if it's already on the list */
+    if (pobject)
+        return;
 
-  for( pobject = &first_object; pobject->next ; pobject = pobject->next );
+    for (pobject = &first_object; pobject->next ; pobject = pobject->next);
 
-  nobject = static_cast<global_object *>(malloc( sizeof(global_object) ));
+    nobject = static_cast<global_object *>(malloc(sizeof(global_object)));
 
-  /* Should this be enough to fail global_add, and therefore also fail
-   * dlopen?
-   */
-  if( !nobject )
-    return;
+    /*  Should this be enough to fail global_add, and therefore also fail
+        dlopen?
+    */
+    if (!nobject)
+        return;
 
-  pobject->next = nobject;
-  nobject->next = NULL;
-  nobject->previous = pobject;
-  nobject->hModule = hModule;
+    pobject->next = nobject;
+    nobject->next = NULL;
+    nobject->previous = pobject;
+    nobject->hModule = hModule;
 }
 
-static void global_rem( HMODULE hModule )
-{
-  global_object *pobject;
+static void global_rem(HMODULE hModule) {
+    global_object *pobject;
 
-  if( hModule == NULL )
-    return;
+    if (hModule == NULL)
+        return;
 
-  pobject = global_search( hModule );
+    pobject = global_search(hModule);
 
-  if( !pobject )
-    return;
+    if (!pobject)
+        return;
 
-  if( pobject->next )
-    pobject->next->previous = pobject->previous;
-  if( pobject->previous )
-    pobject->previous->next = pobject->next;
+    if (pobject->next)
+        pobject->next->previous = pobject->previous;
+    if (pobject->previous)
+        pobject->previous->next = pobject->next;
 
-  free( pobject );
+    free(pobject);
 }
 
-/* POSIX says dlerror( ) doesn't have to be thread-safe, so we use one
- * static buffer.
- * MSDN says the buffer cannot be larger than 64K bytes, so we set it to
- * the limit.
- */
+/*  POSIX says dlerror( ) doesn't have to be thread-safe, so we use one
+    static buffer.
+    MSDN says the buffer cannot be larger than 64K bytes, so we set it to
+    the limit.
+*/
 static char error_buffer[65535];
 static char *current_error;
 
-static int copy_string( char *dest, int dest_size, const char *src )
-{
-  int i = 0;
+static int copy_string(char *dest, int dest_size, const char *src) {
+    int i = 0;
 
-  /* gcc should optimize this out */
-  if( !src && !dest )
-    return 0;
+    /* gcc should optimize this out */
+    if (!src && !dest)
+        return 0;
 
-  for( i = 0 ; i < dest_size-1 ; i++ )
-    {
-      if( !src[i] )
-	break;
-      else
-	dest[i] = src[i];
+    for (i = 0 ; i < dest_size - 1 ; i++) {
+        if (!src[i])
+            break;
+        else
+            dest[i] = src[i];
     }
-  dest[i] = '\0';
+    dest[i] = '\0';
 
-  return i;
+    return i;
 }
 
-static void save_err_str( const char *str )
-{
-  DWORD dwMessageId;
-  DWORD pos;
+static void save_err_str(const char *str) {
+    DWORD dwMessageId;
+    DWORD pos;
 
-  dwMessageId = GetLastError( );
+    dwMessageId = GetLastError();
 
-  if( dwMessageId == 0 )
-    return;
+    if (dwMessageId == 0)
+        return;
 
-  /* Format error message to:
-   * "<argument to function that failed>": <Windows localized error message>
-   */
+    /*  Format error message to:
+        "<argument to function that failed>": <Windows localized error message>
+    */
 
-  pos  = copy_string( error_buffer,     sizeof(error_buffer),     "\"" );
-  pos += copy_string( error_buffer+pos, sizeof(error_buffer)-pos, str );
-  pos += copy_string( error_buffer+pos, sizeof(error_buffer)-pos, "\": " );
+    pos  = copy_string(error_buffer,     sizeof(error_buffer),     "\"");
+    pos += copy_string(error_buffer + pos, sizeof(error_buffer) - pos, str);
+    pos += copy_string(error_buffer + pos, sizeof(error_buffer) - pos, "\": ");
 
-  size_t size = sizeof(error_buffer) - pos;
-  wchar_t * wErrorBuffer = new wchar_t[size];
-  size_t message_size = FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwMessageId,
-                        MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ),
-                        wErrorBuffer, size, NULL );
-  wcstombs (error_buffer+pos, wErrorBuffer, size);
-  delete [] wErrorBuffer;
-  pos += message_size;
+    size_t size = sizeof(error_buffer) - pos;
+    wchar_t *wErrorBuffer = new wchar_t[size];
+    size_t message_size = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwMessageId,
+                                        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                        wErrorBuffer, size, NULL);
+    wcstombs(error_buffer + pos, wErrorBuffer, size);
+    delete [] wErrorBuffer;
+    pos += message_size;
 
-  if( pos > 1 )
-    {
-      /* POSIX says the string must not have trailing <newline> */
-      if( error_buffer[pos-2] == '\r' && error_buffer[pos-1] == '\n' )
-	error_buffer[pos-2] = '\0';
+    if (pos > 1) {
+        /* POSIX says the string must not have trailing <newline> */
+        if (error_buffer[pos - 2] == '\r' && error_buffer[pos - 1] == '\n')
+            error_buffer[pos - 2] = '\0';
     }
 
-  current_error = error_buffer;
+    current_error = error_buffer;
 }
 
-static void save_err_ptr_str( const void *ptr )
-{
-  char ptr_buf[19]; /* 0x<pointer> up to 64 bits. */
+static void save_err_ptr_str(const void *ptr) {
+    char ptr_buf[19]; /* 0x<pointer> up to 64 bits. */
 
-  sprintf( ptr_buf, "0x%p", ptr );
+    sprintf(ptr_buf, "0x%p", ptr);
 
-  save_err_str( ptr_buf );
+    save_err_str(ptr_buf);
 }
 
-void *dlopen( const char *file, int mode )
-{
-  HMODULE hModule;
-  UINT uMode;
+void *dlopen(const char *file, int mode) {
+    HMODULE hModule;
+    UINT uMode;
 
-  current_error = NULL;
+    current_error = NULL;
 
-  /* Do not let Windows display the critical-error-handler message box */
-  uMode = SetErrorMode( SEM_FAILCRITICALERRORS );
+    /* Do not let Windows display the critical-error-handler message box */
+    uMode = SetErrorMode(SEM_FAILCRITICALERRORS);
 
-  if( file == 0 )
-    {
-      /* POSIX says that if the value of file is 0, a handle on a global
-       * symbol object must be provided. That object must be able to access
-       * all symbols from the original program file, and any objects loaded
-       * with the RTLD_GLOBAL flag.
-       * The return value from GetModuleHandle( ) allows us to retrieve
-       * symbols only from the original program file. For objects loaded with
-       * the RTLD_GLOBAL flag, we create our own list later on.
-       */
-      hModule = GetModuleHandle( NULL );
+    if (file == 0) {
+        /*  POSIX says that if the value of file is 0, a handle on a global
+            symbol object must be provided. That object must be able to access
+            all symbols from the original program file, and any objects loaded
+            with the RTLD_GLOBAL flag.
+            The return value from GetModuleHandle( ) allows us to retrieve
+            symbols only from the original program file. For objects loaded with
+            the RTLD_GLOBAL flag, we create our own list later on.
+        */
+        hModule = GetModuleHandle(NULL);
 
-      if( !hModule )
-	save_err_ptr_str( file );
+        if (!hModule)
+            save_err_ptr_str(file);
     }
-  else
-    {
-      char lpFileName[MAX_PATH];
-      int i;
+    else {
+        char lpFileName[MAX_PATH];
+        int i;
 
-      /* MSDN says backslashes *must* be used instead of forward slashes. */
-      for( i = 0 ; i < sizeof(lpFileName)-1 ; i++ )
-        {
-	  if( !file[i] )
-	    break;
-	  else if( file[i] == '/' )
-	    lpFileName[i] = '\\';
-	  else
-	    lpFileName[i] = file[i];
+        /* MSDN says backslashes *must* be used instead of forward slashes. */
+        for (i = 0 ; i < sizeof(lpFileName) - 1 ; i++) {
+            if (!file[i])
+                break;
+            else if (file[i] == '/')
+                lpFileName[i] = '\\';
+            else
+                lpFileName[i] = file[i];
         }
-      lpFileName[i] = '\0';
+        lpFileName[i] = '\0';
 
-      /* POSIX says the search path is implementation-defined.
-       * LOAD_WITH_ALTERED_SEARCH_PATH is used to make it behave more closely
-       * to UNIX's search paths (start with system folders instead of current
-       * folder).
-       */
-    size_t newsize = strlen(lpFileName) + 1;
-	  wchar_t * wFileName = new wchar_t[newsize];
-    mbstowcs ( wFileName, lpFileName, newsize );
-    hModule = LoadLibraryEx(wFileName, NULL, LOAD_WITH_ALTERED_SEARCH_PATH );
-	  delete [] wFileName;
+        /*  POSIX says the search path is implementation-defined.
+            LOAD_WITH_ALTERED_SEARCH_PATH is used to make it behave more closely
+            to UNIX's search paths (start with system folders instead of current
+            folder).
+        */
+        size_t newsize = strlen(lpFileName) + 1;
+        wchar_t *wFileName = new wchar_t[newsize];
+        mbstowcs(wFileName, lpFileName, newsize);
+        hModule = LoadLibraryEx(wFileName, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+        delete [] wFileName;
 
-      /* If the object was loaded with RTLD_GLOBAL, add it to list of global
-       * objects, so that its symbols may be retrieved even if the handle for
-       * the original program file is passed. POSIX says that if the same
-       * file is specified in multiple invocations, and any of them are
-       * RTLD_GLOBAL, even if any further invocations use RTLD_LOCAL, the
-       * symbols will remain global.
-       */
-      if( !hModule )
-	save_err_str( lpFileName );
-      else if( (mode & RTLD_GLOBAL) )
-	global_add( hModule );
+        /*  If the object was loaded with RTLD_GLOBAL, add it to list of global
+            objects, so that its symbols may be retrieved even if the handle for
+            the original program file is passed. POSIX says that if the same
+            file is specified in multiple invocations, and any of them are
+            RTLD_GLOBAL, even if any further invocations use RTLD_LOCAL, the
+            symbols will remain global.
+        */
+        if (!hModule)
+            save_err_str(lpFileName);
+        else if ((mode & RTLD_GLOBAL))
+            global_add(hModule);
     }
 
-  /* Return to previous state of the error-mode bit flags. */
-  SetErrorMode( uMode );
+    /* Return to previous state of the error-mode bit flags. */
+    SetErrorMode(uMode);
 
-  return (void *) hModule;
+    return (void *) hModule;
 }
 
-int dlclose( void *handle )
-{
-  HMODULE hModule = (HMODULE) handle;
-  BOOL ret;
+int dlclose(void *handle) {
+    HMODULE hModule = (HMODULE) handle;
+    BOOL ret;
 
-  current_error = NULL;
+    current_error = NULL;
 
-  ret = FreeLibrary( hModule );
+    ret = FreeLibrary(hModule);
 
-  /* If the object was loaded with RTLD_GLOBAL, remove it from list of global
-   * objects.
-   */
-  if( ret )
-    global_rem( hModule );
-  else
-    save_err_ptr_str( handle );
+    /*  If the object was loaded with RTLD_GLOBAL, remove it from list of global
+        objects.
+    */
+    if (ret)
+        global_rem(hModule);
+    else
+        save_err_ptr_str(handle);
 
-  /* dlclose's return value in inverted in relation to FreeLibrary's. */
-  ret = !ret;
+    /* dlclose's return value in inverted in relation to FreeLibrary's. */
+    ret = !ret;
 
-  return (int) ret;
+    return (int) ret;
 }
 
-void *dlsym( void *handle, const char *name )
-{
-  FARPROC symbol;
+void *dlsym(void *handle, const char *name) {
+    FARPROC symbol;
 
-  current_error = NULL;
+    current_error = NULL;
 
-  symbol = GetProcAddress( static_cast<HMODULE>(handle), name );
+    symbol = GetProcAddress(static_cast<HMODULE>(handle), name);
 
-  if( symbol == NULL )
-    {
-      HMODULE hModule;
+    if (symbol == NULL) {
+        HMODULE hModule;
 
-      /* If the handle for the original program file is passed, also search
-       * in all globally loaded objects.
-       */
+        /*  If the handle for the original program file is passed, also search
+            in all globally loaded objects.
+        */
 
-      hModule = GetModuleHandle( NULL );
+        hModule = GetModuleHandle(NULL);
 
-      if( hModule == handle )
-        {
-	  global_object *pobject;
+        if (hModule == handle) {
+            global_object *pobject;
 
-	  for( pobject = &first_object; pobject ; pobject = pobject->next )
-            {
-	      if( pobject->hModule )
-                {
-		  symbol = GetProcAddress( pobject->hModule, name );
-		  if( symbol != NULL )
-		    break;
+            for (pobject = &first_object; pobject ; pobject = pobject->next) {
+                if (pobject->hModule) {
+                    symbol = GetProcAddress(pobject->hModule, name);
+                    if (symbol != NULL)
+                        break;
                 }
             }
         }
 
-      CloseHandle( hModule );
+        CloseHandle(hModule);
     }
 
-  if( symbol == NULL )
-    save_err_str( name );
+    if (symbol == NULL)
+        save_err_str(name);
 
-  return (void*) symbol;
+    return (void *) symbol;
 }
 
-char *dlerror( void )
-{
-  char *error_pointer = current_error;
+char *dlerror(void) {
+    char *error_pointer = current_error;
 
-  /* POSIX says that invoking dlerror( ) a second time, immediately following
-   * a prior invocation, shall result in NULL being returned.
-   */
-  current_error = NULL;
+    /*  POSIX says that invoking dlerror( ) a second time, immediately following
+        a prior invocation, shall result in NULL being returned.
+    */
+    current_error = NULL;
 
-  return error_pointer;
+    return error_pointer;
 }

--- a/src/dof.cpp
+++ b/src/dof.cpp
@@ -36,1067 +36,1042 @@
 //#define GRASPITDBG
 #include "debug.h"
 
-  /*! Initializes everything to zero. */
-DOF::DOF() : owner(NULL), q(0.0),desiredq(0.0), desiredVelocity(0.0),defaultVelocity(0.0), defaultValue(0.0),
-	actualVelocity(0.0), maxAccel(10.0), force(0.0),maxForce(0.0),
-	extForce(0.0), Kv(0.0),Kp(0.0),mHistoryMaxSize(10), mDynStartTime(0.0), currTrajPt(0), 
-	draggerScale(20.0)
-{
+/*! Initializes everything to zero. */
+DOF::DOF() : owner(NULL), q(0.0), desiredq(0.0), desiredVelocity(0.0), defaultVelocity(0.0), defaultValue(0.0),
+    actualVelocity(0.0), maxAccel(10.0), force(0.0), maxForce(0.0),
+    extForce(0.0), Kv(0.0), Kp(0.0), mHistoryMaxSize(10), mDynStartTime(0.0), currTrajPt(0),
+    draggerScale(20.0) {
 }
 
-/*! This copy constructor only copies the paramters of the DOF, but none of 
-	its dynamic state or the joints or robot. Use initDOF(), like you would 
-	with a regularly contructed DOF, to assign joints to it.
+/*! This copy constructor only copies the paramters of the DOF, but none of
+    its dynamic state or the joints or robot. Use initDOF(), like you would
+    with a regularly contructed DOF, to assign joints to it.
 */
-DOF::DOF(const DOF *original)
-{
-  owner = NULL;
-  dofNum = original->dofNum;
-  maxq = original->maxq;
-  minq = original->minq;
-  q = 0.0;
-  desiredq = 0.0;
+DOF::DOF(const DOF *original) {
+    owner = NULL;
+    dofNum = original->dofNum;
+    maxq = original->maxq;
+    minq = original->minq;
+    q = 0.0;
+    desiredq = 0.0;
 
-  defaultVelocity = original->defaultVelocity;
-  maxAccel = original->maxAccel;
-  desiredVelocity = 0.0;
-  actualVelocity = 0.0;
+    defaultVelocity = original->defaultVelocity;
+    maxAccel = original->maxAccel;
+    desiredVelocity = 0.0;
+    actualVelocity = 0.0;
 
-  maxForce = original->maxForce;
-  force = 0.0;
-  extForce = 0.0;
+    maxForce = original->maxForce;
+    force = 0.0;
+    extForce = 0.0;
 
-  Kv = original->Kv;
-  Kp = original->Kp;
+    Kv = original->Kv;
+    Kp = original->Kp;
 
-  mHistoryMaxSize = original->mHistoryMaxSize;
-  draggerScale = original->draggerScale;
-  currTrajPt = 0;
+    mHistoryMaxSize = original->mHistoryMaxSize;
+    draggerScale = original->draggerScale;
+    currTrajPt = 0;
 }
 
 /*!
-  Initializes a DOF by giving it the owning robot \a myRobot, and the list
-  of joints connected to this DOF, \a jList.  Also sets the max and min vals
-  of the DOF from the smallest range of the joint limits.
+    Initializes a DOF by giving it the owning robot \a myRobot, and the list
+    of joints connected to this DOF, \a jList.  Also sets the max and min vals
+    of the DOF from the smallest range of the joint limits.
 */
 void
-DOF::initDOF(Robot *myRobot,const std::vector<Joint *>& jList)
-{
-  owner = myRobot;  
-  jointList = jList; // copy jList
-  updateMinMax();
+DOF::initDOF(Robot *myRobot, const std::vector<Joint *> &jList) {
+    owner = myRobot;
+    jointList = jList; // copy jList
+    updateMinMax();
 }
 
-/*! Sets the max and min vals of the DOF from the smallest range of the joint 
-  limits. Also forces defaultValue to be inside those limits.*/
-void DOF::updateMinMax()
-{
-  maxq = (*jointList.begin())->getMax()/getStaticRatio(*jointList.begin());
-  minq = (*jointList.begin())->getMin()/getStaticRatio(*jointList.begin());
-  DBGP("Joint 0 min "  << minq << " max " << maxq);
-  if (maxq < minq) std::swap(maxq, minq);  
-  DBGP("maxq " << maxq << " minq " << minq);
-  std::vector<Joint *>::iterator j;
-  double testMin, testMax;
-  DBGST(int num = 0;)
-  for(j=++jointList.begin();j!=jointList.end();j++) {
-    testMax = (*j)->getMax()/getStaticRatio(*j);
-    testMin = (*j)->getMin()/getStaticRatio(*j);
-    //can happen if ratio is negative
-    if (testMax < testMin) std::swap(testMin, testMax);
-    DBGP("Joint " << num++ << " min "  << testMin << " max " << testMax);
-    maxq = ( testMax < maxq ? testMax : maxq);
-    minq = ( testMin > minq ? testMin : minq);
+/*! Sets the max and min vals of the DOF from the smallest range of the joint
+    limits. Also forces defaultValue to be inside those limits.*/
+void DOF::updateMinMax() {
+    maxq = (*jointList.begin())->getMax() / getStaticRatio(*jointList.begin());
+    minq = (*jointList.begin())->getMin() / getStaticRatio(*jointList.begin());
+    DBGP("Joint 0 min "  << minq << " max " << maxq);
+    if (maxq < minq) std::swap(maxq, minq);
     DBGP("maxq " << maxq << " minq " << minq);
-  }
-  if (maxq < defaultValue) {DBGA("DOF default value too large; setting to max"); defaultValue = maxq;}
-  if (minq > defaultValue) {DBGA("DOF default value too small; setting to min"); defaultValue = minq;}
+    std::vector<Joint *>::iterator j;
+    double testMin, testMax;
+    DBGST(int num = 0;)
+    for (j = ++jointList.begin(); j != jointList.end(); j++) {
+        testMax = (*j)->getMax() / getStaticRatio(*j);
+        testMin = (*j)->getMin() / getStaticRatio(*j);
+        //can happen if ratio is negative
+        if (testMax < testMin) std::swap(testMin, testMax);
+        DBGP("Joint " << num++ << " min "  << testMin << " max " << testMax);
+        maxq = (testMax < maxq ? testMax : maxq);
+        minq = (testMin > minq ? testMin : minq);
+        DBGP("maxq " << maxq << " minq " << minq);
+    }
+    if (maxq < defaultValue) {
+        DBGA("DOF default value too large; setting to max");
+        defaultValue = maxq;
+    }
+    if (minq > defaultValue) {
+        DBGA("DOF default value too small; setting to min");
+        defaultValue = minq;
+    }
 }
 
 /*!
-  If a trajectory exists, this increments the \a currTrajPt counter, and
-  makes the \a setPoint the next point of the trajectory.  Otherwise, it
-  makes the \a setPoint the current desired value.  The \a setPoint is used
-  by the PD controller to determine the proper force to apply to this DOF.
+    If a trajectory exists, this increments the \a currTrajPt counter, and
+    makes the \a setPoint the next point of the trajectory.  Otherwise, it
+    makes the \a setPoint the current desired value.  The \a setPoint is used
+    by the PD controller to determine the proper force to apply to this DOF.
 */
 void
 DOF::updateSetPoint() {
-	if (!trajectory.empty()) {    
-		setPoint = trajectory[currTrajPt++];
-		if (trajectory.begin()+currTrajPt==trajectory.end()) {
-			trajectory.clear();
-		}
-	}else if (setPoint != desiredq) {
-		setPoint=desiredq;
-	}
-	DBGP("Update set point: " << setPoint);
+    if (!trajectory.empty()) {
+        setPoint = trajectory[currTrajPt++];
+        if (trajectory.begin() + currTrajPt == trajectory.end()) {
+            trajectory.clear();
+        }
+    }
+    else if (setPoint != desiredq) {
+        setPoint = desiredq;
+    }
+    DBGP("Update set point: " << setPoint);
 }
 
 /*!
-  Given an array of DOF values, and the length of the array, this clears the
-  current trajectory and sets the trajectory to the given values.
+    Given an array of DOF values, and the length of the array, this clears the
+    current trajectory and sets the trajectory to the given values.
 */
 void
-DOF::setTrajectory(double *traj,int numPts)
-{
-	trajectory.clear();
-	currTrajPt = 0;
-	trajectory.reserve(numPts);
-	for (int i=0;i<numPts;i++) {
-		trajectory.push_back(traj[i]);
-	}
-	desiredq = traj[numPts-1];
-	mErrorHistory.clear();
-	mPositionHistory.clear();
-	mForceHistory.clear();
-	//reset the dynamics start time
-	mDynStartTime = owner->getWorld()->getWorldTime();
+DOF::setTrajectory(double *traj, int numPts) {
+    trajectory.clear();
+    currTrajPt = 0;
+    trajectory.reserve(numPts);
+    for (int i = 0; i < numPts; i++) {
+        trajectory.push_back(traj[i]);
+    }
+    desiredq = traj[numPts - 1];
+    mErrorHistory.clear();
+    mPositionHistory.clear();
+    mForceHistory.clear();
+    //reset the dynamics start time
+    mDynStartTime = owner->getWorld()->getWorldTime();
 }
 
-/*!	Adds \a numPts values to the current trajectory.*/
+/*! Adds \a numPts values to the current trajectory.*/
 void
-DOF::addToTrajectory(double *traj,int numPts)
-{
-	for (int i=0;i<numPts;i++){
-		trajectory.push_back(traj[i]);
-	}
-	desiredq = trajectory.back();
+DOF::addToTrajectory(double *traj, int numPts) {
+    for (int i = 0; i < numPts; i++) {
+        trajectory.push_back(traj[i]);
+    }
+    desiredq = trajectory.back();
 }
 
 /*! This wraps the controller call so we can have different types of
-	DOF's call different controllers if we want to.
+    DOF's call different controllers if we want to.
 */
 void
-DOF::callController(double timeStep)
-{
-	//we need to update the current position based on current joint values 
-	//we rely on those having already been set from dynamics
-	updateFromJointValues();
+DOF::callController(double timeStep) {
+    //we need to update the current position based on current joint values
+    //we rely on those having already been set from dynamics
+    updateFromJointValues();
 
-	//bookkeeping
-	mErrorHistory.push_front(setPoint - q);
-	while ((int)mErrorHistory.size() > mHistoryMaxSize) {
-		mErrorHistory.pop_back();
-	}
-	//the error wrt the last desired position in the trajectory
-	/*
-	if (!trajectory.empty()) {
-		mPositionHistory.push_front(trajectory.back() - q);
-	} else {
-		mPositionHistory.push_front(setPoint - q);
-	}
-	*/
-	if (!mPositionHistory.empty()) {
-		mVelocityHistory.push_front( (q - mPositionHistory.front() ) / timeStep );
-		while ((int)mVelocityHistory.size() > mHistoryMaxSize) {
-			mVelocityHistory.pop_back();
-		}
-	}
+    //bookkeeping
+    mErrorHistory.push_front(setPoint - q);
+    while ((int)mErrorHistory.size() > mHistoryMaxSize) {
+        mErrorHistory.pop_back();
+    }
+    //the error wrt the last desired position in the trajectory
+    /*
+        if (!trajectory.empty()) {
+        mPositionHistory.push_front(trajectory.back() - q);
+        } else {
+        mPositionHistory.push_front(setPoint - q);
+        }
+    */
+    if (!mPositionHistory.empty()) {
+        mVelocityHistory.push_front((q - mPositionHistory.front()) / timeStep);
+        while ((int)mVelocityHistory.size() > mHistoryMaxSize) {
+            mVelocityHistory.pop_back();
+        }
+    }
 
-	mPositionHistory.push_front(q);
-	while ((int)mPositionHistory.size() > mHistoryMaxSize) {
-		mPositionHistory.pop_back();
-	}
-	
-	//call the appropriate controller
-	double newForce = PDPositionController(timeStep);
-	//actually sets the force
+    mPositionHistory.push_front(q);
+    while ((int)mPositionHistory.size() > mHistoryMaxSize) {
+        mPositionHistory.pop_back();
+    }
+
+    //call the appropriate controller
+    double newForce = PDPositionController(timeStep);
+    //actually sets the force
     setForce(newForce);
 
-	mForceHistory.push_front(newForce);
-	while ((int)mForceHistory.size() > mHistoryMaxSize) {
-		mForceHistory.pop_back();
-	}
+    mForceHistory.push_front(newForce);
+    while ((int)mForceHistory.size() > mHistoryMaxSize) {
+        mForceHistory.pop_back();
+    }
 }
 
 /*!
-  Updates the error between the current DOF value and its setpoint and uses
-  this along with the rate of change of the error (first-order approx) to
-  compute a force that should be applied to the DOF to correct the error.  The
-  gains for this controller are read from the robot configuration file.
+    Updates the error between the current DOF value and its setpoint and uses
+    this along with the rate of change of the error (first-order approx) to
+    compute a force that should be applied to the DOF to correct the error.  The
+    gains for this controller are read from the robot configuration file.
 */
 double
-DOF::PDPositionController(double timeStep)
-{
+DOF::PDPositionController(double timeStep) {
     double error = mErrorHistory.front();
     double lastError;
-	if (mErrorHistory.size() >= 2) {
-		lastError = *(++mErrorHistory.begin());
+    if (mErrorHistory.size() >= 2) {
+        lastError = *(++mErrorHistory.begin());
     }
-    else if(mErrorHistory.size() == 0) {
+    else if (mErrorHistory.size() == 0) {
         error = 0;
         lastError = 0;
     }
     else {
-		lastError = error;
-	}
-
-    if (error < -M_PI)
-    {
-        error += (2*M_PI);
+        lastError = error;
     }
 
-    if (lastError < -M_PI)
-    {
-        lastError += (2*M_PI);
+    if (error < -M_PI) {
+        error += (2 * M_PI);
+    }
+
+    if (lastError < -M_PI) {
+        lastError += (2 * M_PI);
     }
 
 
-    if (error > M_PI)
-    {
-        error -= (2*M_PI);
+    if (error > M_PI) {
+        error -= (2 * M_PI);
     }
 
-    if (lastError > M_PI)
-    {
-        lastError -= (2*M_PI);
+    if (lastError > M_PI) {
+        lastError -= (2 * M_PI);
     }
 
-	double newForce;
-    newForce = Kp * error + Kv * (error-lastError)/timeStep;
+    double newForce;
+    newForce = Kp * error + Kv * (error - lastError) / timeStep;
 
     DBGP("PDPositionController: DOF " << getDOFNum() << std::endl) ;
     DBGP("PDPositionController: error =" << error << std::endl);
-    DBGP( "PDPositionController: setPoint =" << setPoint << " error ="<<error<<" edot = "<<(error-lastError) << std::endl);
-    DBGP("PDPositionController: proportional: "<<error<<"*"<<Kp<<"="<<error*Kp << std::endl);
-    DBGP("PDPositionController: derivative: "<<Kv<<"*"<<(error-lastError)/timeStep << std::endl);
-    DBGP("PDPositionController: cap: "<<getMaxForce()*0.8 << " Force: "<<newForce << std::endl);
-    DBGP( "PDPositionController: e " << error << " de " << error-lastError << " ts " << timeStep << " f " << newForce << std::endl);
-	return newForce;
+    DBGP("PDPositionController: setPoint =" << setPoint << " error =" << error << " edot = " << (error - lastError) << std::endl);
+    DBGP("PDPositionController: proportional: " << error << "*" << Kp << "=" << error * Kp << std::endl);
+    DBGP("PDPositionController: derivative: " << Kv << "*" << (error - lastError) / timeStep << std::endl);
+    DBGP("PDPositionController: cap: " << getMaxForce() * 0.8 << " Force: " << newForce << std::endl);
+    DBGP("PDPositionController: e " << error << " de " << error - lastError << " ts " << timeStep << " f " << newForce << std::endl);
+    return newForce;
 }
 
 /*! Not implemented for the general case. This is a more difficult feature than
-	originally thought. What is a good test of whether dynamic progress has
-	stopped?
+    originally thought. What is a good test of whether dynamic progress has
+    stopped?
 */
 bool
-DOF::dynamicsProgress()
-{
-	return true;
+DOF::dynamicsProgress() {
+    return true;
 }
 
 /*! Reads the parameters (not the value) of this DOF from XML. Used
-	when reading robot configuration files, where we want to define a
-	DOF, not set a particular value.
+    when reading robot configuration files, where we want to define a
+    DOF, not set a particular value.
 */
 bool
-DOF::readParametersFromXml(const TiXmlElement* root)
-{
-  if(!getDouble(root,"defaultVelocity", defaultVelocity)) return false;
-  double defaultValueDegrees;
-  if(getDouble(root,"defaultValue", defaultValueDegrees)) defaultValue = defaultValueDegrees * M_PI / 180.0;
-  else defaultValue = 0.0;
-  if(!getDouble(root,"maxEffort", maxForce)) return false;
-  if(!getDouble(root,"Kp", Kp)) return false;
-  if(!getDouble(root,"Kd", Kv)) return false;
-  if(!getDouble(root,"draggerScale", draggerScale)) return false;
-  return true;
+DOF::readParametersFromXml(const TiXmlElement *root) {
+    if (!getDouble(root, "defaultVelocity", defaultVelocity)) return false;
+    double defaultValueDegrees;
+    if (getDouble(root, "defaultValue", defaultValueDegrees)) defaultValue = defaultValueDegrees * M_PI / 180.0;
+    else defaultValue = 0.0;
+    if (!getDouble(root, "maxEffort", maxForce)) return false;
+    if (!getDouble(root, "Kp", Kp)) return false;
+    if (!getDouble(root, "Kd", Kv)) return false;
+    if (!getDouble(root, "draggerScale", draggerScale)) return false;
+    return true;
 }
 
 /*! Write the value, or the overall state, of this DOF to a stream. Used
-	for saving the posture of a robot, either to a variable or to a file.
+    for saving the posture of a robot, either to a variable or to a file.
 */
 bool
-DOF::writeToStream(QTextStream &stream)
-{
-	stream << q;
-	return true;
+DOF::writeToStream(QTextStream &stream) {
+    stream << q;
+    return true;
 }
 
-/*! Read in the value (or for more complex dof's the complete state) of 
-	this dof from a stream.
+/*! Read in the value (or for more complex dof's the complete state) of
+    this dof from a stream.
 */
 bool
-DOF::readFromStream(QTextStream &stream)
-{
-	if (stream.atEnd()) return false;
-	stream >> q;
-	return true;
+DOF::readFromStream(QTextStream &stream) {
+    if (stream.atEnd()) return false;
+    stream >> q;
+    return true;
 }
 
 /*!
-  Sets the current force applied to this DOF, keeping it within the maximum
-  force limits.  This force is then applied to the joints based on the 
-  transmission type implemented by each dof.
+    Sets the current force applied to this DOF, keeping it within the maximum
+    force limits.  This force is then applied to the joints based on the
+    transmission type implemented by each dof.
 */
 void
-RigidDOF::setForce(double f)
-{
-	Joint *activeJoint = *(jointList.begin());
-	if (f > maxForce) force = maxForce;
-	else if (f < -maxForce) force = -maxForce;
-	else force = f;
+RigidDOF::setForce(double f) {
+    Joint *activeJoint = *(jointList.begin());
+    if (f > maxForce) force = maxForce;
+    else if (f < -maxForce) force = -maxForce;
+    else force = f;
 
-	//set force for the first joint only, passive joint constraints will take care of the others
-	activeJoint->applyInternalWrench(force);
-	DBGP("Applied force = " << force);
+    //set force for the first joint only, passive joint constraints will take care of the others
+    activeJoint->applyInternalWrench(force);
+    DBGP("Applied force = " << force);
 }
 
 /*! Returns how far this dof is from exceeding one of it's joint limits.
-	The return value is the distance between the current value and the
-	joint limit, positive if the joint is inside its limit or negative if
-	the joint has already exceeded its limit. \a direction is set to +1 if
-	the limit is a positive one, or -1 if the limit is a negative one.
+    The return value is the distance between the current value and the
+    joint limit, positive if the joint is inside its limit or negative if
+    the joint has already exceeded its limit. \a direction is set to +1 if
+    the limit is a positive one, or -1 if the limit is a negative one.
 */
 double
-RigidDOF::getClosestJointLimit(int *direction)
-{
-	bool firstTime = true;
-	double closestLimit = 0.0;
-	*direction = 0.0;
-    std::vector<Joint*>::iterator j;
-	for (j=jointList.begin(); j!=jointList.end(); j++) {
-		double val = (*j)->getVal();
-		double maxError = val - (*j)->getMax();
-		double minError = (*j)->getMin() - val;
-		double error; int jdir;
-		if (maxError > minError) {
-			error = maxError;
-			jdir = -1;
-		} else {
-			error = minError;
-			jdir = +1;
-		}
-		error /= getStaticRatio(*j);
-		if (firstTime || fabs(error) > fabs(closestLimit)) {
-			closestLimit = error;
-			*direction = jdir;
-			firstTime = false;
-		}
-	}
-	return closestLimit;
+RigidDOF::getClosestJointLimit(int *direction) {
+    bool firstTime = true;
+    double closestLimit = 0.0;
+    *direction = 0.0;
+    std::vector<Joint *>::iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        double val = (*j)->getVal();
+        double maxError = val - (*j)->getMax();
+        double minError = (*j)->getMin() - val;
+        double error;
+        int jdir;
+        if (maxError > minError) {
+            error = maxError;
+            jdir = -1;
+        }
+        else {
+            error = minError;
+            jdir = +1;
+        }
+        error /= getStaticRatio(*j);
+        if (firstTime || fabs(error) > fabs(closestLimit)) {
+            closestLimit = error;
+            *direction = jdir;
+            firstTime = false;
+        }
+    }
+    return closestLimit;
 }
 
 /*! If any of the joints are too close (or over) their range, we still
-	have a single contraint that we will use to correct this
+    have a single contraint that we will use to correct this
 */
 int
-RigidDOF::getNumLimitConstraints() 
-{
-	int d;
-	if (getClosestJointLimit(&d) < -0.01) return 0;
-	return 1;
+RigidDOF::getNumLimitConstraints() {
+    int d;
+    if (getClosestJointLimit(&d) < -0.01) return 0;
+    return 1;
 }
 
 /*! The regular DOF only imposes a single limit constraint, which will be placed
-	on the first joint in this DOF. Assumes the rest of the joints are rigidly
-	connected, so coupling constraints will take care of the rest.
+    on the first joint in this DOF. Assumes the rest of the joints are rigidly
+    connected, so coupling constraints will take care of the rest.
 */
-void 
-RigidDOF::buildDynamicLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-								  double* H, double *g, int &hcn)
-{	
-	int dir;
-	double error = getClosestJointLimit(&dir);
-	if ( error < -0.01) return;
+void
+RigidDOF::buildDynamicLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                       double *H, double *g, int &hcn) {
+    int dir;
+    double error = getClosestJointLimit(&dir);
+    if (error < -0.01) return;
 
-	g[hcn] = MIN(0.0, -error - 0.005);
-	DBGP("adding dof limit constraint for DOF " << dofNum << " in dir " << dir << "; error: "<<g[hcn]);
+    g[hcn] = MIN(0.0, -error - 0.005);
+    DBGP("adding dof limit constraint for DOF " << dofNum << " in dir " << dir << "; error: " << g[hcn]);
 
-	//the first joint in the list is considered the master joint
-	Joint *currentJoint = jointList.front();
+    //the first joint in the list is considered the master joint
+    Joint *currentJoint = jointList.front();
     DynamicBody *prevLink = currentJoint->getDynJoint()->getPrevLink();
     DynamicBody *nextLink = currentJoint->getDynJoint()->getNextLink();
-   
-	assert( islandIndices[prevLink]>=0 );
-	int row = 6*islandIndices[prevLink];
-	H[(hcn)*6*numBodies + row+3] -= dir * currentJoint->getWorldAxis()[0];
-	H[(hcn)*6*numBodies + row+4] -= dir * currentJoint->getWorldAxis()[1];
-	H[(hcn)*6*numBodies + row+5] -= dir * currentJoint->getWorldAxis()[2];
 
-    assert( islandIndices[nextLink]>=0 );
-	row = 6*islandIndices[nextLink];
-	H[(hcn)*6*numBodies + row+3] +=  dir * currentJoint->getWorldAxis()[0];
-	H[(hcn)*6*numBodies + row+4] +=  dir * currentJoint->getWorldAxis()[1];
-	H[(hcn)*6*numBodies + row+5] +=  dir * currentJoint->getWorldAxis()[2];
+    assert(islandIndices[prevLink] >= 0);
+    int row = 6 * islandIndices[prevLink];
+    H[(hcn) * 6 * numBodies + row + 3] -= dir * currentJoint->getWorldAxis()[0];
+    H[(hcn) * 6 * numBodies + row + 4] -= dir * currentJoint->getWorldAxis()[1];
+    H[(hcn) * 6 * numBodies + row + 5] -= dir * currentJoint->getWorldAxis()[2];
 
-	hcn++;
+    assert(islandIndices[nextLink] >= 0);
+    row = 6 * islandIndices[nextLink];
+    H[(hcn) * 6 * numBodies + row + 3] +=  dir * currentJoint->getWorldAxis()[0];
+    H[(hcn) * 6 * numBodies + row + 4] +=  dir * currentJoint->getWorldAxis()[1];
+    H[(hcn) * 6 * numBodies + row + 5] +=  dir * currentJoint->getWorldAxis()[2];
+
+    hcn++;
 }
 
 /*! On the rigid dof, all joints are coupled together, enforcing that the movement
-	in all joints is identical to the movement in the first joint in the list
-	controlled by this DOF.
+    in all joints is identical to the movement in the first joint in the list
+    controlled by this DOF.
 */
-void 
-RigidDOF::buildDynamicCouplingConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-									 double* Nu, double*, int &ncn)
-{
-	//again we consider the first joint as the master joint 
-	Joint *masterJoint = jointList.front();
-	
+void
+RigidDOF::buildDynamicCouplingConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                          double *Nu, double *, int &ncn) {
+    //again we consider the first joint as the master joint
+    Joint *masterJoint = jointList.front();
+
     DynamicBody *masterPrevLink = masterJoint->getDynJoint()->getPrevLink();
     DynamicBody *masterNextLink = masterJoint->getDynJoint()->getNextLink();
-	double masterRatio = getStaticRatio(masterJoint);
-	vec3 masterFreeRotAxis = masterJoint->getWorldAxis();
+    double masterRatio = getStaticRatio(masterJoint);
+    vec3 masterFreeRotAxis = masterJoint->getWorldAxis();
 
-    std::vector<Joint*>::iterator it = jointList.begin();
-	while(++it != jointList.end()) {
-		Joint *currentJoint = (*it);
-		//for now this only works on revolute dynamic joints
-		//which means made up of a single revolute static joint
-		//(unlike universal dynamic joints which are made up of 2
-		//revolute static joints)
+    std::vector<Joint *>::iterator it = jointList.begin();
+    while (++it != jointList.end()) {
+        Joint *currentJoint = (*it);
+        //for now this only works on revolute dynamic joints
+        //which means made up of a single revolute static joint
+        //(unlike universal dynamic joints which are made up of 2
+        //revolute static joints)
 
-		if (currentJoint->getType() != REVOLUTE) continue;
-		
+        if (currentJoint->getType() != REVOLUTE) continue;
+
         DynamicBody *prevLink = currentJoint->getDynJoint()->getPrevLink();
         DynamicBody *nextLink = currentJoint->getDynJoint()->getNextLink();
-		vec3 freeRotAxis = currentJoint->getWorldAxis();
+        vec3 freeRotAxis = currentJoint->getWorldAxis();
 
-		//the *rotation* between these joint links...
-		double ratio = 1.0/getStaticRatio(currentJoint);
-		assert( islandIndices[prevLink] >= 0 );
-		int row = 6*islandIndices[prevLink];
-		Nu[(ncn)*6*numBodies + row+3] -= ratio * freeRotAxis[0];
-		Nu[(ncn)*6*numBodies + row+4] -= ratio * freeRotAxis[1];
-		Nu[(ncn)*6*numBodies + row+5] -= ratio * freeRotAxis[2];
-		assert( islandIndices[nextLink] >= 0 );
-		row = 6*islandIndices[nextLink];
-		Nu[(ncn)*6*numBodies + row+3] +=  ratio * freeRotAxis[0];
-		Nu[(ncn)*6*numBodies + row+4] +=  ratio * freeRotAxis[1];
-		Nu[(ncn)*6*numBodies + row+5] +=  ratio * freeRotAxis[2];
+        //the *rotation* between these joint links...
+        double ratio = 1.0 / getStaticRatio(currentJoint);
+        assert(islandIndices[prevLink] >= 0);
+        int row = 6 * islandIndices[prevLink];
+        Nu[(ncn) * 6 * numBodies + row + 3] -= ratio * freeRotAxis[0];
+        Nu[(ncn) * 6 * numBodies + row + 4] -= ratio * freeRotAxis[1];
+        Nu[(ncn) * 6 * numBodies + row + 5] -= ratio * freeRotAxis[2];
+        assert(islandIndices[nextLink] >= 0);
+        row = 6 * islandIndices[nextLink];
+        Nu[(ncn) * 6 * numBodies + row + 3] +=  ratio * freeRotAxis[0];
+        Nu[(ncn) * 6 * numBodies + row + 4] +=  ratio * freeRotAxis[1];
+        Nu[(ncn) * 6 * numBodies + row + 5] +=  ratio * freeRotAxis[2];
 
-		//... must be the same as the movement between the master joint links
-		ratio = 1.0/masterRatio;
-		assert( islandIndices[masterPrevLink] >= 0 );
-		row = 6*islandIndices[masterPrevLink];
-		Nu[(ncn)*6*numBodies + row+3] += ratio * masterFreeRotAxis[0];
-		Nu[(ncn)*6*numBodies + row+4] += ratio * masterFreeRotAxis[1];
-		Nu[(ncn)*6*numBodies + row+5] += ratio * masterFreeRotAxis[2];
-		assert( islandIndices[masterNextLink] >= 0 );
-		row = 6*islandIndices[masterNextLink];
-		Nu[(ncn)*6*numBodies + row+3] += - ratio * masterFreeRotAxis[0];
-		Nu[(ncn)*6*numBodies + row+4] += - ratio * masterFreeRotAxis[1];
-		Nu[(ncn)*6*numBodies + row+5] += - ratio * masterFreeRotAxis[2];
+        //... must be the same as the movement between the master joint links
+        ratio = 1.0 / masterRatio;
+        assert(islandIndices[masterPrevLink] >= 0);
+        row = 6 * islandIndices[masterPrevLink];
+        Nu[(ncn) * 6 * numBodies + row + 3] += ratio * masterFreeRotAxis[0];
+        Nu[(ncn) * 6 * numBodies + row + 4] += ratio * masterFreeRotAxis[1];
+        Nu[(ncn) * 6 * numBodies + row + 5] += ratio * masterFreeRotAxis[2];
+        assert(islandIndices[masterNextLink] >= 0);
+        row = 6 * islandIndices[masterNextLink];
+        Nu[(ncn) * 6 * numBodies + row + 3] += - ratio * masterFreeRotAxis[0];
+        Nu[(ncn) * 6 * numBodies + row + 4] += - ratio * masterFreeRotAxis[1];
+        Nu[(ncn) * 6 * numBodies + row + 5] += - ratio * masterFreeRotAxis[2];
 
-		ncn++;		
+        ncn++;
 
-		//there should be a corrective term added here!!!
-	}
+        //there should be a corrective term added here!!!
+    }
 }
 
-double 
-RigidDOF::getStaticRatio(Joint *j) const 
-{
-	return j->getCouplingRatio();
+double
+RigidDOF::getStaticRatio(Joint *j) const {
+    return j->getCouplingRatio();
 }
 
 void
-RigidDOF::getJointValues(double *jointVals) const
-{
-    std::vector<Joint*>::const_iterator j;
-	for(j=jointList.begin();j!=jointList.end();j++) {
-		jointVals[ (*j)->getNum() ] = q * getStaticRatio(*j);
-	}
+RigidDOF::getJointValues(double *jointVals) const {
+    std::vector<Joint *>::const_iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        jointVals[(*j)->getNum() ] = q * getStaticRatio(*j);
+    }
 }
 
 /*! The RigidDOF stops altogether if a single joint that it controls is stopped.
-	If not, it sets all joints based on their ratio to the DOF value */
+    If not, it sets all joints based on their ratio to the DOF value */
 bool
-RigidDOF::accumulateMove(double q1, double *jointVals, int *stoppedJoints)
-{
-	if ( fabs(q-q1) < 1.0e-5 ) return false;
-    std::vector<Joint*>::iterator j;
-	if (stoppedJoints) {
-		for(j=jointList.begin();j!=jointList.end();j++) {
-			if ( stoppedJoints[ (*j)->getNum()] ) return false;
-		}
-	}
-	for(j=jointList.begin();j!=jointList.end();j++) {
-		jointVals[ (*j)->getNum() ] = q1 * getStaticRatio(*j);
-	}
-	return true;
+RigidDOF::accumulateMove(double q1, double *jointVals, int *stoppedJoints) {
+    if (fabs(q - q1) < 1.0e-5) return false;
+    std::vector<Joint *>::iterator j;
+    if (stoppedJoints) {
+        for (j = jointList.begin(); j != jointList.end(); j++) {
+            if (stoppedJoints[(*j)->getNum()]) return false;
+        }
+    }
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        jointVals[(*j)->getNum() ] = q1 * getStaticRatio(*j);
+    }
+    return true;
 }
 
-/*! In the RigidDOF all joint values behave the same way (either they are 
-	all stopped or they all move based on the DOF ratios. Therefore it is 
-	enough to look at a single joint in the list (such as the first one) 
-	to know what the DOF value should be.
+/*! In the RigidDOF all joint values behave the same way (either they are
+    all stopped or they all move based on the DOF ratios. Therefore it is
+    enough to look at a single joint in the list (such as the first one)
+    to know what the DOF value should be.
 */
 void
-RigidDOF::updateFromJointValues(const double *jointVals)
-{
-	assert(!jointList.empty());
-	double val;
-	if (jointVals) {
-		val = jointVals[ jointList.front()->getNum() ];
-	}
-	else {
-		val = jointList.front()->getVal();
-	}
-	q = val / getStaticRatio(jointList.front());
-	DBGP("DOF " << getDOFNum() << ": set value " << q);
+RigidDOF::updateFromJointValues(const double *jointVals) {
+    assert(!jointList.empty());
+    double val;
+    if (jointVals) {
+        val = jointVals[ jointList.front()->getNum() ];
+    }
+    else {
+        val = jointList.front()->getVal();
+    }
+    q = val / getStaticRatio(jointList.front());
+    DBGP("DOF " << getDOFNum() << ": set value " << q);
 }
 
-BreakAwayDOF::~BreakAwayDOF()
-{
-	if (mInBreakAway) delete [] mInBreakAway;
-	if (mBreakAwayValues) delete [] mBreakAwayValues;
+BreakAwayDOF::~BreakAwayDOF() {
+    if (mInBreakAway) delete [] mInBreakAway;
+    if (mBreakAwayValues) delete [] mBreakAwayValues;
 }
 
-void BreakAwayDOF::initDOF(Robot *myRobot, const std::vector<Joint*> &jList)
-{
-	DOF::initDOF(myRobot, jList);
-	int size = (int)jList.size();
-	assert(size>0);
-	mInBreakAway = new int[size];
-	mBreakAwayValues = new double[size];
-	for (int i=0; i<size; i++) {
-		mInBreakAway[i] = 0;
-		//maybe useful for debugging purposes; should not matter what we put here
-		mBreakAwayValues[i] = -10;
-	}
+void BreakAwayDOF::initDOF(Robot *myRobot, const std::vector<Joint *> &jList) {
+    DOF::initDOF(myRobot, jList);
+    int size = (int)jList.size();
+    assert(size > 0);
+    mInBreakAway = new int[size];
+    mBreakAwayValues = new double[size];
+    for (int i = 0; i < size; i++) {
+        mInBreakAway[i] = 0;
+        //maybe useful for debugging purposes; should not matter what we put here
+        mBreakAwayValues[i] = -10;
+    }
 }
 
 /*! Each joint is either in breakaway, or connected to the dof
-	value by it's static ratio.
+    value by it's static ratio.
 */
 void
-BreakAwayDOF::getJointValues(double *jointVals) const
-{
-	int index = -1;
-    std::vector<Joint*>::const_iterator j;
-	for (j=jointList.begin(); j!=jointList.end(); j++) {	
-		index++;
-		if (mInBreakAway[index] && q > mBreakAwayValues[index]) {
-			jointVals[ (*j)->getNum() ] = mBreakAwayValues[index] * getStaticRatio(*j);
-		} else {
-			jointVals[ (*j)->getNum() ] = q * getStaticRatio(*j);
-		}
-	}
+BreakAwayDOF::getJointValues(double *jointVals) const {
+    int index = -1;
+    std::vector<Joint *>::const_iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        index++;
+        if (mInBreakAway[index] && q > mBreakAwayValues[index]) {
+            jointVals[(*j)->getNum() ] = mBreakAwayValues[index] * getStaticRatio(*j);
+        }
+        else {
+            jointVals[(*j)->getNum() ] = q * getStaticRatio(*j);
+        }
+    }
 }
 
-/*! If proximal joints are stopped or in breakaway, distal joints continue to 
-	close when the dof is moving in the positive direction.
+/*! If proximal joints are stopped or in breakaway, distal joints continue to
+    close when the dof is moving in the positive direction.
 */
 bool
-BreakAwayDOF::accumulateMove(double q1, double *jointVals, int *stoppedJoints)
-{
-	if ( fabs(q-q1) < 1.0e-5 ) {
-		DBGP("DOF new value same as current value");
-		return false;
-	}
-    std::vector<Joint*>::iterator j;
-	//check if we are moving in the negative direction of the DOF and some joint is stopped
-	for (j=jointList.begin(); j!=jointList.end(); j++) {	
-		if (stoppedJoints && stoppedJoints[ (*j)->getNum()] ) {
-			if (q1 < q){
-				DBGP("Joint stopped in the negative direction; stopping all movement");
-				return false;
-			}
-		}
-	}
+BreakAwayDOF::accumulateMove(double q1, double *jointVals, int *stoppedJoints) {
+    if (fabs(q - q1) < 1.0e-5) {
+        DBGP("DOF new value same as current value");
+        return false;
+    }
+    std::vector<Joint *>::iterator j;
+    //check if we are moving in the negative direction of the DOF and some joint is stopped
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        if (stoppedJoints && stoppedJoints[(*j)->getNum()]) {
+            if (q1 < q) {
+                DBGP("Joint stopped in the negative direction; stopping all movement");
+                return false;
+            }
+        }
+    }
 
-	//we are moving in the positive direction of the DOF
-	bool movement = false;
-	int index = -1;
-	for (j=jointList.begin(); j!=jointList.end(); j++) {	
-		index++;
-		if (mInBreakAway[index] && q1 > mBreakAwayValues[index]) {
-			DBGP("Joint " << index << " is in break away");
-			continue;
-		}
-		double newVal = q1 * getStaticRatio(*j);
-		DBGP("q1 " << q1 << " * ratio " << getStaticRatio(*j) << " = " << newVal);
-		double oldVal = (*j)->getVal();
-		if (stoppedJoints) {
-			if (newVal > oldVal && (stoppedJoints[ (*j)->getNum()] & 1) ) {
-				DBGP("Joint " << index << " is stopped in the positive direction");
-				continue;
-			}
-			if (newVal < oldVal && (stoppedJoints[ (*j)->getNum()] & 2) ) {
-				DBGP("Joint " << index << " is stopped in the negative direction");
-				continue;
-			}
-		}
-		jointVals[ (*j)->getNum() ] = newVal;
-		movement = true;
-	}
-	return movement;
+    //we are moving in the positive direction of the DOF
+    bool movement = false;
+    int index = -1;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        index++;
+        if (mInBreakAway[index] && q1 > mBreakAwayValues[index]) {
+            DBGP("Joint " << index << " is in break away");
+            continue;
+        }
+        double newVal = q1 * getStaticRatio(*j);
+        DBGP("q1 " << q1 << " * ratio " << getStaticRatio(*j) << " = " << newVal);
+        double oldVal = (*j)->getVal();
+        if (stoppedJoints) {
+            if (newVal > oldVal && (stoppedJoints[(*j)->getNum()] & 1)) {
+                DBGP("Joint " << index << " is stopped in the positive direction");
+                continue;
+            }
+            if (newVal < oldVal && (stoppedJoints[(*j)->getNum()] & 2)) {
+                DBGP("Joint " << index << " is stopped in the negative direction");
+                continue;
+            }
+        }
+        jointVals[(*j)->getNum() ] = newVal;
+        movement = true;
+    }
+    return movement;
 }
 
 void
-BreakAwayDOF::updateVal(double q1)
-{
-    std::vector<Joint*>::iterator j;
-	int index;
-	for(j=jointList.begin(), index=0; j!=jointList.end(); j++,index++) {
-		double jVal = (*j)->getVal() / getStaticRatio(*j);
-		if (mInBreakAway[index]) {
-			if (q1 < mBreakAwayValues[index] - 1.0e-5) {
-				mInBreakAway[index] = false;
-				DBGP("DOF " << dofNum << " joint " << index << " re-engaged");
-			}
-		} else {
-			if (jVal < q1 - 1.0e-5) {
-				DBGP("DOF " << dofNum << " joint " << index << " disengaged at " << jVal);
-				mInBreakAway[index] = true;
-				mBreakAwayValues[index] = jVal;
-			}
-		}
-	}
-	q = q1;
+BreakAwayDOF::updateVal(double q1) {
+    std::vector<Joint *>::iterator j;
+    int index;
+    for (j = jointList.begin(), index = 0; j != jointList.end(); j++, index++) {
+        double jVal = (*j)->getVal() / getStaticRatio(*j);
+        if (mInBreakAway[index]) {
+            if (q1 < mBreakAwayValues[index] - 1.0e-5) {
+                mInBreakAway[index] = false;
+                DBGP("DOF " << dofNum << " joint " << index << " re-engaged");
+            }
+        }
+        else {
+            if (jVal < q1 - 1.0e-5) {
+                DBGP("DOF " << dofNum << " joint " << index << " disengaged at " << jVal);
+                mInBreakAway[index] = true;
+                mBreakAwayValues[index] = jVal;
+            }
+        }
+    }
+    q = q1;
 }
 
 /*! For this type of dof, the value of any joint that is not in breakaway
-	can give us the value of the dof.
+    can give us the value of the dof.
 */
 void
-BreakAwayDOF::updateFromJointValues(const double *jointVals)
-{
-    std::vector<Joint*>::iterator j;
-	int index;
-	double val;
-	for(j=jointList.begin(),index=0; j!=jointList.end(); j++,index++) {
-		if (mInBreakAway[index]) continue;
-		if (!jointVals) {
-			val = (*j)->getVal() / getStaticRatio(*j);
-		} else {
-			val = jointVals[ (*j)->getNum() ] / getStaticRatio(*j);
-		}
-		break;
-	}
-	//all joints in breakaway?
-	assert( j!= jointList.end() );
-	q = val;
-	DBGP("DOF " << getDOFNum() << ": set value " << q);
+BreakAwayDOF::updateFromJointValues(const double *jointVals) {
+    std::vector<Joint *>::iterator j;
+    int index;
+    double val;
+    for (j = jointList.begin(), index = 0; j != jointList.end(); j++, index++) {
+        if (mInBreakAway[index]) continue;
+        if (!jointVals) {
+            val = (*j)->getVal() / getStaticRatio(*j);
+        }
+        else {
+            val = jointVals[(*j)->getNum() ] / getStaticRatio(*j);
+        }
+        break;
+    }
+    //all joints in breakaway?
+    assert(j != jointList.end());
+    q = val;
+    DBGP("DOF " << getDOFNum() << ": set value " << q);
 }
 
 /*! Clears all the breakaway flags, effectively re-engaging all joints. */
 void
-BreakAwayDOF::reset()
-{
-	if (!mInBreakAway) return;
-	for (int j=0; j<(int)jointList.size(); j++) {
-		mInBreakAway[j] = false;
-	}
+BreakAwayDOF::reset() {
+    if (!mInBreakAway) return;
+    for (int j = 0; j < (int)jointList.size(); j++) {
+        mInBreakAway[j] = false;
+    }
 }
 
 bool
-BreakAwayDOF::writeToStream(QTextStream &stream)
-{
-	stream << q;
-	for (int j=0; j<(int)jointList.size(); j++) {
-		if (!mInBreakAway || !mInBreakAway[j]) {
-			stream << " " << 0;
-		} else {
-			stream << " " << 1 << " " << mBreakAwayValues[j];
-		}
-	}
-	return true;
+BreakAwayDOF::writeToStream(QTextStream &stream) {
+    stream << q;
+    for (int j = 0; j < (int)jointList.size(); j++) {
+        if (!mInBreakAway || !mInBreakAway[j]) {
+            stream << " " << 0;
+        }
+        else {
+            stream << " " << 1 << " " << mBreakAwayValues[j];
+        }
+    }
+    return true;
 }
 
 /*! Returns the smallest breakaway value of all the joints
-	of this DOF.
+    of this DOF.
 */
 double
-BreakAwayDOF::getSaveVal() const
-{
-	if (!mInBreakAway) return q;
-	double val = q;
-	for (int j=0; j<(int)jointList.size(); j++) {
-		if ( mInBreakAway[j] ) {
-			if ( mBreakAwayValues[j] < val ) {
-				val = mBreakAwayValues[j];
-			}
-		}
-	}
-	return val;
+BreakAwayDOF::getSaveVal() const {
+    if (!mInBreakAway) return q;
+    double val = q;
+    for (int j = 0; j < (int)jointList.size(); j++) {
+        if (mInBreakAway[j]) {
+            if (mBreakAwayValues[j] < val) {
+                val = mBreakAwayValues[j];
+            }
+        }
+    }
+    return val;
 }
 
 bool
-BreakAwayDOF::readFromStream(QTextStream &stream)
-{
-	if (stream.atEnd()) return false;
-	stream >> q;
-	DBGP("Value: " << q);
-	for (int j=0; j<(int)jointList.size(); j++) {
-		assert(mInBreakAway);
-		stream >> mInBreakAway[j];
-		DBGP("  bway: " << mInBreakAway[j]);
-		if (mInBreakAway[j] == 1) {
-			stream >> mBreakAwayValues[j];
-		} else if (mInBreakAway[j]==0) {
-			mBreakAwayValues[j] = -10;
-		} else {
-			return false;
-		}
-	}
-	return true;
+BreakAwayDOF::readFromStream(QTextStream &stream) {
+    if (stream.atEnd()) return false;
+    stream >> q;
+    DBGP("Value: " << q);
+    for (int j = 0; j < (int)jointList.size(); j++) {
+        assert(mInBreakAway);
+        stream >> mInBreakAway[j];
+        DBGP("  bway: " << mInBreakAway[j]);
+        if (mInBreakAway[j] == 1) {
+            stream >> mBreakAwayValues[j];
+        }
+        else if (mInBreakAway[j] == 0) {
+            mBreakAwayValues[j] = -10;
+        }
+        else {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool
-BreakAwayDOF::readParametersFromXml(const TiXmlElement* root)
-{
-	if (!DOF::readParametersFromXml(root)) return false;
-	if(!getDouble(root,"breakAwayTorque", mBreakAwayTorque)||mBreakAwayTorque < 0){
-		//the break away torque is missing; warn and use default value
-		DBGA("BreakAway torque missing or negative, using default value 0.0");
-		mBreakAwayTorque = 0.0f;
-	} else {
-		//convert to N mm
-		mBreakAwayTorque *= 1.0e3;
-	}
-	return true;
+BreakAwayDOF::readParametersFromXml(const TiXmlElement *root) {
+    if (!DOF::readParametersFromXml(root)) return false;
+    if (!getDouble(root, "breakAwayTorque", mBreakAwayTorque) || mBreakAwayTorque < 0) {
+        //the break away torque is missing; warn and use default value
+        DBGA("BreakAway torque missing or negative, using default value 0.0");
+        mBreakAwayTorque = 0.0f;
+    }
+    else {
+        //convert to N mm
+        mBreakAwayTorque *= 1.0e3;
+    }
+    return true;
 }
 
-/*! We assume that any joint that is in breakaway is applying exactly the 
-	breakaway torque. This is probably not accurate, as after breakaway occurs, 
-	the joint is disengaged. But it is accurate in the sense that no joint can 
-	apply more than the breakaway torque. 
+/*! We assume that any joint that is in breakaway is applying exactly the
+    breakaway torque. This is probably not accurate, as after breakaway occurs,
+    the joint is disengaged. But it is accurate in the sense that no joint can
+    apply more than the breakaway torque.
 */
 bool
-BreakAwayDOF::computeStaticJointTorques(double *jointTorques, double)
-{
-    std::vector<Joint*>::iterator j;
-	int index;
-	for(j=jointList.begin(), index=0; j!=jointList.end(); j++,index++) {
-		if (mInBreakAway[index]) {
-			jointTorques[ (*j)->getNum() ] += mBreakAwayTorque;
-		}
-	}
-	return true;
+BreakAwayDOF::computeStaticJointTorques(double *jointTorques, double) {
+    std::vector<Joint *>::iterator j;
+    int index;
+    for (j = jointList.begin(), index = 0; j != jointList.end(); j++, index++) {
+        if (mInBreakAway[index]) {
+            jointTorques[(*j)->getNum() ] += mBreakAwayTorque;
+        }
+    }
+    return true;
 }
 
 void
-CompliantDOF::initDOF(Robot *myRobot, const std::vector<Joint*> &jList)
-{
-	DOF::initDOF(myRobot, jList);
-    std::vector<Joint*>::iterator j;
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		if ( (*j)->getSpringStiffness() == 0.0 ) {
-			DBGA("ERROR: Compliant joint has no stiffness! DEFAULT VALUE will be used!");
-		}
-	}
+CompliantDOF::initDOF(Robot *myRobot, const std::vector<Joint *> &jList) {
+    DOF::initDOF(myRobot, jList);
+    std::vector<Joint *>::iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        if ((*j)->getSpringStiffness() == 0.0) {
+            DBGA("ERROR: Compliant joint has no stiffness! DEFAULT VALUE will be used!");
+        }
+    }
 }
 
-double 
+double
 CompliantDOF::getStaticRatio(Joint *j) const {
-	double ref = jointList.front()->getSpringStiffness();
-	assert(ref!=0.0);
-	double k = j->getSpringStiffness();
-	if (k == 0.0) k = ref;
-	/* this is actually incorrect. I will hard-code in the right relationship
-		for the HH, but in the future, todo: generalize this */
-	//return j->getCouplingRatio() * ( ref / k );
-	int jn = j->getNum();
-	if (jn==0 || jn==2 || jn== 4 || jn==6) {
-		return j->getCouplingRatio();
-	} else {
-		double tau2 = j->getCouplingRatio();
-		double tau1 = jointList.front()->getCouplingRatio();
-		return (ref / k) * ( tau1 * tau2) / (tau1 + tau2);
-	} 
+    double ref = jointList.front()->getSpringStiffness();
+    assert(ref != 0.0);
+    double k = j->getSpringStiffness();
+    if (k == 0.0) k = ref;
+    /*  this is actually incorrect. I will hard-code in the right relationship
+        for the HH, but in the future, todo: generalize this */
+    //return j->getCouplingRatio() * ( ref / k );
+    int jn = j->getNum();
+    if (jn == 0 || jn == 2 || jn == 4 || jn == 6) {
+        return j->getCouplingRatio();
+    }
+    else {
+        double tau2 = j->getCouplingRatio();
+        double tau1 = jointList.front()->getCouplingRatio();
+        return (ref / k) * (tau1 * tau2) / (tau1 + tau2);
+    }
 }
 
-void 
-CompliantDOF::getJointValues(double* jointVals) const 
-{
-    std::vector<Joint*>::const_iterator j;
-	for (j=jointList.begin(); j!=jointList.end(); j++) {	
-		jointVals[ (*j)->getNum() ] = q * getStaticRatio(*j);
-	}
+void
+CompliantDOF::getJointValues(double *jointVals) const {
+    std::vector<Joint *>::const_iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        jointVals[(*j)->getNum() ] = q * getStaticRatio(*j);
+    }
 }
 
-/*! Make the assumption that the joint that's most flexed gives the value of the 
-	DOF.	This doesn't always work. In general, due to the nature of this DOF 
-	and the fact that it is implemented as stateless, link positions can be
-	ambiguous, so this function only provides a best effort but no guarantee. 
+/*! Make the assumption that the joint that's most flexed gives the value of the
+    DOF.    This doesn't always work. In general, due to the nature of this DOF
+    and the fact that it is implemented as stateless, link positions can be
+    ambiguous, so this function only provides a best effort but no guarantee.
 */
-void 
-CompliantDOF::updateFromJointValues(const double* jointVals)
-{
-	double max = -1.0e5;
-    std::vector<Joint*>::const_iterator j;
-	for (j=jointList.begin(); j!=jointList.end(); j++) {
-		double v;
-		if (jointVals) {
-			v = jointVals[ (*j)->getNum() ] / getStaticRatio(*j);
-		} else {
-			v = (*j)->getVal() / getStaticRatio(*j);
-		}
-		max = std::max(max,v);
-	}
-	q = max;
+void
+CompliantDOF::updateFromJointValues(const double *jointVals) {
+    double max = -1.0e5;
+    std::vector<Joint *>::const_iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        double v;
+        if (jointVals) {
+            v = jointVals[(*j)->getNum() ] / getStaticRatio(*j);
+        }
+        else {
+            v = (*j)->getVal() / getStaticRatio(*j);
+        }
+        max = std::max(max, v);
+    }
+    q = max;
 }
 
 /*! Proximal joints do not affect distal joints, in any direction of movement. */
-bool 
-CompliantDOF::accumulateMove(double q1, double *jointVals, int *stoppedJoints)
-{
-	if ( fabs(q-q1) < 1.0e-5 ) {
-		DBGP("DOF is already at desired value");
-		return false;
-	}
+bool
+CompliantDOF::accumulateMove(double q1, double *jointVals, int *stoppedJoints) {
+    if (fabs(q - q1) < 1.0e-5) {
+        DBGP("DOF is already at desired value");
+        return false;
+    }
 
-	bool movement = false;
-    std::vector<Joint*>::const_iterator j; int index;
-	for (j=jointList.begin(), index=0; j!=jointList.end(); j++, index++) {	
-		double newVal = q1 * getStaticRatio(*j);
-		double oldVal = (*j)->getVal();
-		if (stoppedJoints) {
-			if (newVal > oldVal && (stoppedJoints[ (*j)->getNum()] & 1) ) {
-				DBGP("Joint " << index << " is stopped in the positive direction");
-				continue;
-			}
-			if (newVal < oldVal && (stoppedJoints[ (*j)->getNum()] & 2) ) {
-				DBGP("Joint " << index << " is stopped in the negative direction");
-				continue;
-			}
-		}
-		jointVals[ (*j)->getNum() ] = newVal;
-		movement = true;
-	}
-	return movement;
+    bool movement = false;
+    std::vector<Joint *>::const_iterator j;
+    int index;
+    for (j = jointList.begin(), index = 0; j != jointList.end(); j++, index++) {
+        double newVal = q1 * getStaticRatio(*j);
+        double oldVal = (*j)->getVal();
+        if (stoppedJoints) {
+            if (newVal > oldVal && (stoppedJoints[(*j)->getNum()] & 1)) {
+                DBGP("Joint " << index << " is stopped in the positive direction");
+                continue;
+            }
+            if (newVal < oldVal && (stoppedJoints[(*j)->getNum()] & 2)) {
+                DBGP("Joint " << index << " is stopped in the negative direction");
+                continue;
+            }
+        }
+        jointVals[(*j)->getNum() ] = newVal;
+        movement = true;
+    }
+    return movement;
 }
 
 
-/*! We use a linear spring model w. stiffness k for any joint. First we 
-	apply the spring force to each joint. Then we say that the dof force 
-	must be enough to balance the largest spring force we have found. 
-	Therefore, we then apply that dof force to all joints.
+/*! We use a linear spring model w. stiffness k for any joint. First we
+    apply the spring force to each joint. Then we say that the dof force
+    must be enough to balance the largest spring force we have found.
+    Therefore, we then apply that dof force to all joints.
 */
-bool 
-CompliantDOF::computeStaticJointTorques(double *jointTorques, double dofForce)
-{
-	//this version assumes that dof force is applied as pure joint
-	//torque. This is probably not physically accurate for most actual hands
-	//dof force ends up as a force on the link, and then joint forces will have
-	//to be computed as JT * link_forces
+bool
+CompliantDOF::computeStaticJointTorques(double *jointTorques, double dofForce) {
+    //this version assumes that dof force is applied as pure joint
+    //torque. This is probably not physically accurate for most actual hands
+    //dof force ends up as a force on the link, and then joint forces will have
+    //to be computed as JT * link_forces
 
-	bool retVal = true;
-	//add the spring forces for all joints
-	double maxDofTorque = 0.0;
-    std::vector<Joint*>::iterator j;
-	Joint *pj = NULL;
-	int count = 0;
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		double springTorque = (*j)->getSpringForce();
-		DBGP("Inner spring: " << springTorque);
-		jointTorques[ (*j)->getNum() ] -= springTorque;
-		//also propagate this to previous joint
-		if (count==1 || count==3 || count==5 || count==7) {
-			assert(pj);
+    bool retVal = true;
+    //add the spring forces for all joints
+    double maxDofTorque = 0.0;
+    std::vector<Joint *>::iterator j;
+    Joint *pj = NULL;
+    int count = 0;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        double springTorque = (*j)->getSpringForce();
+        DBGP("Inner spring: " << springTorque);
+        jointTorques[(*j)->getNum() ] -= springTorque;
+        //also propagate this to previous joint
+        if (count == 1 || count == 3 || count == 5 || count == 7) {
+            assert(pj);
             vec3 axis1 = (*j)->getDynJoint()->getPrevLink()->getTran().affine().row(2);
             vec3 axis2 =   pj->getDynJoint()->getPrevLink()->getTran().affine().row(2);
-			double t = fabs(axis1 % axis2);
-			//todo what about non-revolute joints, complex kinematic chains, etc...
-			jointTorques[pj->getNum()] += springTorque * t;
-		}
-		pj = (*j);
-		count++;
-	}
-        /*
+            double t = fabs(axis1 % axis2);
+            //todo what about non-revolute joints, complex kinematic chains, etc...
+            jointTorques[pj->getNum()] += springTorque * t;
+        }
+        pj = (*j);
+        count++;
+    }
+    /*
         std::cerr << "before max torque:\n";
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-          std::cerr << jointTorques[ (*j)->getNum() ] << " ";
+        for(j=jointList.begin(); j!=jointList.end(); j++) {
+             std::cerr << jointTorques[ (*j)->getNum() ] << " ";
+           }
+           std::cerr << "\n";
+    */
+    //what is the max torque that the dof must balance at any joint
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        double springTorque = - jointTorques[(*j)->getNum()];
+        double dofTorque = springTorque / (*j)->getCouplingRatio();
+        if (fabs(dofTorque) > fabs(maxDofTorque)) {
+            maxDofTorque = dofTorque;
         }
-        std::cerr << "\n";
-        */
-	//what is the max torque that the dof must balance at any joint
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		double springTorque = - jointTorques[(*j)->getNum()];
-		double dofTorque = springTorque / (*j)->getCouplingRatio();
-		if (fabs(dofTorque) > fabs(maxDofTorque)) {
-			maxDofTorque = dofTorque;
-		}
-	}
-	DBGP("Max dof torque: " << maxDofTorque);
+    }
+    DBGP("Max dof torque: " << maxDofTorque);
 
-	double dofTorque;
-	if (dofForce < 0) {
-		//dof force has not been passed in. We thus compute the case where all we
-		//want is to keep the joints in their current position. Therefore, the dof
-		//force has to balance the max spring force found at any joint
-		dofTorque = maxDofTorque;
-	} else {
-		//we have some level of dof force applied. Use that one.
-		//hard-coded 4cm moment arm, same as in setForce. At some point we'll have
-		//to use actual insertion points
-		dofTorque = force * 40.0;
-		if (dofTorque < maxDofTorque) {
-			DBGA("For now, dof torque must at least balance spring forces!");
-			//give it a little bit of extra woomph
-			dofTorque = maxDofTorque + 3.0e7;
-		}
-	}
+    double dofTorque;
+    if (dofForce < 0) {
+        //dof force has not been passed in. We thus compute the case where all we
+        //want is to keep the joints in their current position. Therefore, the dof
+        //force has to balance the max spring force found at any joint
+        dofTorque = maxDofTorque;
+    }
+    else {
+        //we have some level of dof force applied. Use that one.
+        //hard-coded 4cm moment arm, same as in setForce. At some point we'll have
+        //to use actual insertion points
+        dofTorque = force * 40.0;
+        if (dofTorque < maxDofTorque) {
+            DBGA("For now, dof torque must at least balance spring forces!");
+            //give it a little bit of extra woomph
+            dofTorque = maxDofTorque + 3.0e7;
+        }
+    }
 
-	//now apply the dof torque to all joints
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		double jointTorque = dofTorque * (*j)->getCouplingRatio();
-		jointTorques[ (*j)->getNum() ] += jointTorque;
-		if ( jointTorques[ (*j)->getNum() ] < -1.0e-5) {
-			DBGP("Error: negative torque on joint " << (*j)->getNum());
-			//now that spring torques are also propagated back, this is no longer an error
-			//retVal = false;
-		}
-                //try to fix numerical errors at least for 0, since it is a special case
-                if ( fabs(jointTorques[(*j)->getNum()]) < 1.0e-5) {
-                  jointTorques[ (*j)->getNum() ] = 0.0;
-                }
-		DBGP(jointTorques[ (*j)->getNum() ]);
-	}
-        /*
+    //now apply the dof torque to all joints
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        double jointTorque = dofTorque * (*j)->getCouplingRatio();
+        jointTorques[(*j)->getNum() ] += jointTorque;
+        if (jointTorques[(*j)->getNum() ] < -1.0e-5) {
+            DBGP("Error: negative torque on joint " << (*j)->getNum());
+            //now that spring torques are also propagated back, this is no longer an error
+            //retVal = false;
+        }
+        //try to fix numerical errors at least for 0, since it is a special case
+        if (fabs(jointTorques[(*j)->getNum()]) < 1.0e-5) {
+            jointTorques[(*j)->getNum() ] = 0.0;
+        }
+        DBGP(jointTorques[(*j)->getNum() ]);
+    }
+    /*
         std::cerr << "after max torque:\n";
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-          std::cerr << jointTorques[ (*j)->getNum() ] << " ";
-        }
-        std::cerr << "\n";
-        */
-	return retVal;
+        for(j=jointList.begin(); j!=jointList.end(); j++) {
+             std::cerr << jointTorques[ (*j)->getNum() ] << " ";
+           }
+           std::cerr << "\n";
+    */
+    return retVal;
 }
 
 /*! We will use one limit constraint for each joint that exceeds is very close to
-	or outside its legal range. */
-int 
-CompliantDOF::getNumLimitConstraints()
-{
-	int numCon = 0;
-    std::vector<Joint*>::iterator j;
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		if ( (*j)->getVal() >= (*j)->getMax() - 0.01) numCon ++;
-		else if ( (*j)->getVal() <= (*j)->getMin() + 0.01) numCon ++;
-	}
-	return numCon;
+    or outside its legal range. */
+int
+CompliantDOF::getNumLimitConstraints() {
+    int numCon = 0;
+    std::vector<Joint *>::iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        if ((*j)->getVal() >= (*j)->getMax() - 0.01) numCon ++;
+        else if ((*j)->getVal() <= (*j)->getMin() + 0.01) numCon ++;
+    }
+    return numCon;
 }
 
-/*! One constraint for each joint that has exceeded its legal range. For now this 
-	duplicates code from the regular DOF, so everything should probably move someplace
-	else.
+/*! One constraint for each joint that has exceeded its legal range. For now this
+    duplicates code from the regular DOF, so everything should probably move someplace
+    else.
 */
-void 
-CompliantDOF::buildDynamicLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-										   double* H, double *g, int &hcn)
-{
-    std::vector<Joint*>::iterator j;
-	int count = 0;
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		Joint *currentJoint = *j;
+void
+CompliantDOF::buildDynamicLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                           double *H, double *g, int &hcn) {
+    std::vector<Joint *>::iterator j;
+    int count = 0;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        Joint *currentJoint = *j;
         DynamicBody *prevLink = currentJoint->getDynJoint()->getPrevLink();
         DynamicBody *nextLink = currentJoint->getDynJoint()->getNextLink();
-		int row, dir;
-		double error;
-		if (currentJoint->getVal() >= currentJoint->getMax()-0.01) {
-			error = currentJoint->getMax() - currentJoint->getVal();
-			dir = -1;
-		} else if (currentJoint->getVal() <= currentJoint->getMin()+0.01) {
-			error = currentJoint->getVal() - currentJoint->getMin();
-			dir = +1;
-		} else continue;
-		    
-		g[hcn] = MIN(0.0, error - 0.005);
-		DBGP("adding dof limit constraint for DOF " << dofNum << "  error: "<<g[hcn]);
+        int row, dir;
+        double error;
+        if (currentJoint->getVal() >= currentJoint->getMax() - 0.01) {
+            error = currentJoint->getMax() - currentJoint->getVal();
+            dir = -1;
+        }
+        else if (currentJoint->getVal() <= currentJoint->getMin() + 0.01) {
+            error = currentJoint->getVal() - currentJoint->getMin();
+            dir = +1;
+        }
+        else continue;
 
-		assert( islandIndices[prevLink]>=0 );
-		row = 6*islandIndices[prevLink];
-		H[(hcn)*6*numBodies + row+3] -= dir * currentJoint->getWorldAxis()[0];
-		H[(hcn)*6*numBodies + row+4] -= dir * currentJoint->getWorldAxis()[1];
-		H[(hcn)*6*numBodies + row+5] -= dir * currentJoint->getWorldAxis()[2];
+        g[hcn] = MIN(0.0, error - 0.005);
+        DBGP("adding dof limit constraint for DOF " << dofNum << "  error: " << g[hcn]);
 
-     	assert( islandIndices[nextLink]>=0 );
-		row = 6*islandIndices[nextLink];
-		H[(hcn)*6*numBodies + row+3] +=  dir * currentJoint->getWorldAxis()[0];
-		H[(hcn)*6*numBodies + row+4] +=  dir * currentJoint->getWorldAxis()[1];
-		H[(hcn)*6*numBodies + row+5] +=  dir * currentJoint->getWorldAxis()[2];
+        assert(islandIndices[prevLink] >= 0);
+        row = 6 * islandIndices[prevLink];
+        H[(hcn) * 6 * numBodies + row + 3] -= dir * currentJoint->getWorldAxis()[0];
+        H[(hcn) * 6 * numBodies + row + 4] -= dir * currentJoint->getWorldAxis()[1];
+        H[(hcn) * 6 * numBodies + row + 5] -= dir * currentJoint->getWorldAxis()[2];
 
-		hcn++;
-		count++;
-	}
+        assert(islandIndices[nextLink] >= 0);
+        row = 6 * islandIndices[nextLink];
+        H[(hcn) * 6 * numBodies + row + 3] +=  dir * currentJoint->getWorldAxis()[0];
+        H[(hcn) * 6 * numBodies + row + 4] +=  dir * currentJoint->getWorldAxis()[1];
+        H[(hcn) * 6 * numBodies + row + 5] +=  dir * currentJoint->getWorldAxis()[2];
+
+        hcn++;
+        count++;
+    }
 }
 
-void 
-CompliantDOF::setForce(double f)
-{
-	//cap the force
-	if (f > maxForce) force = maxForce;
-	if (force < 0) force = 0;
-	else if (f < -maxForce) force = -maxForce;
-	else force = f;
+void
+CompliantDOF::setForce(double f) {
+    //cap the force
+    if (f > maxForce) force = maxForce;
+    if (force < 0) force = 0;
+    else if (f < -maxForce) force = -maxForce;
+    else force = f;
 
-	//apply it to links. compute moment arms in order to obtain required torque ratios
-	//reference is a moment arm of 40mm
-    std::vector<Joint*>::iterator j;
-	for(j=jointList.begin(); j!=jointList.end(); j++) {
-		double torqueRatio = (*j)->getCouplingRatio();
-        DynamicBody* body = (*j)->getDynJoint()->getNextLink();
-		//assume a pure torque is applied to the joint
-		//easier to match in the statics computation
-		//assume a moment arm of 40mm for the conversion
-		//could keep dof effort as torques in the files, but this is how we have it now
-		double jointTorque = force * 40.0 * torqueRatio;
-		//since a pure torque is applied, maybe we just need to apply to the next link
-		//and let joint constraints take care of the rest?
-		body->addTorque(jointTorque * (*j)->getWorldAxis());
-		
-		/*
-		//assume force is applied to the link - probably more correct
-		//joint location in body coordinates
-		vec3 bodyJoint = (*j)->dynJoint->getNextTrans().translation();
-		//vector from joint location to body cog in body coordinates
-		vec3 cog = (body->getCoG()  - position::ORIGIN) - bodyJoint;
-		//joint axis in body coordinates
-		vec3 axis = (*j)->getWorldAxis() * body->getTran().inverse();
-		//force is cross product of the two, scaled to desired force magnitude
-		vec3 forceVector = force * normalise( axis * cog );
-		//scale the arm based on how much torque we want around the joint
-		//40mm arm is reference
-		vec3 arm = 40.0 * torqueRatio * normalise(cog);
-		//position on body
-		vec3 bodyPosition = bodyJoint + arm;
-		position bodyPos(bodyPosition.x(), bodyPosition.y(), bodyPosition.z());
-		body->addForceAtRelPos(forceVector, bodyPos);
-		*/
-	}
+    //apply it to links. compute moment arms in order to obtain required torque ratios
+    //reference is a moment arm of 40mm
+    std::vector<Joint *>::iterator j;
+    for (j = jointList.begin(); j != jointList.end(); j++) {
+        double torqueRatio = (*j)->getCouplingRatio();
+        DynamicBody *body = (*j)->getDynJoint()->getNextLink();
+        //assume a pure torque is applied to the joint
+        //easier to match in the statics computation
+        //assume a moment arm of 40mm for the conversion
+        //could keep dof effort as torques in the files, but this is how we have it now
+        double jointTorque = force * 40.0 * torqueRatio;
+        //since a pure torque is applied, maybe we just need to apply to the next link
+        //and let joint constraints take care of the rest?
+        body->addTorque(jointTorque * (*j)->getWorldAxis());
+
+        /*
+            //assume force is applied to the link - probably more correct
+            //joint location in body coordinates
+            vec3 bodyJoint = (*j)->dynJoint->getNextTrans().translation();
+            //vector from joint location to body cog in body coordinates
+            vec3 cog = (body->getCoG()  - position::ORIGIN) - bodyJoint;
+            //joint axis in body coordinates
+            vec3 axis = (*j)->getWorldAxis() * body->getTran().inverse();
+            //force is cross product of the two, scaled to desired force magnitude
+            vec3 forceVector = force * normalise( axis * cog );
+            //scale the arm based on how much torque we want around the joint
+            //40mm arm is reference
+            vec3 arm = 40.0 * torqueRatio * normalise(cog);
+            //position on body
+            vec3 bodyPosition = bodyJoint + arm;
+            position bodyPos(bodyPosition.x(), bodyPosition.y(), bodyPosition.z());
+            body->addForceAtRelPos(forceVector, bodyPos);
+        */
+    }
 }
 
 /*! A stub for now. Always applies max force no matter what. For now, the simulation of
-	the Harvard Hand behaves reasonably like this, but in the future this should be
-	fixed.
+    the Harvard Hand behaves reasonably like this, but in the future this should be
+    fixed.
 */
 double
-CompliantDOF::PDPositionController(double timeStep)
-{
-	//todo find a better home for the PD controller (at the DOF level)
-	return smoothProfileController(timeStep);
-	//return DOF::PDPositionController(timeStep);
-	//return getMaxForce();
+CompliantDOF::PDPositionController(double timeStep) {
+    //todo find a better home for the PD controller (at the DOF level)
+    return smoothProfileController(timeStep);
+    //return DOF::PDPositionController(timeStep);
+    //return getMaxForce();
 }
 
 /*! Simply looks at the change in position of this dof. Since it is hard-coded
-	to always apply the max force, no motion always means no progress.
+    to always apply the max force, no motion always means no progress.
 */
 bool
-CompliantDOF::dynamicsProgress()
-{
-	double eps = 1.0e-5;
-	if ((int)mPositionHistory.size() < mHistoryMaxSize) return true;
-	std::list<double>::iterator it = mPositionHistory.begin();
-	double ref = *it; it++;
-	//fprintf(stderr,"%f: ", ref);
-	while (it!=mPositionHistory.end()) {
-		//fprintf(stderr,"%f ", *it);
-		if ( fabs(*it-ref) > eps) {
-			//fprintf(stderr,"move.\n");
-			return true;
-		}
-		it++;
-	}
-	//fprintf(stderr,"no move.\n");
-	return false;
+CompliantDOF::dynamicsProgress() {
+    double eps = 1.0e-5;
+    if ((int)mPositionHistory.size() < mHistoryMaxSize) return true;
+    std::list<double>::iterator it = mPositionHistory.begin();
+    double ref = *it;
+    it++;
+    //fprintf(stderr,"%f: ", ref);
+    while (it != mPositionHistory.end()) {
+        //fprintf(stderr,"%f ", *it);
+        if (fabs(*it - ref) > eps) {
+            //fprintf(stderr,"move.\n");
+            return true;
+        }
+        it++;
+    }
+    //fprintf(stderr,"no move.\n");
+    return false;
 }
 
 /*! Tries to build up the force slowly looking at the time elapsed since the
-	last reset. This is something of a hack, but it's the best I could come
-	up with to avoid jerking the hand around.
+    last reset. This is something of a hack, but it's the best I could come
+    up with to avoid jerking the hand around.
 */
-double 
-CompliantDOF::smoothProfileController(double)
-{
-	double time = owner->getWorld()->getWorldTime() - mDynStartTime;
-	time = std::min(time, 1.0);
-	if (time < 0) {
-		DBGA("Zero elapsed time in CD controller");
-	}
-	time = std::max(time, 0.0);
-	return time * getMaxForce();
+double
+CompliantDOF::smoothProfileController(double) {
+    double time = owner->getWorld()->getWorldTime() - mDynStartTime;
+    time = std::min(time, 1.0);
+    if (time < 0) {
+        DBGA("Zero elapsed time in CD controller");
+    }
+    time = std::max(time, 0.0);
+    return time * getMaxForce();
 }

--- a/src/eigenGrasp.cpp
+++ b/src/eigenGrasp.cpp
@@ -39,684 +39,709 @@
 #include "debug.h"
 
 /*! The eigengrasp is initialized to all 0s*/
-EigenGrasp::EigenGrasp(int size, double e)
-{
-	if (size <= 0 ) {
-		fprintf(stderr,"Wrong size of eigen grasp\n");
-		return;
-	}
-	mVals = new double[size];
-	for (int i=0; i < size; i++)
-		mVals[i] = 0;
-	mSize = size;
-	mEigenValue = e;
-	mFixed = false;
-	mPredefinedLimits=false;
+EigenGrasp::EigenGrasp(int size, double e) {
+    if (size <= 0) {
+        fprintf(stderr, "Wrong size of eigen grasp\n");
+        return;
+    }
+    mVals = new double[size];
+    for (int i = 0; i < size; i++)
+        mVals[i] = 0;
+    mSize = size;
+    mEigenValue = e;
+    mFixed = false;
+    mPredefinedLimits = false;
 }
 
-EigenGrasp::EigenGrasp(const EigenGrasp *orig)
-{
-	mSize = orig->mSize;
-	mVals = new double[mSize];
-	memcpy(mVals, orig->mVals, mSize*sizeof(double));
-	mEigenValue = orig->mEigenValue;
-	mMin = orig->mMin; mMax = orig->mMax;
-	mFixed = orig->mFixed;
-	fixedAmplitude = orig->fixedAmplitude;
-	mPredefinedLimits=orig->mPredefinedLimits;
+EigenGrasp::EigenGrasp(const EigenGrasp *orig) {
+    mSize = orig->mSize;
+    mVals = new double[mSize];
+    memcpy(mVals, orig->mVals, mSize * sizeof(double));
+    mEigenValue = orig->mEigenValue;
+    mMin = orig->mMin;
+    mMax = orig->mMax;
+    mFixed = orig->mFixed;
+    fixedAmplitude = orig->fixedAmplitude;
+    mPredefinedLimits = orig->mPredefinedLimits;
 }
 
-EigenGrasp::~EigenGrasp()
-{
-	delete [] mVals;
-}
-
-void
-EigenGrasp::getEigenGrasp(double *eg) const
-{
-	for (int i=0; i<mSize; i++)
-		eg[i] = mVals[i];
+EigenGrasp::~EigenGrasp() {
+    delete [] mVals;
 }
 
 void
-EigenGrasp::setEigenGrasp(const double *eg)
-{
-	for (int i=0; i<mSize; i++)
-		mVals[i] = eg[i];
+EigenGrasp::getEigenGrasp(double *eg) const {
+    for (int i = 0; i < mSize; i++)
+        eg[i] = mVals[i];
+}
+
+void
+EigenGrasp::setEigenGrasp(const double *eg) {
+    for (int i = 0; i < mSize; i++)
+        mVals[i] = eg[i];
 }
 
 double
-EigenGrasp::normalize()
-{
-	int i;
-	double norm = 0;
-	for (i=0; i<mSize; i++) {
-		norm += mVals[i] * mVals[i];
-	}
-	norm = sqrt(norm);
-	for (i=0; i<mSize; i++) {
-		mVals[i] = mVals[i] / norm;
-	}
-	return norm;
-}
-
-void 
-EigenGrasp::writeToFile(TiXmlElement *ep)
-{
-    	TiXmlElement * EigenValue = new TiXmlElement( "EigenValue" );  
-	EigenValue->SetDoubleAttribute("value",mEigenValue);
-	ep->LinkEndChild( EigenValue );  
-	
-	if(mPredefinedLimits)
-	{
-		TiXmlElement * Limits = new TiXmlElement( "Limits" );
-		Limits->SetDoubleAttribute("min",mMin);
-		Limits->SetDoubleAttribute("max",mMax);
-		ep->LinkEndChild( Limits );
-	}
-
-	TiXmlElement * DimVals = new TiXmlElement( "DimVals" );  
-	QString varStr;
-	for (int i=0; i<mSize; i++) 
-	{
-	    	varStr.setNum(i);
-	    	varStr="d"+varStr;
-		DimVals->SetDoubleAttribute(varStr,mVals[i]);
-	}
-	ep->LinkEndChild( DimVals );  
-	
+EigenGrasp::normalize() {
+    int i;
+    double norm = 0;
+    for (i = 0; i < mSize; i++) {
+        norm += mVals[i] * mVals[i];
+    }
+    norm = sqrt(norm);
+    for (i = 0; i < mSize; i++) {
+        mVals[i] = mVals[i] / norm;
+    }
+    return norm;
 }
 
 void
-EigenGrasp::writeToFile(FILE *fp)
-{
-	fprintf(fp,"%f\n",mEigenValue);
-	for (int i=0; i<mSize; i++) {
-		fprintf(fp,"%f ", mVals[i]);
-	}
-	fprintf(fp,"\n");
+EigenGrasp::writeToFile(TiXmlElement *ep) {
+    TiXmlElement *EigenValue = new TiXmlElement("EigenValue");
+    EigenValue->SetDoubleAttribute("value", mEigenValue);
+    ep->LinkEndChild(EigenValue);
+
+    if (mPredefinedLimits) {
+        TiXmlElement *Limits = new TiXmlElement("Limits");
+        Limits->SetDoubleAttribute("min", mMin);
+        Limits->SetDoubleAttribute("max", mMax);
+        ep->LinkEndChild(Limits);
+    }
+
+    TiXmlElement *DimVals = new TiXmlElement("DimVals");
+    QString varStr;
+    for (int i = 0; i < mSize; i++) {
+        varStr.setNum(i);
+        varStr = "d" + varStr;
+        DimVals->SetDoubleAttribute(varStr, mVals[i]);
+    }
+    ep->LinkEndChild(DimVals);
+
 }
 
-void 
-EigenGrasp::readFromFile(FILE *fp)
-{
-	float v;
-	if (fscanf(fp,"%f",&v) <= 0) {
-	  DBGA("EigenGrasp::readFromFile - failed to read eigenvalue");
-	  return;
-	}
-	mEigenValue = v;
-	for (int i=0; i<mSize; i++) {
-	  if(fscanf(fp,"%f",&v) <= 0) {
-	    DBGA("EigenGrasp::readFromFile - failed to read eigenvector");
-	    return;
-	  }
-		mVals[i] = v;
-	}
+void
+EigenGrasp::writeToFile(FILE *fp) {
+    fprintf(fp, "%f\n", mEigenValue);
+    for (int i = 0; i < mSize; i++) {
+        fprintf(fp, "%f ", mVals[i]);
+    }
+    fprintf(fp, "\n");
+}
+
+void
+EigenGrasp::readFromFile(FILE *fp) {
+    float v;
+    if (fscanf(fp, "%f", &v) <= 0) {
+        DBGA("EigenGrasp::readFromFile - failed to read eigenvalue");
+        return;
+    }
+    mEigenValue = v;
+    for (int i = 0; i < mSize; i++) {
+        if (fscanf(fp, "%f", &v) <= 0) {
+            DBGA("EigenGrasp::readFromFile - failed to read eigenvector");
+            return;
+        }
+        mVals[i] = v;
+    }
 }
 
 int
-EigenGrasp::readFromStream(QTextStream *stream)
-{
-	if (stream->atEnd()) {fprintf(stderr,"Unable to read EG, end of file\n");return 0;}
-	QString line = stream->readLine();
-	bool ok;
-	mEigenValue = line.toDouble(&ok); if (!ok) {DBGA("ERROR: EigenValue should be a number.");return 0;}
-	if (stream->atEnd()) {fprintf(stderr,"Unable to read EG, end of file\n");return 0;}
-	line = stream->readLine();
-	for (int i=0; i<mSize; i++) {
-		QString val = line.section(' ',i,i,QString::SectionSkipEmpty);
-		if ( val.isNull() || val.isEmpty() ) {fprintf(stderr,"Unable to read EG value #%d\n",i);return 0;}
-		mVals[i] = val.toDouble(&ok); if (!ok) {DBGA("ERROR: Entries should be numbers.");return 0;}
-	}
-	return 1;
+EigenGrasp::readFromStream(QTextStream *stream) {
+    if (stream->atEnd()) {
+        fprintf(stderr, "Unable to read EG, end of file\n");
+        return 0;
+    }
+    QString line = stream->readLine();
+    bool ok;
+    mEigenValue = line.toDouble(&ok);
+    if (!ok) {
+        DBGA("ERROR: EigenValue should be a number.");
+        return 0;
+    }
+    if (stream->atEnd()) {
+        fprintf(stderr, "Unable to read EG, end of file\n");
+        return 0;
+    }
+    line = stream->readLine();
+    for (int i = 0; i < mSize; i++) {
+        QString val = line.section(' ', i, i, QString::SectionSkipEmpty);
+        if (val.isNull() || val.isEmpty()) {
+            fprintf(stderr, "Unable to read EG value #%d\n", i);
+            return 0;
+        }
+        mVals[i] = val.toDouble(&ok);
+        if (!ok) {
+            DBGA("ERROR: Entries should be numbers.");
+            return 0;
+        }
+    }
+    return 1;
 }
 
 int
-EigenGrasp::readFromXml(const TiXmlElement *element)
-{
-	bool ok;
-	QString valueStr;
-    	std::list<const TiXmlElement*> EVList = findAllXmlElements(element, "EigenValue");
-	if(!countXmlElements(element, "EigenValue")) 
-	{
-		DBGA("WARNING: EigenValue tag missing from file defaulting EigenValue to 0.5!");
-		mEigenValue=0.5;
-	}
-	else
-	{
-		valueStr=(*EVList.begin())->Attribute("value");
-		if(valueStr.isNull()){
-			QTWARNING("DOF Type not found");
-			return 0;
-		}
-		mEigenValue=valueStr.toDouble(&ok); if (!ok) {DBGA("ERROR: EigenValue entries should only contain numbers.");return 0;}
-	}
+EigenGrasp::readFromXml(const TiXmlElement *element) {
+    bool ok;
+    QString valueStr;
+    std::list<const TiXmlElement *> EVList = findAllXmlElements(element, "EigenValue");
+    if (!countXmlElements(element, "EigenValue")) {
+        DBGA("WARNING: EigenValue tag missing from file defaulting EigenValue to 0.5!");
+        mEigenValue = 0.5;
+    }
+    else {
+        valueStr = (*EVList.begin())->Attribute("value");
+        if (valueStr.isNull()) {
+            QTWARNING("DOF Type not found");
+            return 0;
+        }
+        mEigenValue = valueStr.toDouble(&ok);
+        if (!ok) {
+            DBGA("ERROR: EigenValue entries should only contain numbers.");
+            return 0;
+        }
+    }
 
-	EVList = findAllXmlElements(element, "DimVals");
-	if(!countXmlElements(element, "DimVals")) {DBGA("DimVals tag missing from file.");return 0;}
-	for (int i=0; i<mSize; i++) {
-	    	valueStr=(*EVList.begin())->Attribute(QString("d") + QString::number(i));
-		if ( valueStr.isNull() || valueStr.isEmpty() ) mVals[i]=0.0;
-		else {
-		    mVals[i] = valueStr.toDouble(&ok); 
-		    if (!ok) {DBGA("ERROR: DimVals entries should only contain numbers.");return 0;}
-		}
-	}
+    EVList = findAllXmlElements(element, "DimVals");
+    if (!countXmlElements(element, "DimVals")) {
+        DBGA("DimVals tag missing from file.");
+        return 0;
+    }
+    for (int i = 0; i < mSize; i++) {
+        valueStr = (*EVList.begin())->Attribute(QString("d") + QString::number(i));
+        if (valueStr.isNull() || valueStr.isEmpty()) mVals[i] = 0.0;
+        else {
+            mVals[i] = valueStr.toDouble(&ok);
+            if (!ok) {
+                DBGA("ERROR: DimVals entries should only contain numbers.");
+                return 0;
+            }
+        }
+    }
 
-	EVList = findAllXmlElements(element, "Limits");
-	if(countXmlElements(element, "Limits")) 
-	{
-		mPredefinedLimits=true;
-	   	valueStr=(*EVList.begin())->Attribute("min");
-		mMin=valueStr.toDouble(&ok); if (!ok) {DBGA("ERROR: min entries should only contain numbers.");return 0;}
-		if ( false ) mPredefinedLimits=false;
-	   	valueStr=(*EVList.begin())->Attribute("max");
-		mMax=valueStr.toDouble(&ok); if (!ok) {DBGA("ERROR: max entries should only contain numbers.");return 0;}
-		if ( false ) mPredefinedLimits=false;
-	}
-	return 1;
+    EVList = findAllXmlElements(element, "Limits");
+    if (countXmlElements(element, "Limits")) {
+        mPredefinedLimits = true;
+        valueStr = (*EVList.begin())->Attribute("min");
+        mMin = valueStr.toDouble(&ok);
+        if (!ok) {
+            DBGA("ERROR: min entries should only contain numbers.");
+            return 0;
+        }
+        if (false) mPredefinedLimits = false;
+        valueStr = (*EVList.begin())->Attribute("max");
+        mMax = valueStr.toDouble(&ok);
+        if (!ok) {
+            DBGA("ERROR: max entries should only contain numbers.");
+            return 0;
+        }
+        if (false) mPredefinedLimits = false;
+    }
+    return 1;
 }
 
 double
-EigenGrasp::dot(double *d)
-{
-	double dot = 0;
-	for (int i=0; i<mSize; i++) {
-		dot += mVals[i] * d[i];
-	}
-	return dot;
+EigenGrasp::dot(double *d) {
+    double dot = 0;
+    for (int i = 0; i < mSize; i++) {
+        dot += mVals[i] * d[i];
+    }
+    return dot;
 }
 
 //---------------------------------------------------- EigenGraspInterface --------------------------------------
 
-EigenGraspInterface::EigenGraspInterface(Robot *r)
-{
-	mRobot = r;
-	dSize = mRobot->getNumDOF();
-	eSize = mGrasps.size();
-	mOrigin = NULL;
-	mNorm = NULL;
-	mRigid = false;
-	mP = mPInv = NULL;
+EigenGraspInterface::EigenGraspInterface(Robot *r) {
+    mRobot = r;
+    dSize = mRobot->getNumDOF();
+    eSize = mGrasps.size();
+    mOrigin = NULL;
+    mNorm = NULL;
+    mRigid = false;
+    mP = mPInv = NULL;
 }
 
-EigenGraspInterface::EigenGraspInterface(const EigenGraspInterface *orig)
-{
-	mRobot = orig->mRobot;
-	dSize = mRobot->getNumDOF();
-	eSize = orig->eSize;
+EigenGraspInterface::EigenGraspInterface(const EigenGraspInterface *orig) {
+    mRobot = orig->mRobot;
+    dSize = mRobot->getNumDOF();
+    eSize = orig->eSize;
 
-	for (int i=0; i<eSize; i++) {
-		mGrasps.push_back( new EigenGrasp(orig->mGrasps[i]) );
-	}
+    for (int i = 0; i < eSize; i++) {
+        mGrasps.push_back(new EigenGrasp(orig->mGrasps[i]));
+    }
 
-	mOrigin = new EigenGrasp( orig->mOrigin );
-	mNorm = new EigenGrasp( orig->mNorm);
-	mName = orig->mName;
-	mRigid = orig->mRigid;
-	mP = mPInv = NULL;
-	if (orig->mP) {
-		mP = new Matrix(*(orig->mP));
-	}
-	if (orig->mPInv) {
-		mPInv = new Matrix(*(orig->mPInv));
-	}
+    mOrigin = new EigenGrasp(orig->mOrigin);
+    mNorm = new EigenGrasp(orig->mNorm);
+    mName = orig->mName;
+    mRigid = orig->mRigid;
+    mP = mPInv = NULL;
+    if (orig->mP) {
+        mP = new Matrix(*(orig->mP));
+    }
+    if (orig->mPInv) {
+        mPInv = new Matrix(*(orig->mPInv));
+    }
 }
 
-EigenGraspInterface::~EigenGraspInterface()
-{
-	clear();
+EigenGraspInterface::~EigenGraspInterface() {
+    clear();
 }
 
 void
-EigenGraspInterface::clear()
-{
-	for (int i=0; i < eSize; i++) {
-		delete mGrasps[i];
-	}
-	mGrasps.clear();
-	eSize = 0;
-	if (mOrigin){
-		delete mOrigin;
-		mOrigin = NULL;
-	}
-	if (mNorm) {
-		delete mNorm;
-		mNorm = NULL;
-	}
-	if (mP) {delete mP; mP = NULL;}
-	if (mPInv) {delete mPInv; mPInv = NULL;}
-	mRigid = false;
+EigenGraspInterface::clear() {
+    for (int i = 0; i < eSize; i++) {
+        delete mGrasps[i];
+    }
+    mGrasps.clear();
+    eSize = 0;
+    if (mOrigin) {
+        delete mOrigin;
+        mOrigin = NULL;
+    }
+    if (mNorm) {
+        delete mNorm;
+        mNorm = NULL;
+    }
+    if (mP) {
+        delete mP;
+        mP = NULL;
+    }
+    if (mPInv) {
+        delete mPInv;
+        mPInv = NULL;
+    }
+    mRigid = false;
 }
 
 /*! Writes the entire interface to a file in the following order:
-	- the size of the eg space
-	- the size of the dof space
-	- all eigengrasps
-	- the origin
-	Seems not to be compatible with the readFromFile fucntion
-	of this class.
+    - the size of the eg space
+    - the size of the dof space
+    - all eigengrasps
+    - the origin
+    Seems not to be compatible with the readFromFile fucntion
+    of this class.
 */
 int
-EigenGraspInterface::writeToFile(const char *filename)
-{
-	TiXmlDocument doc;  
- 	TiXmlDeclaration* decl = new TiXmlDeclaration( "1.0", "", "" );  
-	doc.LinkEndChild( decl );  
- 
-	TiXmlElement * root = new TiXmlElement( "EigenGrasps" );  
-	root->SetAttribute("dimensions", mRobot->getNumDOF());
-	doc.LinkEndChild( root );  
+EigenGraspInterface::writeToFile(const char *filename) {
+    TiXmlDocument doc;
+    TiXmlDeclaration *decl = new TiXmlDeclaration("1.0", "", "");
+    doc.LinkEndChild(decl);
 
-	TiXmlElement * ep;
-	for (int i=0; i<eSize; i++) {
-	    	ep= new TiXmlElement("EG");
-		mGrasps[i]->writeToFile(ep);
-		root->LinkEndChild(ep);
-		
-	}
-	//TODO Should ouput norm here
-    	ep = new TiXmlElement("ORIGIN");
-	mOrigin->writeToFile(ep);
-	root->LinkEndChild(ep);
+    TiXmlElement *root = new TiXmlElement("EigenGrasps");
+    root->SetAttribute("dimensions", mRobot->getNumDOF());
+    doc.LinkEndChild(root);
 
-	doc.SaveFile(filename);
+    TiXmlElement *ep;
+    for (int i = 0; i < eSize; i++) {
+        ep = new TiXmlElement("EG");
+        mGrasps[i]->writeToFile(ep);
+        root->LinkEndChild(ep);
 
-	return 1;
+    }
+    //TODO Should ouput norm here
+    ep = new TiXmlElement("ORIGIN");
+    mOrigin->writeToFile(ep);
+    root->LinkEndChild(ep);
+
+    doc.SaveFile(filename);
+
+    return 1;
 }
 
 int
-EigenGraspInterface::setTrivial()
-{
-	if (dSize != mRobot->getNumDOF() ) {
-		fprintf(stderr,"ERROR setting trivial EG's\n");
-		return 0;
-	}
-	clear();
-	eSize = mRobot->getNumDOF();
-	double *eg = new double[eSize];
-	for (int i=0; i<eSize; i++) {
-		eg[i] = 0;
-	}
-	for (int i=0; i<eSize; i++) {
-		EigenGrasp *newGrasp = new EigenGrasp(eSize);
-		eg[i]=1;
-		newGrasp->setEigenGrasp(eg);
-		eg[i]=0;
-		mGrasps.push_back(newGrasp);
-	}
-	mNorm = new EigenGrasp(dSize);
-	mNorm->setOnes();
-	mOrigin = new EigenGrasp(dSize);
-	setSimpleOrigin();
-	computeProjectionMatrices();
-	setName("Identity");
-	delete [] eg;
-	return 1;
+EigenGraspInterface::setTrivial() {
+    if (dSize != mRobot->getNumDOF()) {
+        fprintf(stderr, "ERROR setting trivial EG's\n");
+        return 0;
+    }
+    clear();
+    eSize = mRobot->getNumDOF();
+    double *eg = new double[eSize];
+    for (int i = 0; i < eSize; i++) {
+        eg[i] = 0;
+    }
+    for (int i = 0; i < eSize; i++) {
+        EigenGrasp *newGrasp = new EigenGrasp(eSize);
+        eg[i] = 1;
+        newGrasp->setEigenGrasp(eg);
+        eg[i] = 0;
+        mGrasps.push_back(newGrasp);
+    }
+    mNorm = new EigenGrasp(dSize);
+    mNorm->setOnes();
+    mOrigin = new EigenGrasp(dSize);
+    setSimpleOrigin();
+    computeProjectionMatrices();
+    setName("Identity");
+    delete [] eg;
+    return 1;
 }
 
-/*! Reads the entire interface from a file, looking for keywords 
-	inside the file. Loads the size of the dof space, all eg's
-	(which define the size of the eg space), any normalization
-	factors (optional) and the origin of the eg space (optional).
+/*! Reads the entire interface from a file, looking for keywords
+    inside the file. Loads the size of the dof space, all eg's
+    (which define the size of the eg space), any normalization
+    factors (optional) and the origin of the eg space (optional).
 
-	The size of the dof space must be loaded before any eg's, 
-	origin, etc can be loaded; is must also match the number of
-	dof's in this robot.
+    The size of the dof space must be loaded before any eg's,
+    origin, etc can be loaded; is must also match the number of
+    dof's in this robot.
 */
 int
-EigenGraspInterface::readFromFile(QString filename)
-{
+EigenGraspInterface::readFromFile(QString filename) {
     //open xml file at "filename"
-    	bool ok;
-    	QString fileType = filename.section('.',-1,-1);
-	QString xmlFilename;
-	if (fileType == "xml"){
-		//the file itself is XML
-		xmlFilename = filename;
-	} else {
-	    	QTWARNING("Could not open " + xmlFilename);
-		DBGA("Old non-xml file format is no longer supported");
-		return 0;
-	}
+    bool ok;
+    QString fileType = filename.section('.', -1, -1);
+    QString xmlFilename;
+    if (fileType == "xml") {
+        //the file itself is XML
+        xmlFilename = filename;
+    }
+    else {
+        QTWARNING("Could not open " + xmlFilename);
+        DBGA("Old non-xml file format is no longer supported");
+        return 0;
+    }
 
-    	//load the graspit specific information in XML format or fail
-	TiXmlDocument doc(xmlFilename);
-	if(doc.LoadFile()==false){
-		DBGA("Failed to open EG file: " << filename.latin1());
-		QTWARNING("Could not open " + xmlFilename);
-		return 0;
-	}
+    //load the graspit specific information in XML format or fail
+    TiXmlDocument doc(xmlFilename);
+    if (doc.LoadFile() == false) {
+        DBGA("Failed to open EG file: " << filename.latin1());
+        QTWARNING("Could not open " + xmlFilename);
+        return 0;
+    }
     //get the dimensions
-	int numDims = 0;
-	QString valueStr;
-	clear();
-	TiXmlElement* root = doc.RootElement();
-    	if(root == NULL){
-		DBGA("The "<<filename.toStdString()<<" file must contain a root tag named EigenGrasps.");
-		return 0;
-	} else{
-		valueStr = root->Attribute("dimensions");
-		numDims = valueStr.toDouble(&ok); if (!ok) {DBGA("ERROR: Dimension should contain a number.");return 0;}
-		if (numDims <= 0) {
-		    	DBGA("invalid number of dimensions in EigenGrasps tag in file: "<<filename.toStdString());
-			return 0;
-		}
-	}
+    int numDims = 0;
+    QString valueStr;
+    clear();
+    TiXmlElement *root = doc.RootElement();
+    if (root == NULL) {
+        DBGA("The " << filename.toStdString() << " file must contain a root tag named EigenGrasps.");
+        return 0;
+    }
+    else {
+        valueStr = root->Attribute("dimensions");
+        numDims = valueStr.toDouble(&ok);
+        if (!ok) {
+            DBGA("ERROR: Dimension should contain a number.");
+            return 0;
+        }
+        if (numDims <= 0) {
+            DBGA("invalid number of dimensions in EigenGrasps tag in file: " << filename.toStdString());
+            return 0;
+        }
+    }
 
-    //get the list of EG's 
-	std::list<const TiXmlElement*> elementList = findAllXmlElements(root, "EG");
-	int numEG = countXmlElements(root, "EG");
-	if (numEG < 1) {
-		DBGA("Number of Eigengrasps specified: " << numEG);
-		return 0;
-	}
-	std::list<const TiXmlElement*>::iterator p = elementList.begin();
-	while(p!=elementList.end()){
-		EigenGrasp *newGrasp = new EigenGrasp(numDims);
-	    	if (!newGrasp->readFromXml(*p++)) return 0;
-		newGrasp->normalize();
-		mGrasps.push_back(newGrasp);
-	}
+    //get the list of EG's
+    std::list<const TiXmlElement *> elementList = findAllXmlElements(root, "EG");
+    int numEG = countXmlElements(root, "EG");
+    if (numEG < 1) {
+        DBGA("Number of Eigengrasps specified: " << numEG);
+        return 0;
+    }
+    std::list<const TiXmlElement *>::iterator p = elementList.begin();
+    while (p != elementList.end()) {
+        EigenGrasp *newGrasp = new EigenGrasp(numDims);
+        if (!newGrasp->readFromXml(*p++)) return 0;
+        newGrasp->normalize();
+        mGrasps.push_back(newGrasp);
+    }
 
 
     //get the orgin and process (if none setsimpleorgin)
-	elementList = findAllXmlElements(root, "ORIGIN");
-	int numORG = countXmlElements(root, "ORIGIN");
-	if (!numORG) {
-	    	DBGA("No EG origin found; using automatic origin");
-		mOrigin = new EigenGrasp(numDims);
-		setSimpleOrigin();
-	}
-	else if(numORG==1)
-	{
-		mOrigin = new EigenGrasp(numDims);
-		if (!mOrigin->readFromXml(*(elementList.begin()))){ return 0;}
-		checkOrigin();
-	}
-	else
-	{
-	    	DBGA("Multiple Origins specified in Eigen Grasp file.");
-		return 0;
-	}
+    elementList = findAllXmlElements(root, "ORIGIN");
+    int numORG = countXmlElements(root, "ORIGIN");
+    if (!numORG) {
+        DBGA("No EG origin found; using automatic origin");
+        mOrigin = new EigenGrasp(numDims);
+        setSimpleOrigin();
+    }
+    else if (numORG == 1) {
+        mOrigin = new EigenGrasp(numDims);
+        if (!mOrigin->readFromXml(*(elementList.begin()))) {
+            return 0;
+        }
+        checkOrigin();
+    }
+    else {
+        DBGA("Multiple Origins specified in Eigen Grasp file.");
+        return 0;
+    }
 
     //get the norm and process (if none set to all 1's)
-	elementList = findAllXmlElements(root, "NORM");
-	int numNORM = countXmlElements(root, "NORM");
-	if (!numNORM) {
-		DBGA("No normalization data found; using factors of 1.0");
-		mNorm = new EigenGrasp(numDims);
-		mNorm->setOnes();
-	}
-	else if(numNORM==1)
-	{
-		mNorm = new EigenGrasp(numDims);
-		if (!mNorm->readFromXml(*(elementList.begin()))){ return 0;}
-		DBGA("EG Normalization data loaded from file");
-	}
-	else
-	{
-	    	DBGA("Multiple Normals specified in Eigen Grasp file.");
-	    	return 0;
-	}
+    elementList = findAllXmlElements(root, "NORM");
+    int numNORM = countXmlElements(root, "NORM");
+    if (!numNORM) {
+        DBGA("No normalization data found; using factors of 1.0");
+        mNorm = new EigenGrasp(numDims);
+        mNorm->setOnes();
+    }
+    else if (numNORM == 1) {
+        mNorm = new EigenGrasp(numDims);
+        if (!mNorm->readFromXml(*(elementList.begin()))) {
+            return 0;
+        }
+        DBGA("EG Normalization data loaded from file");
+    }
+    else {
+        DBGA("Multiple Normals specified in Eigen Grasp file.");
+        return 0;
+    }
 
-	eSize = mGrasps.size();
-	DBGA("Read " << eSize << " eigengrasps from EG file");
+    eSize = mGrasps.size();
+    DBGA("Read " << eSize << " eigengrasps from EG file");
 
-	computeProjectionMatrices();
-	setMinMax();
-	return 1;
+    computeProjectionMatrices();
+    setMinMax();
+    return 1;
 }
 
 /*! If the origin of the eigengrasp subspace is not inside the legal range
-	of the dof, the coordinate of the origin along the offending axis is 
-	set to either the min or the max of that dof.
+    of the dof, the coordinate of the origin along the offending axis is
+    set to either the min or the max of that dof.
 */
 void
-EigenGraspInterface::checkOrigin()
-{
-	for (int d=0; d < dSize; d++) {
-		if (mOrigin->getAxisValue(d) < mRobot->getDOF(d)->getMin()) {
-			fprintf(stderr,"WARNING: Eigengrasp origin lower than DOF %d range\n",d);
-			mOrigin->setAxisValue( d, mRobot->getDOF(d)->getMin() );
-//			mOrigin->setAxisValue( d, 0.5 * (mRobot->getDOF(d)->getMin() + mRobot->getDOF(d)->getMax()) );
-		}
-		if (mOrigin->getAxisValue(d) > mRobot->getDOF(d)->getMax()) {
-			fprintf(stderr,"WARNING: Eigengrasp origin greater than DOF %d range\n",d);
-			mOrigin->setAxisValue( d, mRobot->getDOF(d)->getMax() );
-//			mOrigin->setAxisValue( d, 0.5 * (mRobot->getDOF(d)->getMin() + mRobot->getDOF(d)->getMax()) );
-		}
-	}
+EigenGraspInterface::checkOrigin() {
+    for (int d = 0; d < dSize; d++) {
+        if (mOrigin->getAxisValue(d) < mRobot->getDOF(d)->getMin()) {
+            fprintf(stderr, "WARNING: Eigengrasp origin lower than DOF %d range\n", d);
+            mOrigin->setAxisValue(d, mRobot->getDOF(d)->getMin());
+            //          mOrigin->setAxisValue( d, 0.5 * (mRobot->getDOF(d)->getMin() + mRobot->getDOF(d)->getMax()) );
+        }
+        if (mOrigin->getAxisValue(d) > mRobot->getDOF(d)->getMax()) {
+            fprintf(stderr, "WARNING: Eigengrasp origin greater than DOF %d range\n", d);
+            mOrigin->setAxisValue(d, mRobot->getDOF(d)->getMax());
+            //          mOrigin->setAxisValue( d, 0.5 * (mRobot->getDOF(d)->getMin() + mRobot->getDOF(d)->getMax()) );
+        }
+    }
 }
 void
-EigenGraspInterface::setOrigin(const double *dof)
-{
-	mOrigin->setEigenGrasp(dof);
-	checkOrigin();
+EigenGraspInterface::setOrigin(const double *dof) {
+    mOrigin->setEigenGrasp(dof);
+    checkOrigin();
 }
 
-/*! Sets as origin of eigengrasp subspace the point which is halfway between 
-	min and max for each DOF of the robot.
+/*! Sets as origin of eigengrasp subspace the point which is halfway between
+    min and max for each DOF of the robot.
 */
 void
-EigenGraspInterface::setSimpleOrigin()
-{
-	double mmin, mmax;
-	double* o = new double[dSize];
-	for (int d=0; d < dSize; d++) {
-		mmin = mRobot->getDOF(d)->getMin();
-		mmax = mRobot->getDOF(d)->getMax();
-		o[d] = (mmax + mmin) / 2.0;
-	}
-	setOrigin(o);
-	delete [] o;
+EigenGraspInterface::setSimpleOrigin() {
+    double mmin, mmax;
+    double *o = new double[dSize];
+    for (int d = 0; d < dSize; d++) {
+        mmin = mRobot->getDOF(d)->getMin();
+        mmax = mRobot->getDOF(d)->getMax();
+        o[d] = (mmax + mmin) / 2.0;
+    }
+    setOrigin(o);
+    delete [] o;
 }
 
 /*! Computes the projection matrices that go between dof and eg space.
-	This works in the general case; no assumptions are made about the
-	basis of the eg space (the eigengrasps themselves) being orthonormal.
-	In the case of orthonormal eg's, simple dot products would do as well,
-	but this is more general and elegant.
+    This works in the general case; no assumptions are made about the
+    basis of the eg space (the eigengrasps themselves) being orthonormal.
+    In the case of orthonormal eg's, simple dot products would do as well,
+    but this is more general and elegant.
 
-	In general, if we define the projection from dof space to eg space as
-	P(x) = a and its inverse as PInv(a) = x, the following rules apply:
-	P(PInv(a)) = a (always)
-	PInv(P(x)) != x (usually)
+    In general, if we define the projection from dof space to eg space as
+    P(x) = a and its inverse as PInv(a) = x, the following rules apply:
+    P(PInv(a)) = a (always)
+    PInv(P(x)) != x (usually)
 */
 
 void
-EigenGraspInterface::computeProjectionMatrices()
-{
-	if (mP) delete mP;
-	if (mPInv) delete mPInv;
+EigenGraspInterface::computeProjectionMatrices() {
+    if (mP) delete mP;
+    if (mPInv) delete mPInv;
 
-	//first build the E matrix that just contains the (potentially non-orthonormal) bases
-	Matrix E(eSize, dSize);
-	for (int e=0; e<eSize; e++) {
-		for (int d=0; d<dSize; d++) {
-			E.elem(e,d) = mGrasps[e]->getAxisValue(d);
-		}
-	}
+    //first build the E matrix that just contains the (potentially non-orthonormal) bases
+    Matrix E(eSize, dSize);
+    for (int e = 0; e < eSize; e++) {
+        for (int d = 0; d < dSize; d++) {
+            E.elem(e, d) = mGrasps[e]->getAxisValue(d);
+        }
+    }
 
-	//the trivial case (assumes ortho-normal E)
-	//mP = new Matrix(E);
-	//mPInv = new Matrix(E.transposed());
+    //the trivial case (assumes ortho-normal E)
+    //mP = new Matrix(E);
+    //mPInv = new Matrix(E.transposed());
 
-	//general case
-	//remember: P(PInv(a)) = a (always)
-	//		    PInv(P(x)) != x (usually)
-	// P = (E*ET)'*E
-	// P' = ET
-	Matrix ET(E.transposed());
-	Matrix EET(eSize, eSize);
-	matrixMultiply(E, ET, EET);
-	Matrix EETInv(eSize, eSize);
-	int result = matrixInverse(EET, EETInv);
-	if (result) {
-		DBGA("Projection matrix is rank deficient!");
-		mP = new Matrix(Matrix::ZEROES<Matrix>(eSize, dSize));
-		mPInv = new Matrix(Matrix::ZEROES<Matrix>(dSize, eSize));
-		return;
-	}
-	mP = new Matrix(eSize, dSize);
-	matrixMultiply(EETInv, E, *mP);
-	mPInv = new Matrix(ET);
+    //general case
+    //remember: P(PInv(a)) = a (always)
+    //          PInv(P(x)) != x (usually)
+    // P = (E*ET)'*E
+    // P' = ET
+    Matrix ET(E.transposed());
+    Matrix EET(eSize, eSize);
+    matrixMultiply(E, ET, EET);
+    Matrix EETInv(eSize, eSize);
+    int result = matrixInverse(EET, EETInv);
+    if (result) {
+        DBGA("Projection matrix is rank deficient!");
+        mP = new Matrix(Matrix::ZEROES<Matrix>(eSize, dSize));
+        mPInv = new Matrix(Matrix::ZEROES<Matrix>(dSize, eSize));
+        return;
+    }
+    mP = new Matrix(eSize, dSize);
+    matrixMultiply(EETInv, E, *mP);
+    mPInv = new Matrix(ET);
 }
 
-/*! The boundary of the "legal" space forms a polygon in EG-subspace 
-	which is not axis-aligned. It is difficult to compute analytically
-	so for any new hand configuration this function re-computes the min 
-	and max values. The min and max along each eigengrasp are then stored
-	inside the eigengrasps themselves.
+/*! The boundary of the "legal" space forms a polygon in EG-subspace
+    which is not axis-aligned. It is difficult to compute analytically
+    so for any new hand configuration this function re-computes the min
+    and max values. The min and max along each eigengrasp are then stored
+    inside the eigengrasps themselves.
 
-	The behavior depends on whether EIGENGRASP_LOOSE is defined. If not, min
-	and max have to be set so that not a single dof is taken outside of its
-	range. If it is not set, then min and max have to be set so that at least
-	one dof is inside the legal range, the others can go out as they will be
-	clamped later.
+    The behavior depends on whether EIGENGRASP_LOOSE is defined. If not, min
+    and max have to be set so that not a single dof is taken outside of its
+    range. If it is not set, then min and max have to be set so that at least
+    one dof is inside the legal range, the others can go out as they will be
+    clamped later.
 
-	For some reason, this apparently simple function has given me a ton of
-	trouble, and I've never been completely happy with it.
+    For some reason, this apparently simple function has given me a ton of
+    trouble, and I've never been completely happy with it.
 */
 void
-EigenGraspInterface::setMinMax()
-{
-	double m,M,mmin,mmax;
-	double* eg = new double[dSize];
-	double* currentDOF = new double[dSize];
-	double* currentAmps  = new double[eSize];
+EigenGraspInterface::setMinMax() {
+    double m, M, mmin, mmax;
+    double *eg = new double[dSize];
+    double *currentDOF = new double[dSize];
+    double *currentAmps  = new double[eSize];
 
-	mRobot->getDOFVals(currentDOF);
-	getAmp(currentAmps, currentDOF);
+    mRobot->getDOFVals(currentDOF);
+    getAmp(currentAmps, currentDOF);
 
-	for (int e = 0; e < eSize; e++)
-	{
-		//fprintf(stderr,"\n------\nEG %d\n",e);
-#ifdef EIGENGRASP_LOOSE
-		mmin = +1.0e5;
-		mmax = -1.0e5;
-#else
-		mmin = -1.0e5;
-		mmax = +1.0e5;
-#endif
-		mGrasps[e]->getEigenGrasp(eg);
-		for (int d=0; d < dSize; d++) {
-			if (eg[d]==0) continue;
-			m = ( mRobot->getDOF(d)->getMin() - currentDOF[d] ) / ( eg[d] * mNorm->getAxisValue(d) );
-			M = ( mRobot->getDOF(d)->getMax() - currentDOF[d] ) / ( eg[d] * mNorm->getAxisValue(d) );
-			if ( m > M) {std::swap(m,M);} //swap m and M if needed
-#ifdef EIGENGRASP_LOOSE
+    for (int e = 0; e < eSize; e++) {
+        //fprintf(stderr,"\n------\nEG %d\n",e);
+        #ifdef EIGENGRASP_LOOSE
+        mmin = +1.0e5;
+        mmax = -1.0e5;
+        #else
+        mmin = -1.0e5;
+        mmax = +1.0e5;
+        #endif
+        mGrasps[e]->getEigenGrasp(eg);
+        for (int d = 0; d < dSize; d++) {
+            if (eg[d] == 0) continue;
+            m = (mRobot->getDOF(d)->getMin() - currentDOF[d]) / (eg[d] * mNorm->getAxisValue(d));
+            M = (mRobot->getDOF(d)->getMax() - currentDOF[d]) / (eg[d] * mNorm->getAxisValue(d));
+            if (m > M) {
+                std::swap(m, M);   //swap m and M if needed
+            }
+            #ifdef EIGENGRASP_LOOSE
             //if ( m < mmin ) {mmin = m; mind = d;}
             //if ( M > mmax ) {mmax = M; maxd = d;}
-            if ( m < mmin ) {mmin = m;}
-            if ( M > mmax ) {mmax = M;}
-#else
+            if (m < mmin) {
+                mmin = m;
+            }
+            if (M > mmax) {
+                mmax = M;
+            }
+            #else
             //if ( m > mmin ) {mmin = m; mind = d;}
             //if ( M < mmax ) {mmax = M; maxd = d;}
-            if ( m > mmin ) {mmin = m;}
-            if ( M < mmax ) {mmax = M;}
-#endif
-		}
-		if(!mGrasps[e]->mPredefinedLimits){
-			mGrasps[e]->mMin = currentAmps[e] + mmin;
-			mGrasps[e]->mMax = currentAmps[e] + mmax;
-		}
-		//fprintf(stderr,"Current: %f; range: %f(%d) -- %f(%d) \n",currentAmps[e],
-		//		mGrasps[e]->mMin, mind, mGrasps[e]->mMax, maxd);
-	}
+            if (m > mmin) {
+                mmin = m;
+            }
+            if (M < mmax) {
+                mmax = M;
+            }
+            #endif
+        }
+        if (!mGrasps[e]->mPredefinedLimits) {
+            mGrasps[e]->mMin = currentAmps[e] + mmin;
+            mGrasps[e]->mMax = currentAmps[e] + mmax;
+        }
+        //fprintf(stderr,"Current: %f; range: %f(%d) -- %f(%d) \n",currentAmps[e],
+        //      mGrasps[e]->mMin, mind, mGrasps[e]->mMax, maxd);
+    }
 
-	delete [] eg;
-	delete [] currentDOF;
-	delete [] currentAmps;
+    delete [] eg;
+    delete [] currentDOF;
+    delete [] currentAmps;
 }
 
 void
-EigenGraspInterface::toDOFSpace(const double *amp, double *dof, const double *origin) const
-{
-	Matrix a(amp, eSize, 1, true);
-	Matrix x(dSize, 1);
-	matrixMultiply(*mPInv, a, x);
-	for(int d=0; d<dSize; d++) {
-		dof[d] = x.elem(d,0) * mNorm->getAxisValue(d) + origin[d];
-	}
+EigenGraspInterface::toDOFSpace(const double *amp, double *dof, const double *origin) const {
+    Matrix a(amp, eSize, 1, true);
+    Matrix x(dSize, 1);
+    matrixMultiply(*mPInv, a, x);
+    for (int d = 0; d < dSize; d++) {
+        dof[d] = x.elem(d, 0) * mNorm->getAxisValue(d) + origin[d];
+    }
 }
 
 void
-EigenGraspInterface::toEigenSpace(double *amp, const double *dof, const double *origin) const
-{
-	Matrix x(dSize, 1);
-	for (int d=0; d < dSize; d++) {
-		x.elem(d,0) = (dof[d] - origin[d]) / mNorm->getAxisValue(d);
-	}
-	Matrix a(eSize, 1);
-	matrixMultiply(*mP, x, a);
-	for (int e=0; e<eSize; e++) {
-		amp[e] = a.elem(e,0);
-	}
+EigenGraspInterface::toEigenSpace(double *amp, const double *dof, const double *origin) const {
+    Matrix x(dSize, 1);
+    for (int d = 0; d < dSize; d++) {
+        x.elem(d, 0) = (dof[d] - origin[d]) / mNorm->getAxisValue(d);
+    }
+    Matrix a(eSize, 1);
+    matrixMultiply(*mP, x, a);
+    for (int e = 0; e < eSize; e++) {
+        amp[e] = a.elem(e, 0);
+    }
 }
 
-/*! Given a vector of EG amplitudes (a point in EG subspace) this 
-	function returns it's equivalent in DOF space. Essentially, it
-	back-projects a point from eg space to dof space.
+/*! Given a vector of EG amplitudes (a point in EG subspace) this
+    function returns it's equivalent in DOF space. Essentially, it
+    back-projects a point from eg space to dof space.
 
-	If the interface is rigid, we add the amplitudes to the pre-specified 
-	eigen space origin. This means we DISCARD whatever component was in 
-	the pose that was not from eigenspace.
-	
-	If the interface is not rigid, we add the change in amplitudes to the 
-	current position of the robot. This means we KEEP the position component 
-	that was not in eigen space.
+    If the interface is rigid, we add the amplitudes to the pre-specified
+    eigen space origin. This means we DISCARD whatever component was in
+    the pose that was not from eigenspace.
+
+    If the interface is not rigid, we add the change in amplitudes to the
+    current position of the robot. This means we KEEP the position component
+    that was not in eigen space.
 */
-void 
-EigenGraspInterface::getDOF(const double *amp, double *dof) const 
-{
-	double *origin = new double[dSize];
-	double *rigidAmp = new double[eSize];
-	
-	for (int e=0; e < eSize; e++) {
-		if ( !mGrasps[e]->mFixed )
-			rigidAmp[e] = amp[e];
-		else {
-			rigidAmp[e] = mGrasps[e]->fixedAmplitude;
-			DBGA(e << " fixed at " << mGrasps[e]->fixedAmplitude);
-		}
-	}
+void
+EigenGraspInterface::getDOF(const double *amp, double *dof) const {
+    double *origin = new double[dSize];
+    double *rigidAmp = new double[eSize];
 
-	if (mRigid) {
-		//if the interface is rigid, we add the amplitudes to the pre-specified eigen space origin
-		//it means we DISCARD whatever component was in the pose that was not from eigenspace
-		mOrigin->getEigenGrasp(origin);
-		toDOFSpace(rigidAmp, dof, origin);
-	} else {
-		//if it is not, we just add the change in amplitudes to the current position of the robot
-		//this means we KEEP the position component that was not in eigen space
-		double *currentAmp = new double[eSize];
-		double *relativeAmp = new double[eSize];
-		mRobot->getDOFVals(origin);
-		getAmp(currentAmp, origin);
-		for (int e=0; e < eSize; e++) {
-			relativeAmp[e] = rigidAmp[e] - currentAmp[e];
-		}
-		toDOFSpace(relativeAmp, dof, origin);
-		delete [] currentAmp;
-		delete [] relativeAmp;		
-	}
+    for (int e = 0; e < eSize; e++) {
+        if (!mGrasps[e]->mFixed)
+            rigidAmp[e] = amp[e];
+        else {
+            rigidAmp[e] = mGrasps[e]->fixedAmplitude;
+            DBGA(e << " fixed at " << mGrasps[e]->fixedAmplitude);
+        }
+    }
 
-	delete [] rigidAmp;
-	delete [] origin;
+    if (mRigid) {
+        //if the interface is rigid, we add the amplitudes to the pre-specified eigen space origin
+        //it means we DISCARD whatever component was in the pose that was not from eigenspace
+        mOrigin->getEigenGrasp(origin);
+        toDOFSpace(rigidAmp, dof, origin);
+    }
+    else {
+        //if it is not, we just add the change in amplitudes to the current position of the robot
+        //this means we KEEP the position component that was not in eigen space
+        double *currentAmp = new double[eSize];
+        double *relativeAmp = new double[eSize];
+        mRobot->getDOFVals(origin);
+        getAmp(currentAmp, origin);
+        for (int e = 0; e < eSize; e++) {
+            relativeAmp[e] = rigidAmp[e] - currentAmp[e];
+        }
+        toDOFSpace(relativeAmp, dof, origin);
+        delete [] currentAmp;
+        delete [] relativeAmp;
+    }
+
+    delete [] rigidAmp;
+    delete [] origin;
 }
 
-/*! Given a set of dof values (a point in dof space), it computes its 
-	eigengrasp amplitudes (its projection in eg space). Just subtracts
-	the origin of the eg space from the provided point, then projects
-	the result along the eg subspace.
+/*! Given a set of dof values (a point in dof space), it computes its
+    eigengrasp amplitudes (its projection in eg space). Just subtracts
+    the origin of the eg space from the provided point, then projects
+    the result along the eg subspace.
 */
-void 
-EigenGraspInterface::getAmp(double *amp, const double *dof) const
-{
-	double *origin = new double[dSize];
-	mOrigin->getEigenGrasp(origin);
-	toEigenSpace(amp, dof, origin);
-	delete [] origin;
+void
+EigenGraspInterface::getAmp(double *amp, const double *dof) const {
+    double *origin = new double[dSize];
+    mOrigin->getEigenGrasp(origin);
+    toEigenSpace(amp, dof, origin);
+    delete [] origin;
 }

--- a/src/gloveInterface.cpp
+++ b/src/gloveInterface.cpp
@@ -46,1092 +46,1051 @@
 #include "debug.h"
 
 //--------------CalibrationPose------------
-void CalibrationPose::init(int size)
-{
-	if (size < 0) {
-		fprintf(stderr,"Wrong size of calibration pose\n");
-		mSize = 0;
-	} else {
-		mSize = size;
-	}
-	if (mSize>0) {
-		jointValues = new double[size];
-		sensorValues = new int[size];
-		sensorMap = new int[size];
-	}
-	recordedDistance = 0;
-	mSize = size;
-	jointsSet = false;
-	sensorsSet = false;
-	mapSet = false;
-	poseSet = false;
-	mTransf = transf::IDENTITY;
+void CalibrationPose::init(int size) {
+    if (size < 0) {
+        fprintf(stderr, "Wrong size of calibration pose\n");
+        mSize = 0;
+    }
+    else {
+        mSize = size;
+    }
+    if (mSize > 0) {
+        jointValues = new double[size];
+        sensorValues = new int[size];
+        sensorMap = new int[size];
+    }
+    recordedDistance = 0;
+    mSize = size;
+    jointsSet = false;
+    sensorsSet = false;
+    mapSet = false;
+    poseSet = false;
+    mTransf = transf::IDENTITY;
 }
 
-CalibrationPose::CalibrationPose(int size)
-{
-	init(size);
+CalibrationPose::CalibrationPose(int size) {
+    init(size);
 }
 
-CalibrationPose::CalibrationPose(int size, double *joints, int *map)
-{
-	init(size);
-	setAllJointValues(joints);
-	for (int i=0; i<size; i++) {
-		jointValues[i] = jointValues[i] * 3.14159 / 180.0;
-	}
-	setAllMaps(map);
+CalibrationPose::CalibrationPose(int size, double *joints, int *map) {
+    init(size);
+    setAllJointValues(joints);
+    for (int i = 0; i < size; i++) {
+        jointValues[i] = jointValues[i] * 3.14159 / 180.0;
+    }
+    setAllMaps(map);
 }
 
-CalibrationPose::~CalibrationPose()
-{
-	delete [] jointValues;
-	delete [] sensorValues;
-	delete [] sensorMap;
+CalibrationPose::~CalibrationPose() {
+    delete [] jointValues;
+    delete [] sensorValues;
+    delete [] sensorMap;
 }
 
-void CalibrationPose::readFromFile(FILE *fp)
-{
-	int val;
-	float floatVal;
-	int j;
+void CalibrationPose::readFromFile(FILE *fp) {
+    int val;
+    float floatVal;
+    int j;
 
-	if(fscanf(fp,"%d",&mSize) <=0){
-	  DBGA("CalibrationPose::readFromFile - Failed to read calibration size");	 
-	  return;
-	}
-	init(mSize);
+    if (fscanf(fp, "%d", &mSize) <= 0) {
+        DBGA("CalibrationPose::readFromFile - Failed to read calibration size");
+        return;
+    }
+    init(mSize);
 
-	if(fscanf(fp,"%f",&floatVal) <= 0) {
-	  DBGA("CalibrationPose::readFromFile - Failed to read recorded distance");	 
-	  return;
-	}
-	recordedDistance = floatVal;
-	if(fscanf(fp,"%d",&val)) {
-	  DBGA("CalibrationPose::readFromFile - Failed to read sensor number");	 
-	  return;
-	}
-	
-	if (val) {
-	  for (j=0; j<mSize; j++) {
-	    if(fscanf(fp,"%d",&val) <= 0) {
-	      DBGA("CalibrationPose::readFromFile - Failed to read sensor value");	 
-	      return;
-	    }
-	    setSensorValue(j,val);
-	  }
-	  sensorsSet = true;
-	} else sensorsSet = false;
+    if (fscanf(fp, "%f", &floatVal) <= 0) {
+        DBGA("CalibrationPose::readFromFile - Failed to read recorded distance");
+        return;
+    }
+    recordedDistance = floatVal;
+    if (fscanf(fp, "%d", &val)) {
+        DBGA("CalibrationPose::readFromFile - Failed to read sensor number");
+        return;
+    }
 
-	if (fscanf(fp,"%d",&val) <= 0) {
-	  DBGA("CalibrationPose::readFromFile - Failed to read map size");	 
-	  return;
-	}
-	
-	if (val) {
-	  for (j=0; j<mSize; j++) {
-	    if(fscanf(fp,"%d",&val) <= 0) {
-	      DBGA("CalibrationPose::readFromFile - Failed to read map value");	 
-	      return;
-	    }
-	    
-	    setMap(j,val);	
-	  }
-	  mapSet = true;
-	} 
-	else mapSet = false;
-	
-	if(fscanf(fp,"%d",&val) <= 0) {
-	  DBGA("CalibrationPose::readFromFile - Failed to read joint number");	 
-	  return;
-	}
-	
-	if (val) {
-	  for (j=0; j<mSize; j++) {
-	    if(fscanf(fp,"%f",&floatVal) >= 0) {
-	      DBGA("CalibrationPose::readFromFile - Failed to read joint value");	 
-	      return;
-	    }
-	    
-	    setJointValue(j,floatVal);
-	  }
-	  jointsSet = true;
-	} else jointsSet = false;
-	
-	
-	//transform rotation
-	float x,y,z,w;
-	if(fscanf(fp,"%f %f %f %f",&x, &y, &z, &w)) {
-	  DBGA("CalibrationPose::readFromFile - Failed to read calibration orientation");	 
-	  return;
-	}
-	Quaternion q(w,x,y,z);
-	if(fscanf(fp,"%f %f %f",&x,&y,&z) <= 0) {
-	  DBGA("CalibrationPose::readFromFile - Failed to read calibration location");	 
-	  return;
-	}
-	
-	vec3 t(x,y,z);
-	mTransf.set(q,t);
+    if (val) {
+        for (j = 0; j < mSize; j++) {
+            if (fscanf(fp, "%d", &val) <= 0) {
+                DBGA("CalibrationPose::readFromFile - Failed to read sensor value");
+                return;
+            }
+            setSensorValue(j, val);
+        }
+        sensorsSet = true;
+    }
+    else sensorsSet = false;
+
+    if (fscanf(fp, "%d", &val) <= 0) {
+        DBGA("CalibrationPose::readFromFile - Failed to read map size");
+        return;
+    }
+
+    if (val) {
+        for (j = 0; j < mSize; j++) {
+            if (fscanf(fp, "%d", &val) <= 0) {
+                DBGA("CalibrationPose::readFromFile - Failed to read map value");
+                return;
+            }
+
+            setMap(j, val);
+        }
+        mapSet = true;
+    }
+    else mapSet = false;
+
+    if (fscanf(fp, "%d", &val) <= 0) {
+        DBGA("CalibrationPose::readFromFile - Failed to read joint number");
+        return;
+    }
+
+    if (val) {
+        for (j = 0; j < mSize; j++) {
+            if (fscanf(fp, "%f", &floatVal) >= 0) {
+                DBGA("CalibrationPose::readFromFile - Failed to read joint value");
+                return;
+            }
+
+            setJointValue(j, floatVal);
+        }
+        jointsSet = true;
+    }
+    else jointsSet = false;
+
+
+    //transform rotation
+    float x, y, z, w;
+    if (fscanf(fp, "%f %f %f %f", &x, &y, &z, &w)) {
+        DBGA("CalibrationPose::readFromFile - Failed to read calibration orientation");
+        return;
+    }
+    Quaternion q(w, x, y, z);
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("CalibrationPose::readFromFile - Failed to read calibration location");
+        return;
+    }
+
+    vec3 t(x, y, z);
+    mTransf.set(q, t);
 }
 
-void CalibrationPose::writeToFile(FILE *fp)
-{
-	fprintf(fp,"%d\n",getSize());
-	fprintf(fp,"%f\n",recordedDistance);
+void CalibrationPose::writeToFile(FILE *fp) {
+    fprintf(fp, "%d\n", getSize());
+    fprintf(fp, "%f\n", recordedDistance);
 
-	if ( sensorsSet ) {
-		fprintf(fp,"1\n");
-		for (int i=0; i<getSize(); i++)
-			fprintf(fp,"%d ",getSensorValue(i));
-		fprintf(fp,"\n");
-	} else fprintf(fp,"0\n");
-	if (mapSet) {
-		fprintf(fp,"1\n");
-		for (int i=0; i<getSize(); i++)
-			fprintf(fp,"%d ",getMap(i) );
-		fprintf(fp,"\n");			
-	} else fprintf(fp,"0\n");
-	if (jointsSet) {
-		fprintf(fp,"1\n");
-		for (int i=0; i<getSize(); i++)
-			fprintf(fp,"%f ",getJointValue(i) );
-		fprintf(fp,"\n");			
-	} else fprintf(fp,"0\n");
-	//transform rotation
-	fprintf(fp,"%f %f %f %f\n",mTransf.rotation().x, mTransf.rotation().y, 
-		    mTransf.rotation().z, mTransf.rotation().w);
-	//transform translation
-	fprintf(fp,"%f %f %f\n",mTransf.translation().x(), mTransf.translation().y(), 
-			mTransf.translation().z());
+    if (sensorsSet) {
+        fprintf(fp, "1\n");
+        for (int i = 0; i < getSize(); i++)
+            fprintf(fp, "%d ", getSensorValue(i));
+        fprintf(fp, "\n");
+    }
+    else fprintf(fp, "0\n");
+    if (mapSet) {
+        fprintf(fp, "1\n");
+        for (int i = 0; i < getSize(); i++)
+            fprintf(fp, "%d ", getMap(i));
+        fprintf(fp, "\n");
+    }
+    else fprintf(fp, "0\n");
+    if (jointsSet) {
+        fprintf(fp, "1\n");
+        for (int i = 0; i < getSize(); i++)
+            fprintf(fp, "%f ", getJointValue(i));
+        fprintf(fp, "\n");
+    }
+    else fprintf(fp, "0\n");
+    //transform rotation
+    fprintf(fp, "%f %f %f %f\n", mTransf.rotation().x, mTransf.rotation().y,
+            mTransf.rotation().z, mTransf.rotation().w);
+    //transform translation
+    fprintf(fp, "%f %f %f\n", mTransf.translation().x(), mTransf.translation().y(),
+            mTransf.translation().z());
 }
 
 //! Loads a list of calibration poses from a file
-/*! Helper function loads all the calibration poses found in a file and 
-	stores them in a given list of poses. The poses have usually been
-	save using \writePoseListToFile(...)
+/*! Helper function loads all the calibration poses found in a file and
+    stores them in a given list of poses. The poses have usually been
+    save using \writePoseListToFile(...)
 */
-void loadPoseListFromFile(std::list<CalibrationPose*> *list, const char *filename)
-{
-	FILE *fp = fopen(filename,"r");
-	if (!fp) {
-		fprintf(stderr,"Unable to open calibration file!\n");
-		return;
-	}
+void loadPoseListFromFile(std::list<CalibrationPose *> *list, const char *filename) {
+    FILE *fp = fopen(filename, "r");
+    if (!fp) {
+        fprintf(stderr, "Unable to open calibration file!\n");
+        return;
+    }
 
-	int nPoses;
-	CalibrationPose *pose;
-	if(fscanf(fp,"%d",&nPoses) <= 0) {
-	  DBGA("loadPoseListFromFile - Failed to read number of poses");	 
-	  return;
-	
-	}
-	fprintf(stderr,"Total of %d poses\n",nPoses);
-	for (int i=0; i<nPoses; i++) {
-		pose = new CalibrationPose(0);
-		pose->readFromFile(fp);
-		list->push_back(pose);
-	}
-	fclose(fp);
+    int nPoses;
+    CalibrationPose *pose;
+    if (fscanf(fp, "%d", &nPoses) <= 0) {
+        DBGA("loadPoseListFromFile - Failed to read number of poses");
+        return;
+
+    }
+    fprintf(stderr, "Total of %d poses\n", nPoses);
+    for (int i = 0; i < nPoses; i++) {
+        pose = new CalibrationPose(0);
+        pose->readFromFile(fp);
+        list->push_back(pose);
+    }
+    fclose(fp);
 }
 
 //! Saves a list of poses to a file
 /*! The poses can be read back by loadPosesListFromFile(...)*/
-void writePoseListToFile(std::list<CalibrationPose*> *list, const char *filename)
-{
-	FILE *fp = fopen(filename,"w");
-	if (!fp) {
-		fprintf(stderr,"Unable to open calibration file!\n");
-		return;
-	}
-	fprintf(fp,"%lu\n",list->size());
-	std::list<CalibrationPose*>::iterator it;
-	for (it = list->begin(); it!=list->end(); it++) {
-		(*it)->writeToFile(fp);
-	}
-	fprintf(stderr,"Calibration poses saved\n");
-	fclose(fp);
+void writePoseListToFile(std::list<CalibrationPose *> *list, const char *filename) {
+    FILE *fp = fopen(filename, "w");
+    if (!fp) {
+        fprintf(stderr, "Unable to open calibration file!\n");
+        return;
+    }
+    fprintf(fp, "%lu\n", list->size());
+    std::list<CalibrationPose *>::iterator it;
+    for (it = list->begin(); it != list->end(); it++) {
+        (*it)->writeToFile(fp);
+    }
+    fprintf(stderr, "Calibration poses saved\n");
+    fclose(fp);
 }
 
-bool CalibrationPose::isSet()
-{
-	return poseSet;
+bool CalibrationPose::isSet() {
+    return poseSet;
 }
 
-void CalibrationPose::setAllJointValues(double *jv)
-{
-	for (int i=0; i<mSize; i++) {
-		jointValues[i] = jv[i];
-	}
-	jointsSet = true;
-	if (sensorsSet && mapSet) poseSet = true;
+void CalibrationPose::setAllJointValues(double *jv) {
+    for (int i = 0; i < mSize; i++) {
+        jointValues[i] = jv[i];
+    }
+    jointsSet = true;
+    if (sensorsSet && mapSet) poseSet = true;
 }
 
-void CalibrationPose::setJointValue(int j, double jv)
-{
-	jointValues[j] = jv;
-	jointsSet = true;
+void CalibrationPose::setJointValue(int j, double jv) {
+    jointValues[j] = jv;
+    jointsSet = true;
 }
 
-void CalibrationPose::setAllSensorValues(int *sv)
-{
-	for (int i=0; i<mSize; i++) {
-		sensorValues[i] = sv[i];
-	}
-	sensorsSet = true;
-	if (jointsSet && mapSet) poseSet = true;
+void CalibrationPose::setAllSensorValues(int *sv) {
+    for (int i = 0; i < mSize; i++) {
+        sensorValues[i] = sv[i];
+    }
+    sensorsSet = true;
+    if (jointsSet && mapSet) poseSet = true;
 }
 
-void CalibrationPose::setSensorValue(int i, int sv)
-{
-	if (i>=mSize) {
-		fprintf(stderr,"Error attempting to set calibration pose sensor value\n");
-		return;
-	}
-	sensorValues[i] = sv;
-	sensorsSet = true;
+void CalibrationPose::setSensorValue(int i, int sv) {
+    if (i >= mSize) {
+        fprintf(stderr, "Error attempting to set calibration pose sensor value\n");
+        return;
+    }
+    sensorValues[i] = sv;
+    sensorsSet = true;
 }
 
-void CalibrationPose::setAllMaps(int *m)
-{
-	for (int i=0; i<mSize; i++) {
-		sensorMap[i] = m[i];
-	}
-	mapSet = true;
-	if (jointsSet && sensorsSet) poseSet = true;
+void CalibrationPose::setAllMaps(int *m) {
+    for (int i = 0; i < mSize; i++) {
+        sensorMap[i] = m[i];
+    }
+    mapSet = true;
+    if (jointsSet && sensorsSet) poseSet = true;
 }
 
-void CalibrationPose::setMap(int i, int mv)
-{
-	if (i>=mSize) {
-		fprintf(stderr,"Error attempting to set calibration pose map value\n");
-		return;
-	}
-	sensorMap[i] = mv;
-	mapSet = true;
+void CalibrationPose::setMap(int i, int mv) {
+    if (i >= mSize) {
+        fprintf(stderr, "Error attempting to set calibration pose map value\n");
+        return;
+    }
+    sensorMap[i] = mv;
+    mapSet = true;
 }
 
 //--------------------------------Conversion Data -------------------------------
 
-CData::CData(int nd, int ns)
-{
-	nDOF = nd;
-	nSensors = ns;
-	slopes = new double[nDOF*nSensors];
-	intercepts = new double[nDOF];
-	reset();
+CData::CData(int nd, int ns) {
+    nDOF = nd;
+    nSensors = ns;
+    slopes = new double[nDOF * nSensors];
+    intercepts = new double[nDOF];
+    reset();
 }
 
-CData::~CData()
-{
-	delete [] slopes;
-	delete [] intercepts;
+CData::~CData() {
+    delete [] slopes;
+    delete [] intercepts;
 }
 
-void CData::reset()
-{
-	int i;
-	for (i=0; i<nDOF*nSensors; i++)
-		slopes[i] = 0;
-	for (i=0; i<nDOF; i++)
-		intercepts[i] = 0;
+void CData::reset() {
+    int i;
+    for (i = 0; i < nDOF * nSensors; i++)
+        slopes[i] = 0;
+    for (i = 0; i < nDOF; i++)
+        intercepts[i] = 0;
 }
 
-void CData::setSlope(int d, int s, double val)
-{
-	if ( d>= nDOF || s >= nSensors) {
-		fprintf(stderr,"Wrong addressing in Conversion Data\n");
-		return;
-	}
-	slopes[d+s*nDOF] = val;
+void CData::setSlope(int d, int s, double val) {
+    if (d >= nDOF || s >= nSensors) {
+        fprintf(stderr, "Wrong addressing in Conversion Data\n");
+        return;
+    }
+    slopes[d + s * nDOF] = val;
 }
 
-void CData::setIntercept(int d, double val)
-{
-	if ( d >= nDOF ) {
-		fprintf(stderr,"Wrong addressing in Conversion Data\n");
-		return;
-	}
-	intercepts[d] = val;
+void CData::setIntercept(int d, double val) {
+    if (d >= nDOF) {
+        fprintf(stderr, "Wrong addressing in Conversion Data\n");
+        return;
+    }
+    intercepts[d] = val;
 }
 
-void CData::addToSlope(int d, int s, double val)
-{
-	if ( d>= nDOF || s >= nSensors) {
-		fprintf(stderr,"Wrong addressing in Conversion Data\n");
-		return;
-	}
-	slopes[d+s*nDOF] += val;
+void CData::addToSlope(int d, int s, double val) {
+    if (d >= nDOF || s >= nSensors) {
+        fprintf(stderr, "Wrong addressing in Conversion Data\n");
+        return;
+    }
+    slopes[d + s * nDOF] += val;
 }
 
-void CData::addToIntercept(int d, double val)
-{
-	if ( d >= nDOF ) {
-		fprintf(stderr,"Wrong addressing in Conversion Data\n");
-		return;
-	}
-	intercepts[d] += val;
+void CData::addToIntercept(int d, double val) {
+    if (d >= nDOF) {
+        fprintf(stderr, "Wrong addressing in Conversion Data\n");
+        return;
+    }
+    intercepts[d] += val;
 }
-double CData::getSlope(int d, int s)
-{
-	if ( d>= nDOF || s >= nSensors) {
-		fprintf(stderr,"Wrong addressing in Conversion Data\n");
-		return 0;
-	}
-	return slopes[d+s*nDOF];
+double CData::getSlope(int d, int s) {
+    if (d >= nDOF || s >= nSensors) {
+        fprintf(stderr, "Wrong addressing in Conversion Data\n");
+        return 0;
+    }
+    return slopes[d + s * nDOF];
 }
 
-double CData::getIntercept(int d)
-{
-	if ( d >= nDOF ) {
-		fprintf(stderr,"Wrong addressing in Conversion Data\n");
-		return 0;
-	}
-	return intercepts[d];
+double CData::getIntercept(int d) {
+    if (d >= nDOF) {
+        fprintf(stderr, "Wrong addressing in Conversion Data\n");
+        return 0;
+    }
+    return intercepts[d];
 }
 
 //---------------------------------GloveInterface--------------------------------
 
-GloveInterface::GloveInterface(Robot *robot)
-{
-	mRobot = robot;
-	rawGlove = NULL;
+GloveInterface::GloveInterface(Robot *robot) {
+    mRobot = robot;
+    rawGlove = NULL;
 
-	savedDOFVals = new double[mRobot->getNumDOF()];
-	mRobot->getDOFVals(savedDOFVals);
+    savedDOFVals = new double[mRobot->getNumDOF()];
+    mRobot->getDOFVals(savedDOFVals);
 
-	mData = new CData( mRobot->getNumDOF(), N_SENSOR_VALUES);
-	currentPose = cPoses.begin();
+    mData = new CData(mRobot->getNumDOF(), N_SENSOR_VALUES);
+    currentPose = cPoses.begin();
 }
 
-GloveInterface::~GloveInterface()
-{
-	delete mData;
-	delete [] savedDOFVals;
+GloveInterface::~GloveInterface() {
+    delete mData;
+    delete [] savedDOFVals;
 }
 
-void GloveInterface::setGlove(CyberGlove *glove)
-{
-	rawGlove = glove;
+void GloveInterface::setGlove(CyberGlove *glove) {
+    rawGlove = glove;
 }
 
-void GloveInterface::saveRobotPose()
-{
-	mRobot->getDOFVals(savedDOFVals);
+void GloveInterface::saveRobotPose() {
+    mRobot->getDOFVals(savedDOFVals);
 }
 
-void GloveInterface::revertRobotPose()
-{
-	mRobot->forceDOFVals(savedDOFVals);
+void GloveInterface::revertRobotPose() {
+    mRobot->forceDOFVals(savedDOFVals);
 }
 
-int GloveInterface::instantRead()
-{
-#ifdef HARDWARE_LIB
-	if (!rawGlove)
-		return 0;
-	if (!rawGlove->instantRead() )
-		return 0;
-	return 1;
-#else
-	return 0;
-#endif
+int GloveInterface::instantRead() {
+    #ifdef HARDWARE_LIB
+    if (!rawGlove)
+        return 0;
+    if (!rawGlove->instantRead())
+        return 0;
+    return 1;
+    #else
+    return 0;
+    #endif
 }
 
-/*! Sets the calibration paramteres given a min-max range for a sensor as 
-	well as the DOF it governs. Should soon be private.
+/*! Sets the calibration paramteres given a min-max range for a sensor as
+    well as the DOF it governs. Should soon be private.
 */
-void GloveInterface::setParameters(int s, int d, float sMin, float sMax, float dMin, float dMax)
-{
-	fprintf(stderr,"sensor %d to DOF %d -- sMin %f sMax %f dMin %f dMax %f\n",s,d,sMin,sMax,dMin,dMax);
+void GloveInterface::setParameters(int s, int d, float sMin, float sMax, float dMin, float dMax) {
+    fprintf(stderr, "sensor %d to DOF %d -- sMin %f sMax %f dMin %f dMax %f\n", s, d, sMin, sMax, dMin, dMax);
 
-	double slope = ( dMax - dMin ) / ( sMax - sMin );
-	double intercept = dMin - sMin * slope;
-	fprintf(stderr,"  Slope %f and intercept %f \n",slope,intercept);
-	mData->setSlope(d, s, slope);
-	mData->setIntercept(d, intercept);
+    double slope = (dMax - dMin) / (sMax - sMin);
+    double intercept = dMin - sMin * slope;
+    fprintf(stderr, "  Slope %f and intercept %f \n", slope, intercept);
+    mData->setSlope(d, s, slope);
+    mData->setIntercept(d, intercept);
 }
 
 
-void GloveInterface::setParameters(int s, int d, float slope, float intercept)
-{
-	fprintf(stderr,"sensor %d to DOF %d -- slope %f and intercept %f \n", s, d, slope, intercept);
-	mData->setSlope(d, s, slope);
-	mData->setIntercept(d, intercept);
+void GloveInterface::setParameters(int s, int d, float slope, float intercept) {
+    fprintf(stderr, "sensor %d to DOF %d -- slope %f and intercept %f \n", s, d, slope, intercept);
+    mData->setSlope(d, s, slope);
+    mData->setIntercept(d, intercept);
 }
 
-int GloveInterface::getNumSensors()
-{
-	return N_SENSOR_VALUES;
+int GloveInterface::getNumSensors() {
+    return N_SENSOR_VALUES;
 }
 
-bool GloveInterface::isDOFControlled(int d)
-{
-	for (int s=0; s<N_SENSOR_VALUES; s++)
-		if ( mData->getSlope(d,s) != 0 )
-			return true;
-	return false;
+bool GloveInterface::isDOFControlled(int d) {
+    for (int s = 0; s < N_SENSOR_VALUES; s++)
+        if (mData->getSlope(d, s) != 0)
+            return true;
+    return false;
 }
 
-/*!	Asks the glove for the value of all sensors, then uses them to convert
-	to a dof value.	In general, the value of the dof #d is obtained by:
-	dof_d = intercepts_d + sum_over_all_sensors_s[slope(s,d) * raw_sensor(s)]
+/*! Asks the glove for the value of all sensors, then uses them to convert
+    to a dof value. In general, the value of the dof #d is obtained by:
+    dof_d = intercepts_d + sum_over_all_sensors_s[slope(s,d) * raw_sensor(s)]
 */
-float GloveInterface::getDOFValue(int d)
-{
-#ifdef HARDWARE_LIB
-	float dofVal = 0;
-	for ( int s=0; s<N_SENSOR_VALUES; s++) {
-		int rawValue = rawGlove->getSensorValue ( s );
-		dofVal += rawValue * mData->getSlope(d,s);
-	}
-	dofVal += mData->getIntercept(d);
-	return dofVal;
-#else
-	assert(0);
-	d = d;
-	return 0;
-#endif
+float GloveInterface::getDOFValue(int d) {
+    #ifdef HARDWARE_LIB
+    float dofVal = 0;
+    for (int s = 0; s < N_SENSOR_VALUES; s++) {
+        int rawValue = rawGlove->getSensorValue(s);
+        dofVal += rawValue * mData->getSlope(d, s);
+    }
+    dofVal += mData->getIntercept(d);
+    return dofVal;
+    #else
+    assert(0);
+    d = d;
+    return 0;
+    #endif
 }
 
-/*! Sort of ugly code... This does the exact same as getDOFValue(int), 
-	but assuming raw values are not actually read from the cyberglove 
-	but passed as a parameter.
+/*! Sort of ugly code... This does the exact same as getDOFValue(int),
+    but assuming raw values are not actually read from the cyberglove
+    but passed as a parameter.
 */
-float GloveInterface::getDOFValue(int d, int *rawValues)
-{
-	float dofVal = 0;
-	for ( int s=0; s<N_SENSOR_VALUES; s++) {
-		int rawValue = rawValues[s];
-		dofVal += rawValue * mData->getSlope(d,s);
-	}
-	dofVal += mData->getIntercept(d);
-	return dofVal;
+float GloveInterface::getDOFValue(int d, int *rawValues) {
+    float dofVal = 0;
+    for (int s = 0; s < N_SENSOR_VALUES; s++) {
+        int rawValue = rawValues[s];
+        dofVal += rawValue * mData->getSlope(d, s);
+    }
+    dofVal += mData->getIntercept(d);
+    return dofVal;
 }
 
 //------------------------------------ CALIBRATION FUNCTIONS --------------------------------------------
 
-void GloveInterface::initCalibration(int type)
-{
-	if ( type == FIST || type == SIMPLE_THUMB  || type == ABD_ADD) {
-		//potential memory leaks!
-		cPoses.clear();
-		if (type == FIST ) {
-			//sets up a simple calibration list with two hard-coded poses
-			//one has all finger extended as if palm was lying on a table
-			//the other one has all fingers curled into the palm
-			//NOTE: THIS DOES NOT CONSIDER THE THUMB AT ALL
-			//int map[] =  {-1,-1,-1,-1, -1, -1,   -1,   -1, -1, -1,-1,   -1,   -1, -1,-1,   -1,   -1,    -1,-1,-1,-1,-1,-1,-1};
-			//			   0  1  2  3   4   5     6     7   8   9 10    11    12  13 14    15    16     17 18 19 20 21 22 23
-			int map[] =  {-1,-1,-1,-1,  1,  2,    3,    5,  6,  7,-1,    9,   10, 11,-1,   13,   14,    15,-1,-1,-1,-1,-1,-1};
-			double cp1[] = {0, 0, 0, 0,  0, -6, -4.5, -5.4,  0,  0, 0, -5.6, -3.7,  2, 0, -9.2, -2.0, -4.5, 0, 0, 0, 0, 0, 0};
-			double cp2[] = {0, 0, 0, 0, 90, 90,   90,   90, 90, 90, 0,   90,   90, 90, 0,   90,   90,   90, 0, 0, 0, 0, 0, 0};
-			cType = FIST;
-			cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES, cp1, map));
-			cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES, cp2, map));
-		} else if (type == SIMPLE_THUMB) {
-			//Very simple calibration that measures cross-talk between thumb CMC sensors from to "L" finger shapes
-			//			     0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
-			int map[] =    {16, -1, -1, 17, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
-			double cp1[] = { 70, 0,  0,-50,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0};
-			double cp2[] = {-10, 0,  0,-50,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0};
-			cType = SIMPLE_THUMB;
-			cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES, cp1, map));
-			cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES, cp2, map));
-		} else if (type == ABD_ADD) {
-			//attempts to calibrate abd-add angles from two hard-coded poses, with finger together and spread out
-			//since we only have three sensors, it assumes middle finger is fixed and there is a 1-to-1 mapping
-			//between sensors and fingers
-			//			     0  1  2  3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
-			int map[] =    {-1,-1,-1,-1, -1, -1, -1, -1, -1, -1,  0, -1, -1, -1,  8, -1, -1, -1, 12, -1, -1, -1, -1, -1};
-			double cp1[] = { 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0};
-			double cp2[] = { 0, 0, 0, 0,  0,  0,  0,  0,  0,  0, 20,  0,  0,  0,-20,  0,  0,  0,-30,  0,  0,  0,  0,  0};
-			cType = ABD_ADD;
-			cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES, cp1, map));
-			cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES, cp2, map));
-		}
-	} else if (type == COMPLEX_THUMB) {
-		cType = COMPLEX_THUMB;
-	} else if (type == MEAN_POSE) {
-		// this one just records a bunch of poses (both sensors and robot joint values), so some calibration
-		// is assumed to already be in place. Then it compute the mean DOF values and writes them to a file
-		cType = MEAN_POSE;
-		cPoses.clear();
-	}
-	mCalibrated = false;
-	currentPose = cPoses.begin();
+void GloveInterface::initCalibration(int type) {
+    if (type == FIST || type == SIMPLE_THUMB  || type == ABD_ADD) {
+        //potential memory leaks!
+        cPoses.clear();
+        if (type == FIST) {
+            //sets up a simple calibration list with two hard-coded poses
+            //one has all finger extended as if palm was lying on a table
+            //the other one has all fingers curled into the palm
+            //NOTE: THIS DOES NOT CONSIDER THE THUMB AT ALL
+            //int map[] =  {-1,-1,-1,-1, -1, -1,   -1,   -1, -1, -1,-1,   -1,   -1, -1,-1,   -1,   -1,    -1,-1,-1,-1,-1,-1,-1};
+            //             0  1  2  3   4   5     6     7   8   9 10    11    12  13 14    15    16     17 18 19 20 21 22 23
+            int map[] =  { -1, -1, -1, -1,  1,  2,    3,    5,  6,  7, -1,    9,   10, 11, -1,   13,   14,    15, -1, -1, -1, -1, -1, -1};
+            double cp1[] = {0, 0, 0, 0,  0, -6, -4.5, -5.4,  0,  0, 0, -5.6, -3.7,  2, 0, -9.2, -2.0, -4.5, 0, 0, 0, 0, 0, 0};
+            double cp2[] = {0, 0, 0, 0, 90, 90,   90,   90, 90, 90, 0,   90,   90, 90, 0,   90,   90,   90, 0, 0, 0, 0, 0, 0};
+            cType = FIST;
+            cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES, cp1, map));
+            cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES, cp2, map));
+        }
+        else if (type == SIMPLE_THUMB) {
+            //Very simple calibration that measures cross-talk between thumb CMC sensors from to "L" finger shapes
+            //               0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
+            int map[] =    {16, -1, -1, 17, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+            double cp1[] = { 70, 0,  0, -50,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0};
+            double cp2[] = { -10, 0,  0, -50,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0};
+            cType = SIMPLE_THUMB;
+            cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES, cp1, map));
+            cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES, cp2, map));
+        }
+        else if (type == ABD_ADD) {
+            //attempts to calibrate abd-add angles from two hard-coded poses, with finger together and spread out
+            //since we only have three sensors, it assumes middle finger is fixed and there is a 1-to-1 mapping
+            //between sensors and fingers
+            //               0  1  2  3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
+            int map[] =    { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  0, -1, -1, -1,  8, -1, -1, -1, 12, -1, -1, -1, -1, -1};
+            double cp1[] = { 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0};
+            double cp2[] = { 0, 0, 0, 0,  0,  0,  0,  0,  0,  0, 20,  0,  0,  0, -20,  0,  0,  0, -30,  0,  0,  0,  0,  0};
+            cType = ABD_ADD;
+            cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES, cp1, map));
+            cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES, cp2, map));
+        }
+    }
+    else if (type == COMPLEX_THUMB) {
+        cType = COMPLEX_THUMB;
+    }
+    else if (type == MEAN_POSE) {
+        // this one just records a bunch of poses (both sensors and robot joint values), so some calibration
+        // is assumed to already be in place. Then it compute the mean DOF values and writes them to a file
+        cType = MEAN_POSE;
+        cPoses.clear();
+    }
+    mCalibrated = false;
+    currentPose = cPoses.begin();
 }
 
-void GloveInterface::nextPose(int direction)
-{
+void GloveInterface::nextPose(int direction) {
 
-	if ( cPoses.empty() ) {
-		fprintf(stderr,"No calibration poses recorded!\n");
-		return;
-	}
+    if (cPoses.empty()) {
+        fprintf(stderr, "No calibration poses recorded!\n");
+        return;
+    }
 
-	if (direction > 0) {
-		currentPose++;
-		if ( currentPose == cPoses.end() ) currentPose = cPoses.begin();
-	} else {
-		if ( currentPose == cPoses.begin() ) currentPose = cPoses.end();
-		currentPose--;
-	}
-	getPoseError();
+    if (direction > 0) {
+        currentPose++;
+        if (currentPose == cPoses.end()) currentPose = cPoses.begin();
+    }
+    else {
+        if (currentPose == cPoses.begin()) currentPose = cPoses.end();
+        currentPose--;
+    }
+    getPoseError();
 }
 
 //asks the robot to replicate the current calibration pose
-void GloveInterface::showCurrentPose()
-{
-	if ( cPoses.empty() ) {
-		fprintf(stderr,"No poses recorded!\n");
-		return;
-	}
+void GloveInterface::showCurrentPose() {
+    if (cPoses.empty()) {
+        fprintf(stderr, "No poses recorded!\n");
+        return;
+    }
 
-	double *desiredVals = new double[mRobot->getNumDOF()];
-	int *map = (*currentPose)->getAllMaps();
-	double *jointVals = (*currentPose)->getAllJointValues();
-	int *sensorVals = (*currentPose)->getAllSensorValues();
+    double *desiredVals = new double[mRobot->getNumDOF()];
+    int *map = (*currentPose)->getAllMaps();
+    double *jointVals = (*currentPose)->getAllJointValues();
+    int *sensorVals = (*currentPose)->getAllSensorValues();
 
-	int s,d;
+    int s, d;
 
-	//first, set all DOFs to current positions
-	for (d=0; d<mRobot->getNumDOF(); d++) {
-		desiredVals[d] = mRobot->getDOF(d)->getVal();
-	}
-	
-	//then see which ones are actually set by the pose
-	for (s=0; s<(*currentPose)->getSize(); s++) {
-		d = map[s];
-		if ( d >= 0) {
-			if ( (*currentPose)->jointsSet )
-				desiredVals[d] = jointVals[s];
-			else if ( (*currentPose)->sensorsSet)
-				desiredVals[d] = getDOFValue(d, sensorVals) ;
-			else fprintf(stderr,"Can not show pose - neither joints nor sensors are set!\n");
+    //first, set all DOFs to current positions
+    for (d = 0; d < mRobot->getNumDOF(); d++) {
+        desiredVals[d] = mRobot->getDOF(d)->getVal();
+    }
 
-		}
-	}
-	mRobot->forceDOFVals(desiredVals);
-	transf t = mRobot->getFlockTran()->getAbsolute( (*currentPose)->getTransf() ); 
-	//transf t = (*currentPose)->getTransf() ; 
-	mRobot->setTran( t );
+    //then see which ones are actually set by the pose
+    for (s = 0; s < (*currentPose)->getSize(); s++) {
+        d = map[s];
+        if (d >= 0) {
+            if ((*currentPose)->jointsSet)
+                desiredVals[d] = jointVals[s];
+            else if ((*currentPose)->sensorsSet)
+                desiredVals[d] = getDOFValue(d, sensorVals) ;
+            else fprintf(stderr, "Can not show pose - neither joints nor sensors are set!\n");
+
+        }
+    }
+    mRobot->forceDOFVals(desiredVals);
+    transf t = mRobot->getFlockTran()->getAbsolute((*currentPose)->getTransf());
+    //transf t = (*currentPose)->getTransf() ;
+    mRobot->setTran(t);
 }
 
-void GloveInterface::recordPoseFromGlove(int d)
-{
-#ifdef HARDWARE_LIB
-	if (!instantRead()) {
-		fprintf(stderr,"Can not read glove for calibration\n");
-		return;
-	}
+void GloveInterface::recordPoseFromGlove(int d) {
+    #ifdef HARDWARE_LIB
+    if (!instantRead()) {
+        fprintf(stderr, "Can not read glove for calibration\n");
+        return;
+    }
 
-	int sv[N_SENSOR_VALUES];
-	double* jv = new double[mRobot->getNumDOF()];
+    int sv[N_SENSOR_VALUES];
+    double *jv = new double[mRobot->getNumDOF()];
 
-	for (int i=0; i<N_SENSOR_VALUES; i++) {
-		sv[i] = rawGlove->getSensorValue(i);
-	}
+    for (int i = 0; i < N_SENSOR_VALUES; i++) {
+        sv[i] = rawGlove->getSensorValue(i);
+    }
 
-	if (cType==FIST || cType==SIMPLE_THUMB || cType == ABD_ADD) {
-		if ( cPoses.empty() ) {
-			fprintf(stderr,"No poses recorded!\n");
-			return;
-		}
-		(*currentPose)->setAllSensorValues(sv);
-	} else if (cType == COMPLEX_THUMB) {
-		cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES) );
-		currentPose = cPoses.end();
-		currentPose--;
+    if (cType == FIST || cType == SIMPLE_THUMB || cType == ABD_ADD) {
+        if (cPoses.empty()) {
+            fprintf(stderr, "No poses recorded!\n");
+            return;
+        }
+        (*currentPose)->setAllSensorValues(sv);
+    }
+    else if (cType == COMPLEX_THUMB) {
+        cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES));
+        currentPose = cPoses.end();
+        currentPose--;
 
-		(*currentPose)->setAllSensorValues(sv);
-		//			  0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
-		int map[] = {16, 18, 19, 17,  1,  2,  3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
-		(*currentPose)->setAllMaps(map);
-		(*currentPose)->recordedDistance = d;
-		fprintf(stderr,"Distance: %d\n",d);
-	} else if (cType == MEAN_POSE) {
-		cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES) );
-		currentPose = cPoses.end();
-		currentPose--;
-		(*currentPose)->setAllSensorValues(sv);
-		for (int d=0; d<mRobot->getNumDOF(); d++) {
-			jv[d] = getDOFValue(d,sv);
-			mRobot->checkSetDOFVals(jv);
-		}
-		(*currentPose)->setAllJointValues(jv);
-		int map[] =  {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,-1,-1,-1,-1};
-		(*currentPose)->setAllMaps(map);
+        (*currentPose)->setAllSensorValues(sv);
+        //            0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
+        int map[] = {16, 18, 19, 17,  1,  2,  3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+        (*currentPose)->setAllMaps(map);
+        (*currentPose)->recordedDistance = d;
+        fprintf(stderr, "Distance: %d\n", d);
+    }
+    else if (cType == MEAN_POSE) {
+        cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES));
+        currentPose = cPoses.end();
+        currentPose--;
+        (*currentPose)->setAllSensorValues(sv);
+        for (int d = 0; d < mRobot->getNumDOF(); d++) {
+            jv[d] = getDOFValue(d, sv);
+            mRobot->checkSetDOFVals(jv);
+        }
+        (*currentPose)->setAllJointValues(jv);
+        int map[] =  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, -1, -1, -1, -1};
+        (*currentPose)->setAllMaps(map);
 
-		//also save flock of birds location
-		transf t = mRobot->getFlockTran()->getMount() * mRobot->getTran();
-		//transf t = mRobot->getTran();
-		(*currentPose)->setTransf(t);
-	
-		fprintf(stderr,"Pose for mean recorded!\n");
-	} else {
-		fprintf(stderr,"No calibration type initialized!\n");
-	}
-	delete [] jv;
-#else
-	d = d;
-	assert(0);
-#endif
+        //also save flock of birds location
+        transf t = mRobot->getFlockTran()->getMount() * mRobot->getTran();
+        //transf t = mRobot->getTran();
+        (*currentPose)->setTransf(t);
+
+        fprintf(stderr, "Pose for mean recorded!\n");
+    }
+    else {
+        fprintf(stderr, "No calibration type initialized!\n");
+    }
+    delete [] jv;
+    #else
+    d = d;
+    assert(0);
+    #endif
 }
 
-bool GloveInterface::poseSet()
-{
-	if ( cPoses.empty() )
-		return false;
+bool GloveInterface::poseSet() {
+    if (cPoses.empty())
+        return false;
 
-	return (*currentPose)->isSet();
+    return (*currentPose)->isSet();
 }
 
 //if at least two calibration poses have been set we are ready to calibrate
-bool GloveInterface::readyToCalibrate()
-{
-	if (cType == FIST || cType == SIMPLE_THUMB || cType == ABD_ADD) {
-		int numSet = 0;
-		std::list<CalibrationPose*>::iterator it;
-		for (it=cPoses.begin(); it!=cPoses.end(); it++) {
-			if ( (*it)->isSet() ) numSet++;
-		}
-		if (numSet>=2) return true;
-	} else if (cType == COMPLEX_THUMB) {
-		if ( (int)cPoses.size() > 5 )return true;
-	} else if (cType == MEAN_POSE) {
-		if (!cPoses.empty()) return true;
-	}
-	return false;
+bool GloveInterface::readyToCalibrate() {
+    if (cType == FIST || cType == SIMPLE_THUMB || cType == ABD_ADD) {
+        int numSet = 0;
+        std::list<CalibrationPose *>::iterator it;
+        for (it = cPoses.begin(); it != cPoses.end(); it++) {
+            if ((*it)->isSet()) numSet++;
+        }
+        if (numSet >= 2) return true;
+    }
+    else if (cType == COMPLEX_THUMB) {
+        if ((int)cPoses.size() > 5)return true;
+    }
+    else if (cType == MEAN_POSE) {
+        if (!cPoses.empty()) return true;
+    }
+    return false;
 }
 
-bool GloveInterface::performCalibration()
-{
-	switch (cType) {
-		case FIST:
-			return performSimpleCalibration();
-			break;
-		case ABD_ADD:
-			return performSimpleCalibration();
-			break;
-		case SIMPLE_THUMB:
-			return performThumbCalibration();
-			break;
-		case COMPLEX_THUMB:
-			performComplexCalibration();
-			mCalibrated = true;
-			//saveCalibrationPoses();
-			return true;
-			break;
-		case MEAN_POSE:
-			computeMeanPose();
-			break;
-		default:
-			fprintf(stderr,"Unknown calibration type requested\n");
-			break;
-	}
-	return false;
+bool GloveInterface::performCalibration() {
+    switch (cType) {
+        case FIST:
+            return performSimpleCalibration();
+            break;
+        case ABD_ADD:
+            return performSimpleCalibration();
+            break;
+        case SIMPLE_THUMB:
+            return performThumbCalibration();
+            break;
+        case COMPLEX_THUMB:
+            performComplexCalibration();
+            mCalibrated = true;
+            //saveCalibrationPoses();
+            return true;
+            break;
+        case MEAN_POSE:
+            computeMeanPose();
+            break;
+        default:
+            fprintf(stderr, "Unknown calibration type requested\n");
+            break;
+    }
+    return false;
 }
 
 //performs a simple calibration looking only at first two calibration poses in list
 //computed slopes and intercepts from those poses. No fitting or anything fancy
-bool GloveInterface::performSimpleCalibration()
-{
-	if (!readyToCalibrate() ){
-		return false;
-	}
+bool GloveInterface::performSimpleCalibration() {
+    if (!readyToCalibrate()) {
+        return false;
+    }
 
-	CalibrationPose *cp1, *cp2;
-	std::list<CalibrationPose*>::iterator it;
-	it = cPoses.begin();
-	cp1 = (*it);
-	it++;
-	cp2 = (*it);
+    CalibrationPose *cp1, *cp2;
+    std::list<CalibrationPose *>::iterator it;
+    it = cPoses.begin();
+    cp1 = (*it);
+    it++;
+    cp2 = (*it);
 
-	float sMin, sMax, dMin, dMax;
-	for (int i=0; i<N_SENSOR_VALUES;i++){
-		//check if both poses constrain this sensor value
-		if ( cp1->getMap(i) < 0 || cp2->getMap(i) < 0 ){
-			fprintf(stderr,"Sensor %d masked\n",i);
-			continue;
-		}
-		int d = cp1->getMap(i);
-		if ( d != cp2->getMap(i) ) {
-			fprintf(stderr,"Error! Sensor %d has different maps in poses!\n",i);
-			continue;
-		}
-		sMin = cp1->getSensorValue(i); sMax = cp2->getSensorValue(i);
-		dMin = cp1->getJointValue(i);  dMax = cp2->getJointValue(i);
-		setParameters(i, d, sMin, sMax, dMin, dMax);
-	}
+    float sMin, sMax, dMin, dMax;
+    for (int i = 0; i < N_SENSOR_VALUES; i++) {
+        //check if both poses constrain this sensor value
+        if (cp1->getMap(i) < 0 || cp2->getMap(i) < 0) {
+            fprintf(stderr, "Sensor %d masked\n", i);
+            continue;
+        }
+        int d = cp1->getMap(i);
+        if (d != cp2->getMap(i)) {
+            fprintf(stderr, "Error! Sensor %d has different maps in poses!\n", i);
+            continue;
+        }
+        sMin = cp1->getSensorValue(i);
+        sMax = cp2->getSensorValue(i);
+        dMin = cp1->getJointValue(i);
+        dMax = cp2->getJointValue(i);
+        setParameters(i, d, sMin, sMax, dMin, dMax);
+    }
 
-	mCalibrated = true;
-	return true;
+    mCalibrated = true;
+    return true;
 }
 
-bool GloveInterface::performThumbCalibration()
-{
-	if (!readyToCalibrate() ){
-		return false;
-	}
+bool GloveInterface::performThumbCalibration() {
+    if (!readyToCalibrate()) {
+        return false;
+    }
 
-	CalibrationPose *cp1, *cp2;
-	std::list<CalibrationPose*>::iterator it;
-	it = cPoses.begin();
-	cp1 = (*it);
-	it++;
-	cp2 = (*it);
+    CalibrationPose *cp1, *cp2;
+    std::list<CalibrationPose *>::iterator it;
+    it = cPoses.begin();
+    cp1 = (*it);
+    it++;
+    cp2 = (*it);
 
-	int R11 = cp1->getSensorValue(3);
-	int R12 = cp2->getSensorValue(3);
+    int R11 = cp1->getSensorValue(3);
+    int R12 = cp2->getSensorValue(3);
 
-	double S1 = mData->getSlope(17, 3);
-	double alpha = S1 * ( R11 - R12 );
+    double S1 = mData->getSlope(17, 3);
+    double alpha = S1 * (R11 - R12);
 
-	int R21 = cp1->getSensorValue(0);
-	int R22 = cp2->getSensorValue(0);
+    int R21 = cp1->getSensorValue(0);
+    int R22 = cp2->getSensorValue(0);
 
-	double S2 = alpha / ( R22 - R21 );
-	double I2 = - S2 * R21;
+    double S2 = alpha / (R22 - R21);
+    double I2 = - S2 * R21;
 
-	mData->setSlope(17, 0, S2);
-	mData->setIntercept(17, mData->getIntercept(17)+I2);
-	fprintf(stderr,"Result: slope %f and intercept %f \n",S2,I2);
+    mData->setSlope(17, 0, S2);
+    mData->setIntercept(17, mData->getIntercept(17) + I2);
+    fprintf(stderr, "Result: slope %f and intercept %f \n", S2, I2);
 
-	mCalibrated = true;
-	return true;
+    mCalibrated = true;
+    return true;
 }
 
-bool GloveInterface::performComplexCalibration()
-{
-	for (int i=0; i<100; i++) {
-		complexCalibrationStep();
-	}
-	return true;
+bool GloveInterface::performComplexCalibration() {
+    for (int i = 0; i < 100; i++) {
+        complexCalibrationStep();
+    }
+    return true;
 }
 
-bool GloveInterface::complexCalibrationStep()
-{
-	//assemble equation
-	int i;
+bool GloveInterface::complexCalibrationStep() {
+    //assemble equation
+    int i;
 
-	int nPoses = 0;
-	for (currentPose = cPoses.begin(); currentPose!=cPoses.end(); currentPose++) {
-		showCurrentPose();
-		//when negative error has greater magnitude than our threshold, we don't have a reliable
-		//estimate of the error VECTOR, so we don't use the pose at all
-		if ( getPoseError() > -7.8)
-			nPoses ++;
-	}
-	double *JD = new double[nPoses * 30];
-	int ldd = nPoses * 3;
+    int nPoses = 0;
+    for (currentPose = cPoses.begin(); currentPose != cPoses.end(); currentPose++) {
+        showCurrentPose();
+        //when negative error has greater magnitude than our threshold, we don't have a reliable
+        //estimate of the error VECTOR, so we don't use the pose at all
+        if (getPoseError() > -7.8)
+            nPoses ++;
+    }
+    double *JD = new double[nPoses * 30];
+    int ldd = nPoses * 3;
 
-	double *P = new double[nPoses * 3];
-	double *fg = new double[10];
+    double *P = new double[nPoses * 3];
+    double *fg = new double[10];
 
-	i=0;
-	for (currentPose = cPoses.begin(); currentPose!=cPoses.end(); currentPose++) {
-		showCurrentPose();
-		if (getPoseError() <= -7.8)
-			continue;
-		assembleJMatrix( JD + i*3, ldd);
-		assemblePMatrix( P + i*3 );
-		i++;
-	}
-/*
-	int j,k;
-	for (k=0; k<nPoses; k++) {
-		for (i=0; i<3; i++) {
-			for (j=0; j<10; j++) {
-				fprintf(stderr,"%.2f ",JD[k*3 + i+j*ldd]);
-				if (j == 3) fprintf(stderr,"  ");
-			}
-			fprintf(stderr,"\n");
-		}
-		fprintf(stderr,"\n\n");
-	}
+    i = 0;
+    for (currentPose = cPoses.begin(); currentPose != cPoses.end(); currentPose++) {
+        showCurrentPose();
+        if (getPoseError() <= -7.8)
+            continue;
+        assembleJMatrix(JD + i * 3, ldd);
+        assemblePMatrix(P + i * 3);
+        i++;
+    }
+    /*
+        int j,k;
+        for (k=0; k<nPoses; k++) {
+            for (i=0; i<3; i++) {
+                for (j=0; j<10; j++) {
+                    fprintf(stderr,"%.2f ",JD[k*3 + i+j*ldd]);
+                    if (j == 3) fprintf(stderr,"  ");
+                }
+                fprintf(stderr,"\n");
+            }
+            fprintf(stderr,"\n\n");
+        }
 
-	for (i=0; i<nPoses; i++) {
-		fprintf(stderr,"%.2f %.2f %.2f \n",P[3*i], P[3*i+1], P[3*i+2]);
-	}
-*/
-//	fprintf(stderr,"Number of poses: %d\n",nPoses);
+        for (i=0; i<nPoses; i++) {
+            fprintf(stderr,"%.2f %.2f %.2f \n",P[3*i], P[3*i+1], P[3*i+2]);
+        }
+    */
+    //  fprintf(stderr,"Number of poses: %d\n",nPoses);
 
-	//solve using pseudo-inverse
-	int info,rank;
-	int lwork = 100 * 3 * nPoses;
-	double *work = new double[lwork];
-	double *SVDs = new double[MIN(3*nPoses,10)];
+    //solve using pseudo-inverse
+    int info, rank;
+    int lwork = 100 * 3 * nPoses;
+    double *work = new double[lwork];
+    double *SVDs = new double[MIN(3 * nPoses, 10)];
 
-	dgelss(3*nPoses, 10, 1, 
-		   JD, 3*nPoses, P, 3*nPoses, SVDs, 1.0e-5, &rank, work, lwork, &info);
+    dgelss(3 * nPoses, 10, 1,
+           JD, 3 * nPoses, P, 3 * nPoses, SVDs, 1.0e-5, &rank, work, lwork, &info);
 
-//	fprintf(stderr,"Solved; info is %d and effective rank %d\n",info,rank);
-//	fprintf(stderr,"Total error before step: %f\n",getTotalError());
-//	for (i=0; i<10; i++) {
-//		fprintf(stderr,"%f ",P[i]);
-//	}
+    //  fprintf(stderr,"Solved; info is %d and effective rank %d\n",info,rank);
+    //  fprintf(stderr,"Total error before step: %f\n",getTotalError());
+    //  for (i=0; i<10; i++) {
+    //      fprintf(stderr,"%f ",P[i]);
+    //  }
 
-	//update parameters
-	mData->addToIntercept(16,P[0]);
-	mData->addToIntercept(17,P[1]);
-	mData->addToIntercept(18,P[2]);
-	mData->addToIntercept(19,P[3]);
+    //update parameters
+    mData->addToIntercept(16, P[0]);
+    mData->addToIntercept(17, P[1]);
+    mData->addToIntercept(18, P[2]);
+    mData->addToIntercept(19, P[3]);
 
-	mData->addToSlope(16,0,P[4]);
-	mData->addToSlope(16,3,P[5]);
-	mData->addToSlope(17,0,P[6]);
-	mData->addToSlope(17,3,P[7]);
-	mData->addToSlope(18,1,P[8]);
-	mData->addToSlope(19,2,P[9]);
+    mData->addToSlope(16, 0, P[4]);
+    mData->addToSlope(16, 3, P[5]);
+    mData->addToSlope(17, 0, P[6]);
+    mData->addToSlope(17, 3, P[7]);
+    mData->addToSlope(18, 1, P[8]);
+    mData->addToSlope(19, 2, P[9]);
 
-	fprintf(stderr,"Total error AFTER step: %f\n",getTotalError());
-	currentPose = cPoses.begin();
+    fprintf(stderr, "Total error AFTER step: %f\n", getTotalError());
+    currentPose = cPoses.begin();
 
-	delete [] SVDs;
-	delete [] work;
-	delete [] JD;
-	delete [] P;
-	delete [] fg;
+    delete [] SVDs;
+    delete [] work;
+    delete [] JD;
+    delete [] P;
+    delete [] fg;
 
-	return true;
+    return true;
 }
 
 bool
-GloveInterface::computeMeanPose()
-{
-	//computed the mean of the saved poses and writes it to a hard-coded file name.
-	double *jv = new double[mRobot->getNumDOF()];
+GloveInterface::computeMeanPose() {
+    //computed the mean of the saved poses and writes it to a hard-coded file name.
+    double *jv = new double[mRobot->getNumDOF()];
 
-	for (int d=0; d<mRobot->getNumDOF(); d++) {
-		jv[d]=0;
-	}
+    for (int d = 0; d < mRobot->getNumDOF(); d++) {
+        jv[d] = 0;
+    }
 
-	for (currentPose = cPoses.begin(); currentPose != cPoses.end(); currentPose++) {
-		for (int d=0; d<mRobot->getNumDOF(); d++) {
-			jv[d] += (*currentPose)->getJointValue(d);
-		}
-	}
+    for (currentPose = cPoses.begin(); currentPose != cPoses.end(); currentPose++) {
+        for (int d = 0; d < mRobot->getNumDOF(); d++) {
+            jv[d] += (*currentPose)->getJointValue(d);
+        }
+    }
 
-	for (int d=0; d<mRobot->getNumDOF(); d++) {
-		jv[d] = jv[d] / cPoses.size();
-	}	
-	
-	cPoses.push_back( new CalibrationPose(N_SENSOR_VALUES) );
-	currentPose = cPoses.end();
-	currentPose--;
-	(*currentPose)->setAllJointValues(jv);
-	int map[] =  {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,-1,-1,-1,-1};
-	(*currentPose)->setAllMaps(map);
-	showCurrentPose();
+    for (int d = 0; d < mRobot->getNumDOF(); d++) {
+        jv[d] = jv[d] / cPoses.size();
+    }
 
-	FILE *fp = fopen("mean_pose.txt","w");
-	fprintf(stderr,"Mean pose written to mean_pose.txt \n");
-	(*currentPose)->writeToFile(fp);
-	fclose(fp);
+    cPoses.push_back(new CalibrationPose(N_SENSOR_VALUES));
+    currentPose = cPoses.end();
+    currentPose--;
+    (*currentPose)->setAllJointValues(jv);
+    int map[] =  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, -1, -1, -1, -1};
+    (*currentPose)->setAllMaps(map);
+    showCurrentPose();
 
-	delete [] jv;
-	return true;
+    FILE *fp = fopen("mean_pose.txt", "w");
+    fprintf(stderr, "Mean pose written to mean_pose.txt \n");
+    (*currentPose)->writeToFile(fp);
+    fclose(fp);
+
+    delete [] jv;
+    return true;
 }
 
-void GloveInterface::saveCalibration(const char* filename)
-{
-	FILE *fp = fopen(filename,"w");
-	if (!fp) {
-		fprintf(stderr,"Unable to open calibration file!\n");
-		return;
-	}
+void GloveInterface::saveCalibration(const char *filename) {
+    FILE *fp = fopen(filename, "w");
+    if (!fp) {
+        fprintf(stderr, "Unable to open calibration file!\n");
+        return;
+    }
 
-	int d,s;
-	fprintf(fp,"%d %d\n",mRobot->getNumDOF(), N_SENSOR_VALUES);
-	for (d=0; d<mRobot->getNumDOF(); d++) {
-		for (s=0; s<N_SENSOR_VALUES; s++)
-			fprintf(fp, "%f ",mData->getSlope(d,s));
-		fprintf(fp,"\n");
-	}
-	for (d=0; d<mRobot->getNumDOF(); d++)
-		fprintf(fp,"%f ",mData->getIntercept(d));
-	fprintf(fp,"\n");
-	fclose(fp);
-	fprintf(stderr,"Calibration saved\n");
+    int d, s;
+    fprintf(fp, "%d %d\n", mRobot->getNumDOF(), N_SENSOR_VALUES);
+    for (d = 0; d < mRobot->getNumDOF(); d++) {
+        for (s = 0; s < N_SENSOR_VALUES; s++)
+            fprintf(fp, "%f ", mData->getSlope(d, s));
+        fprintf(fp, "\n");
+    }
+    for (d = 0; d < mRobot->getNumDOF(); d++)
+        fprintf(fp, "%f ", mData->getIntercept(d));
+    fprintf(fp, "\n");
+    fclose(fp);
+    fprintf(stderr, "Calibration saved\n");
 }
 
-bool GloveInterface::loadCalibration(const char* filename)
-{
-	FILE *fp = fopen(filename,"r");
-	if (!fp) {
-		fprintf(stderr,"Unable to open calibration file!\n");
-		return false;
-	}
+bool GloveInterface::loadCalibration(const char *filename) {
+    FILE *fp = fopen(filename, "r");
+    if (!fp) {
+        fprintf(stderr, "Unable to open calibration file!\n");
+        return false;
+    }
 
-	int d,s;
-	int numDOF, numSens;
-	float val;
+    int d, s;
+    int numDOF, numSens;
+    float val;
 
-	if (fscanf(fp,"%d %d ",&numDOF,&numSens)  <= 0) { 
-	  DBGA("GloveInterface::loadCalibration - Failed to read dof num or sensor num");	 
-	  return false;
-	}
-	
-	if ( numDOF != mRobot->getNumDOF() || numSens != N_SENSOR_VALUES ) {
-	  fprintf(stderr,"WARNING: calibration file contains wrong number of DOFs/sensors\n");
-	  return false;
-	}
-	
-	mData->reset();
-	for (d=0; d<numDOF; d++) {
-	  for (s=0; s<numSens; s++) {
-	    if(fscanf(fp,"%f",&val) <= 0) {
-	      DBGA("GloveInterface::loadCalibration - Failed to read dof or sensor value");	 
-	      return false; 
-	    }
-	  }
-	  mData->setSlope(d,s,val);
-	}
-	
-	for (d=0; d<mRobot->getNumDOF(); d++) {
-	  if(fscanf(fp,"%f",&val) <= 0){
-	     DBGA("GloveInterface::loadCalibration - Failed to read dof num or sensor num");	 
-	     return false;
-	  }
-	  mData->setIntercept(d,val);
-	}
-	
-	fclose(fp);
-	fprintf(stderr,"Calibration loaded from file\n");
-	return true;
+    if (fscanf(fp, "%d %d ", &numDOF, &numSens)  <= 0) {
+        DBGA("GloveInterface::loadCalibration - Failed to read dof num or sensor num");
+        return false;
+    }
+
+    if (numDOF != mRobot->getNumDOF() || numSens != N_SENSOR_VALUES) {
+        fprintf(stderr, "WARNING: calibration file contains wrong number of DOFs/sensors\n");
+        return false;
+    }
+
+    mData->reset();
+    for (d = 0; d < numDOF; d++) {
+        for (s = 0; s < numSens; s++) {
+            if (fscanf(fp, "%f", &val) <= 0) {
+                DBGA("GloveInterface::loadCalibration - Failed to read dof or sensor value");
+                return false;
+            }
+        }
+        mData->setSlope(d, s, val);
+    }
+
+    for (d = 0; d < mRobot->getNumDOF(); d++) {
+        if (fscanf(fp, "%f", &val) <= 0) {
+            DBGA("GloveInterface::loadCalibration - Failed to read dof num or sensor num");
+            return false;
+        }
+        mData->setIntercept(d, val);
+    }
+
+    fclose(fp);
+    fprintf(stderr, "Calibration loaded from file\n");
+    return true;
 }
 
 /* saves the calibration poses to a file. For now, just sensor values and maps */
-void GloveInterface::saveCalibrationPoses(const char *filename)
-{
-	writePoseListToFile(&cPoses, filename);
-	currentPose = cPoses.begin();
+void GloveInterface::saveCalibrationPoses(const char *filename) {
+    writePoseListToFile(&cPoses, filename);
+    currentPose = cPoses.begin();
 }
 
-void GloveInterface::loadCalibrationPoses(const char *filename)
-{
-	loadPoseListFromFile(&cPoses, filename);
-	currentPose = cPoses.begin();
+void GloveInterface::loadCalibrationPoses(const char *filename) {
+    loadPoseListFromFile(&cPoses, filename);
+    currentPose = cPoses.begin();
 }
 
-double GloveInterface::getPoseError(vec3* error, position* thumbLocation)
-{
-	double shellDistance = 8;
-	double cFactor = (*currentPose)->recordedDistance;
+double GloveInterface::getPoseError(vec3 *error, position *thumbLocation) {
+    double shellDistance = 8;
+    double cFactor = (*currentPose)->recordedDistance;
 
-	vec3 expectedVector, measuredVector, e;
+    vec3 expectedVector, measuredVector, e;
 
-	showCurrentPose();
-	Body *thumbTip = mRobot->getChain(4)->getLink(2);
-	Body *indexTip = mRobot->getChain(0)->getLink(2);
-	position p1, p2;
-	mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
+    showCurrentPose();
+    Body *thumbTip = mRobot->getChain(4)->getLink(2);
+    Body *indexTip = mRobot->getChain(0)->getLink(2);
+    position p1, p2;
+    mRobot->getWorld()->getDist(thumbTip, indexTip, p1, p2);
 
-	if (thumbLocation != NULL) {
-		*thumbLocation = p1;
-	}
+    if (thumbLocation != NULL) {
+        *thumbLocation = p1;
+    }
 
-	p1 = p1 * thumbTip->getTran() * mRobot->getChain(4)->getTran().inverse();
-	p2 = p2 * indexTip->getTran() * mRobot->getChain(4)->getTran().inverse();
-	measuredVector = p2 - p1;
+    p1 = p1 * thumbTip->getTran() * mRobot->getChain(4)->getTran().inverse();
+    p2 = p2 * indexTip->getTran() * mRobot->getChain(4)->getTran().inverse();
+    measuredVector = p2 - p1;
 
-	expectedVector = normalise(measuredVector);
-	expectedVector = ( cFactor + shellDistance) * expectedVector;
+    expectedVector = normalise(measuredVector);
+    expectedVector = (cFactor + shellDistance) * expectedVector;
 
-	//this isn't really the error, it's the motion that will COMPENSATE for the error
-	//so it's actually the negated error (which would be expected - measured)
-	e = measuredVector - expectedVector;
+    //this isn't really the error, it's the motion that will COMPENSATE for the error
+    //so it's actually the negated error (which would be expected - measured)
+    e = measuredVector - expectedVector;
 
-	if (error != NULL) {
-		*error = e;
-	}
+    if (error != NULL) {
+        *error = e;
+    }
 
-//	fprintf(stderr,"Compensated: %f\n",rawDistance - shellDistance);
-//	fprintf(stderr,"Expected: %f; abs error: %f\n",cFactor, e.len());
-//	fprintf(stderr,"X: %f  Y: %f  Z: %f\n",e.x(), e.y(), e.z());
+    //  fprintf(stderr,"Compensated: %f\n",rawDistance - shellDistance);
+    //  fprintf(stderr,"Expected: %f; abs error: %f\n",cFactor, e.len());
+    //  fprintf(stderr,"X: %f  Y: %f  Z: %f\n",e.x(), e.y(), e.z());
 
-	return e.len();
+    return e.len();
 }
 
-double GloveInterface::getTotalError()
-{
-	double totalError = 0;
-	for ( currentPose=cPoses.begin(); currentPose!=cPoses.end(); currentPose++) {
-		totalError += getPoseError();
-	}
-	totalError /= cPoses.size();
-	return totalError;
+double GloveInterface::getTotalError() {
+    double totalError = 0;
+    for (currentPose = cPoses.begin(); currentPose != cPoses.end(); currentPose++) {
+        totalError += getPoseError();
+    }
+    totalError /= cPoses.size();
+    return totalError;
 }
 
-void GloveInterface::getPoseJacobian(double *J)
-{
-	double t1 = mRobot->getDOF(16)->getVal();
-	double t2 = mRobot->getDOF(17)->getVal() + 0.8639;
-	double t3 = mRobot->getDOF(18)->getVal() + 0.0873;
-	double t4 = mRobot->getDOF(19)->getVal() + 1.4835;
+void GloveInterface::getPoseJacobian(double *J) {
+    double t1 = mRobot->getDOF(16)->getVal();
+    double t2 = mRobot->getDOF(17)->getVal() + 0.8639;
+    double t3 = mRobot->getDOF(18)->getVal() + 0.0873;
+    double t4 = mRobot->getDOF(19)->getVal() + 1.4835;
 
-	jacobian(t1, t2, t3, t4, 0, 0, 1000, J);
+    jacobian(t1, t2, t3, t4, 0, 0, 1000, J);
 }
 
-void GloveInterface::assembleJMatrix(double *D, int ldd)
-{
-	double t1 = mRobot->getDOF(16)->getVal();
-	double t2 = mRobot->getDOF(17)->getVal() + 0.8639;
-	double t3 = mRobot->getDOF(18)->getVal() + 0.0873;
-	double t4 = mRobot->getDOF(19)->getVal() + 1.4835;
+void GloveInterface::assembleJMatrix(double *D, int ldd) {
+    double t1 = mRobot->getDOF(16)->getVal();
+    double t2 = mRobot->getDOF(17)->getVal() + 0.8639;
+    double t3 = mRobot->getDOF(18)->getVal() + 0.0873;
+    double t4 = mRobot->getDOF(19)->getVal() + 1.4835;
 
-	position errorPos;
-	getPoseError(NULL,&errorPos);
+    position errorPos;
+    getPoseError(NULL, &errorPos);
 
-	double J[12];
-//	fprintf(stderr,"Pose err: %.2f %.2f %.2f\n",errorPos.x(), errorPos.y(), errorPos.z());
-	jacobian(t1, t2, t3, t4, errorPos.x(), errorPos.y(), errorPos.z(), J);
+    double J[12];
+    //  fprintf(stderr,"Pose err: %.2f %.2f %.2f\n",errorPos.x(), errorPos.y(), errorPos.z());
+    jacobian(t1, t2, t3, t4, errorPos.x(), errorPos.y(), errorPos.z(), J);
 
-	double s0 = (*currentPose)->getSensorValue(0);
-	double s1 = (*currentPose)->getSensorValue(3);
-	double s2 = (*currentPose)->getSensorValue(1);
-	double s3 = (*currentPose)->getSensorValue(2);
+    double s0 = (*currentPose)->getSensorValue(0);
+    double s1 = (*currentPose)->getSensorValue(3);
+    double s2 = (*currentPose)->getSensorValue(1);
+    double s3 = (*currentPose)->getSensorValue(2);
 
-	double dTdG[4*6];
-	compute_dTdG(s0, s1, s2, s3, dTdG);
+    double dTdG[4 * 6];
+    compute_dTdG(s0, s1, s2, s3, dTdG);
 
-	double JD[3*6];
-	dgemm("N", "N", 3, 6, 4, 
-		  1, J, 3, 
-		  dTdG, 4, 
-		  0, JD, 3);
+    double JD[3 * 6];
+    dgemm("N", "N", 3, 6, 4,
+          1, J, 3,
+          dTdG, 4,
+          0, JD, 3);
 
-	int i,j;
-	for (i=0; i<3; i++) {
-		for (j=0; j<4; j++) {
-			D[ i + j*ldd] = J[ i + 3*j];
-		}
-	}
-	for (i=0; i<3; i++) {
-		for (j=0; j<6; j++) {
-			D[ i + (4+j)*ldd ] = JD[ i + 3*j ];
-		}
-	}
+    int i, j;
+    for (i = 0; i < 3; i++) {
+        for (j = 0; j < 4; j++) {
+            D[ i + j * ldd] = J[ i + 3 * j];
+        }
+    }
+    for (i = 0; i < 3; i++) {
+        for (j = 0; j < 6; j++) {
+            D[ i + (4 + j)*ldd ] = JD[ i + 3 * j ];
+        }
+    }
 }
 
-void GloveInterface::assemblePMatrix( double *P )
-{
-	vec3 error;
-	getPoseError(&error);
-	
-	P[0] = error.x();
-	P[1] = error.y();
-	P[2] = error.z();
+void GloveInterface::assemblePMatrix(double *P) {
+    vec3 error;
+    getPoseError(&error);
+
+    P[0] = error.x();
+    P[1] = error.y();
+    P[2] = error.z();
 }
 
-void GloveInterface::clearPoses()
-{
-	cPoses.clear();
-	currentPose = cPoses.begin();
+void GloveInterface::clearPoses() {
+    cPoses.clear();
+    currentPose = cPoses.begin();
 }
 
-void GloveInterface::startGlove()
-{
-	DBGA("Disabled... Init glove from World menu");
+void GloveInterface::startGlove() {
+    DBGA("Disabled... Init glove from World menu");
 }

--- a/src/grasp.cpp
+++ b/src/grasp.cpp
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Implements the grasp class, which analyzes grasps
- */
+/*! \file
+    \brief Implements the grasp class, which analyzes grasps
+*/
 
 /* standard C includes */
 #include <stdio.h>
@@ -69,7 +69,7 @@
 #define G_ 9.81
 
 /*! This replicates GWS::ALL_DIMENSIONS, but it was needed here too
-	so that we don't have to give any caller access to GWS.
+    so that we don't have to give any caller access to GWS.
 */
 const std::vector<int> Grasp::ALL_DIMENSIONS = std::vector<int>(6, 1);
 
@@ -78,1374 +78,1346 @@ const int Grasp::CONTACT_FORCE_OPTIMIZATION = 1;
 const int Grasp::GRASP_FORCE_EXISTENCE = 2;
 const int Grasp::GRASP_FORCE_OPTIMIZATION = 3;
 
- 
+
 /*!
-  Initialize grasp object variables.  A grasp should only be created by a
-  hand constructor, which passes a pointer to itself.
+    Initialize grasp object variables.  A grasp should only be created by a
+    hand constructor, which passes a pointer to itself.
 */
-Grasp::Grasp(Hand *h)
-{
-  int i;
+Grasp::Grasp(Hand *h) {
+    int i;
 
-  hand = h;
-  object = NULL;
-  numContacts=0;
-  valid=true;
-  useGravity = false;
+    hand = h;
+    object = NULL;
+    numContacts = 0;
+    valid = true;
+    useGravity = false;
 
-  for (i=0;i<6;i++) minWrench[i]=0.0;
+    for (i = 0; i < 6; i++) minWrench[i] = 0.0;
 
-  numQM = 0;
+    numQM = 0;
 }
 
 /*!
-  Deletes all quality measures, grasps wrench spaces, and projections
-  associated with this grasp.  Frees all of the dynamically allocated
-  vectors and matrics used for GFO.
- */
-Grasp::~Grasp()
-{
-  int i;
-  std::list<GWSprojection *>::iterator gpp;
-  std::list<GWS *>::iterator gp;
+    Deletes all quality measures, grasps wrench spaces, and projections
+    associated with this grasp.  Frees all of the dynamically allocated
+    vectors and matrics used for GFO.
+*/
+Grasp::~Grasp() {
+    int i;
+    std::list<GWSprojection *>::iterator gpp;
+    std::list<GWS *>::iterator gp;
 
-  std::cout << "Deleting grasp" <<std::endl;
+    std::cout << "Deleting grasp" << std::endl;
 
-  for (i=0;i<numQM;i++) removeQM(0);
-  for (gpp=projectionList.begin();gpp!=projectionList.end();gpp++)
-    delete *gpp;
-  for (gp=gwsList.begin();gp!=gwsList.end();gp++)
-    delete *gp;
+    for (i = 0; i < numQM; i++) removeQM(0);
+    for (gpp = projectionList.begin(); gpp != projectionList.end(); gpp++)
+        delete *gpp;
+    for (gp = gwsList.begin(); gp != gwsList.end(); gp++)
+        delete *gp;
 }
 
 /*!
-	Returns a pointer to the GWS of type \a type if one exists. If one doesn't
-	it returns NULL
+    Returns a pointer to the GWS of type \a type if one exists. If one doesn't
+    it returns NULL
 */
 GWS *
-Grasp::getGWS(const char *type)
-{
-	GWS *gws = NULL;
-	std::list<GWS *>::iterator gp;
-	for (gp=gwsList.begin();gp!=gwsList.end();gp++) {
-		if (!strcmp((*gp)->getType(),type)) {
-			gws = *gp;
-		}
-	}
-	if (gws) gws->ref();  // add 1 to the reference count
-	return gws;
+Grasp::getGWS(const char *type) {
+    GWS *gws = NULL;
+    std::list<GWS *>::iterator gp;
+    for (gp = gwsList.begin(); gp != gwsList.end(); gp++) {
+        if (!strcmp((*gp)->getType(), type)) {
+            gws = *gp;
+        }
+    }
+    if (gws) gws->ref();  // add 1 to the reference count
+    return gws;
 }
 
 /*!
-  Creates a new GWS of type \a type and adds it to the list of GWS's associated
-  with this grasp if it does not exist already.  Current possible types of
-  GWS's are "L1 Norm", and "LInfinity Norm".  Returns a pointer to a gws
-  of the requested type that was either created or found.
+    Creates a new GWS of type \a type and adds it to the list of GWS's associated
+    with this grasp if it does not exist already.  Current possible types of
+    GWS's are "L1 Norm", and "LInfinity Norm".  Returns a pointer to a gws
+    of the requested type that was either created or found.
 */
 GWS *
-Grasp::addGWS(const char *type)
-{
-  GWS *gws = NULL;
-  std::list<GWS *>::iterator gp;
+Grasp::addGWS(const char *type) {
+    GWS *gws = NULL;
+    std::list<GWS *>::iterator gp;
 
-  //first check if we have the needed GWS already
-  for (gp=gwsList.begin();gp!=gwsList.end();gp++)
-    if (!strcmp((*gp)->getType(),type))
-      gws = *gp;
-    
-  if (!gws) {
-    gws = GWS::createInstance(type,this);
-    
-    gwsList.push_back(gws);
-    printf("created new %s GWS.\n",type);
-  }
+    //first check if we have the needed GWS already
+    for (gp = gwsList.begin(); gp != gwsList.end(); gp++)
+        if (!strcmp((*gp)->getType(), type))
+            gws = *gp;
 
-  gws->ref();  // add 1 to the reference count
-    
-  return gws;
+    if (!gws) {
+        gws = GWS::createInstance(type, this);
+
+        gwsList.push_back(gws);
+        printf("created new %s GWS.\n", type);
+    }
+
+    gws->ref();  // add 1 to the reference count
+
+    return gws;
 }
 
 /*!
-  Given a pointer to the GWS to remove, this decrements the reference count
-  for that GWS.  If the reference count becomes 0, the GWS is deleted.
+    Given a pointer to the GWS to remove, this decrements the reference count
+    for that GWS.  If the reference count becomes 0, the GWS is deleted.
 */
 void
-Grasp::removeGWS(GWS *gws)
-{
-  DBGP("removing gws");
-  gws->unref();
-  if (gws->getRefCount() == 0) {
-    DBGP("deleting gws");
-    gwsList.remove(gws);
-    delete gws;
-  } else {
-	  DBGP("gws refcount: "<<gws->getRefCount());
-  }
+Grasp::removeGWS(GWS *gws) {
+    DBGP("removing gws");
+    gws->unref();
+    if (gws->getRefCount() == 0) {
+        DBGP("deleting gws");
+        gwsList.remove(gws);
+        delete gws;
+    }
+    else {
+        DBGP("gws refcount: " << gws->getRefCount());
+    }
 }
 
 /*!
-  Adds the quality measure to the grasp's list of quality measures.
+    Adds the quality measure to the grasp's list of quality measures.
 */
 void
-Grasp::addQM(QualityMeasure *qm)
-{
-   qmList.push_back(qm);
-   numQM++;
+Grasp::addQM(QualityMeasure *qm) {
+    qmList.push_back(qm);
+    numQM++;
 }
 
 /*!
-  Replaces an existing quality measure with a new one and deletes the old one.
-  \a which selects which qm to replace where the index of the first qm in the
-  list is 0.
+    Replaces an existing quality measure with a new one and deletes the old one.
+    \a which selects which qm to replace where the index of the first qm in the
+    list is 0.
 */
 void
-Grasp::replaceQM(int which,QualityMeasure *qm)
-{
-  int i;
-  std::list<QualityMeasure *>::iterator qp;
-  
-  for (qp=qmList.begin(),i=0; qp!=qmList.end() && i!=which; qp++,i++);
-  qmList.insert(qp,qm);
+Grasp::replaceQM(int which, QualityMeasure *qm) {
+    int i;
+    std::list<QualityMeasure *>::iterator qp;
 
-  if (qp!=qmList.end()) {
-    delete *qp;
-    qmList.erase(qp);
-  }
+    for (qp = qmList.begin(), i = 0; qp != qmList.end() && i != which; qp++, i++);
+    qmList.insert(qp, qm);
+
+    if (qp != qmList.end()) {
+        delete *qp;
+        qmList.erase(qp);
+    }
 }
 
 /*!
-  Returns a pointer to the requested quality measure.  \a which is the index
-  of the qm to return, where 0 is the first qm in the list.
+    Returns a pointer to the requested quality measure.  \a which is the index
+    of the qm to return, where 0 is the first qm in the list.
 */
 QualityMeasure *
-Grasp::getQM(int which)
-{
-  int i;
-  std::list<QualityMeasure *>::iterator qp;
-  
-  for (qp=qmList.begin(),i=0; qp!=qmList.end() && i!=which; qp++,i++);
-  if (qp!=qmList.end()) return *qp;
-  return NULL;
+Grasp::getQM(int which) {
+    int i;
+    std::list<QualityMeasure *>::iterator qp;
+
+    for (qp = qmList.begin(), i = 0; qp != qmList.end() && i != which; qp++, i++);
+    if (qp != qmList.end()) return *qp;
+    return NULL;
 }
 
 /*!
-  Removes a quality measure from the list and deletes it.  \a which is the
-  index of the qm to remove, where 0 is the first qm in the list.
+    Removes a quality measure from the list and deletes it.  \a which is the
+    index of the qm to remove, where 0 is the first qm in the list.
 */
 void
-Grasp::removeQM(int which)
-{
-  int i;
-  std::list<QualityMeasure *>::iterator qp;
-  
-  for (qp=qmList.begin(),i=0; qp!=qmList.end() && i!=which; qp++,i++);
-  if (qp!=qmList.end()) {
-    printf("Removing QM\n");
-    delete *qp;
-    qmList.erase(qp);
-    numQM--;
-  }
+Grasp::removeQM(int which) {
+    int i;
+    std::list<QualityMeasure *>::iterator qp;
+
+    for (qp = qmList.begin(), i = 0; qp != qmList.end() && i != which; qp++, i++);
+    if (qp != qmList.end()) {
+        printf("Removing QM\n");
+        delete *qp;
+        qmList.erase(qp);
+        numQM--;
+    }
 }
 
 /*!
-  Add a grasp wrench space projection to the grasp's list of projections.
+    Add a grasp wrench space projection to the grasp's list of projections.
 */
 void
-Grasp::addProjection(GWSprojection *gp)
-{
-  projectionList.push_back(gp);
-  update();
+Grasp::addProjection(GWSprojection *gp) {
+    projectionList.push_back(gp);
+    update();
 }
 
 /*!
-  Removes a grasp wrench space projection from the list and deletes it.
+    Removes a grasp wrench space projection from the list and deletes it.
 */
 void
-Grasp::removeProjection(GWSprojection *gp)
-{
+Grasp::removeProjection(GWSprojection *gp) {
     projectionList.remove(gp);
     delete gp;
 }
 
 /*!
-  This is the projection window close callback function.  When the projection
-  window is closed, this removes the associated GWSprojection.
+    This is the projection window close callback function.  When the projection
+    window is closed, this removes the associated GWSprojection.
 */
 void
-Grasp::destroyProjection(void * user, SoQtComponent *)
-{
-  GWSprojection *gp = (GWSprojection *)user;
-  gp->getGWS()->getGrasp()->removeProjection(gp);
+Grasp::destroyProjection(void *user, SoQtComponent *) {
+    GWSprojection *gp = (GWSprojection *)user;
+    gp->getGWS()->getGrasp()->removeProjection(gp);
 }
 
 /*!
-  Updates the grasp by collecting all the current contacts on the hand and
-  rebuilding any grasp wrench spaces and their projections.  This is usually
-  called after the contacts on the hand have changed.
+    Updates the grasp by collecting all the current contacts on the hand and
+    rebuilding any grasp wrench spaces and their projections.  This is usually
+    called after the contacts on the hand have changed.
 
-  Also collects and uses any contacts on robots that are attached to this
-  one. See \a collectContacts() for details.
+    Also collects and uses any contacts on robots that are attached to this
+    one. See \a collectContacts() for details.
 
-  You can ask for the GWS to be built using only a subset of the 6 dimensions 
-  of force and torque normally available. These are, in this order: 
-  
-  fx, fy, fz, tx, ty, tz
+    You can ask for the GWS to be built using only a subset of the 6 dimensions
+    of force and torque normally available. These are, in this order:
 
-  If you want only a subset to be used, pass a vector of 6 ints with 1 for the
-  dimensions you want or 0 for those that you do not want. For example, if you
-  want a GWS that only uses fx, fy and tz, pass the following vector:
+    fx, fy, fz, tx, ty, tz
 
-  1, 1, 0, 0, 0, 1
+    If you want only a subset to be used, pass a vector of 6 ints with 1 for the
+    dimensions you want or 0 for those that you do not want. For example, if you
+    want a GWS that only uses fx, fy and tz, pass the following vector:
 
-  If you want to use all 6 dimensions, pass the default value of 
-  Grasp::ALL_DIMENSIONS.
+    1, 1, 0, 0, 0, 1
 
-  Note that the dimensions along which the GWS is built affects any subsequent
-  projections that are created
+    If you want to use all 6 dimensions, pass the default value of
+    Grasp::ALL_DIMENSIONS.
+
+    Note that the dimensions along which the GWS is built affects any subsequent
+    projections that are created
 */
 void
-Grasp::update(std::vector<int> useDimensions)
-{
-	if (hand) {
-		std::vector<Robot*> robotVec;
-		hand->getAllAttachedRobots(robotVec);
-		for (std::vector<Robot*>::iterator it=robotVec.begin(); it!=robotVec.end(); it++) {
-			(*it)->resetContactsChanged();
-		}
-		if (object) {
-			collectContacts();
-		} else {
-			collectVirtualContacts();
-		}
-	} else if (object) {
-		// contact only on the object: a kind of virtual contact
-		collectVirtualContactsOnObject();
-	}
+Grasp::update(std::vector<int> useDimensions) {
+    if (hand) {
+        std::vector<Robot *> robotVec;
+        hand->getAllAttachedRobots(robotVec);
+        for (std::vector<Robot *>::iterator it = robotVec.begin(); it != robotVec.end(); it++) {
+            (*it)->resetContactsChanged();
+        }
+        if (object) {
+            collectContacts();
+        }
+        else {
+            collectVirtualContacts();
+        }
+    }
+    else if (object) {
+        // contact only on the object: a kind of virtual contact
+        collectVirtualContactsOnObject();
+    }
 
-	DBGP("numContacts: " << numContacts);
-	updateWrenchSpaces(useDimensions);
+    DBGP("numContacts: " << numContacts);
+    updateWrenchSpaces(useDimensions);
 }
 
-/*! See Grasp::update() for details about \a useDimensions which affect the 
-	dimensions that are used to build the GWS.
+/*! See Grasp::update() for details about \a useDimensions which affect the
+    dimensions that are used to build the GWS.
 */
 void
-Grasp::updateWrenchSpaces(std::vector<int> useDimensions)
-{
-  std::list<GWS *>::iterator gp; 
-  std::list<GWSprojection *>::iterator pp;  
+Grasp::updateWrenchSpaces(std::vector<int> useDimensions) {
+    std::list<GWS *>::iterator gp;
+    std::list<GWSprojection *>::iterator pp;
 
-  //for tests with the online planner
-  vec3 gravDirection(0,0,1);
-  
-  //SCALE gravity to some arbitrary value; here to 0.5 of what one contact can apply
-  gravDirection = 0.5 * gravDirection;
+    //for tests with the online planner
+    vec3 gravDirection(0, 0, 1);
 
-  //compute the direction of world gravity forces relative to the object
-  if (useGravity && object) {
-	  gravDirection = gravDirection * object->getTran().inverse();
-  }
+    //SCALE gravity to some arbitrary value; here to 0.5 of what one contact can apply
+    gravDirection = 0.5 * gravDirection;
 
-  // rebuild grasp wrench spaces
-  for (gp=gwsList.begin();gp!=gwsList.end();gp++) {
-	  if (useGravity && object) {
-		  (*gp)->setGravity(true, gravDirection);
-	  } else {
-		  (*gp)->setGravity(false);
-	  }
-      (*gp)->build(useDimensions);
-  }
+    //compute the direction of world gravity forces relative to the object
+    if (useGravity && object) {
+        gravDirection = gravDirection * object->getTran().inverse();
+    }
 
-  // update the GWS projections
-  for (pp=projectionList.begin();pp!=projectionList.end();pp++) {
-    (*pp)->update();
-  }
+    // rebuild grasp wrench spaces
+    for (gp = gwsList.begin(); gp != gwsList.end(); gp++) {
+        if (useGravity && object) {
+            (*gp)->setGravity(true, gravDirection);
+        }
+        else {
+            (*gp)->setGravity(false);
+        }
+        (*gp)->build(useDimensions);
+    }
+
+    // update the GWS projections
+    for (pp = projectionList.begin(); pp != projectionList.end(); pp++) {
+        (*pp)->update();
+    }
 
 }
 
 /*!
-  Gathers the contacts on all links of the hand that are mated with contacts
-  on the grasped object and adds them to the contactVec.
+    Gathers the contacts on all links of the hand that are mated with contacts
+    on the grasped object and adds them to the contactVec.
 
-  It also collects all contacts from hands attached to this one, and treats all
-  of them as one big grasp. This allows us to do grasp analysis for complex
-  robots, such as the M7, which has manipulators attached at the end of the arms.
-  If you want to do grasp analysis just for the contacts on one of the manipulators,
-  use the instance of Grasp of that particular hand.
+    It also collects all contacts from hands attached to this one, and treats all
+    of them as one big grasp. This allows us to do grasp analysis for complex
+    robots, such as the M7, which has manipulators attached at the end of the arms.
+    If you want to do grasp analysis just for the contacts on one of the manipulators,
+    use the instance of Grasp of that particular hand.
 */
 void
-Grasp::collectContacts()
-{
-	contactVec.clear();
-	//get the contacts from this as well as all attached robots
-	std::vector<Robot*> robotVec;
-	hand->getAllAttachedRobots(robotVec);
-	for (std::vector<Robot*>::iterator it=robotVec.begin(); it!=robotVec.end(); it++) {
-		std::list<Contact*> contacts = (*it)->getContacts(object);
-		contactVec.insert(contactVec.end(), contacts.begin(), contacts.end());
-	}
-	//update wrenches for all contacts
-	for (std::vector<Contact *>::iterator cp=contactVec.begin(); cp!=contactVec.end(); cp++) {
-		(*cp)->getMate()->computeWrenches();
-	}
-	numContacts = (int)contactVec.size();
-	DBGP("Contacts: " << numContacts);
+Grasp::collectContacts() {
+    contactVec.clear();
+    //get the contacts from this as well as all attached robots
+    std::vector<Robot *> robotVec;
+    hand->getAllAttachedRobots(robotVec);
+    for (std::vector<Robot *>::iterator it = robotVec.begin(); it != robotVec.end(); it++) {
+        std::list<Contact *> contacts = (*it)->getContacts(object);
+        contactVec.insert(contactVec.end(), contacts.begin(), contacts.end());
+    }
+    //update wrenches for all contacts
+    for (std::vector<Contact *>::iterator cp = contactVec.begin(); cp != contactVec.end(); cp++) {
+        (*cp)->getMate()->computeWrenches();
+    }
+    numContacts = (int)contactVec.size();
+    DBGP("Contacts: " << numContacts);
 }
 
-vec3 Grasp::virtualCentroid()
-{
-	vec3 cog(0,0,0);
-	position pos;
+vec3 Grasp::virtualCentroid() {
+    vec3 cog(0, 0, 0);
+    position pos;
 
-	/*
-	//COG AS CENTROID
-	for (int i=0; i<(int)contactVec.size(); i++) {
-		pos = ((VirtualContact*)contactVec[i])->getWorldLocation();
-		cog = cog + vec3( pos.toSbVec3f() );
-	}
-	cog = ( 1.0 / (int)contactVec.size() ) * cog;
-	//fprintf(stderr,"CoG: %f %f %f\n",cog.x(), cog.y(), cog.z());
-	*/
+    /*
+        //COG AS CENTROID
+        for (int i=0; i<(int)contactVec.size(); i++) {
+        pos = ((VirtualContact*)contactVec[i])->getWorldLocation();
+        cog = cog + vec3( pos.toSbVec3f() );
+        }
+        cog = ( 1.0 / (int)contactVec.size() ) * cog;
+        //fprintf(stderr,"CoG: %f %f %f\n",cog.x(), cog.y(), cog.z());
+    */
 
-	//COG as center of bounding box
-	position topCorner(-1.0e5, -1.0e5, -1.0e5), bottomCorner(1.0e5, 1.0e5, 1.0e5);
-	for (int i=0; i<(int)contactVec.size(); i++) {
-		pos = ((VirtualContact*)contactVec[i])->getWorldLocation();
-		if ( pos.x() > topCorner.x() ) topCorner.x() = pos.x();
-		if ( pos.y() > topCorner.y() ) topCorner.y() = pos.y();
-		if ( pos.z() > topCorner.z() ) topCorner.z() = pos.z();
-		if ( pos.x() < bottomCorner.x() ) bottomCorner.x() = pos.x();
-		if ( pos.y() < bottomCorner.y() ) bottomCorner.y() = pos.y();
-		if ( pos.z() < bottomCorner.z() ) bottomCorner.z() = pos.z();
-	}
-	cog = 0.5 * (topCorner - bottomCorner);
-	cog = vec3(bottomCorner.toSbVec3f()) + cog;
+    //COG as center of bounding box
+    position topCorner(-1.0e5, -1.0e5, -1.0e5), bottomCorner(1.0e5, 1.0e5, 1.0e5);
+    for (int i = 0; i < (int)contactVec.size(); i++) {
+        pos = ((VirtualContact *)contactVec[i])->getWorldLocation();
+        if (pos.x() > topCorner.x()) topCorner.x() = pos.x();
+        if (pos.y() > topCorner.y()) topCorner.y() = pos.y();
+        if (pos.z() > topCorner.z()) topCorner.z() = pos.z();
+        if (pos.x() < bottomCorner.x()) bottomCorner.x() = pos.x();
+        if (pos.y() < bottomCorner.y()) bottomCorner.y() = pos.y();
+        if (pos.z() < bottomCorner.z()) bottomCorner.z() = pos.z();
+    }
+    cog = 0.5 * (topCorner - bottomCorner);
+    cog = vec3(bottomCorner.toSbVec3f()) + cog;
 
-	return cog;
+    return cog;
 }
 
 /*! Assumes all the contacts in the list are virtual, and computes the centroid
-	and max radius for the grasp based on these virtual contacts.
+    and max radius for the grasp based on these virtual contacts.
 */
 void
-Grasp::setVirtualCentroid()
-{
-	vec3 cog = virtualCentroid();
-	position pos;
+Grasp::setVirtualCentroid() {
+    vec3 cog = virtualCentroid();
+    position pos;
 
-	//VARIABLE RADIUS relative to cog location
-	vec3 radius;
-	double maxRadius = 0;
-	for (int i=0; i<(int)contactVec.size(); i++) {
-		pos = ((VirtualContact*)contactVec[i])->getWorldLocation();
-		radius =  vec3( pos.toSbVec3f() ) - cog;
-		if ( radius.len() > maxRadius) maxRadius = radius.len();
-	}
+    //VARIABLE RADIUS relative to cog location
+    vec3 radius;
+    double maxRadius = 0;
+    for (int i = 0; i < (int)contactVec.size(); i++) {
+        pos = ((VirtualContact *)contactVec[i])->getWorldLocation();
+        radius =  vec3(pos.toSbVec3f()) - cog;
+        if (radius.len() > maxRadius) maxRadius = radius.len();
+    }
 
-	//FIXED radius to allow better inter-grasp comparison (exact value pulled out of thin air)
-	maxRadius = 150;
+    //FIXED radius to allow better inter-grasp comparison (exact value pulled out of thin air)
+    maxRadius = 150;
 
-	//fprintf(stderr,"Max radius: %f\n",maxRadius);
+    //fprintf(stderr,"Max radius: %f\n",maxRadius);
 
-	for (int i=0; i<(int)contactVec.size(); i++) {
-		((VirtualContact*)contactVec[i])->setCenter( position(cog.toSbVec3f()) );
-		((VirtualContact*)contactVec[i])->setRadius(maxRadius);
-		//((VirtualContact*)contactVec[i])->getWorldIndicator();
-	}
+    for (int i = 0; i < (int)contactVec.size(); i++) {
+        ((VirtualContact *)contactVec[i])->setCenter(position(cog.toSbVec3f()));
+        ((VirtualContact *)contactVec[i])->setRadius(maxRadius);
+        //((VirtualContact*)contactVec[i])->getWorldIndicator();
+    }
 }
 
-/*!	Assumes that all contacts are virtual, but we do have an object so we 
-	set its centroid  (IN WORLD COORDINATES) and maxradius to all virtual 
-	contacts.
+/*! Assumes that all contacts are virtual, but we do have an object so we
+    set its centroid  (IN WORLD COORDINATES) and maxradius to all virtual
+    contacts.
 */
 void
-Grasp::setRealCentroid(GraspableBody *body)
-{
-	position cog = body->getCoG() * body->getTran();
-	double maxRadius = body->getMaxRadius();
-	for (int i=0; i<(int)contactVec.size(); i++) {
-		((VirtualContact*)contactVec[i])->setCenter(cog);
-		((VirtualContact*)contactVec[i])->setRadius(maxRadius);
-	}
+Grasp::setRealCentroid(GraspableBody *body) {
+    position cog = body->getCoG() * body->getTran();
+    double maxRadius = body->getMaxRadius();
+    for (int i = 0; i < (int)contactVec.size(); i++) {
+        ((VirtualContact *)contactVec[i])->setCenter(cog);
+        ((VirtualContact *)contactVec[i])->setRadius(maxRadius);
+    }
 }
 
-/*!  Gathers the virtual contacts on all links of the hand and adds them to 
-	the internal list in contactVec. Any GWS computations should then be 
-	able to proceed regardless of the fact that these are virtual contacts.
-	However, since we might not have an object, information about the 
-	centroid to be used as reference point, and the max radius used for
-	converting torques, are also computed and stored in the virtual
-	contacts themselves.
+/*!  Gathers the virtual contacts on all links of the hand and adds them to
+    the internal list in contactVec. Any GWS computations should then be
+    able to proceed regardless of the fact that these are virtual contacts.
+    However, since we might not have an object, information about the
+    centroid to be used as reference point, and the max radius used for
+    converting torques, are also computed and stored in the virtual
+    contacts themselves.
 */
 void
-Grasp::collectVirtualContacts()
-{
-	int f,l;
-	std::list<Contact *>::iterator cp;
-	std::list<Contact *> contactList;
+Grasp::collectVirtualContacts() {
+    int f, l;
+    std::list<Contact *>::iterator cp;
+    std::list<Contact *> contactList;
 
-	contactVec.clear();
-	numContacts = 0;
+    contactVec.clear();
+    numContacts = 0;
 
-	contactList = hand->getPalm()->getVirtualContacts();
-	for (cp=contactList.begin();cp!=contactList.end();cp++) {
-		contactVec.push_back(*cp);
-		numContacts++;
-	}
+    contactList = hand->getPalm()->getVirtualContacts();
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        contactVec.push_back(*cp);
+        numContacts++;
+    }
 
-	for(f=0;f<hand->getNumFingers();f++) {
-		for (l=0;l<hand->getFinger(f)->getNumLinks();l++) {
-			contactList = hand->getFinger(f)->getLink(l)->getVirtualContacts();
-			for (cp=contactList.begin();cp!=contactList.end();cp++){
-				contactVec.push_back(*cp);
-				numContacts++;
-			}
-		}
-	}
+    for (f = 0; f < hand->getNumFingers(); f++) {
+        for (l = 0; l < hand->getFinger(f)->getNumLinks(); l++) {
+            contactList = hand->getFinger(f)->getLink(l)->getVirtualContacts();
+            for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+                contactVec.push_back(*cp);
+                numContacts++;
+            }
+        }
+    }
 
-	if (object == NULL) {
-		setVirtualCentroid();
-		for (int i=0; i<(int)contactVec.size(); i++) {
-			((VirtualContact*)contactVec[i])->computeWrenches(false);
-		}
-	} else {
-		setRealCentroid(object);
-		//for (int i=0; i<(int)contactVec.size(); i++) {
-			//((VirtualContact*)contactVec[i])->setObject(object);
-			//((VirtualContact*)contactVec[i])->computeWrenches(true);
-			//((VirtualContact*)contactVec[i])->getWorldIndicator(true);
-		//}
-	}
- }
+    if (object == NULL) {
+        setVirtualCentroid();
+        for (int i = 0; i < (int)contactVec.size(); i++) {
+            ((VirtualContact *)contactVec[i])->computeWrenches(false);
+        }
+    }
+    else {
+        setRealCentroid(object);
+        //for (int i=0; i<(int)contactVec.size(); i++) {
+        //((VirtualContact*)contactVec[i])->setObject(object);
+        //((VirtualContact*)contactVec[i])->computeWrenches(true);
+        //((VirtualContact*)contactVec[i])->getWorldIndicator(true);
+        //}
+    }
+}
 
 /*!
-	When we are dealing with an object but no hand, gathers the virtual contacts from the
-object and adds them to the contactVec, doing the same thing as collectContacts() and
-collectVirtualContacts() do for the hand-and-object and the hand-only cases.
+    When we are dealing with an object but no hand, gathers the virtual contacts from the
+    object and adds them to the contactVec, doing the same thing as collectContacts() and
+    collectVirtualContacts() do for the hand-and-object and the hand-only cases.
 */
 void
-Grasp::collectVirtualContactsOnObject()
-{
-	std::list<Contact *>::iterator cp;
-	std::list<Contact *> contactList;
-	
-	contactVec.clear();
-	numContacts = 0;
-	contactList = object->getVirtualContacts();
-	for (cp=contactList.begin();cp!=contactList.end();cp++){
-		contactVec.push_back(*cp);
-		numContacts++;
-	}
-	for (int i=0; i<(int)contactVec.size(); i++) {
-		// use computeWrenches defined in Contact class
-		((Contact*)contactVec[i])->computeWrenches();
-	}
-#ifdef GRASPITDBG
-		fprintf(stderr,"ContactOnObject has been pushed, number is %d\n",numContacts);
-#endif
-	setRealCentroid(object);
+Grasp::collectVirtualContactsOnObject() {
+    std::list<Contact *>::iterator cp;
+    std::list<Contact *> contactList;
+
+    contactVec.clear();
+    numContacts = 0;
+    contactList = object->getVirtualContacts();
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        contactVec.push_back(*cp);
+        numContacts++;
+    }
+    for (int i = 0; i < (int)contactVec.size(); i++) {
+        // use computeWrenches defined in Contact class
+        ((Contact *)contactVec[i])->computeWrenches();
+    }
+    #ifdef GRASPITDBG
+    fprintf(stderr, "ContactOnObject has been pushed, number is %d\n", numContacts);
+    #endif
+    setRealCentroid(object);
 }
 
 double
-Grasp::getMaxRadius()
-{
-	if (object) return object->getMaxRadius();
-	if (numContacts == 0) return 0;
-	return ((VirtualContact*)contactVec[0])->getMaxRadius();
+Grasp::getMaxRadius() {
+    if (object) return object->getMaxRadius();
+    if (numContacts == 0) return 0;
+    return ((VirtualContact *)contactVec[0])->getMaxRadius();
 }
 
 position
-Grasp::getCoG()
-{
-	if (object) return object->getCoG();
-	if (numContacts == 0) return position(0,0,0);
-	return ((VirtualContact*)contactVec[0])->getCenter();
+Grasp::getCoG() {
+    if (object) return object->getCoG();
+    if (numContacts == 0) return position(0, 0, 0);
+    return ((VirtualContact *)contactVec[0])->getCenter();
 }
 
 /*!
-  Computes the jacobian for the base frame of link \a l on finger \a f
-  relative to the base frame of the finger. This is wrt THE FRAME OF LINK!!!
-  
-  Distances USED TO BE converted to meters (check why this is...). Now they are
-  kept in MILLIMETERS!
+    Computes the jacobian for the base frame of link \a l on finger \a f
+    relative to the base frame of the finger. This is wrt THE FRAME OF LINK!!!
+
+    Distances USED TO BE converted to meters (check why this is...). Now they are
+    kept in MILLIMETERS!
 */
 double *
-Grasp::getLinkJacobian(int f, int l)
-{
-  int j,col;
-  Joint *jointPtr;
-  int numDOF = hand->getNumDOF();
-  double *jac = new double[6*numDOF];
-  double k;
-  mat3 m;
-  vec3 p;
-  transf T;
-  double db0 = 0.0;
+Grasp::getLinkJacobian(int f, int l) {
+    int j, col;
+    Joint *jointPtr;
+    int numDOF = hand->getNumDOF();
+    double *jac = new double[6 * numDOF];
+    double k;
+    mat3 m;
+    vec3 p;
+    transf T;
+    double db0 = 0.0;
 
-  dcopy(6*numDOF,&db0,0,jac,1);
-  
-  //I use f=-1 on virtual contacts to show that a contact is on the palm
-  if (f < 0) return jac;
+    dcopy(6 * numDOF, &db0, 0, jac, 1);
 
-  for (j=hand->getFinger(f)->getLastJoint(l);j>=0;j--) {
-    jointPtr = hand->getFinger(f)->getJoint(j);
-    col = jointPtr->getDOFNum();
-    
-	k = hand->getDOF(jointPtr->getDOFNum())->getStaticRatio(jointPtr);
-	T = T * jointPtr->getDH()->getTran();
-    m = T.affine();
-    p = T.translation();
-    
-    if (jointPtr->getType() == REVOLUTE) {
-      jac[col*6]   += k*(-m.element(0,0)*p.y() + m.element(0,1)*p.x());
-      jac[col*6+1] += k*(-m.element(1,0)*p.y() + m.element(1,1)*p.x());
-      jac[col*6+2] += k*(-m.element(2,0)*p.y() + m.element(2,1)*p.x());
-      jac[col*6+3] += k*m.element(0,2);
-      jac[col*6+4] += k*m.element(1,2);
-      jac[col*6+5] += k*m.element(2,2);
-    } else {
-      jac[col*6]   += k*m.element(0,2);
-      jac[col*6+1] += k*m.element(1,2);
-      jac[col*6+2] += k*m.element(2,2);
-      jac[col*6+3] += 0.0;
-      jac[col*6+4] += 0.0;
-      jac[col*6+5] += 0.0;
+    //I use f=-1 on virtual contacts to show that a contact is on the palm
+    if (f < 0) return jac;
+
+    for (j = hand->getFinger(f)->getLastJoint(l); j >= 0; j--) {
+        jointPtr = hand->getFinger(f)->getJoint(j);
+        col = jointPtr->getDOFNum();
+
+        k = hand->getDOF(jointPtr->getDOFNum())->getStaticRatio(jointPtr);
+        T = T * jointPtr->getDH()->getTran();
+        m = T.affine();
+        p = T.translation();
+
+        if (jointPtr->getType() == REVOLUTE) {
+            jac[col * 6]   += k * (-m.element(0, 0) * p.y() + m.element(0, 1) * p.x());
+            jac[col * 6 + 1] += k * (-m.element(1, 0) * p.y() + m.element(1, 1) * p.x());
+            jac[col * 6 + 2] += k * (-m.element(2, 0) * p.y() + m.element(2, 1) * p.x());
+            jac[col * 6 + 3] += k * m.element(0, 2);
+            jac[col * 6 + 4] += k * m.element(1, 2);
+            jac[col * 6 + 5] += k * m.element(2, 2);
+        }
+        else {
+            jac[col * 6]   += k * m.element(0, 2);
+            jac[col * 6 + 1] += k * m.element(1, 2);
+            jac[col * 6 + 2] += k * m.element(2, 2);
+            jac[col * 6 + 3] += 0.0;
+            jac[col * 6 + 4] += 0.0;
+            jac[col * 6 + 5] += 0.0;
+        }
     }
-  }
-  return jac;
+    return jac;
 }
 
-/*! Computes the contact jacobian J. J relates joint angle motion to 
-  contact motion. Its transpose, JT, relates contact forces to joint
-  forces.
-  
-  The joints and the contacts must both be passed in. Their order in 
-  the incoming vectors will determine their indices in the Jacobian.
-  This function will make sure that only the right joints affect each
-  contact: joints that come before the link in contact, on the same
-  chain.
-  
-  The Jacobian is ALWAYS computed in the local coordinate system of each
-  contact. When multiplied by joint torques, it will thus yield contact
-  forces and torques in the local contact coordinate system of each contact.
-  It is easy to do computations in world coordinates too, but then it
-  is impossible to discards rows that correspond to directions that the
-  contact can not apply force or torque in.
+/*! Computes the contact jacobian J. J relates joint angle motion to
+    contact motion. Its transpose, JT, relates contact forces to joint
+    forces.
+
+    The joints and the contacts must both be passed in. Their order in
+    the incoming vectors will determine their indices in the Jacobian.
+    This function will make sure that only the right joints affect each
+    contact: joints that come before the link in contact, on the same
+    chain.
+
+    The Jacobian is ALWAYS computed in the local coordinate system of each
+    contact. When multiplied by joint torques, it will thus yield contact
+    forces and torques in the local contact coordinate system of each contact.
+    It is easy to do computations in world coordinates too, but then it
+    is impossible to discards rows that correspond to directions that the
+    contact can not apply force or torque in.
 */
-Matrix 
-Grasp::contactJacobian(const std::list<Joint*> &joints, 
-                       const std::list< std::pair<transf, Link*> > &contact_locations)
-{
-  //compute the world locations of all the joints of the robot
-  //this is overkill, as we might not need all of them
-  std::vector< std::vector<transf> > jointTransf(hand->getNumChains());
-  for (int c=0; c<hand->getNumChains(); c++) {
-    jointTransf[c].resize(hand->getChain(c)->getNumJoints(), transf::IDENTITY);
-    hand->getChain(c)->getJointLocations(NULL, jointTransf[c]);
-  }
-  
-  Matrix J( Matrix::ZEROES<Matrix>(int(contact_locations.size()) * 6, (int)joints.size()) );
-  std::list<Joint*>::const_iterator joint_it;
-  int joint_count = 0;
-  int numRows = 0;
-  for (joint_it=joints.begin(); joint_it!=joints.end(); joint_it++) {
-    std::list< std::pair<transf, Link*> >::const_iterator contact_it;
-    numRows = 0;
-    for(contact_it=contact_locations.begin(); contact_it!=contact_locations.end(); contact_it++, numRows+=6) {
-      Link *link = contact_it->second;
-      //check if the contact is on the same chain that this joint belongs too
-      if ( (*joint_it)->getChainNum() != link->getChainNum() ) {
-        continue;
-      }
-      KinematicChain *chain = hand->getChain( link->getChainNum() );
-      //check that the joint comes before the contact in the chain
-      int last_joint = chain->getLastJoint( link->getLinkNum() );
-      //remember that the index of a joint in a chain is different from
-      //the index of a joint in a robot
-      int jointNumInChain = (*joint_it)->getNum() - chain->getFirstJointNum();
-      assert(jointNumInChain >= 0);
-      if ( jointNumInChain > last_joint) continue;
-      //compute the individual jacobian
-      transf joint_tran = jointTransf.at(link->getChainNum()).at(jointNumInChain);
-      transf contact_tran = contact_it->first * link->getTran();
-      //always get the individual jacobian in local coordinates
-      Matrix indJ(Joint::jacobian(*joint_it, joint_tran, contact_tran, false));
-      //place it at the correct spot in the global jacobian
-      J.copySubMatrix(numRows, joint_count, indJ);
+Matrix
+Grasp::contactJacobian(const std::list<Joint *> &joints,
+                       const std::list< std::pair<transf, Link *> > &contact_locations) {
+    //compute the world locations of all the joints of the robot
+    //this is overkill, as we might not need all of them
+    std::vector< std::vector<transf> > jointTransf(hand->getNumChains());
+    for (int c = 0; c < hand->getNumChains(); c++) {
+        jointTransf[c].resize(hand->getChain(c)->getNumJoints(), transf::IDENTITY);
+        hand->getChain(c)->getJointLocations(NULL, jointTransf[c]);
     }
-    joint_count++;
-  }
-  return J;
+
+    Matrix J(Matrix::ZEROES<Matrix>(int(contact_locations.size()) * 6, (int)joints.size()));
+    std::list<Joint *>::const_iterator joint_it;
+    int joint_count = 0;
+    int numRows = 0;
+    for (joint_it = joints.begin(); joint_it != joints.end(); joint_it++) {
+        std::list< std::pair<transf, Link *> >::const_iterator contact_it;
+        numRows = 0;
+        for (contact_it = contact_locations.begin(); contact_it != contact_locations.end(); contact_it++, numRows += 6) {
+            Link *link = contact_it->second;
+            //check if the contact is on the same chain that this joint belongs too
+            if ((*joint_it)->getChainNum() != link->getChainNum()) {
+                continue;
+            }
+            KinematicChain *chain = hand->getChain(link->getChainNum());
+            //check that the joint comes before the contact in the chain
+            int last_joint = chain->getLastJoint(link->getLinkNum());
+            //remember that the index of a joint in a chain is different from
+            //the index of a joint in a robot
+            int jointNumInChain = (*joint_it)->getNum() - chain->getFirstJointNum();
+            assert(jointNumInChain >= 0);
+            if (jointNumInChain > last_joint) continue;
+            //compute the individual jacobian
+            transf joint_tran = jointTransf.at(link->getChainNum()).at(jointNumInChain);
+            transf contact_tran = contact_it->first * link->getTran();
+            //always get the individual jacobian in local coordinates
+            Matrix indJ(Joint::jacobian(*joint_it, joint_tran, contact_tran, false));
+            //place it at the correct spot in the global jacobian
+            J.copySubMatrix(numRows, joint_count, indJ);
+        }
+        joint_count++;
+    }
+    return J;
 }
 
 /*! Simply calls the general contactJacobian function with the CoG of each link passed in as the location
-   of the contact. Useful for computing the effects of gravity for example.
+    of the contact. Useful for computing the effects of gravity for example.
 */
 Matrix
-Grasp::CoGJacobian(const std::list<Joint*> &joints, 
-                   const std::list<Link*> &links)
-{
-  std::list< std::pair<transf, Link*> > cog_locations;
-  std::list<Link*>::const_iterator link_it;
-  for(link_it=links.begin(); link_it!=links.end(); link_it++) {
-    transf tr( Quaternion::IDENTITY, vec3( (*link_it)->getCoG().toSbVec3f() ) );
-    cog_locations.push_back( std::pair<transf, Link*>(tr, *link_it) );
-  }
-  return contactJacobian(joints, cog_locations);
+Grasp::CoGJacobian(const std::list<Joint *> &joints,
+                   const std::list<Link *> &links) {
+    std::list< std::pair<transf, Link *> > cog_locations;
+    std::list<Link *>::const_iterator link_it;
+    for (link_it = links.begin(); link_it != links.end(); link_it++) {
+        transf tr(Quaternion::IDENTITY, vec3((*link_it)->getCoG().toSbVec3f()));
+        cog_locations.push_back(std::pair<transf, Link *>(tr, *link_it));
+    }
+    return contactJacobian(joints, cog_locations);
 }
 
 /*! Mass is taken into account, and g is used at 9.81 */
 Matrix
-Grasp::gravityMatrix(const std::list<Joint*> &joints, 
-                     const std::list<Link*> &links,
-                     vec3 gravityWorldDirection)
-{
-  normalise(gravityWorldDirection);
-  Matrix J( CoGJacobian(joints, links) );
-  J.transpose();
-  Matrix f( Matrix::ZEROES<Matrix>(links.size() * 6, 1) );
-  std::list<Link*>::const_iterator link_it; int i;
-  for (link_it=links.begin(), i=0; link_it!=links.end(); link_it++, i++)
-  {
-    vec3 gravLocal =   (*link_it)->getTran().rotation().inverse() * gravityWorldDirection;
-    gravLocal = 9810 * (*link_it)->getMass() * gravLocal;
-    f.elem( i*6 + 0, 0) = gravLocal.x();
-    f.elem( i*6 + 1, 0) = gravLocal.y();
-    f.elem( i*6 + 2, 0) = gravLocal.z();
-  }
-  Matrix r(joints.size(), 1);
-  matrixMultiply(J, f, r);
-  return r;
+Grasp::gravityMatrix(const std::list<Joint *> &joints,
+                     const std::list<Link *> &links,
+                     vec3 gravityWorldDirection) {
+    normalise(gravityWorldDirection);
+    Matrix J(CoGJacobian(joints, links));
+    J.transpose();
+    Matrix f(Matrix::ZEROES<Matrix>(links.size() * 6, 1));
+    std::list<Link *>::const_iterator link_it;
+    int i;
+    for (link_it = links.begin(), i = 0; link_it != links.end(); link_it++, i++) {
+        vec3 gravLocal = (*link_it)->getTran().rotation().inverse() * gravityWorldDirection;
+        gravLocal = 9810 * (*link_it)->getMass() * gravLocal;
+        f.elem(i * 6 + 0, 0) = gravLocal.x();
+        f.elem(i * 6 + 1, 0) = gravLocal.y();
+        f.elem(i * 6 + 2, 0) = gravLocal.z();
+    }
+    Matrix r(joints.size(), 1);
+    matrixMultiply(J, f, r);
+    return r;
 }
 
 /*! Simply gets the locations of all the contacts in the list and calls the
-  more general version that takes in std::list< std::pair<transf, Link*> > &contact_locations */
-Matrix 
-Grasp::contactJacobian(const std::list<Joint*> &joints, 
-                       const std::list<Contact*> &contacts)
-{
-  std::list< std::pair<transf, Link*> > contact_locations;
-  std::list<Contact*>::const_iterator contact_it;
-  for(contact_it=contacts.begin(); contact_it!=contacts.end(); contact_it++) {
-    if ((*contact_it)->getBody1()->getOwner() != hand) {
-      DBGA("Grasp jacobian: contact not on hand");
-      continue;
+    more general version that takes in std::list< std::pair<transf, Link*> > &contact_locations */
+Matrix
+Grasp::contactJacobian(const std::list<Joint *> &joints,
+                       const std::list<Contact *> &contacts) {
+    std::list< std::pair<transf, Link *> > contact_locations;
+    std::list<Contact *>::const_iterator contact_it;
+    for (contact_it = contacts.begin(); contact_it != contacts.end(); contact_it++) {
+        if ((*contact_it)->getBody1()->getOwner() != hand) {
+            DBGA("Grasp jacobian: contact not on hand");
+            continue;
+        }
+        Link *link = static_cast<Link *>((*contact_it)->getBody1());
+        contact_locations.push_back(std::pair<transf, Link *>((*contact_it)->getContactFrame(), link));
     }
-    Link *link = static_cast<Link*>((*contact_it)->getBody1());
-    contact_locations.push_back( std::pair<transf, Link*>((*contact_it)->getContactFrame(), link) );
-  }
-  return contactJacobian(joints, contact_locations);
+    return contactJacobian(joints, contact_locations);
 }
 
 /*! Simply gets the locations of all the contacts in the list and calls the
-  more general version that takes in std::list< std::pair<transf, Link*> > &contact_locations */
-Matrix 
-Grasp::contactJacobian(const std::list<Joint*> &joints, 
-                       const std::list<VirtualContact*> &contacts)
-{
-  std::list< std::pair<transf, Link*> > contact_locations;
-  std::list<VirtualContact*>::const_iterator contact_it;
-  for(contact_it=contacts.begin(); contact_it!=contacts.end(); contact_it++) {
-    if ((*contact_it)->getBody1()->getOwner() != hand) {
-      DBGA("Grasp jacobian: contact not on hand");
-      continue;
+    more general version that takes in std::list< std::pair<transf, Link*> > &contact_locations */
+Matrix
+Grasp::contactJacobian(const std::list<Joint *> &joints,
+                       const std::list<VirtualContact *> &contacts) {
+    std::list< std::pair<transf, Link *> > contact_locations;
+    std::list<VirtualContact *>::const_iterator contact_it;
+    for (contact_it = contacts.begin(); contact_it != contacts.end(); contact_it++) {
+        if ((*contact_it)->getBody1()->getOwner() != hand) {
+            DBGA("Grasp jacobian: contact not on hand");
+            continue;
+        }
+        Link *link = static_cast<Link *>((*contact_it)->getBody1());
+        contact_locations.push_back(std::pair<transf, Link *>((*contact_it)->getContactFrame(), link));
     }
-    Link *link = static_cast<Link*>((*contact_it)->getBody1());
-    contact_locations.push_back( std::pair<transf, Link*>((*contact_it)->getContactFrame(), link) );
-  }
-  return contactJacobian(joints, contact_locations);
+    return contactJacobian(joints, contact_locations);
 }
 
 /*! Computes the grasp map G. D is the matrix that relates friction edge
-  amplitudes to contact force and R is the matrix that transorms contact
-  forces to world coordinate system. We then need to sum all of them up
-  by multiplication with a summation matrix to get the grasp map
-  
-  G = S R D
-  
-  G relates friction edge amplitudes from all contacts to resultant 
-  object wrench.
+    amplitudes to contact force and R is the matrix that transorms contact
+    forces to world coordinate system. We then need to sum all of them up
+    by multiplication with a summation matrix to get the grasp map
+
+    G = S R D
+
+    G relates friction edge amplitudes from all contacts to resultant
+    object wrench.
 */
-Matrix 
-Grasp::graspMapMatrix(const Matrix &R, const Matrix &D)
-{
-  int numContacts = R.rows() / 6;
-  assert(6 * numContacts == R.rows());
-  //summation matrix that adds full 6D object wrenches
-  Matrix S(6, 6*numContacts);
-  for(int i=0; i<numContacts; i++) {
-    S.copySubMatrix(0, 6*i, Matrix::EYE(6,6));
-  }
-  
-  Matrix SR(S.rows(), R.cols());
-  matrixMultiply(S, R, SR);
-  Matrix G(S.rows(), D.cols());
-  matrixMultiply(SR, D, G);
-  return G;
+Matrix
+Grasp::graspMapMatrix(const Matrix &R, const Matrix &D) {
+    int numContacts = R.rows() / 6;
+    assert(6 * numContacts == R.rows());
+    //summation matrix that adds full 6D object wrenches
+    Matrix S(6, 6 * numContacts);
+    for (int i = 0; i < numContacts; i++) {
+        S.copySubMatrix(0, 6 * i, Matrix::EYE(6, 6));
+    }
+
+    Matrix SR(S.rows(), R.cols());
+    matrixMultiply(S, R, SR);
+    Matrix G(S.rows(), D.cols());
+    matrixMultiply(SR, D, G);
+    return G;
 }
 
 
 /*! One possible version of the GFO problem.
 
-	Given a matrix of joint torques applied to the robot joints, this will check
-	if there exists a set of legal contact forces that balance them. If so, it
-	will compute the set of contact forces that adds up to the wrench of least
-	magnitude on the object.
+    Given a matrix of joint torques applied to the robot joints, this will check
+    if there exists a set of legal contact forces that balance them. If so, it
+    will compute the set of contact forces that adds up to the wrench of least
+    magnitude on the object.
 
-	For now, this output of this function is to set the computed contact forces
-	on each contact as dynamic forces, and also to accumulate the resulting
-	wrench on the object in its external wrench accumulator.
+    For now, this output of this function is to set the computed contact forces
+    on each contact as dynamic forces, and also to accumulate the resulting
+    wrench on the object in its external wrench accumulator.
 
-	Return codes: 0 is success, >0 means finger slip, no legal contact forces 
-	exist; <0 means error in computation 
+    Return codes: 0 is success, >0 means finger slip, no legal contact forces
+    exist; <0 means error in computation
 */
-int 
-Grasp::computeQuasistaticForces(const Matrix &robotTau)
-{
-	//WARNING: for now, this ignores contacts on the palm. That might change in the future
+int
+Grasp::computeQuasistaticForces(const Matrix &robotTau) {
+    //WARNING: for now, this ignores contacts on the palm. That might change in the future
 
-	//for now, if the hand is touching anything other then the object, abort
-	for (int c=0; c<hand->getNumChains(); c++) {
-		if ( hand->getChain(c)->getNumContacts(NULL) !=
-			hand->getChain(c)->getNumContacts(object) ) {
-				DBGA("Hand contacts not on object");
-				return 1;
-			}
-	}
+    //for now, if the hand is touching anything other then the object, abort
+    for (int c = 0; c < hand->getNumChains(); c++) {
+        if (hand->getChain(c)->getNumContacts(NULL) !=
+                hand->getChain(c)->getNumContacts(object)) {
+            DBGA("Hand contacts not on object");
+            return 1;
+        }
+    }
 
-	std::list<Contact*> contacts;
-	std::list<Joint*> joints;
+    std::list<Contact *> contacts;
+    std::list<Joint *> joints;
 
-	bool freeChainForces = false;
-	for(int c=0; c<hand->getNumChains(); c++) {
-		//for now, we look at all contacts
-		std::list<Contact*> chainContacts = hand->getChain(c)->getContacts(object);
-		contacts.insert(contacts.end(), chainContacts.begin(), chainContacts.end());
-		if (!chainContacts.empty()) {
-			std::list<Joint*> chainJoints = hand->getChain(c)->getJoints();
-			joints.insert(joints.end(), chainJoints.begin(), chainJoints.end());
-		} else {
-			//the chain has no contacts
-			//check if any joint forces are not 0
-			Matrix chainTau = hand->getChain(c)->jointTorquesVector(robotTau);
-			//torque units should be N * 1.0e6 * mm
-			if (chainTau.absMax() > 1.0e3) {
-				DBGA("Joint torque " << chainTau.absMax() << " on chain " << c 
-									 << " with no contacts");
-				freeChainForces = true;
-			}
-		}
-	}
-	//if there are no contacts, nothing to compute!
-	if (contacts.empty()) return 0;
+    bool freeChainForces = false;
+    for (int c = 0; c < hand->getNumChains(); c++) {
+        //for now, we look at all contacts
+        std::list<Contact *> chainContacts = hand->getChain(c)->getContacts(object);
+        contacts.insert(contacts.end(), chainContacts.begin(), chainContacts.end());
+        if (!chainContacts.empty()) {
+            std::list<Joint *> chainJoints = hand->getChain(c)->getJoints();
+            joints.insert(joints.end(), chainJoints.begin(), chainJoints.end());
+        }
+        else {
+            //the chain has no contacts
+            //check if any joint forces are not 0
+            Matrix chainTau = hand->getChain(c)->jointTorquesVector(robotTau);
+            //torque units should be N * 1.0e6 * mm
+            if (chainTau.absMax() > 1.0e3) {
+                DBGA("Joint torque " << chainTau.absMax() << " on chain " << c
+                     << " with no contacts");
+                freeChainForces = true;
+            }
+        }
+    }
+    //if there are no contacts, nothing to compute!
+    if (contacts.empty()) return 0;
 
-	//assemble the joint forces matrix
-	Matrix tau((int)joints.size(), 1);
-	int jc; std::list<Joint*>::iterator jit;
-	for (jc=0, jit = joints.begin(); jit!=joints.end(); jc++,jit++) {
-		tau.elem(jc,0) = robotTau.elem( (*jit)->getNum(), 0 );
-	}
-	//if all the joint forces we care about are zero, do an early exit 
-	//as zero contact forces are guaranteed to balance the chain
-	//we should probably be able to use a much larger threshold here, if
-	//units are what I think they are
-	if (tau.absMax() < 1.0e-3) {
-		return 0;
-	}
+    //assemble the joint forces matrix
+    Matrix tau((int)joints.size(), 1);
+    int jc;
+    std::list<Joint *>::iterator jit;
+    for (jc = 0, jit = joints.begin(); jit != joints.end(); jc++, jit++) {
+        tau.elem(jc, 0) = robotTau.elem((*jit)->getNum(), 0);
+    }
+    //if all the joint forces we care about are zero, do an early exit
+    //as zero contact forces are guaranteed to balance the chain
+    //we should probably be able to use a much larger threshold here, if
+    //units are what I think they are
+    if (tau.absMax() < 1.0e-3) {
+        return 0;
+    }
 
-	//if there are forces on chains with no contacts, we have no hope to balance them
-	if (freeChainForces) {
-		return 1;
-	}
+    //if there are forces on chains with no contacts, we have no hope to balance them
+    if (freeChainForces) {
+        return 1;
+    }
 
-	Matrix J(contactJacobian(joints, contacts));
-	Matrix D(Contact::frictionForceBlockMatrix(contacts));
-	Matrix F(Contact::frictionConstraintsBlockMatrix(contacts));
-	Matrix R(Contact::localToWorldWrenchBlockMatrix(contacts));
+    Matrix J(contactJacobian(joints, contacts));
+    Matrix D(Contact::frictionForceBlockMatrix(contacts));
+    Matrix F(Contact::frictionConstraintsBlockMatrix(contacts));
+    Matrix R(Contact::localToWorldWrenchBlockMatrix(contacts));
 
-	//grasp map G = S*R*D
-	Matrix G(graspMapMatrix(R, D));
+    //grasp map G = S*R*D
+    Matrix G(graspMapMatrix(R, D));
 
-	//left-hand equality matrix JTD = JTran * D
-	Matrix JTran(J.transposed());
-	Matrix JTD(JTran.rows(), D.cols());
-	matrixMultiply(JTran, D, JTD);
+    //left-hand equality matrix JTD = JTran * D
+    Matrix JTran(J.transposed());
+    Matrix JTD(JTran.rows(), D.cols());
+    matrixMultiply(JTran, D, JTD);
 
-	//matrix of zeroes for right-hand of friction inequality
-	Matrix zeroes(Matrix::ZEROES<Matrix>(F.rows(), 1));
+    //matrix of zeroes for right-hand of friction inequality
+    Matrix zeroes(Matrix::ZEROES<Matrix>(F.rows(), 1));
 
-	//matrix of unknowns
-	Matrix c_beta(D.cols(), 1);
+    //matrix of unknowns
+    Matrix c_beta(D.cols(), 1);
 
-	//bounds: all variables greater than 0
-	Matrix lowerBounds(Matrix::ZEROES<Matrix>(D.cols(),1));
-	Matrix upperBounds(Matrix::MAX_VECTOR(D.cols()));
+    //bounds: all variables greater than 0
+    Matrix lowerBounds(Matrix::ZEROES<Matrix>(D.cols(), 1));
+    Matrix upperBounds(Matrix::MAX_VECTOR(D.cols()));
 
-	//solve QP
-	double objVal;
-	int result = factorizedQPSolver(G, JTD, tau, F, zeroes, lowerBounds, upperBounds, 
-									c_beta, &objVal);
-	if (result) {
-		if( result > 0) {
-			DBGP("Grasp: problem unfeasible");
-		} else {
-			DBGA("Grasp: QP solver error");
-		}
-		return result;
-	}
+    //solve QP
+    double objVal;
+    int result = factorizedQPSolver(G, JTD, tau, F, zeroes, lowerBounds, upperBounds,
+                                    c_beta, &objVal);
+    if (result) {
+        if (result > 0) {
+            DBGP("Grasp: problem unfeasible");
+        }
+        else {
+            DBGA("Grasp: QP solver error");
+        }
+        return result;
+    }
 
-	//retrieve contact wrenchs in local contact coordinate systems
-	Matrix cWrenches(D.rows(), 1);
-	matrixMultiply(D, c_beta, cWrenches);
-	DBGP("Contact wrenches:\n" << cWrenches);
+    //retrieve contact wrenchs in local contact coordinate systems
+    Matrix cWrenches(D.rows(), 1);
+    matrixMultiply(D, c_beta, cWrenches);
+    DBGP("Contact wrenches:\n" << cWrenches);
 
-	//compute wrenches relative to object origin and expressed in world coordinates
-	Matrix objectWrenches(R.rows(), cWrenches.cols());
-	matrixMultiply(R, cWrenches, objectWrenches);
-	DBGP("Object wrenches:\n" << objectWrenches);
+    //compute wrenches relative to object origin and expressed in world coordinates
+    Matrix objectWrenches(R.rows(), cWrenches.cols());
+    matrixMultiply(R, cWrenches, objectWrenches);
+    DBGP("Object wrenches:\n" << objectWrenches);
 
-	//display them on the contacts and accumulate them on the object
-	displayContactWrenches(&contacts, cWrenches);
-	accumulateAndDisplayObjectWrenches(&contacts, objectWrenches);
+    //display them on the contacts and accumulate them on the object
+    displayContactWrenches(&contacts, cWrenches);
+    accumulateAndDisplayObjectWrenches(&contacts, objectWrenches);
 
-	//simple sanity check: JT * c = tau
-	Matrix fCheck(tau.rows(), 1);
-	matrixMultiply(JTran, cWrenches, fCheck);
-	for (int j=0; j<tau.rows(); j++) {
-		//I am not sure this works well for universal and ball joints
-		double err = fabs(tau.elem(j, 0) - fCheck.elem(j,0));
-		//take error as a percentage of desired force, if force is non-zero
-		if ( fabs(tau.elem(j,0)) > 1.0e-2) {
-			err = err / fabs(tau.elem(j, 0));
-		} else {
-			//for zero desired torque, out of thin air we pull an error threshold of 1.0e2
-			//which is 0.1% of the normal range of torques at 1.0e6
-			if (err < 1.0e2) err = 0;
-		}
-		// 0.1% error is considered too much
-		if (  err > 1.0e-1) {
-			DBGA("Desired torque not obtained on joint " << j << ", error " << err << 
-				" out of " << fabs(tau.elem(j, 0)) );
-			return -1;
-		}
-	}
+    //simple sanity check: JT * c = tau
+    Matrix fCheck(tau.rows(), 1);
+    matrixMultiply(JTran, cWrenches, fCheck);
+    for (int j = 0; j < tau.rows(); j++) {
+        //I am not sure this works well for universal and ball joints
+        double err = fabs(tau.elem(j, 0) - fCheck.elem(j, 0));
+        //take error as a percentage of desired force, if force is non-zero
+        if (fabs(tau.elem(j, 0)) > 1.0e-2) {
+            err = err / fabs(tau.elem(j, 0));
+        }
+        else {
+            //for zero desired torque, out of thin air we pull an error threshold of 1.0e2
+            //which is 0.1% of the normal range of torques at 1.0e6
+            if (err < 1.0e2) err = 0;
+        }
+        // 0.1% error is considered too much
+        if (err > 1.0e-1) {
+            DBGA("Desired torque not obtained on joint " << j << ", error " << err <<
+                 " out of " << fabs(tau.elem(j, 0)));
+            return -1;
+        }
+    }
 
-	//complex sanity check: is object force same as QP optimization result?
-	//this is only expected to work if all contacts are on the same object
-	double* extWrench = object->getExtWrenchAcc();
-	vec3 force(extWrench[0], extWrench[1], extWrench[2]);
-	vec3 torque(extWrench[3], extWrench[4], extWrench[5]);
-	//take into account the scaling that has taken place
-	double wrenchError = objVal*1.0e-6 - (force.len_sq() + torque.len_sq()) * 1.0e6;
-	//units here are N * 1.0e-6; errors should be in the range on miliN
-	if (wrenchError > 1.0e3) {
-		DBGA("Wrench sanity check error: " << wrenchError);
-		return -1;
-	}
-	return 0;
+    //complex sanity check: is object force same as QP optimization result?
+    //this is only expected to work if all contacts are on the same object
+    double *extWrench = object->getExtWrenchAcc();
+    vec3 force(extWrench[0], extWrench[1], extWrench[2]);
+    vec3 torque(extWrench[3], extWrench[4], extWrench[5]);
+    //take into account the scaling that has taken place
+    double wrenchError = objVal * 1.0e-6 - (force.len_sq() + torque.len_sq()) * 1.0e6;
+    //units here are N * 1.0e-6; errors should be in the range on miliN
+    if (wrenchError > 1.0e3) {
+        DBGA("Wrench sanity check error: " << wrenchError);
+        return -1;
+    }
+    return 0;
 }
 
 /*! One possible formulation of the core GFO problem. Checks if some
-	combination of joint forces exists so that the resultant object
-	wrench is 0. See inner comments for exact mathematical formulation.
-	Not for standalone use; is called by the GFO functions in the 
-	Grasp class.
+    combination of joint forces exists so that the resultant object
+    wrench is 0. See inner comments for exact mathematical formulation.
+    Not for standalone use; is called by the GFO functions in the
+    Grasp class.
 */
 int
-graspForceExistence(Matrix &JTD, Matrix &D, Matrix &F, Matrix &G, 
-					Matrix &beta, Matrix &tau, double *objVal)
-{
-	// exact problem formulation
-	// unknowns: [beta tau]			   (contact forces and joint forces)
-	// minimize [beta tau]T*[G 0]T*[G 0]*[beta tau] (magnitude of resultant object wrench)
-	// subject to:
-	// [JTD -I] * [beta tau] = 0       (contact forces balance joint forces)
-	// [0 sum] * [beta tau] = 1        (we are applying some joint forces)
-	// [F 0] [beta tau] <= 0		   (all forces inside friction cones)
-	// [beta tau] >= 0	  		       (all forces must be positive)
-	// overall equality constraint:
-	// | JTD -I |  | beta |   |0|
-	// | 0   sum|  |  tau | = |1|
+graspForceExistence(Matrix &JTD, Matrix &D, Matrix &F, Matrix &G,
+                    Matrix &beta, Matrix &tau, double *objVal) {
+    // exact problem formulation
+    // unknowns: [beta tau]            (contact forces and joint forces)
+    // minimize [beta tau]T*[G 0]T*[G 0]*[beta tau] (magnitude of resultant object wrench)
+    // subject to:
+    // [JTD -I] * [beta tau] = 0       (contact forces balance joint forces)
+    // [0 sum] * [beta tau] = 1        (we are applying some joint forces)
+    // [F 0] [beta tau] <= 0           (all forces inside friction cones)
+    // [beta tau] >= 0                 (all forces must be positive)
+    // overall equality constraint:
+    // | JTD -I |  | beta |   |0|
+    // | 0   sum|  |  tau | = |1|
 
-	int numJoints = tau.rows();
-	Matrix beta_tau(beta.rows() + tau.rows(), 1);
+    int numJoints = tau.rows();
+    Matrix beta_tau(beta.rows() + tau.rows(), 1);
 
-	//right-hand side of equality constraint
-	Matrix right_hand( JTD.rows() + 1, 1);
-	right_hand.setAllElements(0.0);
-	//actually, we use 1.0e9 here as units are in N * 1.0e-6 * mm
-	//so we want a total joint torque of 1000 N mm
-	right_hand.elem( right_hand.rows()-1, 0) = 1.0e10;
+    //right-hand side of equality constraint
+    Matrix right_hand(JTD.rows() + 1, 1);
+    right_hand.setAllElements(0.0);
+    //actually, we use 1.0e9 here as units are in N * 1.0e-6 * mm
+    //so we want a total joint torque of 1000 N mm
+    right_hand.elem(right_hand.rows() - 1, 0) = 1.0e10;
 
-	//left-hand side of equality constraint
-	Matrix LeftHand( JTD.rows() + 1, D.cols() + numJoints);
-	LeftHand.setAllElements(0.0);
-	LeftHand.copySubMatrix(0, 0, JTD);
-	LeftHand.copySubMatrix(0, D.cols(), Matrix::NEGEYE(numJoints, numJoints) );
-	for (int i=0; i<numJoints; i++) {
-		LeftHand.elem( JTD.rows(), D.cols() + i) = 1.0;
-	}
+    //left-hand side of equality constraint
+    Matrix LeftHand(JTD.rows() + 1, D.cols() + numJoints);
+    LeftHand.setAllElements(0.0);
+    LeftHand.copySubMatrix(0, 0, JTD);
+    LeftHand.copySubMatrix(0, D.cols(), Matrix::NEGEYE(numJoints, numJoints));
+    for (int i = 0; i < numJoints; i++) {
+        LeftHand.elem(JTD.rows(), D.cols() + i) = 1.0;
+    }
 
-	//matrix F padded with zeroes for tau
-	//left hand side of the inequality matrix
-	Matrix FO(F.rows(), F.cols() + numJoints);
-	FO.setAllElements(0.0);
-	FO.copySubMatrix(0, 0, F);
+    //matrix F padded with zeroes for tau
+    //left hand side of the inequality matrix
+    Matrix FO(F.rows(), F.cols() + numJoints);
+    FO.setAllElements(0.0);
+    FO.copySubMatrix(0, 0, F);
 
-	//right-hand side of inequality matrix
-	Matrix inEqZeroes(FO.rows(), 1);
-	inEqZeroes.setAllElements(0.0);
+    //right-hand side of inequality matrix
+    Matrix inEqZeroes(FO.rows(), 1);
+    inEqZeroes.setAllElements(0.0);
 
-	//objective matrix: G padded with zeroes 
-	Matrix GO(Matrix::ZEROES<Matrix>(G.rows(), G.cols() + numJoints));
-	GO.copySubMatrix(0, 0, G);
+    //objective matrix: G padded with zeroes
+    Matrix GO(Matrix::ZEROES<Matrix>(G.rows(), G.cols() + numJoints));
+    GO.copySubMatrix(0, 0, G);
 
-	//bounds: all variables greater than 0
-	// CHANGE: only beta >= 0, tau is not
-	Matrix lowerBounds(Matrix::MIN_VECTOR(beta_tau.rows()));
-	lowerBounds.copySubMatrix( 0, 0, Matrix::ZEROES<Matrix>(beta.rows(), 1) );
-	Matrix upperBounds(Matrix::MAX_VECTOR(beta_tau.rows()));
+    //bounds: all variables greater than 0
+    // CHANGE: only beta >= 0, tau is not
+    Matrix lowerBounds(Matrix::MIN_VECTOR(beta_tau.rows()));
+    lowerBounds.copySubMatrix(0, 0, Matrix::ZEROES<Matrix>(beta.rows(), 1));
+    Matrix upperBounds(Matrix::MAX_VECTOR(beta_tau.rows()));
 
 
-	/*
-	FILE *fp = fopen("gfo.txt","w");
-	fprintf(fp,"left hand:\n");
-	LeftHand.print(fp);
-	fprintf(fp,"right hand:\n");
-	right_hand.print(fp);
-	fprintf(fp,"friction inequality:\n");
-	FO.print(fp);
-	fprintf(fp,"Objective:\n");
-	GO.print(fp);
-	fclose(fp);
-	*/
-	// assembled system:
-	// minimize beta_tauT*QOT*QO*beta_tau subject to:
-	// LeftHand * beta_tau = right_hand
-	// FO * beta_tau <= inEqZeroes
-	// beta_tau >= 0
-	// CHANGE: only beta >= 0, tau is not
-	int result = factorizedQPSolver(GO, LeftHand, right_hand, FO, inEqZeroes, 
-									lowerBounds, upperBounds,
-									beta_tau, objVal);
-	beta.copySubBlock(0, 0, beta.rows(), 1, beta_tau, 0, 0);
-	tau.copySubBlock(0, 0, tau.rows(), 1, beta_tau, beta.rows(), 0);
-	return result;
+    /*
+        FILE *fp = fopen("gfo.txt","w");
+        fprintf(fp,"left hand:\n");
+        LeftHand.print(fp);
+        fprintf(fp,"right hand:\n");
+        right_hand.print(fp);
+        fprintf(fp,"friction inequality:\n");
+        FO.print(fp);
+        fprintf(fp,"Objective:\n");
+        GO.print(fp);
+        fclose(fp);
+    */
+    // assembled system:
+    // minimize beta_tauT*QOT*QO*beta_tau subject to:
+    // LeftHand * beta_tau = right_hand
+    // FO * beta_tau <= inEqZeroes
+    // beta_tau >= 0
+    // CHANGE: only beta >= 0, tau is not
+    int result = factorizedQPSolver(GO, LeftHand, right_hand, FO, inEqZeroes,
+                                    lowerBounds, upperBounds,
+                                    beta_tau, objVal);
+    beta.copySubBlock(0, 0, beta.rows(), 1, beta_tau, 0, 0);
+    tau.copySubBlock(0, 0, tau.rows(), 1, beta_tau, beta.rows(), 0);
+    return result;
 }
 
 /*! One possible formulation of the core GFO problem. Checks if some
-	combination of contacts forces exists so that the resultant object
-	wrench is 0. See inner comments for exact mathematical formulation.
-	Not for standalone use; is called by the GFO functions in the 
-	Grasp class.
+    combination of contacts forces exists so that the resultant object
+    wrench is 0. See inner comments for exact mathematical formulation.
+    Not for standalone use; is called by the GFO functions in the
+    Grasp class.
 */
 int
-contactForceExistence(Matrix &F, Matrix &N, Matrix &Q, Matrix &beta, double *objVal)
-{
-	// exact problem formulation
-	// unknowns: beta					(contact forces)
-	// minimize betaT*QT*Q*beta			(magnitude of resultant object wrench)
-	// subject to:
-	// sum_normal * beta = 1			(we are applying some contact forces)
-	// F * beta <= 0					(all forces inside friction cones)
-	// beta >= 0	  				    (all forces must be positive)
+contactForceExistence(Matrix &F, Matrix &N, Matrix &Q, Matrix &beta, double *objVal) {
+    // exact problem formulation
+    // unknowns: beta                   (contact forces)
+    // minimize betaT*QT*Q*beta         (magnitude of resultant object wrench)
+    // subject to:
+    // sum_normal * beta = 1            (we are applying some contact forces)
+    // F * beta <= 0                    (all forces inside friction cones)
+    // beta >= 0                        (all forces must be positive)
 
-	Matrix right_hand(1,1);
-	//a total of 10N of normal force
-	right_hand.elem(0,0) = 1.0e7;
+    Matrix right_hand(1, 1);
+    //a total of 10N of normal force
+    right_hand.elem(0, 0) = 1.0e7;
 
-	//right-hand side of inequality matrix
-	Matrix inEqZeroes(F.rows(), 1);
-	inEqZeroes.setAllElements(0.0);
+    //right-hand side of inequality matrix
+    Matrix inEqZeroes(F.rows(), 1);
+    inEqZeroes.setAllElements(0.0);
 
-	//bounds: all variables greater than 0
-	Matrix lowerBounds(Matrix::ZEROES<Matrix>(beta.rows(),1));
-	Matrix upperBounds(Matrix::MAX_VECTOR(beta.rows()));
+    //bounds: all variables greater than 0
+    Matrix lowerBounds(Matrix::ZEROES<Matrix>(beta.rows(), 1));
+    Matrix upperBounds(Matrix::MAX_VECTOR(beta.rows()));
 
-	/*
-	FILE *fp = fopen("gfo.txt","w");
-	fprintf(fp,"N:\n");
-	N.print(fp);
-	fprintf(fp,"right hand:\n");
-	right_hand.print(fp);
-	fprintf(fp,"friction inequality:\n");
-	F.print(fp);
-	fprintf(fp,"Objective:\n");
-	Q.print(fp);
-	fclose(fp);
-	*/
-	int result = factorizedQPSolver(Q, N, right_hand, F, inEqZeroes, 
-									lowerBounds, upperBounds,
-									beta, objVal);
-	return result;
+    /*
+        FILE *fp = fopen("gfo.txt","w");
+        fprintf(fp,"N:\n");
+        N.print(fp);
+        fprintf(fp,"right hand:\n");
+        right_hand.print(fp);
+        fprintf(fp,"friction inequality:\n");
+        F.print(fp);
+        fprintf(fp,"Objective:\n");
+        Q.print(fp);
+        fclose(fp);
+    */
+    int result = factorizedQPSolver(Q, N, right_hand, F, inEqZeroes,
+                                    lowerBounds, upperBounds,
+                                    beta, objVal);
+    return result;
 }
 
 /*! One possible formulation of the core GFO problem. Finds the contacts
-	forces that result in 0 object wrench and are as far as possible 
-	from the edges of the friction cones. Assumes that at least one set
-	of contact forces that satisfy this criterion exist; see 
-	contactForceExistence for that problem. See inner comments for exact 
-	mathematical formulation. Not for standalone use; is called by the GFO 
-	functions in the Grasp class.
+    forces that result in 0 object wrench and are as far as possible
+    from the edges of the friction cones. Assumes that at least one set
+    of contact forces that satisfy this criterion exist; see
+    contactForceExistence for that problem. See inner comments for exact
+    mathematical formulation. Not for standalone use; is called by the GFO
+    functions in the Grasp class.
 */
 int
-contactForceOptimization(Matrix &F, Matrix &N, Matrix &Q, Matrix &beta, double *objVal)
-{
-	// exact problem formulation
-	// unknowns: beta					(contact forces)
-	// minimize sum * F * beta			(crude measure of friction resistance abilities)
-	// subject to:
-	// Q * beta = 0						(0 resultant object wrench)
-	// sum_normal * beta = 1			(we are applying some contact forces)
-	// F * beta <= 0					(each individual forces inside friction cones)
-	// beta >= 0	  				    (all forces must be positive)
-	// overall equality constraint:
-	// | Q | |beta|   |0|
-	// | N |        = |1|
+contactForceOptimization(Matrix &F, Matrix &N, Matrix &Q, Matrix &beta, double *objVal) {
+    // exact problem formulation
+    // unknowns: beta                   (contact forces)
+    // minimize sum * F * beta          (crude measure of friction resistance abilities)
+    // subject to:
+    // Q * beta = 0                     (0 resultant object wrench)
+    // sum_normal * beta = 1            (we are applying some contact forces)
+    // F * beta <= 0                    (each individual forces inside friction cones)
+    // beta >= 0                        (all forces must be positive)
+    // overall equality constraint:
+    // | Q | |beta|   |0|
+    // | N |        = |1|
 
-	//right hand of equality
-	Matrix right_hand(Matrix::ZEROES<Matrix>(Q.rows()+1, 1));
-	//a total of 10N of normal force
-	right_hand.elem(Q.rows(),0) = 1.0e7;
+    //right hand of equality
+    Matrix right_hand(Matrix::ZEROES<Matrix>(Q.rows() + 1, 1));
+    //a total of 10N of normal force
+    right_hand.elem(Q.rows(), 0) = 1.0e7;
 
-	//left hand of equality
-	Matrix LeftHand(Q.rows() + 1, Q.cols());
-	LeftHand.copySubMatrix(0, 0, Q);
-	LeftHand.copySubMatrix(Q.rows(), 0, N);
+    //left hand of equality
+    Matrix LeftHand(Q.rows() + 1, Q.cols());
+    LeftHand.copySubMatrix(0, 0, Q);
+    LeftHand.copySubMatrix(Q.rows(), 0, N);
 
-	//bounds: all variables greater than 0
-	Matrix lowerBounds(Matrix::ZEROES<Matrix>(beta.rows(),1));
-	Matrix upperBounds(Matrix::MAX_VECTOR(beta.rows()));
+    //bounds: all variables greater than 0
+    Matrix lowerBounds(Matrix::ZEROES<Matrix>(beta.rows(), 1));
+    Matrix upperBounds(Matrix::MAX_VECTOR(beta.rows()));
 
-	//objective: sum of F
-	Matrix FSum(1,F.rows());
-	FSum.setAllElements(1.0);
-	Matrix FObj(1,F.cols());
-	matrixMultiply(FSum, F, FObj);
-	/*
-	FILE *fp = fopen("gfo.txt","w");
-	fprintf(fp,"Left Hand:\n");
-	LeftHand.print(fp);
-	fprintf(fp,"right hand:\n");
-	right_hand.print(fp);
-	fprintf(fp,"friction inequality:\n");
-	F.print(fp);
-	fprintf(fp,"Objective:\n");
-	Q.print(fp);
-	fclose(fp);
-	*/
-	int result = LPSolver(FObj, LeftHand, right_hand, F, Matrix::ZEROES<Matrix>(F.rows(), 1), 
-						  lowerBounds, upperBounds, 
-						  beta, objVal);
-	return result;
+    //objective: sum of F
+    Matrix FSum(1, F.rows());
+    FSum.setAllElements(1.0);
+    Matrix FObj(1, F.cols());
+    matrixMultiply(FSum, F, FObj);
+    /*
+        FILE *fp = fopen("gfo.txt","w");
+        fprintf(fp,"Left Hand:\n");
+        LeftHand.print(fp);
+        fprintf(fp,"right hand:\n");
+        right_hand.print(fp);
+        fprintf(fp,"friction inequality:\n");
+        F.print(fp);
+        fprintf(fp,"Objective:\n");
+        Q.print(fp);
+        fclose(fp);
+    */
+    int result = LPSolver(FObj, LeftHand, right_hand, F, Matrix::ZEROES<Matrix>(F.rows(), 1),
+                          lowerBounds, upperBounds,
+                          beta, objVal);
+    return result;
 }
 
 /*! One possible formulation of the core GFO problem. Finds the joint
-	forces that result in 0 object wrench such that contact forces are as 
-	far as possible from the edges of the friction cones. Assumes that at 
-	least one set of contact forces that satisfy this criterion exist; see 
-	contactForceExistence for that problem. See inner comments for exact 
-	mathematical formulation. Not for standalone use; is called by the GFO 
-	functions in the Grasp class.
+    forces that result in 0 object wrench such that contact forces are as
+    far as possible from the edges of the friction cones. Assumes that at
+    least one set of contact forces that satisfy this criterion exist; see
+    contactForceExistence for that problem. See inner comments for exact
+    mathematical formulation. Not for standalone use; is called by the GFO
+    functions in the Grasp class.
 */
 int
-graspForceOptimization(Matrix &JTD, Matrix &D, Matrix &F, Matrix &G, 
-                       Matrix &beta, Matrix &tau, double *objVal)
-{
-	// exact problem formulation
-	// unknowns: [beta tau]            (contact forces and joint forces)
-	// minimize [sum] [F 0] [beta tau] (sort of as far inside the friction cone as possible, not ideal)
-	// subject to:
-	// [JTD -I] * [beta tau] = 0       (contact forces balance joint forces)
-	// [G 0]* [beta tau] = 0           (0 resultant object wrench)
-	// [0 sum] * [beta tau] = 1        (we are applying some joint forces)
-	// [F 0] [beta tau] <= 0		   (all forces inside friction cones)
-	// [beta tau] >= 0	  		       (all forces must be positive)
-	// overall equality constraint:
-	// | JTD -I |  | beta |   |0|
-	// | G    0 |  | tau  | = |0|
-	// | 0   sum|		      |1|
+graspForceOptimization(Matrix &JTD, Matrix &D, Matrix &F, Matrix &G,
+                       Matrix &beta, Matrix &tau, double *objVal) {
+    // exact problem formulation
+    // unknowns: [beta tau]            (contact forces and joint forces)
+    // minimize [sum] [F 0] [beta tau] (sort of as far inside the friction cone as possible, not ideal)
+    // subject to:
+    // [JTD -I] * [beta tau] = 0       (contact forces balance joint forces)
+    // [G 0]* [beta tau] = 0           (0 resultant object wrench)
+    // [0 sum] * [beta tau] = 1        (we are applying some joint forces)
+    // [F 0] [beta tau] <= 0           (all forces inside friction cones)
+    // [beta tau] >= 0                 (all forces must be positive)
+    // overall equality constraint:
+    // | JTD -I |  | beta |   |0|
+    // | G    0 |  | tau  | = |0|
+    // | 0   sum|             |1|
 
-	Matrix beta_tau(beta.rows() + tau.rows(), 1);
-	int numJoints = tau.rows();
+    Matrix beta_tau(beta.rows() + tau.rows(), 1);
+    int numJoints = tau.rows();
 
-	//right-hand side of equality constraint
-	Matrix right_hand( JTD.rows() + G.rows() + 1, 1);
-	right_hand.setAllElements(0.0);
-	//actually, we use 1.0e8 here as units are in N * 1.0e-6 * mm
-	//so we want a total joint torque of 100 N mm
-	right_hand.elem( right_hand.rows()-1, 0) = 1.0e10;
+    //right-hand side of equality constraint
+    Matrix right_hand(JTD.rows() + G.rows() + 1, 1);
+    right_hand.setAllElements(0.0);
+    //actually, we use 1.0e8 here as units are in N * 1.0e-6 * mm
+    //so we want a total joint torque of 100 N mm
+    right_hand.elem(right_hand.rows() - 1, 0) = 1.0e10;
 
-	//left-hand side of equality constraint
-	Matrix LeftHand( JTD.rows() + G.rows() + 1, D.cols() + numJoints);
-	LeftHand.setAllElements(0.0);
-	LeftHand.copySubMatrix(0, 0, JTD);
-	LeftHand.copySubMatrix(0, D.cols(), Matrix::NEGEYE(numJoints, numJoints) );
-	LeftHand.copySubMatrix(JTD.rows(), 0, G);
-	for (int i=0; i<numJoints; i++) {
-		LeftHand.elem( JTD.rows() + G.rows(), D.cols() + i) = 1.0;
-	}
+    //left-hand side of equality constraint
+    Matrix LeftHand(JTD.rows() + G.rows() + 1, D.cols() + numJoints);
+    LeftHand.setAllElements(0.0);
+    LeftHand.copySubMatrix(0, 0, JTD);
+    LeftHand.copySubMatrix(0, D.cols(), Matrix::NEGEYE(numJoints, numJoints));
+    LeftHand.copySubMatrix(JTD.rows(), 0, G);
+    for (int i = 0; i < numJoints; i++) {
+        LeftHand.elem(JTD.rows() + G.rows(), D.cols() + i) = 1.0;
+    }
 
-	//objective matrix
-	//matrix F padded with zeroes for tau
-	//will also serve as the left hand side of the inequality matrix
-	Matrix FO(F.rows(), F.cols() + numJoints);
-	FO.setAllElements(0.0);
-	FO.copySubMatrix(0, 0, F);
-	//summing matrix and objective matrix
-	Matrix FSum(1, F.rows());
-	FSum.setAllElements(1.0);
-	Matrix FObj(1, FO.cols());
-	matrixMultiply(FSum, FO, FObj);
+    //objective matrix
+    //matrix F padded with zeroes for tau
+    //will also serve as the left hand side of the inequality matrix
+    Matrix FO(F.rows(), F.cols() + numJoints);
+    FO.setAllElements(0.0);
+    FO.copySubMatrix(0, 0, F);
+    //summing matrix and objective matrix
+    Matrix FSum(1, F.rows());
+    FSum.setAllElements(1.0);
+    Matrix FObj(1, FO.cols());
+    matrixMultiply(FSum, FO, FObj);
 
-	//bounds: all variables greater than 0
-	Matrix lowerBounds(Matrix::ZEROES<Matrix>(beta_tau.rows(),1));
-	Matrix upperBounds(Matrix::MAX_VECTOR(beta_tau.rows()));
+    //bounds: all variables greater than 0
+    Matrix lowerBounds(Matrix::ZEROES<Matrix>(beta_tau.rows(), 1));
+    Matrix upperBounds(Matrix::MAX_VECTOR(beta_tau.rows()));
 
-	//right-hand side of inequality matrix
-	Matrix inEqZeroes(FO.rows(), 1);
-	inEqZeroes.setAllElements(0.0);
+    //right-hand side of inequality matrix
+    Matrix inEqZeroes(FO.rows(), 1);
+    inEqZeroes.setAllElements(0.0);
 
-	
-	FILE *fp = fopen("gfo.txt","w");
-	fprintf(fp,"left hand:\n");
-	LeftHand.print(fp);
-	fprintf(fp,"right hand:\n");
-	right_hand.print(fp);
-	fprintf(fp,"friction inequality:\n");
-	FO.print(fp);
-	fprintf(fp,"Objective:\n");
-	FObj.print(fp);
-	fclose(fp);
-	
 
-	// assembled system:
-	// minimize FObj * beta_tau subject to:
-	// LeftHand * beta_tau = right_hand
-	// FO * beta_tau <= inEqZeroes
-	// beta_tau >= 0
-	int result = LPSolver(FObj, LeftHand, right_hand, FO, inEqZeroes,
-						  lowerBounds, upperBounds, 
-						  beta_tau, objVal);
-	beta.copySubBlock(0, 0, beta.rows(), 1, beta_tau, 0, 0);
-	tau.copySubBlock(0, 0, tau.rows(), 1, beta_tau, beta.rows(), 0);
-	return result;
+    FILE *fp = fopen("gfo.txt", "w");
+    fprintf(fp, "left hand:\n");
+    LeftHand.print(fp);
+    fprintf(fp, "right hand:\n");
+    right_hand.print(fp);
+    fprintf(fp, "friction inequality:\n");
+    FO.print(fp);
+    fprintf(fp, "Objective:\n");
+    FObj.print(fp);
+    fclose(fp);
+
+
+    // assembled system:
+    // minimize FObj * beta_tau subject to:
+    // LeftHand * beta_tau = right_hand
+    // FO * beta_tau <= inEqZeroes
+    // beta_tau >= 0
+    int result = LPSolver(FObj, LeftHand, right_hand, FO, inEqZeroes,
+                          lowerBounds, upperBounds,
+                          beta_tau, objVal);
+    beta.copySubBlock(0, 0, beta.rows(), 1, beta_tau, 0, 0);
+    tau.copySubBlock(0, 0, tau.rows(), 1, beta_tau, beta.rows(), 0);
+    return result;
 }
 
 /*! Retrieve all the joints of the robot, but only if their chains have contacts on
-  them. Joints on chains with no contact have a trivial 0 solution so they only
-  make the problem larger for no good reason.
-  we could go even further and only keep the joints that come *before* the contacts
-  in the chain.
+    them. Joints on chains with no contact have a trivial 0 solution so they only
+    make the problem larger for no good reason.
+    we could go even further and only keep the joints that come *before* the contacts
+    in the chain.
 */
-std::list<Joint*> Grasp::getJointsOnContactChains()
-{
-	std::list<Joint*> joints;
-	for (int c=0; c<hand->getNumChains(); c++) {
-		if (hand->getChain(c)->getNumContacts(object) != 0) {
-			std::list<Joint*> chainJoints = hand->getChain(c)->getJoints();
-			joints.insert(joints.end(), chainJoints.begin(), chainJoints.end());
-		}
-	}
-        return joints;
+std::list<Joint *> Grasp::getJointsOnContactChains() {
+    std::list<Joint *> joints;
+    for (int c = 0; c < hand->getNumChains(); c++) {
+        if (hand->getChain(c)->getNumContacts(object) != 0) {
+            std::list<Joint *> chainJoints = hand->getChain(c)->getJoints();
+            joints.insert(joints.end(), chainJoints.begin(), chainJoints.end());
+        }
+    }
+    return joints;
 }
 
 /*! This function is the equivalent of the Grasp Force Optimization, but done with
-  the quasi-static formulation cast as a Quadratic Program.
-  
-  It can perform four types of computation:
-  - contact force existence: are there contact forces that balance out on the object
-  - contact force optimization: what are the optimal contact forces (as far as possible
+    the quasi-static formulation cast as a Quadratic Program.
+
+    It can perform four types of computation:
+    - contact force existence: are there contact forces that balance out on the object
+    - contact force optimization: what are the optimal contact forces (as far as possible
     from the edges of the friction cones) that balance out on the object
-  - grasp force existence: are there joint forces which produce contact forces which 
+    - grasp force existence: are there joint forces which produce contact forces which
     balance out on the object
-  - grasp force optimization: what are the optimal joint forces, producing contact
-    forces that are as far as possible from the edges of the friction cones and 
+    - grasp force optimization: what are the optimal joint forces, producing contact
+    forces that are as far as possible from the edges of the friction cones and
     balance out on the object.
-   See individual computation routines for more details.
-  
-  There might exist cases of grasps that are reported as form-closed where grasp force
-  existence fails, as this function also asks that the contact forces that balance
-  the object must be possible to apply from actuated DOF's.
-  
-  For now, this function displays the computed contact forces on the contacts, 
-  rather than returning them. It also copies the computed joint forces in the
-  matrix \a robotTau which is assumed to be large enough for all the joints of
-  the robot and use the robot's numbering scheme.
-  
-  Return codes: 0 is success, >0 means problem is unfeasible, no equilibrium forces
-  exist; <0 means error in computation 
+    See individual computation routines for more details.
+
+    There might exist cases of grasps that are reported as form-closed where grasp force
+    existence fails, as this function also asks that the contact forces that balance
+    the object must be possible to apply from actuated DOF's.
+
+    For now, this function displays the computed contact forces on the contacts,
+    rather than returning them. It also copies the computed joint forces in the
+    matrix \a robotTau which is assumed to be large enough for all the joints of
+    the robot and use the robot's numbering scheme.
+
+    Return codes: 0 is success, >0 means problem is unfeasible, no equilibrium forces
+    exist; <0 means error in computation
 */
-int 
-Grasp::computeQuasistaticForcesAndTorques(Matrix *robotTau, int computation)
-{
-	//use the pre-set list of contacts. This includes contacts on the palm, but
-	//not contacts with other objects or obstacles
-	std::list<Contact*> contacts;
-	contacts.insert(contacts.begin(),contactVec.begin(), contactVec.end());
-	//if there are no contacts we are done
-	if (contacts.empty()) return 0;
+int
+Grasp::computeQuasistaticForcesAndTorques(Matrix *robotTau, int computation) {
+    //use the pre-set list of contacts. This includes contacts on the palm, but
+    //not contacts with other objects or obstacles
+    std::list<Contact *> contacts;
+    contacts.insert(contacts.begin(), contactVec.begin(), contactVec.end());
+    //if there are no contacts we are done
+    if (contacts.empty()) return 0;
 
-        //get only the joints on chains that make contact;
-	std::list<Joint*> joints = getJointsOnContactChains();
+    //get only the joints on chains that make contact;
+    std::list<Joint *> joints = getJointsOnContactChains();
 
-	//build the Jacobian and the other matrices that are needed.
-	//this is the same as in the equilibrium function above.
-	Matrix J(contactJacobian(joints, contacts));
-	Matrix D(Contact::frictionForceBlockMatrix(contacts));
-	Matrix F(Contact::frictionConstraintsBlockMatrix(contacts));
-	Matrix R(Contact::localToWorldWrenchBlockMatrix(contacts));
+    //build the Jacobian and the other matrices that are needed.
+    //this is the same as in the equilibrium function above.
+    Matrix J(contactJacobian(joints, contacts));
+    Matrix D(Contact::frictionForceBlockMatrix(contacts));
+    Matrix F(Contact::frictionConstraintsBlockMatrix(contacts));
+    Matrix R(Contact::localToWorldWrenchBlockMatrix(contacts));
 
-	Matrix N(Contact::normalForceSumMatrix(contacts));
+    Matrix N(Contact::normalForceSumMatrix(contacts));
 
-	//grasp map that relates contact amplitudes to object wrench G = S*R*D
-	Matrix G(graspMapMatrix(R,D));
+    //grasp map that relates contact amplitudes to object wrench G = S*R*D
+    Matrix G(graspMapMatrix(R, D));
 
-	//matrix that relates contact forces to joint torques JTD = JTran * D
-	Matrix JTran(J.transposed());
-	Matrix JTD(JTran.rows(), D.cols());
-	matrixMultiply(JTran, D, JTD);
+    //matrix that relates contact forces to joint torques JTD = JTran * D
+    Matrix JTran(J.transposed());
+    Matrix JTD(JTran.rows(), D.cols());
+    matrixMultiply(JTran, D, JTD);
 
-	// vectors of unknowns
-	Matrix beta( D.cols(), 1);
-	Matrix tau( (int)joints.size(), 1);
+    // vectors of unknowns
+    Matrix beta(D.cols(), 1);
+    Matrix tau((int)joints.size(), 1);
 
-	double objVal;
-	/* This is the core computation. There are many ways of combining the 
-	   optimization criterion and the constraints. Four of them are presented 
-	   here, each encapsulated in its own helper function.
-        */
+    double objVal;
+    /*  This is the core computation. There are many ways of combining the
+        optimization criterion and the constraints. Four of them are presented
+        here, each encapsulated in its own helper function.
+    */
 
-        int result;
-        switch(computation)
-        {
+    int result;
+    switch (computation) {
         case GRASP_FORCE_EXISTENCE:
-          result = graspForceExistence(JTD, D, F, G, beta, tau, &objVal);
-          break;
+            result = graspForceExistence(JTD, D, F, G, beta, tau, &objVal);
+            break;
         case GRASP_FORCE_OPTIMIZATION:
-          result = graspForceOptimization(JTD, D, F, G, beta, tau, &objVal);
-          break;
+            result = graspForceOptimization(JTD, D, F, G, beta, tau, &objVal);
+            break;
         case CONTACT_FORCE_EXISTENCE:
-          result = contactForceExistence(F, N, G, beta, &objVal);
-          matrixMultiply(JTD, beta, tau);
-          break;
+            result = contactForceExistence(F, N, G, beta, &objVal);
+            matrixMultiply(JTD, beta, tau);
+            break;
         case CONTACT_FORCE_OPTIMIZATION:
-          result = contactForceOptimization(F, N, G, beta, &objVal);
-          matrixMultiply(JTD, beta, tau);
-          break;
+            result = contactForceOptimization(F, N, G, beta, &objVal);
+            matrixMultiply(JTD, beta, tau);
+            break;
         default:
-          DBGA("Unknown computation type requested");
-          return -1;
+            DBGA("Unknown computation type requested");
+            return -1;
+    }
+
+    if (result) {
+        if (result > 0) {
+            DBGA("Grasp: problem unfeasible");
         }
+        else {
+            DBGA("Grasp: solver error");
+        }
+        return result;
+    }
+    DBGA("Optimization solved; objective: " << objVal);
 
-	if (result) {
-		if( result > 0) {
-			DBGA("Grasp: problem unfeasible");
-		} else {
-			DBGA("Grasp: solver error");
-		}
-		return result;
-	}
-	DBGA("Optimization solved; objective: " << objVal);
+    DBGP("beta:\n" << beta);
+    DBGP("tau:\n" << tau);
+    DBGP("Joint forces sum: " << tau.elementSum());
 
-	DBGP("beta:\n" << beta);
-	DBGP("tau:\n" << tau);
-	DBGP("Joint forces sum: " << tau.elementSum());
+    Matrix Gbeta(G.rows(), beta.cols());
+    matrixMultiply(G, beta, Gbeta);
+    DBGP("Total object wrench:\n" << Gbeta);
 
-	Matrix Gbeta(G.rows(), beta.cols());
-	matrixMultiply(G, beta, Gbeta);
-	DBGP("Total object wrench:\n" << Gbeta);
+    //retrieve contact wrenches in local contact coordinate systems
+    Matrix cWrenches(D.rows(), 1);
+    matrixMultiply(D, beta, cWrenches);
+    DBGP("Contact forces:\n " << cWrenches);
 
-	//retrieve contact wrenches in local contact coordinate systems
-	Matrix cWrenches(D.rows(), 1);
-	matrixMultiply(D, beta, cWrenches);
-	DBGP("Contact forces:\n " << cWrenches);
+    //compute object wrenches relative to object origin and expressed in world coordinates
+    Matrix objectWrenches(R.rows(), cWrenches.cols());
+    matrixMultiply(R, cWrenches, objectWrenches);
+    DBGP("Object wrenches:\n" << objectWrenches);
 
-	//compute object wrenches relative to object origin and expressed in world coordinates
-	Matrix objectWrenches(R.rows(), cWrenches.cols());
-	matrixMultiply(R, cWrenches, objectWrenches);
-	DBGP("Object wrenches:\n" << objectWrenches);
+    //display them on the contacts and accumulate them on the object
+    displayContactWrenches(&contacts, cWrenches);
+    accumulateAndDisplayObjectWrenches(&contacts, objectWrenches);
 
-	//display them on the contacts and accumulate them on the object
-	displayContactWrenches(&contacts, cWrenches);
-	accumulateAndDisplayObjectWrenches(&contacts, objectWrenches);
+    //set the robot joint values for the return
+    std::list<Joint *>::iterator it;
+    int jc;
+    for (it = joints.begin(), jc = 0; it != joints.end(); it++, jc++) {
+        robotTau->elem((*it)->getNum(), 0) = 1.0 * tau.elem(jc, 0);
+    }
 
-	//set the robot joint values for the return
-	std::list<Joint*>::iterator it;
-	int jc;
-	for(it=joints.begin(), jc=0; it!=joints.end(); it++,jc++) {
-		robotTau->elem( (*it)->getNum(), 0 ) = 1.0 * tau.elem(jc,0);
-	}
+    //sanity check: contact forces balance joint forces
 
-	//sanity check: contact forces balance joint forces
+    //sanity check: resultant object wrench is 0
 
-	//sanity check: resultant object wrench is 0
-
-	return 0;
+    return 0;
 }
 
 /*! This is a helper function for grasp force optimization routines. Given a
-	set of contacts and a matrix of contact wrenches expressed in *local* 
-	contact coordinates, it will set these wrenches in the dynamic wrench slot
-	of the contacts for rendering purposes.
+    set of contacts and a matrix of contact wrenches expressed in *local*
+    contact coordinates, it will set these wrenches in the dynamic wrench slot
+    of the contacts for rendering purposes.
 */
 void
-Grasp::displayContactWrenches(std::list<Contact*> *contacts, 
-						      const Matrix &contactWrenches)
-{
-	int count = 0;
-	std::list<Contact*>::iterator it;
-	for (it=contacts->begin(); it!=contacts->end(); it++, count++) {
-		Contact *contact = *it;
-		if (contact->getBody2()->isDynamic()) {
-			//wrench is also scaled down for now for rendering and output purposes
-			//we also transform the wrench to the mate's coordinate system, which
-			//usually involves negating the x and z axes
-			double dynWrench[6];
-			for (int i=0; i<6; i++) {
-				dynWrench[i] = -1.0 * 1.0e-6 * contactWrenches.elem(6*count+i,0);
-			}
-			//the y axis is not negated
-			dynWrench[1] = -1.0 * dynWrench[1];
-			dynWrench[4] = -1.0 * dynWrench[4];
-			contact->getMate()->setDynamicContactWrench(dynWrench);
-		}
-	}
+Grasp::displayContactWrenches(std::list<Contact *> *contacts,
+                              const Matrix &contactWrenches) {
+    int count = 0;
+    std::list<Contact *>::iterator it;
+    for (it = contacts->begin(); it != contacts->end(); it++, count++) {
+        Contact *contact = *it;
+        if (contact->getBody2()->isDynamic()) {
+            //wrench is also scaled down for now for rendering and output purposes
+            //we also transform the wrench to the mate's coordinate system, which
+            //usually involves negating the x and z axes
+            double dynWrench[6];
+            for (int i = 0; i < 6; i++) {
+                dynWrench[i] = -1.0 * 1.0e-6 * contactWrenches.elem(6 * count + i, 0);
+            }
+            //the y axis is not negated
+            dynWrench[1] = -1.0 * dynWrench[1];
+            dynWrench[4] = -1.0 * dynWrench[4];
+            contact->getMate()->setDynamicContactWrench(dynWrench);
+        }
+    }
 }
 
 
 /*! This is a helper function for grasp force optimization routines. Given a
-	set of contacts, and a matrix of contact wrenches expressed in *world*
-	coordinates and relative to object origin (as computed in gfo routines)
-	this function will convert them to object coordinate system and accumulate
-	them in the object's external wrench accumulator. This can serve as an
-	output of the gfo functions and also for rendering purposes, as the 
-	external wrench accumulator can then be rendered.
+    set of contacts, and a matrix of contact wrenches expressed in *world*
+    coordinates and relative to object origin (as computed in gfo routines)
+    this function will convert them to object coordinate system and accumulate
+    them in the object's external wrench accumulator. This can serve as an
+    output of the gfo functions and also for rendering purposes, as the
+    external wrench accumulator can then be rendered.
 */
 void
-Grasp::accumulateAndDisplayObjectWrenches(std::list<Contact*> *contacts, 
-										  const Matrix &objectWrenches)
-{
-	int count = 0;
-	std::list<Contact*>::iterator it;
-	for (it=contacts->begin(); it!=contacts->end(); it++, count++) {
-		Contact *contact = *it;
-		vec3 force(objectWrenches.elem(6*count+0,0), 
-					objectWrenches.elem(6*count+1,0), 
-					objectWrenches.elem(6*count+2,0));
-		vec3 torque(objectWrenches.elem(6*count+3,0), 
-					objectWrenches.elem(6*count+4,0), 
-					objectWrenches.elem(6*count+5,0));
-		if (contact->getBody2()->isDynamic()) {
-			DynamicBody *object = (DynamicBody*)(contact->getBody2());
-			//compute force and torque in body reference frame
-			//and scale them down for now for rendering and output purposes
-			force = 1.0e-6 * force * object->getTran().inverse();
-			//torque is also scaled by maxRadius in conversion matrix
-			torque = 1.0e-6 * torque * object->getTran().inverse();
-			//accumulate them on object
-			object->addForce(force);
-			object->addTorque(torque);
-		}
-	}
+Grasp::accumulateAndDisplayObjectWrenches(std::list<Contact *> *contacts,
+                                          const Matrix &objectWrenches) {
+    int count = 0;
+    std::list<Contact *>::iterator it;
+    for (it = contacts->begin(); it != contacts->end(); it++, count++) {
+        Contact *contact = *it;
+        vec3 force(objectWrenches.elem(6 * count + 0, 0),
+                   objectWrenches.elem(6 * count + 1, 0),
+                   objectWrenches.elem(6 * count + 2, 0));
+        vec3 torque(objectWrenches.elem(6 * count + 3, 0),
+                    objectWrenches.elem(6 * count + 4, 0),
+                    objectWrenches.elem(6 * count + 5, 0));
+        if (contact->getBody2()->isDynamic()) {
+            DynamicBody *object = (DynamicBody *)(contact->getBody2());
+            //compute force and torque in body reference frame
+            //and scale them down for now for rendering and output purposes
+            force = 1.0e-6 * force * object->getTran().inverse();
+            //torque is also scaled by maxRadius in conversion matrix
+            torque = 1.0e-6 * torque * object->getTran().inverse();
+            //accumulate them on object
+            object->addForce(force);
+            object->addTorque(torque);
+        }
+    }
 }

--- a/src/graspRecord.cpp
+++ b/src/graspRecord.cpp
@@ -27,108 +27,104 @@
 #include "gloveInterface.h"
 #include "debug.h"
 
-GraspRecord::GraspRecord(int size)
-{
-	mSize = size;
-	mPose = new CalibrationPose(mSize);
+GraspRecord::GraspRecord(int size) {
+    mSize = size;
+    mPose = new CalibrationPose(mSize);
 
-	mTran = transf::IDENTITY;
-	mObjectName = mRobotName = QString("not_set");
+    mTran = transf::IDENTITY;
+    mObjectName = mRobotName = QString("not_set");
 }
 
-GraspRecord::~GraspRecord()
-{
-	delete mPose;
+GraspRecord::~GraspRecord() {
+    delete mPose;
 }
 
-void GraspRecord::writeToFile(FILE *fp)
-{
-	//write names
-	fprintf(fp,"%s\n",mObjectName.latin1());
-	fprintf(fp,"%s\n",mRobotName.latin1());
-	//write transform
-	Quaternion q = mTran.rotation();
-	fprintf(fp,"%f %f %f %f ",q.x, q.y, q.z, q.w);
-	vec3 t = mTran.translation();
-	fprintf(fp,"%f %f %f\n",t.x(), t.y(), t.z());
-	//write pose
-	mPose->writeToFile(fp);
+void GraspRecord::writeToFile(FILE *fp) {
+    //write names
+    fprintf(fp, "%s\n", mObjectName.latin1());
+    fprintf(fp, "%s\n", mRobotName.latin1());
+    //write transform
+    Quaternion q = mTran.rotation();
+    fprintf(fp, "%f %f %f %f ", q.x, q.y, q.z, q.w);
+    vec3 t = mTran.translation();
+    fprintf(fp, "%f %f %f\n", t.x(), t.y(), t.z());
+    //write pose
+    mPose->writeToFile(fp);
 }
 
-void GraspRecord::readFromFile(FILE *fp)
-{
-	float x,y,z,w;
-	//read names
-	char name[1000];
-	do {
-	  if(fgets(name, 1000, fp) == NULL) {
-	    DBGA("GraspRecord::readFromFile - failed to read record name");
-	    return;
-	  } 
-	} while (name[0]=='\n' || name[0]=='\0' || name[0]==' ');
-	mObjectName = QString(name);
-	mObjectName = mObjectName.stripWhiteSpace();
-	fprintf(stderr,"object: %s__\n",mObjectName.latin1());
-	do {
-	  if(fgets(name, 1000, fp) == NULL) {
-	    DBGA("GraspRecord::readFromFile - failed to read robot name");
-	    return;
-	  }
-	} while (name[0]=='\n' || name[0]=='\0' || name[0]==' ');
-	mRobotName = QString(name);
-	mRobotName = mRobotName.stripWhiteSpace();
-	fprintf(stderr,"robot: %s__\n",mRobotName.latin1());
-	//read transform
-	if( fscanf(fp,"%f %f %f %f",&x, &y, &z, &w) <= 0) {
-	  DBGA("GraspRecord::readFromFile - failed to read record orientation.");
-	  return;
-	}
-	Quaternion q(w, x, y, z);
-	if( fscanf(fp,"%f %f %f",&x, &y, &z) <= 0) {
-	  DBGA("GraspRecord::readFromFile - failed to read record location");
-	}
-	vec3 t(x,y,z);
-	mTran.set(q,t);
-	//read pose
-	mPose->readFromFile(fp);
-	mSize = mPose->getSize();
+void GraspRecord::readFromFile(FILE *fp) {
+    float x, y, z, w;
+    //read names
+    char name[1000];
+    do {
+        if (fgets(name, 1000, fp) == NULL) {
+            DBGA("GraspRecord::readFromFile - failed to read record name");
+            return;
+        }
+    }
+    while (name[0] == '\n' || name[0] == '\0' || name[0] == ' ');
+    mObjectName = QString(name);
+    mObjectName = mObjectName.stripWhiteSpace();
+    fprintf(stderr, "object: %s__\n", mObjectName.latin1());
+    do {
+        if (fgets(name, 1000, fp) == NULL) {
+            DBGA("GraspRecord::readFromFile - failed to read robot name");
+            return;
+        }
+    }
+    while (name[0] == '\n' || name[0] == '\0' || name[0] == ' ');
+    mRobotName = QString(name);
+    mRobotName = mRobotName.stripWhiteSpace();
+    fprintf(stderr, "robot: %s__\n", mRobotName.latin1());
+    //read transform
+    if (fscanf(fp, "%f %f %f %f", &x, &y, &z, &w) <= 0) {
+        DBGA("GraspRecord::readFromFile - failed to read record orientation.");
+        return;
+    }
+    Quaternion q(w, x, y, z);
+    if (fscanf(fp, "%f %f %f", &x, &y, &z) <= 0) {
+        DBGA("GraspRecord::readFromFile - failed to read record location");
+    }
+    vec3 t(x, y, z);
+    mTran.set(q, t);
+    //read pose
+    mPose->readFromFile(fp);
+    mSize = mPose->getSize();
 }
 
-void loadGraspListFromFile(std::vector<GraspRecord*> *list, const char *filename)
-{
-	FILE *fp = fopen(filename, "r");
-	if (fp==NULL) {
-		fprintf(stderr,"Unable to open file %s for reading\n",filename);
-		return;
-	}
+void loadGraspListFromFile(std::vector<GraspRecord *> *list, const char *filename) {
+    FILE *fp = fopen(filename, "r");
+    if (fp == NULL) {
+        fprintf(stderr, "Unable to open file %s for reading\n", filename);
+        return;
+    }
 
-	GraspRecord *newGrasp;
-	int nGrasps;
-	if(fscanf(fp,"%d",&nGrasps)) { 
-	  DBGA("loadGraspListFromFile - failed to read number of grasps");
-	  return;
-	}
-	for(int i=0; i<nGrasps; i++) {
-		newGrasp = new GraspRecord(0);
-		newGrasp->readFromFile(fp);
-		list->push_back(newGrasp);
-	}
+    GraspRecord *newGrasp;
+    int nGrasps;
+    if (fscanf(fp, "%d", &nGrasps)) {
+        DBGA("loadGraspListFromFile - failed to read number of grasps");
+        return;
+    }
+    for (int i = 0; i < nGrasps; i++) {
+        newGrasp = new GraspRecord(0);
+        newGrasp->readFromFile(fp);
+        list->push_back(newGrasp);
+    }
 
-	fclose(fp);
+    fclose(fp);
 }
 
-void writeGraspListToFile (std::vector<GraspRecord*> *list, const char *filename)
-{
-	FILE *fp = fopen(filename, "w");
-	if (fp==NULL) {
-		fprintf(stderr,"Unable to open file %s for reading\n",filename);
-		return;
-	}
+void writeGraspListToFile(std::vector<GraspRecord *> *list, const char *filename) {
+    FILE *fp = fopen(filename, "w");
+    if (fp == NULL) {
+        fprintf(stderr, "Unable to open file %s for reading\n", filename);
+        return;
+    }
 
-	fprintf(fp,"%d\n",(int)list->size());
-	for (int i=0; i<(int)list->size(); i++) {
-		(*list)[i]->writeToFile(fp);
-	}
+    fprintf(fp, "%d\n", (int)list->size());
+    for (int i = 0; i < (int)list->size(); i++) {
+        (*list)[i]->writeToFile(fp);
+    }
 
-	fclose(fp);
+    fclose(fp);
 }

--- a/src/graspitApp.cpp
+++ b/src/graspitApp.cpp
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: graspitApp.cpp,v 1.5 2009/03/30 20:42:02 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Implements GraspItApp, a subclass of QApplication.
+    \brief Implements GraspItApp, a subclass of QApplication.
 */
 
 #include "graspitApp.h"
@@ -38,48 +38,46 @@
 /*! A pointer to the splash screen, implemented as a QLabel. */
 static QLabel *splash = 0;
 
-/*! 
-  Reads the registry to determine the location of the main window, and whether
-  or not to display the splash screen.  If so, it shows the GraspIt! logo
-  splash screen in the center of the screen.
- */
+/*!
+    Reads the registry to determine the location of the main window, and whether
+    or not to display the splash screen.  If so, it shows the GraspIt! logo
+    splash screen in the center of the screen.
+*/
 void
-GraspItApp::showSplash()
-{
+GraspItApp::showSplash() {
     QRect screen = QApplication::desktop()->screenGeometry();
     QSettings config;
-    config.insertSearchPath( QSettings::Windows, "/Columbia" );
+    config.insertSearchPath(QSettings::Windows, "/Columbia");
 
     QRect mainRect;
     QString keybase = "/GraspIt/0.9/";
-    bool show = config.readBoolEntry( keybase + "SplashScreen", TRUE );
-    mainRect.setX( config.readNumEntry( keybase + "Geometries/MainwindowX", 0 ) );
-    mainRect.setY( config.readNumEntry( keybase + "Geometries/MainwindowY", 0 ) );
-    mainRect.setWidth( config.readNumEntry( keybase + "Geometries/MainwindowWidth", 500 ) );
-    mainRect.setHeight( config.readNumEntry( keybase + "Geometries/MainwindowHeight", 500 ) );
-    screen = QApplication::desktop()->screenGeometry( QApplication::desktop()->screenNumber( mainRect.center() ) );
+    bool show = config.readBoolEntry(keybase + "SplashScreen", TRUE);
+    mainRect.setX(config.readNumEntry(keybase + "Geometries/MainwindowX", 0));
+    mainRect.setY(config.readNumEntry(keybase + "Geometries/MainwindowY", 0));
+    mainRect.setWidth(config.readNumEntry(keybase + "Geometries/MainwindowWidth", 500));
+    mainRect.setHeight(config.readNumEntry(keybase + "Geometries/MainwindowHeight", 500));
+    screen = QApplication::desktop()->screenGeometry(QApplication::desktop()->screenNumber(mainRect.center()));
 
-    if ( show ) {
-		splash = new QLabel( 0, "splash",Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
-	// WStyle_Customize | WStyle_StaysOnTop
-	splash->setAttribute(Qt::WA_DeleteOnClose,true);
-	splash->setFrameStyle( QFrame::WinPanel | QFrame::Raised );
-	splash->setPixmap(load_pixmap( "splash.jpg" ));
-	splash->adjustSize();
-	splash->setFixedSize(splash->sizeHint());
-	splash->setCaption( "GraspIt!" );
-	splash->move( screen.center() - QPoint( splash->width() / 2, splash->height() / 2 ) );
-	splash->show();
-	splash->repaint( FALSE );
-	QApplication::flush();
-	//	set_splash_status( "Initializing..." );
+    if (show) {
+        splash = new QLabel(0, "splash", Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
+        // WStyle_Customize | WStyle_StaysOnTop
+        splash->setAttribute(Qt::WA_DeleteOnClose, true);
+        splash->setFrameStyle(QFrame::WinPanel | QFrame::Raised);
+        splash->setPixmap(load_pixmap("splash.jpg"));
+        splash->adjustSize();
+        splash->setFixedSize(splash->sizeHint());
+        splash->setCaption("GraspIt!");
+        splash->move(screen.center() - QPoint(splash->width() / 2, splash->height() / 2));
+        splash->show();
+        splash->repaint(FALSE);
+        QApplication::flush();
+        //  set_splash_status( "Initializing..." );
     }
 }
 
-/*! 
-  Removes the splash screen, freeing its memory.
+/*!
+    Removes the splash screen, freeing its memory.
 */
-void GraspItApp::closeSplash()
-{
+void GraspItApp::closeSplash() {
     if (splash) delete splash;
 }

--- a/src/graspitGUI.cpp
+++ b/src/graspitGUI.cpp
@@ -24,7 +24,7 @@
 //######################################################################
 
 /*! \file
-  \brief Implements the graspit user interface.  Responsible for creating both MainWindow and IVmgr.
+    \brief Implements the graspit user interface.  Responsible for creating both MainWindow and IVmgr.
 */
 
 #include <Q3GroupBox>
@@ -34,7 +34,7 @@
 #include <QLayout>
 
 #ifdef Q_WS_X11
-  #include <unistd.h>
+#include <unistd.h>
 #endif
 
 #include "graspitParser.h"
@@ -58,7 +58,7 @@ bool GraspItGUI::initialized = false;
 int GraspItGUI::initResult = SUCCESS;
 
 // Used by getopt in ProcessArgs
-extern int optind,optopt,opterr;
+extern int optind, optopt, opterr;
 extern char *optarg;
 
 ////////////////////////// SYSTEM WIDE GLOBALS ///////////////////////////////
@@ -73,78 +73,75 @@ GraspItGUI *graspItGUI = 0;
 //////////////////////////////////////////////////////////////////////////////
 
 /*!
-  If this class hasn't been initialized in another instance, it performs
-  the following operations:
-  - creates a new MainWindow,
-  - starts Coin by initializing SoQt,
-  - initializes our Coin add on classes,
-  - creates a new IVmgr,
-  - sets the focus policy of the SoQt viewer so keyboard events are accepted
-  - calls a method to process the command line arguments.
- */
-GraspItGUI::GraspItGUI(int argc,char **argv) : mDispatch(NULL)
-{
-  if (!initialized) {
-    mainWindow = new MainWindow;
-    SoQt::init(mainWindow->mWindow);
-
-    // initialize my Inventor additions
-    SoComplexShape::initClass();
-    SoArrow::initClass();
-    SoTorquePointer::initClass();
-
-    ivmgr = new IVmgr((QWidget *)mainWindow->mUI->viewerHolder,"myivmgr");
-
-//	mainWindow->viewerHolder->setFocusProxy(ivmgr->getViewer()->getWidget());
-//	mainWindow->viewerHolder->setFocusPolicy(QWidget::StrongFocus);
-
-    ivmgr->getViewer()->getWidget()->setFocusPolicy(Qt::StrongFocus);
-
-    initialized = true;
-    graspItGUI = this;
-    mExitCode = 0;
-    initResult = processArgs(argc,argv);
-  }
-}
-
-/*!
-  Deletes both the IVmgr and the MainWindow.
+    If this class hasn't been initialized in another instance, it performs
+    the following operations:
+    - creates a new MainWindow,
+    - starts Coin by initializing SoQt,
+    - initializes our Coin add on classes,
+    - creates a new IVmgr,
+    - sets the focus policy of the SoQt viewer so keyboard events are accepted
+    - calls a method to process the command line arguments.
 */
-GraspItGUI::~GraspItGUI()
-{
-  //originally, ivmgr is first
-//	fprintf(stderr,"Delete children\n");
-//  mainWindow->destroyChildren();
-//  fprintf(stderr,"Delete ivmgr\n");
-  //if a dispatcher was being used, set exit code based on its result
+GraspItGUI::GraspItGUI(int argc, char **argv) : mDispatch(NULL) {
+    if (!initialized) {
+        mainWindow = new MainWindow;
+        SoQt::init(mainWindow->mWindow);
 
-  //clean up plugins and creators
-  stopAllPlugins();
-  for (size_t i=0; i<mPluginCreators.size(); i++) {
-    delete mPluginCreators[i];
-  }
+        // initialize my Inventor additions
+        SoComplexShape::initClass();
+        SoArrow::initClass();
+        SoTorquePointer::initClass();
 
-#ifdef CGDB_ENABLED
-  if (mDispatch) {
-    delete mDispatch;
-  }
-#endif
-  delete ivmgr;
-  delete mainWindow;
+        ivmgr = new IVmgr((QWidget *)mainWindow->mUI->viewerHolder, "myivmgr");
+
+        //  mainWindow->viewerHolder->setFocusProxy(ivmgr->getViewer()->getWidget());
+        //  mainWindow->viewerHolder->setFocusPolicy(QWidget::StrongFocus);
+
+        ivmgr->getViewer()->getWidget()->setFocusPolicy(Qt::StrongFocus);
+
+        initialized = true;
+        graspItGUI = this;
+        mExitCode = 0;
+        initResult = processArgs(argc, argv);
+    }
 }
 
 /*!
-  Processes the command line arguments.  It first checks to make sure the
-  GRASPIT environment variable is set, then if this is run under X11 it
-  examines the command line.  The usage is the following:
-\p graspit \p [-w worldname] \p [-r robotname] \p [-o objectname]
-\p [-b obstaclename]
+    Deletes both the IVmgr and the MainWindow.
+*/
+GraspItGUI::~GraspItGUI() {
+    //originally, ivmgr is first
+    //  fprintf(stderr,"Delete children\n");
+    //  mainWindow->destroyChildren();
+    //  fprintf(stderr,"Delete ivmgr\n");
+    //if a dispatcher was being used, set exit code based on its result
+
+    //clean up plugins and creators
+    stopAllPlugins();
+    for (size_t i = 0; i < mPluginCreators.size(); i++) {
+        delete mPluginCreators[i];
+    }
+
+    #ifdef CGDB_ENABLED
+    if (mDispatch) {
+        delete mDispatch;
+    }
+    #endif
+    delete ivmgr;
+    delete mainWindow;
+}
+
+/*!
+    Processes the command line arguments.  It first checks to make sure the
+    GRASPIT environment variable is set, then if this is run under X11 it
+    examines the command line.  The usage is the following:
+    \p graspit \p [-w worldname] \p [-r robotname] \p [-o objectname]
+    \p [-b obstaclename]
 */
 int
-GraspItGUI::processArgs(int argc, char** argv)
-{
+GraspItGUI::processArgs(int argc, char **argv) {
 
-    int errorFlag=0;
+    int errorFlag = 0;
 
     GraspitParser *graspitParser = new GraspitParser();
     graspitParser->parseArgs(argc, argv);
@@ -152,205 +149,187 @@ GraspItGUI::processArgs(int argc, char** argv)
 
     //Ensure that $GRASPIT is set.
     QString graspitRoot = QString(getenv("GRASPIT"));
-    if (graspitRoot.isNull() ) {
+    if (graspitRoot.isNull()) {
         std::cerr << "Please set the GRASPIT environment variable to the root directory of graspIt." << std::endl;
         return FAILURE;
     }
 
-    if(args->exist("plugin"))
-    {
+    if (args->exist("plugin")) {
         QString plugins_arg_string = QString::fromStdString(args->get<std::string>("plugin"));
         QStringList plugins_list = plugins_arg_string.split(',');
-        for(int i=0; i < plugins_list.size(); i++)
-        {
-            std::cout << "Loading Plugin: "<< plugins_list.at(i).toStdString().c_str();
-            PluginCreator* creator = PluginCreator::loadFromLibrary(plugins_list.at(i).toStdString());
-            if (creator){
-              mPluginCreators.push_back(creator);
-            } else {
-              DBGA("Failed to load plugin: " << plugins_list.at(i).toStdString());
+        for (int i = 0; i < plugins_list.size(); i++) {
+            std::cout << "Loading Plugin: " << plugins_list.at(i).toStdString().c_str();
+            PluginCreator *creator = PluginCreator::loadFromLibrary(plugins_list.at(i).toStdString());
+            if (creator) {
+                mPluginCreators.push_back(creator);
+            }
+            else {
+                DBGA("Failed to load plugin: " << plugins_list.at(i).toStdString());
             }
         }
     }
 
     //start any plugins with auto start enabled
-    mPluginSensor = new SoIdleSensor(GraspItGUI::sensorCB, (void*)this);
-    for (size_t i = 0; i < mPluginCreators.size(); i++)
-    {
+    mPluginSensor = new SoIdleSensor(GraspItGUI::sensorCB, (void *)this);
+    for (size_t i = 0; i < mPluginCreators.size(); i++) {
         std::cout << "plugin creator autostart " << mPluginCreators[i]->autoStart() << std::endl;
-        if (mPluginCreators[i]->autoStart())
-        {
+        if (mPluginCreators[i]->autoStart()) {
             startPlugin(mPluginCreators[i], argc, argv);
         }
     }
 
-  if(argc > 1){
-#ifdef CGDB_ENABLED
-      if(!strcmp(argv[1],"dbase")){
-          DBaseBatchPlanner *dbp = new DBaseBatchPlanner(graspItGUI->getIVmgr(), this);
-          dbp->processArguments(argc, argv);
-          dbp->startPlanner();
-      }
-      if (!strcmp(argv[1],"db_dispatch")) {
-          mDispatch = new TaskDispatcher();
-          if (mDispatch->connect("wgs36",5432,"willow","willow","household_objects")) {
-              std::cerr << "DBase dispatch failed to connect to database\n";
-              return TERMINAL_FAILURE;
-          }
-          std::cerr << "DBase dispatch connected to database\n";
-          mDispatch->mainLoop();
-          if (mDispatch->getStatus() != TaskDispatcher::RUNNING) {
-              mExitCode = mDispatch->getStatus();
-              return TERMINAL_FAILURE;
-          }
-      }
-#endif
-  }
+    if (argc > 1) {
+        #ifdef CGDB_ENABLED
+        if (!strcmp(argv[1], "dbase")) {
+            DBaseBatchPlanner *dbp = new DBaseBatchPlanner(graspItGUI->getIVmgr(), this);
+            dbp->processArguments(argc, argv);
+            dbp->startPlanner();
+        }
+        if (!strcmp(argv[1], "db_dispatch")) {
+            mDispatch = new TaskDispatcher();
+            if (mDispatch->connect("wgs36", 5432, "willow", "willow", "household_objects")) {
+                std::cerr << "DBase dispatch failed to connect to database\n";
+                return TERMINAL_FAILURE;
+            }
+            std::cerr << "DBase dispatch connected to database\n";
+            mDispatch->mainLoop();
+            if (mDispatch->getStatus() != TaskDispatcher::RUNNING) {
+                mExitCode = mDispatch->getStatus();
+                return TERMINAL_FAILURE;
+            }
+        }
+        #endif
+    }
 
-#ifdef Q_WS_X11
+    #ifdef Q_WS_X11
 
-  if (args->exist("world"))
-  {
-      QString filename = graspitRoot + QString("/worlds/") + QString::fromStdString(args->get<std::string>("world")) + QString(".xml");
-      if (ivmgr->getWorld()->load(filename)==FAILURE){
-          ++errorFlag;
-      }
-      else{
-          mainWindow->mUI->worldBox->setTitle(filename);
-      }
-  }
+    if (args->exist("world")) {
+        QString filename = graspitRoot + QString("/worlds/") + QString::fromStdString(args->get<std::string>("world")) + QString(".xml");
+        if (ivmgr->getWorld()->load(filename) == FAILURE) {
+            ++errorFlag;
+        }
+        else {
+            mainWindow->mUI->worldBox->setTitle(filename);
+        }
+    }
 
-  if (args->exist("robot"))
-  {
-      QString filename = graspitRoot +
-              QString("/models/robots/") +
-              QString::fromStdString(args->get<std::string>("robot")) +
-              QString("/")+
-              QString::fromStdString(args->get<std::string>("robot")) +
-              QString(".xml");
-      if (ivmgr->getWorld()->importRobot(filename)==NULL){
-          ++errorFlag;
-      }
-  }
+    if (args->exist("robot")) {
+        QString filename = graspitRoot +
+                           QString("/models/robots/") +
+                           QString::fromStdString(args->get<std::string>("robot")) +
+                           QString("/") +
+                           QString::fromStdString(args->get<std::string>("robot")) +
+                           QString(".xml");
+        if (ivmgr->getWorld()->importRobot(filename) == NULL) {
+            ++errorFlag;
+        }
+    }
 
-  if (args->exist("obstacle"))
-  {
-      QString filename = graspitRoot +
-              QString("/models/obstacles/") +
-              QString::fromStdString(args->get<std::string>("obstacle")) +
-              QString(".iv");
+    if (args->exist("obstacle")) {
+        QString filename = graspitRoot +
+                           QString("/models/obstacles/") +
+                           QString::fromStdString(args->get<std::string>("obstacle")) +
+                           QString(".iv");
 
-      if (!ivmgr->getWorld()->importBody("Body",filename))
-      {
-        ++errorFlag;
-      }
-  }
+        if (!ivmgr->getWorld()->importBody("Body", filename)) {
+            ++errorFlag;
+        }
+    }
 
-  if (args->exist("object"))
-  {
-      QString filename = graspitRoot +
-              QString("/models/objects/") +
-              QString::fromStdString(args->get<std::string>("object")) +
-              QString(".iv");
+    if (args->exist("object")) {
+        QString filename = graspitRoot +
+                           QString("/models/objects/") +
+                           QString::fromStdString(args->get<std::string>("object")) +
+                           QString(".iv");
 
-      if (!ivmgr->getWorld()->importBody("GraspableBody",filename))
-      {
-        ++errorFlag;
-      }
-  }
+        if (!ivmgr->getWorld()->importBody("GraspableBody", filename)) {
+            ++errorFlag;
+        }
+    }
 
-  if (errorFlag)
-  {
-      std::cerr << "Failed to Parse args." << std::endl;
-      return FAILURE;
-  }
+    if (errorFlag) {
+        std::cerr << "Failed to Parse args." << std::endl;
+        return FAILURE;
+    }
 
- #endif // Q_WS_X11
-  return SUCCESS;
+    #endif // Q_WS_X11
+    return SUCCESS;
 }
 
 /*!
-  Shows the mainWindow, sets its size, and starts the Qt event loop.
+    Shows the mainWindow, sets its size, and starts the Qt event loop.
 */
 void
-GraspItGUI::startMainLoop()
-{
-  SoQt::show(mainWindow->mWindow);
-  mainWindow->setMainWorld(ivmgr->getWorld());
-  mainWindow->mWindow->resize(QSize(1070,937));
-  SoQt::mainLoop();
+GraspItGUI::startMainLoop() {
+    SoQt::show(mainWindow->mWindow);
+    mainWindow->setMainWorld(ivmgr->getWorld());
+    mainWindow->mWindow->resize(QSize(1070, 937));
+    SoQt::mainLoop();
 }
 
 /*!
-  Exits the Qt event loop.
+    Exits the Qt event loop.
 */
 void
-GraspItGUI::exitMainLoop()
-{
-  SoQt::exitMainLoop();
+GraspItGUI::exitMainLoop() {
+    SoQt::exitMainLoop();
 }
 
 bool
-GraspItGUI::terminalFailure() const
-{
-  return initResult == TERMINAL_FAILURE;
+GraspItGUI::terminalFailure() const {
+    return initResult == TERMINAL_FAILURE;
 }
 
 void
-GraspItGUI::sensorCB(void*, SoSensor*)
-{
-  graspItGUI->processPlugins();
+GraspItGUI::sensorCB(void *, SoSensor *) {
+    graspItGUI->processPlugins();
 }
 
 void
-GraspItGUI::startPlugin(PluginCreator* creator, int argc, char** argv)
-{
-  Plugin *plugin = creator->createPlugin(argc,argv);
-  if (plugin) mActivePlugins.push_back( std::pair<Plugin*, std::string>(plugin, creator->type()) );
-  if (!mActivePlugins.empty()) {
-    mPluginSensor->schedule();
-  }
-}
-
-void GraspItGUI::processPlugins()
-{
-  std::list< std::pair<Plugin*, std::string> >::iterator it = mActivePlugins.begin();
-  while (it != mActivePlugins.end()) {
-    if (it->first->mainLoop() == SUCCESS) {
-      it++;
-    } else{
-      delete it->first;
-      it = mActivePlugins.erase(it);
+GraspItGUI::startPlugin(PluginCreator *creator, int argc, char **argv) {
+    Plugin *plugin = creator->createPlugin(argc, argv);
+    if (plugin) mActivePlugins.push_back(std::pair<Plugin *, std::string>(plugin, creator->type()));
+    if (!mActivePlugins.empty()) {
+        mPluginSensor->schedule();
     }
-  }
-  if (!mActivePlugins.empty()) {
-    mPluginSensor->schedule();
-  }
 }
 
-void GraspItGUI::stopPlugin(Plugin *plugin)
-{
-  std::list< std::pair<Plugin*, std::string> >::iterator it;
-  for (it = mActivePlugins.begin(); it!=mActivePlugins.end(); it++) {
-    if (it->first == plugin) {
-      delete it->first;
-      mActivePlugins.erase(it);
-      return;
+void GraspItGUI::processPlugins() {
+    std::list< std::pair<Plugin *, std::string> >::iterator it = mActivePlugins.begin();
+    while (it != mActivePlugins.end()) {
+        if (it->first->mainLoop() == SUCCESS) {
+            it++;
+        }
+        else {
+            delete it->first;
+            it = mActivePlugins.erase(it);
+        }
     }
-  }
-  DBGA("Stop plugin: plugin not found");
+    if (!mActivePlugins.empty()) {
+        mPluginSensor->schedule();
+    }
 }
 
-void GraspItGUI::stopAllPlugins()
-{
-  std::list< std::pair<Plugin*, std::string> >::iterator it = mActivePlugins.begin();
-  while (it != mActivePlugins.end()) {
-    delete it->first;
-    it = mActivePlugins.erase(it);
-  }
+void GraspItGUI::stopPlugin(Plugin *plugin) {
+    std::list< std::pair<Plugin *, std::string> >::iterator it;
+    for (it = mActivePlugins.begin(); it != mActivePlugins.end(); it++) {
+        if (it->first == plugin) {
+            delete it->first;
+            mActivePlugins.erase(it);
+            return;
+        }
+    }
+    DBGA("Stop plugin: plugin not found");
 }
 
-World* GraspItGUI::getMainWorld() const
-{
-  return getMainWindow()->getMainWorld();
+void GraspItGUI::stopAllPlugins() {
+    std::list< std::pair<Plugin *, std::string> >::iterator it = mActivePlugins.begin();
+    while (it != mActivePlugins.end()) {
+        delete it->first;
+        it = mActivePlugins.erase(it);
+    }
+}
+
+World *GraspItGUI::getMainWorld() const {
+    return getMainWindow()->getMainWorld();
 }

--- a/src/graspitParser.cpp
+++ b/src/graspitParser.cpp
@@ -1,78 +1,77 @@
 #include "graspitParser.h"
 
 const std::string GraspitParser::version =
-        "GraspIt!\n"
-        "Copyright (C) 2002-2009  Columbia University in the City of New York.\n"
-        "All rights reserved.\n"
-        "\n"
-        "GraspIt! is free software: you can redistribute it and/or modify\n"
-        "it under the terms of the GNU General Public License as published by\n"
-        "the Free Software Foundation, either version 3 of the License, or\n"
-        "(at your option) any later version.\n"
-        "\n"
-        "GraspIt! is distributed in the hope that it will be useful,\n"
-        "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
-        "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
-        "GNU General Public License for more details.\n"
-        "\n"
-        "You should have received a copy of the GNU General Public License\n"
-        "along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.\n";
+    "GraspIt!\n"
+    "Copyright (C) 2002-2009  Columbia University in the City of New York.\n"
+    "All rights reserved.\n"
+    "\n"
+    "GraspIt! is free software: you can redistribute it and/or modify\n"
+    "it under the terms of the GNU General Public License as published by\n"
+    "the Free Software Foundation, either version 3 of the License, or\n"
+    "(at your option) any later version.\n"
+    "\n"
+    "GraspIt! is distributed in the hope that it will be useful,\n"
+    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+    "GNU General Public License for more details.\n"
+    "\n"
+    "You should have received a copy of the GNU General Public License\n"
+    "along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.\n";
 
 const std::string GraspitParser::footer =
-        "\n\n"
-        "Environment Variables:\n"
-        "GRASPIT\n"
-        "\t models, and worlds are loaded relative to this path,\n"
-        "\t normally should be set to directory containing the \n"
-        "\t subfolders worlds and models\n"
-        "GRASPIT_PLUGIN_DIR\n"
-        "\t point to director containined plugin libs, if using ros plugins\n"
-        "\t then normally should be set to my_ros_wkspace/devel/lib\n";
+    "\n\n"
+    "Environment Variables:\n"
+    "GRASPIT\n"
+    "\t models, and worlds are loaded relative to this path,\n"
+    "\t normally should be set to directory containing the \n"
+    "\t subfolders worlds and models\n"
+    "GRASPIT_PLUGIN_DIR\n"
+    "\t point to director containined plugin libs, if using ros plugins\n"
+    "\t then normally should be set to my_ros_wkspace/devel/lib\n";
 
 const std::string GraspitParser::help_help =
-        "Print this message\n";
+    "Print this message\n";
 
 const std::string GraspitParser::plugin_help =
-        "Name of plugin to load, multiple plugins may be loaded"
-        "\n\t\t\t seperated by comma."
-        "\n\t\t\t Ex: graspit -p plugin1,plugin2"
-        "\n\t\t\t would load plugin1 and plugin2"
-        "\n\t\t\t";
+    "Name of plugin to load, multiple plugins may be loaded"
+    "\n\t\t\t seperated by comma."
+    "\n\t\t\t Ex: graspit -p plugin1,plugin2"
+    "\n\t\t\t would load plugin1 and plugin2"
+    "\n\t\t\t";
 
 const std::string GraspitParser::world_help =
-         "World file to load from $GRASPIT/worlds."
-         "\n\t\t\t Ex: --world myworld"
-         "\n\t\t\t would load $GRASPIT/worlds/myworld.xml"
-         "\n\t\t\t";
+    "World file to load from $GRASPIT/worlds."
+    "\n\t\t\t Ex: --world myworld"
+    "\n\t\t\t would load $GRASPIT/worlds/myworld.xml"
+    "\n\t\t\t";
 
 const std::string GraspitParser::object_help =
-        "Name of object to load from $GRASPIT/models/objects/"
-        "\n\t\t\t imported as a GraspableBody"
-        "\n\t\t\t Ex: graspit -o mug"
-        "\n\t\t\t would load $GRASPIT/models/objects/mug.xml"
-        "\n\t\t\t";
+    "Name of object to load from $GRASPIT/models/objects/"
+    "\n\t\t\t imported as a GraspableBody"
+    "\n\t\t\t Ex: graspit -o mug"
+    "\n\t\t\t would load $GRASPIT/models/objects/mug.xml"
+    "\n\t\t\t";
 
 const std::string GraspitParser::obstacle_help =
-        "Name of obstacle to load from $GRASPIT/models/obstacles/,"
-        "\n\t\t\t imported as a Body."
-        "\n\t\t\t Ex: graspit -o table"
-        "\n\t\t\t would load $GRASPIT/models/obstacles/table.xml"
-        "\n\t\t\t";
+    "Name of obstacle to load from $GRASPIT/models/obstacles/,"
+    "\n\t\t\t imported as a Body."
+    "\n\t\t\t Ex: graspit -o table"
+    "\n\t\t\t would load $GRASPIT/models/obstacles/table.xml"
+    "\n\t\t\t";
 
 const std::string GraspitParser::robot_help =
-        "Name of robot to load, from $GRASPIT/models/robots."
-        "\n\t\t\t The robot directory must have an xml file of the same name"
-        "\n\t\t\t as the folder.  For example $GRASPIT/models/robots/Barrett "
-        "\n\t\t\t has a matching Barrett.xml file inside of it."
-        "\n\t\t\t Ex: graspit -r Barrett"
-        "\n\t\t\t would load $GRASPIT/models/robots/Barrett/Barrett.xml"
-        "\n\t\t\t";
+    "Name of robot to load, from $GRASPIT/models/robots."
+    "\n\t\t\t The robot directory must have an xml file of the same name"
+    "\n\t\t\t as the folder.  For example $GRASPIT/models/robots/Barrett "
+    "\n\t\t\t has a matching Barrett.xml file inside of it."
+    "\n\t\t\t Ex: graspit -r Barrett"
+    "\n\t\t\t would load $GRASPIT/models/robots/Barrett/Barrett.xml"
+    "\n\t\t\t";
 
 const std::string GraspitParser::version_help =
-        "print GraspIt! version\n";
+    "print GraspIt! version\n";
 
-GraspitParser::GraspitParser()
-{
+GraspitParser::GraspitParser() {
 
     bool is_required_arg = false;
 
@@ -90,24 +89,20 @@ GraspitParser::GraspitParser()
 
 }
 
-GraspitParser::~GraspitParser()
-{
+GraspitParser::~GraspitParser() {
     delete parser;
 }
 
-cmdline::parser* GraspitParser::parseArgs(int argc, char *argv[])
-{
+cmdline::parser *GraspitParser::parseArgs(int argc, char *argv[]) {
     parser->parse(argc, argv);
 
-    if(parser->exist("help"))
-    {
-            std::cerr << parser->usage();
-            exit(0);
+    if (parser->exist("help")) {
+        std::cerr << parser->usage();
+        exit(0);
     }
-    if(parser->exist("version"))
-    {
-            std::cerr << version << std::endl;
-            exit(0);
+    if (parser->exist("version")) {
+        std::cerr << version << std::endl;
+        exit(0);
     }
 
     return  parser;

--- a/src/graspitServer.cpp
+++ b/src/graspitServer.cpp
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: graspitServer.cpp,v 1.7 2009/03/25 22:10:04 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Implements the application's TCP server.
- */
+/*! \file
+    \brief Implements the application's TCP server.
+*/
 
 #include <QTextStream>
 #include <iostream>
@@ -38,619 +38,609 @@
 #include "contact.h"
 
 /*!
-  Stub destructor.
+    Stub destructor.
 */
-ClientSocket::~ClientSocket()
-{
-#ifdef GRASPITDBG
-  std::cout << "client socket destroyed"<<std::endl;
-#endif
+ClientSocket::~ClientSocket() {
+    #ifdef GRASPITDBG
+    std::cout << "client socket destroyed" << std::endl;
+    #endif
 }
 
 /*!
-  This reads the next portion of a command line after the command to collect
-  the body indices, and returns a vector of pointers to those bodies.  If
-  this portion starts with the word "ALL", then all the bodies in the world
-  are added to the body vector.  Otherwise it reads the number of body
-  indices, and reads each index in turn, adding the corresponding body
-  pointer to the vector.  If an index is read that does not exist, an error
-  message is sent back and this method returns FAILURE.
+    This reads the next portion of a command line after the command to collect
+    the body indices, and returns a vector of pointers to those bodies.  If
+    this portion starts with the word "ALL", then all the bodies in the world
+    are added to the body vector.  Otherwise it reads the number of body
+    indices, and reads each index in turn, adding the corresponding body
+    pointer to the vector.  If an index is read that does not exist, an error
+    message is sent back and this method returns FAILURE.
 */
 int
-ClientSocket::readBodyIndList(std::vector<Body *> &bodyVec)
-{
-  QTextStream os(this);
-  int i,numBodies,bodNum;
-  bool ok;
-  World *world = graspItGUI->getIVmgr()->getWorld();
-  std::cout << "ReadBodyIndList Line:"<<line.latin1() << std::endl;
+ClientSocket::readBodyIndList(std::vector<Body *> &bodyVec) {
+    QTextStream os(this);
+    int i, numBodies, bodNum;
+    bool ok;
+    World *world = graspItGUI->getIVmgr()->getWorld();
+    std::cout << "ReadBodyIndList Line:" << line.latin1() << std::endl;
 
-  /* if the index list is empty, use every body and send
-     back the count
-  */
+    /*  if the index list is empty, use every body and send
+        back the count
+    */
 
-  if (strPtr == lineStrList.end()) return FAILURE;
+    if (strPtr == lineStrList.end()) return FAILURE;
 
-  if ((*strPtr).startsWith("ALL")) {
+    if ((*strPtr).startsWith("ALL")) {
+        strPtr++;
+        for (i = 0; i < world->getNumBodies(); i++)
+            bodyVec.push_back(world->getBody(i));
+        std::cout << "Sending num bodies: " << world->getNumBodies() << std::endl;
+        os << world->getNumBodies() << endl;
+        return SUCCESS;
+    }
+
+    numBodies = (*strPtr).toInt(&ok);
+    if (!ok) return FAILURE;
     strPtr++;
-    for (i=0;i<world->getNumBodies();i++)
-      bodyVec.push_back(world->getBody(i));
-    std::cout << "Sending num bodies: "<<world->getNumBodies()<<std::endl;
-    os << world->getNumBodies() << endl;
+
+    for (i = 0; i < numBodies; i++) {
+        if (strPtr == lineStrList.end()) return FAILURE;
+        bodNum = (*strPtr).toInt(&ok);
+        if (!ok) return FAILURE;
+
+        if (bodNum >= 0 && bodNum < world->getNumBodies()) {
+            bodyVec.push_back(world->getBody(bodNum));
+            if (world->getBody(bodNum) == NULL) {
+                os << "Error: Cannot find body " << bodNum << "\n";
+                return FAILURE;
+            }
+        }
+        else {
+            os << "Error: Cannot find body " << bodNum << "\n";
+            return FAILURE;
+        }
+        strPtr++;
+    }
     return SUCCESS;
-  }
-  
-  numBodies = (*strPtr).toInt(&ok);
-  if (!ok) return FAILURE;
-  strPtr++;
-  
-  for (i=0;i<numBodies;i++) {
-    if (strPtr == lineStrList.end()) return FAILURE;
-    bodNum = (*strPtr).toInt(&ok);
-    if (!ok) return FAILURE;
-    
-    if (bodNum>=0 && bodNum<world->getNumBodies()) {
-      bodyVec.push_back(world->getBody(bodNum));
-      if (world->getBody(bodNum)==NULL) {
-	os << "Error: Cannot find body " << bodNum <<"\n";
-        return FAILURE;
-      }
-    }
-    else {
-      os << "Error: Cannot find body " << bodNum <<"\n";
-      return FAILURE;
-    }
-    strPtr++;
-  }
-  return SUCCESS;
 }
 
 
 /*!
-  This reads the next portion of a command line after the command to collect
-  the robot indices, and returns a vector of pointers to those robots.  If
-  this portion starts with the word "ALL", then all the robots in the world
-  are added to the robot vector.  Otherwise it reads the number of robot
-  indices, and reads each index in turn, adding the corresponding robot
-  pointer to the vector.  If an index is read that does not exist, an error
-  message is sent back and this method returns FAILURE.
+    This reads the next portion of a command line after the command to collect
+    the robot indices, and returns a vector of pointers to those robots.  If
+    this portion starts with the word "ALL", then all the robots in the world
+    are added to the robot vector.  Otherwise it reads the number of robot
+    indices, and reads each index in turn, adding the corresponding robot
+    pointer to the vector.  If an index is read that does not exist, an error
+    message is sent back and this method returns FAILURE.
 */
 int
-ClientSocket::readRobotIndList(std::vector<Robot *> &robVec)
-{
-  QTextStream os(this);
-  int i,robNum,numRobots;
-  bool ok;
-  World *world = graspItGUI->getIVmgr()->getWorld();
-  std::cout << "ReadRobotIndList Line:"<<line.latin1() << std::endl;
+ClientSocket::readRobotIndList(std::vector<Robot *> &robVec) {
+    QTextStream os(this);
+    int i, robNum, numRobots;
+    bool ok;
+    World *world = graspItGUI->getIVmgr()->getWorld();
+    std::cout << "ReadRobotIndList Line:" << line.latin1() << std::endl;
 
-  /* if the index list is empty, use every robot and send
-     back the count
-  */
-  if (strPtr == lineStrList.end()) return FAILURE;
+    /*  if the index list is empty, use every robot and send
+        back the count
+    */
+    if (strPtr == lineStrList.end()) return FAILURE;
 
-  if ((*strPtr).startsWith("ALL")) {
+    if ((*strPtr).startsWith("ALL")) {
+        strPtr++;
+        for (i = 0; i < world->getNumRobots(); i++)
+            robVec.push_back(world->getRobot(i));
+        std::cout << "Sending num robots: " << world->getNumRobots() << std::endl;
+        os << world->getNumRobots() << endl;
+        return SUCCESS;
+    }
+
+    numRobots = (*strPtr).toInt(&ok);
+    if (!ok) return FAILURE;
     strPtr++;
-    for (i=0;i<world->getNumRobots();i++)
-      robVec.push_back(world->getRobot(i));
-    std::cout << "Sending num robots: "<<world->getNumRobots()<<std::endl;
-    os << world->getNumRobots() << endl;
+
+    for (i = 0; i < numRobots; i++) {
+        if (strPtr == lineStrList.end()) return FAILURE;
+        robNum = (*strPtr).toInt(&ok);
+        if (!ok) return FAILURE;
+
+        if (robNum >= 0 && robNum < world->getNumRobots()) {
+            robVec.push_back(world->getRobot(robNum));
+            if (world->getRobot(robNum) == NULL) {
+                os << "Error: Cannot find robot " << robNum << "\n";
+                return FAILURE;
+            }
+        }
+        else {
+            os << "Error: Cannot find robot " << robNum << "\n";
+            return FAILURE;
+        }
+        strPtr++;
+    }
     return SUCCESS;
-  }
-  
-  numRobots = (*strPtr).toInt(&ok);
-  if (!ok) return FAILURE;
-  strPtr++;
-  
-  for (i=0;i<numRobots;i++) {
-    if (strPtr == lineStrList.end()) return FAILURE;
-    robNum = (*strPtr).toInt(&ok);
-    if (!ok) return FAILURE;
-    
-    if (robNum>=0 && robNum<world->getNumRobots()) {
-      robVec.push_back(world->getRobot(robNum));
-      if (world->getRobot(robNum)==NULL) {
-	os << "Error: Cannot find robot " << robNum <<"\n";
+}
+
+/*!
+    This is the main routine for parsing input on the clientSocket.
+    There should be one command for each line of input.  This reads one
+    line, and looks at the first word (up to the first space character) to
+    determine the command.   Then if there are body or robot indices to read,
+    it calls a support routine to read those and return a vector of bodies or
+    robots.  These are then passed to the appropriate routine to carry out the
+    action and write out any necessary results.
+*/
+void
+ClientSocket::readClient() {
+    int i, numData, numBodies, numRobots;
+    double time;
+    std::vector<Body *> bodyVec;
+    std::vector<Robot *> robVec;
+
+    bool ok;
+
+    while (canReadLine()) {
+        line = readLine();
+        line.truncate(line.length() - 1); //strip newline character
+        lineStrList =
+            QStringList::split(' ', line);
+        strPtr = lineStrList.begin();
+
+        #ifdef GRASPITDBG
+        std::cout << "Command parser line: " << line << std::endl;
+        #endif
+
+        if (*strPtr == "getContacts") {
+            strPtr++;
+            if (strPtr == lineStrList.end()) continue;
+            numData = (*strPtr).toInt(&ok);
+            strPtr++;
+            if (!ok) continue;
+
+            #ifdef GRASPITDBG
+            std::cout << "Num data: " << numData << std::endl;
+            #endif
+
+            if (readBodyIndList(bodyVec)) continue;
+            numBodies = bodyVec.size();
+            for (i = 0; i < numBodies; i++)
+                sendContacts(bodyVec[i], numData);
+        }
+
+        else if (*strPtr == "getAverageContacts") {
+            strPtr++;
+            if (readBodyIndList(bodyVec)) continue;
+            numBodies = bodyVec.size();
+            for (i = 0; i < numBodies; i++)
+                sendAverageContacts(bodyVec[i]);
+        }
+
+        else if (*strPtr == "getBodyName") {
+            strPtr++;
+            if (readBodyIndList(bodyVec)) continue;
+            numBodies = bodyVec.size();
+            for (i = 0; i < numBodies; i++)
+                sendBodyName(bodyVec[i]);
+        }
+
+        else if (*strPtr == "getRobotName") {
+            strPtr++;
+            if (readRobotIndList(robVec)) continue;
+            numRobots = robVec.size();
+            for (i = 0; i < numRobots; i++)
+                sendRobotName(robVec[i]);
+        }
+
+        else if (*strPtr == "getDOFVals") {
+            strPtr++;
+            if (readRobotIndList(robVec)) continue;
+            numRobots = robVec.size();
+            for (i = 0; i < numRobots; i++)
+                sendDOFVals(robVec[i]);
+        }
+
+        else if (*strPtr == "moveDOFs") {
+            strPtr++;
+            readDOFVals();
+        }
+
+        else if (*strPtr == "render")
+            graspItGUI->getIVmgr()->getViewer()->render();
+
+        else if (*strPtr == "setDOFForces") {
+            strPtr++;
+            if (readRobotIndList(robVec)) continue;
+            numRobots = robVec.size();
+            for (i = 0; i < numRobots; i++)
+                if (readDOFForces(robVec[i]) == FAILURE) continue;
+        }
+        else if (*strPtr == "moveToContacts")
+            graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->approachToContact(30, true);
+
+        else if ((*strPtr) == "moveDynamicBodies") {
+            strPtr++;
+            if (strPtr == lineStrList.end()) ok = FALSE;
+            else {
+                time = (*strPtr).toDouble(&ok);
+                strPtr++;
+            }
+            if (!ok)
+                moveDynamicBodies(-1);
+            else
+                moveDynamicBodies(time);
+        }
+
+        else if (*strPtr == "computeNewVelocities") {
+
+            #ifdef GRASPITDBG
+            std::cout << "cnv" << std::endl;
+            #endif
+
+            strPtr++;
+            if (strPtr == lineStrList.end()) continue;
+            time = (*strPtr).toDouble(&ok);
+            strPtr++;
+            if (!ok) continue;
+
+            #ifdef GRASPITDBG
+            std::cout << time << std::endl;
+            #endif
+            computeNewVelocities(time);
+        }
+
+    }
+}
+
+/*!
+    Given a pointer to a body, this examines all the contacts on that body and
+    finds the average wrench acting on the body through those contacts and the
+    average contact location in body coordinates.  This is written to the
+    socket on 2 separate lines.
+*/
+void
+ClientSocket::sendAverageContacts(Body *bod) {
+    QTextStream os(this);
+    std::list<Contact *> contactList;
+    std::list<Contact *>::iterator cp;
+    int i, numContacts;
+    double totalWrench[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    double *wrench;
+    vec3 totalLoc = vec3::ZERO;
+
+    numContacts = bod->getNumContacts();
+    contactList = bod->getContacts();
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        wrench = (*cp)->getDynamicContactWrench();
+        for (i = 0; i < 6; i++) totalWrench[i] += wrench[i];
+        totalLoc += (*cp)->getContactFrame().translation();
+    }
+
+    if (numContacts > 1) {
+        for (i = 0; i < 6; i++) totalWrench[i] /= numContacts;
+        totalLoc = totalLoc / numContacts;
+    }
+
+    os << totalWrench[0] << " " << totalWrench[1] << " " << totalWrench[2] <<
+       " " << totalWrench[3] << " " << totalWrench[4] << " " << totalWrench[5] << "\n";
+    os << totalLoc[0] << " " << totalLoc[1] << " " << totalLoc[2] << "\n";
+
+}
+
+/*!
+    Given a pointer to a body, this writes the name of the body and a newline
+    to the socket.
+*/
+void
+ClientSocket::sendBodyName(Body *bod) {
+    QTextStream os(this);
+    std::cout << "sending " << bod->getName().latin1() << "\n";
+    os << bod->getName().latin1() << "\n";
+}
+
+/*!
+    Given a pointer to a robot, this writes the name of the robot and a newline
+    to the socket.
+*/
+void
+ClientSocket::sendRobotName(Robot *rob) {
+    QTextStream os(this);
+    std::cout << "sending " << rob->getName().latin1() << "\n";
+    os << rob->getName().latin1() << "\n";
+}
+
+/*!
+    Given a pointer to a body, this first writes a line containing the number
+    of contacts on the body.  Then it writes \a numData lines for each contact.
+    The first line contains the 6 numbers of the contact wrench.  The next line
+    (if required) contains the 3 numbers specifying the contact location in
+    body coordinates, and the last line (if required) contains the scalar
+    constraint error for that contact.
+*/
+void
+ClientSocket::sendContacts(Body *bod, int numData) {
+    QTextStream os(this);
+    std::list<Contact *> contactList;
+    std::list<Contact *>::iterator cp;
+    vec3 loc;
+    double err;
+    double *wrench;
+
+    #ifdef GRASPITDBG
+    std::cout << "sending numContacts: " << bod->getNumContacts() << std::endl;
+    #endif
+
+    os << bod->getNumContacts() << "\n";
+
+    contactList = bod->getContacts();
+    for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+        wrench = (*cp)->getDynamicContactWrench();
+        loc = (*cp)->getContactFrame().translation();
+        err = (*cp)->getConstraintError();
+
+        os << wrench[0] << " " << wrench[1] << " " << wrench[2] << " " << wrench[3] << " " <<
+           wrench[4] << " " << wrench[5] << "\n";
+        if (numData > 1)
+            os << loc[0] << " " << loc[1] << " " << loc[2] << "\n";
+        if (numData > 2)
+            os << err << "\n";
+    }
+}
+
+/*!
+    Given a pointer to robot, this first writes a line to the socket containing
+    the number of %DOF's in the robot, then for each %DOF, it writes a line
+    containting the current value of that %DOF.
+*/
+void
+ClientSocket::sendDOFVals(Robot *rob) {
+    QTextStream os(this);
+    int i;
+
+    os << rob->getNumDOF() << "\n";
+    for (i = 0; i < rob->getNumDOF(); i++)
+        os << rob->getDOF(i)->getVal() << "\n";
+}
+
+/*!
+    After the readDOFVals command was read by readClient, this expects to
+    read a valid robot index, then the correct number of %DOF's for this robot,
+    then a desired value for each %DOF, and finally a value for each DOF to step
+    by during the move.  It performs the %DOF moves, finds the new contacts,
+    updates the grasp, and then it sends one line for each %DOF containing
+    the actual value for the %DOF after the move.
+*/
+int
+ClientSocket::readDOFVals() {
+    Robot *rob;
+    double *val, *stepby;
+    QTextStream os(this);
+    int numDOF, i, robNum;
+    bool ok = TRUE;
+
+    #ifdef GRASPITDBG
+    std::cout << "in read dof vals" << std::endl;
+    #endif
+
+    if (strPtr == lineStrList.end()) ok = FALSE;
+    if (ok) robNum = (*strPtr).toInt(&ok);
+
+    if (!ok || robNum < 0 ||
+            robNum >= graspItGUI->getIVmgr()->getWorld()->getNumRobots()) {
+        os << "Error: Robot does not exist.\n";
         return FAILURE;
-      }
     }
-    else {
-      os << "Error: Cannot find robot " << robNum <<"\n";
-      return FAILURE;
-    }
+    rob = graspItGUI->getIVmgr()->getWorld()->getRobot(robNum);
+
+    #ifdef GRASPITDBG
+    std::cout << "robnum: " << robNum << std::endl;
+    #endif
+
     strPtr++;
-  }
-  return SUCCESS;
-}
-
-/*!
-  This is the main routine for parsing input on the clientSocket.
-  There should be one command for each line of input.  This reads one
-  line, and looks at the first word (up to the first space character) to
-  determine the command.   Then if there are body or robot indices to read,
-  it calls a support routine to read those and return a vector of bodies or
-  robots.  These are then passed to the appropriate routine to carry out the
-  action and write out any necessary results.
-*/
-void
-ClientSocket::readClient()
-{
-  int i,numData,numBodies,numRobots;
-  double time;
-  std::vector<Body *> bodyVec;
-  std::vector<Robot *> robVec;
-
-  bool ok;
-
-  while ( canReadLine() ) {
-    line = readLine();
-    line.truncate(line.length()-1); //strip newline character
-    lineStrList =
-      QStringList::split(' ',line);
-    strPtr = lineStrList.begin();
-
-#ifdef GRASPITDBG
-    std::cout <<"Command parser line: "<<line << std::endl;
-#endif
-    
-    if (*strPtr == "getContacts") {
-      strPtr++; if (strPtr == lineStrList.end()) continue;
-      numData = (*strPtr).toInt(&ok); strPtr++;
-      if (!ok) continue;
-
-#ifdef GRASPITDBG
-      std::cout << "Num data: "<<numData<<std::endl;
-#endif
-
-      if (readBodyIndList(bodyVec)) continue;
-      numBodies = bodyVec.size();
-      for (i=0;i<numBodies;i++)
-        sendContacts(bodyVec[i],numData);
-    }
-    
-    else if (*strPtr == "getAverageContacts") {
-      strPtr++;
-      if (readBodyIndList(bodyVec)) continue;
-      numBodies = bodyVec.size();
-      for (i=0;i<numBodies;i++)
-	sendAverageContacts(bodyVec[i]);
-    }
-    
-    else if (*strPtr == "getBodyName") {
-      strPtr++;
-      if (readBodyIndList(bodyVec)) continue;
-      numBodies = bodyVec.size();
-      for (i=0;i<numBodies;i++)
-	sendBodyName(bodyVec[i]);
-    }
-    
-    else if (*strPtr == "getRobotName") {
-      strPtr++;
-      if (readRobotIndList(robVec)) continue;
-      numRobots = robVec.size();
-      for (i=0;i<numRobots;i++)
-	sendRobotName(robVec[i]);
-    }
-    
-    else if (*strPtr == "getDOFVals") {
-      strPtr++;
-      if (readRobotIndList(robVec)) continue;
-      numRobots = robVec.size();
-      for (i=0;i<numRobots;i++)
-	sendDOFVals(robVec[i]);
-    }
-    
-    else if (*strPtr == "moveDOFs") {
-      strPtr++;
-      readDOFVals();
-    }
-    
-    else if (*strPtr == "render")
-      graspItGUI->getIVmgr()->getViewer()->render();
-    
-    else if (*strPtr == "setDOFForces") {
-      strPtr++;
-      if (readRobotIndList(robVec)) continue;
-      numRobots = robVec.size();
-      for (i=0;i<numRobots;i++)
-	if (readDOFForces(robVec[i])==FAILURE) continue;
-    }
-    else if (*strPtr == "moveToContacts")
-      graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->approachToContact(30, true);
- 
-    else if ((*strPtr) == "moveDynamicBodies") {
-      strPtr++;
-      if (strPtr == lineStrList.end()) ok = FALSE;
-      else {
-	time = (*strPtr).toDouble(&ok); strPtr++;
-      }
-      if (!ok)
-	moveDynamicBodies(-1);
-      else
-	moveDynamicBodies(time);
-    }
-    
-    else if (*strPtr == "computeNewVelocities") {
-
-#ifdef GRASPITDBG
-      std::cout << "cnv" << std::endl;
-#endif
-
-      strPtr++; if (strPtr == lineStrList.end()) continue;
-      time = (*strPtr).toDouble(&ok); strPtr++;
-      if (!ok) continue;
-
-#ifdef GRASPITDBG
-      std::cout << time <<std::endl;
-#endif
-      computeNewVelocities(time);
-    }
-    
-  }
-}
-
-/*!
-  Given a pointer to a body, this examines all the contacts on that body and
-  finds the average wrench acting on the body through those contacts and the
-  average contact location in body coordinates.  This is written to the
-  socket on 2 separate lines.
-*/
-void
-ClientSocket::sendAverageContacts(Body* bod)
-{
-  QTextStream os(this);
-  std::list<Contact *> contactList;
-  std::list<Contact *>::iterator cp;
-  int i,numContacts;
-  double totalWrench[6]={0.0,0.0,0.0,0.0,0.0,0.0};
-  double *wrench;
-  vec3 totalLoc = vec3::ZERO;
-
-  numContacts = bod->getNumContacts();
-  contactList = bod->getContacts();
-  for (cp=contactList.begin();cp!=contactList.end();cp++) {
-    wrench = (*cp)->getDynamicContactWrench();
-    for (i=0;i<6;i++) totalWrench[i] += wrench[i];
-    totalLoc += (*cp)->getContactFrame().translation();
-  }
-
-  if (numContacts>1) {
-    for (i=0;i<6;i++) totalWrench[i] /= numContacts;
-    totalLoc = totalLoc / numContacts;
-  }
-
-  os << totalWrench[0]<<" "<<totalWrench[1]<<" "<<totalWrench[2]<<
-    " "<<totalWrench[3]<<" "<<totalWrench[4]<<" "<<totalWrench[5]<<"\n";
-  os << totalLoc[0] << " "<<totalLoc[1] << " " <<totalLoc[2]<<"\n";
-
-}
-
-/*!
-  Given a pointer to a body, this writes the name of the body and a newline
-  to the socket.
-*/
-void
-ClientSocket::sendBodyName(Body* bod)
-{
-  QTextStream os(this);
-  std::cout << "sending " << bod->getName().latin1() << "\n";
-  os << bod->getName().latin1() << "\n";
-}
-
-/*!
-  Given a pointer to a robot, this writes the name of the robot and a newline
-  to the socket.
-*/
-void
-ClientSocket::sendRobotName(Robot* rob)
-{
-  QTextStream os(this);
-  std::cout << "sending " << rob->getName().latin1() << "\n";
-  os << rob->getName().latin1() << "\n";
-}
-
-/*!
-  Given a pointer to a body, this first writes a line containing the number
-  of contacts on the body.  Then it writes \a numData lines for each contact.
-  The first line contains the 6 numbers of the contact wrench.  The next line
-  (if required) contains the 3 numbers specifying the contact location in
-  body coordinates, and the last line (if required) contains the scalar
-  constraint error for that contact.
-*/
-void
-ClientSocket::sendContacts(Body *bod,int numData)
-{
-  QTextStream os(this);
-  std::list<Contact *> contactList;
-  std::list<Contact *>::iterator cp;
-  vec3 loc;
-  double err;
-  double *wrench;
-
-#ifdef GRASPITDBG
-  std::cout << "sending numContacts: "<<bod->getNumContacts()<<std::endl;
-#endif
-
-  os << bod->getNumContacts()<<"\n";
-
-  contactList = bod->getContacts();
-  for (cp=contactList.begin();cp!=contactList.end();cp++) {
-	wrench = (*cp)->getDynamicContactWrench();
-	loc = (*cp)->getContactFrame().translation();
-	err = (*cp)->getConstraintError();
-
-    os << wrench[0]<<" "<<wrench[1]<<" "<<wrench[2]<<" "<<wrench[3]<<" "<<
-      wrench[4]<<" "<<wrench[5]<<"\n";
-	if (numData > 1) 
-	  os << loc[0] << " "<< loc[1] << " " << loc[2]<<"\n";
-	if (numData > 2)
-	  os << err << "\n";
-  }
-}
-
-/*!
-  Given a pointer to robot, this first writes a line to the socket containing
-  the number of %DOF's in the robot, then for each %DOF, it writes a line
-  containting the current value of that %DOF.
-*/
-void
-ClientSocket::sendDOFVals(Robot *rob)
-{
-  QTextStream os(this);
-  int i;
-
-  os << rob->getNumDOF() << "\n";
-  for (i=0;i<rob->getNumDOF();i++)
-    os << rob->getDOF(i)->getVal() << "\n";
-}
-
-/*!
-  After the readDOFVals command was read by readClient, this expects to
-  read a valid robot index, then the correct number of %DOF's for this robot,
-  then a desired value for each %DOF, and finally a value for each DOF to step
-  by during the move.  It performs the %DOF moves, finds the new contacts,
-  updates the grasp, and then it sends one line for each %DOF containing
-  the actual value for the %DOF after the move.
-*/
-int
-ClientSocket::readDOFVals()
-{
-  Robot *rob;
-  double *val,*stepby;
-  QTextStream os(this);
-  int numDOF,i,robNum;
-  bool ok=TRUE;
-
-#ifdef GRASPITDBG
-  std::cout << "in read dof vals"<<std::endl;
-#endif
-
-  if (strPtr == lineStrList.end()) ok=FALSE;
-  if (ok) robNum = (*strPtr).toInt(&ok);
-
-  if (!ok || robNum < 0 ||
-    robNum >= graspItGUI->getIVmgr()->getWorld()->getNumRobots()) {
-	os <<"Error: Robot does not exist.\n";
-    return FAILURE;
-  }
-  rob = graspItGUI->getIVmgr()->getWorld()->getRobot(robNum);
-
-#ifdef GRASPITDBG
-  std::cout << "robnum: "<<robNum<<std::endl;
-#endif
-
-  strPtr++;
-  if (strPtr == lineStrList.end()) return FAILURE;
-
-  numDOF=(*strPtr).toInt(&ok);
-  if (!ok) return FAILURE;
-  strPtr++;
-
-#ifdef GRASPITDBG
-  std::cout << "read robot has: "<< numDOF << " DOF?"<<std::endl;
-#endif
-
-  if (numDOF < 1) {
-
-#ifdef GRASPITDBG
-	std::cout << "numDOF was zero."<<std::endl;
-#endif
-	return FAILURE;
-  }
-  if (numDOF != rob->getNumDOF()) {
-    os <<"Error: robot has " << rob->getNumDOF() <<" DOF."<<endl;
-	return FAILURE;
-  }
-
-  val = new double[numDOF];
-  stepby = new double[numDOF];
-
-  for (i=0;i<rob->getNumDOF();i++) {
-	if (strPtr == lineStrList.end()) return FAILURE;
-	val[i] = (*strPtr).toDouble(&ok);
-	if (!ok) return FAILURE;
-	strPtr++;
-#ifdef GRASPITDBG
-	std::cout<<val[i]<<" ";
-#endif
-  }
-
-#ifdef GRASPITDBG
-  std::cout<<std::endl;
-#endif
-
-  for (i=0;i<rob->getNumDOF();i++) {
     if (strPtr == lineStrList.end()) return FAILURE;
-	stepby[i] = (*strPtr).toDouble(&ok);
-	if (!ok) return FAILURE;
-	strPtr++;
-  }
 
-  rob->moveDOFToContacts(val,stepby,true);
-
-  // these should be separate commands
-  graspItGUI->getIVmgr()->getWorld()->findAllContacts();
-  graspItGUI->getIVmgr()->getWorld()->updateGrasps();
-
-  for (i=0;i<rob->getNumDOF();i++) {
-    os << rob->getDOF(i)->getVal() << "\n";
-
-#ifdef GRASPITDBG
-    std::cout << "Sending: "<< rob->getDOF(i)->getVal() << "\n";
-#endif
-  }
-  delete [] val;
-  delete [] stepby;
-  return SUCCESS;
-}
-
-/*!
-  After the readDOFForces command was read by readClient, this expects to
-  the correct number of %DOF's for this robot, and then a desired force for
-  each %DOF.  It sets each %DOF force and sends a line for each containing
-  the current force.
-*/
-int
-ClientSocket::readDOFForces(Robot *rob)
-{
-  double val;
-  bool ok;
- // QTextStream is(this);
-  QTextStream os(this);
-  int numDOF,i;
-
-  if (strPtr == lineStrList.end()) return FAILURE;
- 
-  numDOF=(*strPtr).toInt(&ok);
-  if (!ok) return FAILURE;
-  strPtr++;
-
-#ifdef GRASPITDBG
-  std::cout << "read robot has: "<< numDOF << " DOF?"<<std::endl;
-#endif
-
-  if (numDOF < 1) {
-#ifdef GRASPITDBG
-    std::cout << "numDOF was zero."<<std::endl;
-#endif
-    return FAILURE;
-  }
-  
-  if (numDOF != rob->getNumDOF()) {
-    os <<"Error: robot has " << rob->getNumDOF() <<" DOF."<<endl;
-    return FAILURE;
-  }
-  
-  for (i=0;i<rob->getNumDOF();i++) {
-    if (strPtr == lineStrList.end()) return FAILURE;
-    val = (*strPtr).toDouble(&ok);
+    numDOF = (*strPtr).toInt(&ok);
     if (!ok) return FAILURE;
     strPtr++;
-    rob->getDOF(i)->setForce(val);
-    
-#ifdef GRASPITDBG
-    std::cout<<val<<" ";
-#endif
-  }
-  
-#ifdef GRASPITDBG
-  std::cout<<std::endl;
-#endif
-  
-  for (i=0;i<rob->getNumDOF();i++) {
-    os << rob->getDOF(i)->getForce() << "\n";
-    
-#ifdef GRASPITDBG
-    std::cout << "Sending: "<< rob->getDOF(i)->getForce() << "\n";
-#endif
-  }
-  return SUCCESS;
+
+    #ifdef GRASPITDBG
+    std::cout << "read robot has: " << numDOF << " DOF?" << std::endl;
+    #endif
+
+    if (numDOF < 1) {
+
+        #ifdef GRASPITDBG
+        std::cout << "numDOF was zero." << std::endl;
+        #endif
+        return FAILURE;
+    }
+    if (numDOF != rob->getNumDOF()) {
+        os << "Error: robot has " << rob->getNumDOF() << " DOF." << endl;
+        return FAILURE;
+    }
+
+    val = new double[numDOF];
+    stepby = new double[numDOF];
+
+    for (i = 0; i < rob->getNumDOF(); i++) {
+        if (strPtr == lineStrList.end()) return FAILURE;
+        val[i] = (*strPtr).toDouble(&ok);
+        if (!ok) return FAILURE;
+        strPtr++;
+        #ifdef GRASPITDBG
+        std::cout << val[i] << " ";
+        #endif
+    }
+
+    #ifdef GRASPITDBG
+    std::cout << std::endl;
+    #endif
+
+    for (i = 0; i < rob->getNumDOF(); i++) {
+        if (strPtr == lineStrList.end()) return FAILURE;
+        stepby[i] = (*strPtr).toDouble(&ok);
+        if (!ok) return FAILURE;
+        strPtr++;
+    }
+
+    rob->moveDOFToContacts(val, stepby, true);
+
+    // these should be separate commands
+    graspItGUI->getIVmgr()->getWorld()->findAllContacts();
+    graspItGUI->getIVmgr()->getWorld()->updateGrasps();
+
+    for (i = 0; i < rob->getNumDOF(); i++) {
+        os << rob->getDOF(i)->getVal() << "\n";
+
+        #ifdef GRASPITDBG
+        std::cout << "Sending: " << rob->getDOF(i)->getVal() << "\n";
+        #endif
+    }
+    delete [] val;
+    delete [] stepby;
+    return SUCCESS;
+}
+
+/*!
+    After the readDOFForces command was read by readClient, this expects to
+    the correct number of %DOF's for this robot, and then a desired force for
+    each %DOF.  It sets each %DOF force and sends a line for each containing
+    the current force.
+*/
+int
+ClientSocket::readDOFForces(Robot *rob) {
+    double val;
+    bool ok;
+    // QTextStream is(this);
+    QTextStream os(this);
+    int numDOF, i;
+
+    if (strPtr == lineStrList.end()) return FAILURE;
+
+    numDOF = (*strPtr).toInt(&ok);
+    if (!ok) return FAILURE;
+    strPtr++;
+
+    #ifdef GRASPITDBG
+    std::cout << "read robot has: " << numDOF << " DOF?" << std::endl;
+    #endif
+
+    if (numDOF < 1) {
+        #ifdef GRASPITDBG
+        std::cout << "numDOF was zero." << std::endl;
+        #endif
+        return FAILURE;
+    }
+
+    if (numDOF != rob->getNumDOF()) {
+        os << "Error: robot has " << rob->getNumDOF() << " DOF." << endl;
+        return FAILURE;
+    }
+
+    for (i = 0; i < rob->getNumDOF(); i++) {
+        if (strPtr == lineStrList.end()) return FAILURE;
+        val = (*strPtr).toDouble(&ok);
+        if (!ok) return FAILURE;
+        strPtr++;
+        rob->getDOF(i)->setForce(val);
+
+        #ifdef GRASPITDBG
+        std::cout << val << " ";
+        #endif
+    }
+
+    #ifdef GRASPITDBG
+    std::cout << std::endl;
+    #endif
+
+    for (i = 0; i < rob->getNumDOF(); i++) {
+        os << rob->getDOF(i)->getForce() << "\n";
+
+        #ifdef GRASPITDBG
+        std::cout << "Sending: " << rob->getDOF(i)->getForce() << "\n";
+        #endif
+    }
+    return SUCCESS;
 }
 
 /*
-//not finished yet
-void
-ClientSocket::moveBody(Body *bod)
-{
-  double x,y,z,ax,ay,az,r;
+    //not finished yet
+    void
+    ClientSocket::moveBody(Body *bod)
+    {
+    double x,y,z,ax,ay,az,r;
 
-  QTextStream is(this);
-  is>>x>>y>>z>>ax>>ay>>az>>r;
-  bod = NULL;  // unused parameter warning
-}
+    QTextStream is(this);
+    is>>x>>y>>z>>ax>>ay>>az>>r;
+    bod = NULL;  // unused parameter warning
+    }
 */
 
 /*!
-  If given a positive time step value, this will move the dynamic world bodies
-  with that value.  Otherwise it uses the world default time step.  A line
-  with the actual length of that timestep is then sent back.
+    If given a positive time step value, this will move the dynamic world bodies
+    with that value.  Otherwise it uses the world default time step.  A line
+    with the actual length of that timestep is then sent back.
 */
 void
-ClientSocket::moveDynamicBodies(double timeStep)
-{
-  QTextStream os(this);
-  if (timeStep<0)
-    timeStep = graspItGUI->getIVmgr()->getWorld()->getTimeStep();
+ClientSocket::moveDynamicBodies(double timeStep) {
+    QTextStream os(this);
+    if (timeStep < 0)
+        timeStep = graspItGUI->getIVmgr()->getWorld()->getTimeStep();
 
-  double actualTimeStep =
-    graspItGUI->getIVmgr()->getWorld()->moveDynamicBodies(timeStep);
-  if (actualTimeStep < 0)
-    os << "Error: Timestep failsafe reached.\n";
-  else 
-    os << actualTimeStep << "\n";
+    double actualTimeStep =
+        graspItGUI->getIVmgr()->getWorld()->moveDynamicBodies(timeStep);
+    if (actualTimeStep < 0)
+        os << "Error: Timestep failsafe reached.\n";
+    else
+        os << actualTimeStep << "\n";
 }
 
 /*!
-  This calls the computeNewVelocities routine in the dynamics with the given
-  value of the timestep.  Afterwards, it sends out a line containing the
-  result code from that operation.
+    This calls the computeNewVelocities routine in the dynamics with the given
+    value of the timestep.  Afterwards, it sends out a line containing the
+    result code from that operation.
 */
 void
-ClientSocket::computeNewVelocities(double timeStep)
-{
-  QTextStream os(this);
-  int result = graspItGUI->getIVmgr()->getWorld()->computeNewVelocities(timeStep);
-  os << result << "\n";
+ClientSocket::computeNewVelocities(double timeStep) {
+    QTextStream os(this);
+    int result = graspItGUI->getIVmgr()->getWorld()->computeNewVelocities(timeStep);
+    os << result << "\n";
 }
 
 /*!
-  This is not complete yet.
+    This is not complete yet.
 
-void
-ClientSocket::readTorques()
-{
-  QString line;
-  line = readLine();
-  int numDOF = line.toInt();
-  
-  if (numDOF < 0) {} //unused parameter warning
-}
+    void
+    ClientSocket::readTorques()
+    {
+    QString line;
+    line = readLine();
+    int numDOF = line.toInt();
+
+    if (numDOF < 0) {} //unused parameter warning
+    }
 */
 
 /*!
-  Starts a TCP server that listens on port \a port.  \a backlog specifies
-  the number of pending connections the server can have.
+    Starts a TCP server that listens on port \a port.  \a backlog specifies
+    the number of pending connections the server can have.
 */
 GraspItServer::GraspItServer(Q_UINT16 port, int backlog,
-			     QObject *parent,const char *name) : 
-  Q3ServerSocket(port,backlog,parent,name)
-{
-  if (!ok()) {
-    qWarning("Failed to bind to port");
-  }
+                             QObject *parent, const char *name) :
+    Q3ServerSocket(port, backlog, parent, name) {
+    if (!ok()) {
+        qWarning("Failed to bind to port");
+    }
 }
 
-/*! 
-  Creates a new ClientSocket to handle communication with this client.
+/*!
+    Creates a new ClientSocket to handle communication with this client.
 */
 void
-GraspItServer::newConnection(int socket)
-{
-  (void)new ClientSocket(socket, this);
+GraspItServer::newConnection(int socket) {
+    (void)new ClientSocket(socket, this);
 
-#ifdef GRASPITDBG
-  std::cout << "new connection" << std::endl;
-#endif
+    #ifdef GRASPITDBG
+    std::cout << "new connection" << std::endl;
+    #endif
 }
 
 

--- a/src/gws.cpp
+++ b/src/gws.cpp
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Implements the abstract Grasp Wrench Space class and specific GWS classes.
- */
+/*! \file
+    \brief Implements the abstract Grasp Wrench Space class and specific GWS classes.
+*/
 
 #include <math.h>
 #include <string.h>
@@ -54,7 +54,7 @@ QMutex qhull_mutex;
 
 #define IVTOL 1e-5
 
-const char *GWS::TYPE_LIST[] = {"L1 Norm","LInfinity Norm",NULL};
+const char *GWS::TYPE_LIST[] = {"L1 Norm", "LInfinity Norm", NULL};
 const char *L1GWS::type = "L1 Norm";
 const char *LInfGWS::type = "LInfinity Norm";
 
@@ -64,720 +64,720 @@ typedef double *doublePtr;
 const std::vector<int> GWS::ALL_DIMENSIONS = std::vector<int>(6, 1);
 
 /*!
-  Deletes all the GWS hyperplanes.
+    Deletes all the GWS hyperplanes.
 */
-GWS::~GWS()
-{
-  DBGA("deleting GWS");
-  clearGWS();
+GWS::~GWS() {
+    DBGA("deleting GWS");
+    clearGWS();
 }
 
 void
-GWS::clearGWS()
-{
-  if (hyperPlanes) {
-    for (int i=0;i<numHyperPlanes;i++)
-      delete [] hyperPlanes[i];
-    delete [] hyperPlanes;
-    hyperPlanes=NULL;
-  }
-  numHyperPlanes = 0;
-  hullArea = hullVolume = 0.0;
-  forceClosure = false;
+GWS::clearGWS() {
+    if (hyperPlanes) {
+        for (int i = 0; i < numHyperPlanes; i++)
+            delete [] hyperPlanes[i];
+        delete [] hyperPlanes;
+        hyperPlanes = NULL;
+    }
+    numHyperPlanes = 0;
+    hullArea = hullVolume = 0.0;
+    forceClosure = false;
 }
 
 /*!
-  Creates a GWS whose type string matches \a desiredType.
+    Creates a GWS whose type string matches \a desiredType.
 */
 GWS *
-GWS::createInstance(const char *desiredType,Grasp *g)
-{
-  if (!strcmp(desiredType,L1GWS::getClassType()))
-    return new L1GWS(g);
+GWS::createInstance(const char *desiredType, Grasp *g) {
+    if (!strcmp(desiredType, L1GWS::getClassType()))
+        return new L1GWS(g);
 
-  if (!strcmp(desiredType,LInfGWS::getClassType()))
-    return new LInfGWS(g);
+    if (!strcmp(desiredType, LInfGWS::getClassType()))
+        return new LInfGWS(g);
 
-  return NULL;
+    return NULL;
 }
 
 
 /*! Uses the \a projCoords and \a fixedCoordSet (which identifies the indices
-	of the fixed coordinates) to project the 6D hyperplanes of the Grasp Wrench 
-	Space into 3D. The \a projCoords is an array of 6 values, but only 3 are used.  
-	It then calls qhull to perform a halfspace intersection to get the vertices 
-	of the 3D volume.  These vertices are stored in \a hullCoords, and indices 
-	of the individual faces that make up the volume are stored in \a hullIndices 
-	(an Indexed Face Set).
+    of the fixed coordinates) to project the 6D hyperplanes of the Grasp Wrench
+    Space into 3D. The \a projCoords is an array of 6 values, but only 3 are used.
+    It then calls qhull to perform a halfspace intersection to get the vertices
+    of the 3D volume.  These vertices are stored in \a hullCoords, and indices
+    of the individual faces that make up the volume are stored in \a hullIndices
+    (an Indexed Face Set).
 */
 int
 GWS::projectTo3D(double *projCoords, std::set<int> fixedCoordSet,
-				 std::vector<position> &hullCoords, std::vector<int> &hullIndices)
-{
-  int i,j,k,numCoords,numInLoop;
-  volatile int validPlanes;
-  double **planes;
-  int freeCoord[3],fixedCoord[3];
+                 std::vector<position> &hullCoords, std::vector<int> &hullIndices) {
+    int i, j, k, numCoords, numInLoop;
+    volatile int validPlanes;
+    double **planes;
+    int freeCoord[3], fixedCoord[3];
 
-  // qhull variables
-  boolT ismalloc;
-  int curlong,totlong,exitcode;
-  char options[200];  
-  facetT *facet;
+    // qhull variables
+    boolT ismalloc;
+    int curlong, totlong, exitcode;
+    char options[200];
+    facetT *facet;
 
-  if (numHyperPlanes == 0) {
-	  DBGP("No hyperplanes");
-	  return SUCCESS;
-  }
+    if (numHyperPlanes == 0) {
+        DBGP("No hyperplanes");
+        return SUCCESS;
+    }
 
-  planes = (double **) malloc(numHyperPlanes * sizeof(double *));
-  if (!planes) {
-#ifdef GRASPITDBG
-    pr_error("GWS::ProjectTo3D,Out of memory allocating planes array");
-    printf("NumHyperplanes: %d\n",numHyperPlanes);
-#endif
-    return FAILURE;
-  }
+    planes = (double **) malloc(numHyperPlanes * sizeof(double *));
+    if (!planes) {
+        #ifdef GRASPITDBG
+        pr_error("GWS::ProjectTo3D,Out of memory allocating planes array");
+        printf("NumHyperplanes: %d\n", numHyperPlanes);
+        #endif
+        return FAILURE;
+    }
 
-  validPlanes = 0;
+    validPlanes = 0;
 
-  // determine which dimensions are free and which are fixed
-  // the set keeps things ordered
-  for (i=0,j=0,k=0;i<6;i++) {
-    if (fixedCoordSet.find(i) == fixedCoordSet.end()) {
-      freeCoord[k++] = i;
-	} else {
-      fixedCoord[j++] = i;
-	}
-  }
-
-  // project the hyperplanes to three dimensional planes
-  for (i=0;i<numHyperPlanes;i++) {
-    double len = sqrt(hyperPlanes[i][freeCoord[0]]*hyperPlanes[i][freeCoord[0]] +
-                      hyperPlanes[i][freeCoord[1]]*hyperPlanes[i][freeCoord[1]] +
-                      hyperPlanes[i][freeCoord[2]]*hyperPlanes[i][freeCoord[2]]);
-
-    if (len>1e-11) {
-      planes[validPlanes] = (double *) malloc(4 * sizeof(double));
-      if (!planes[validPlanes]) {
-		pr_error("Out of memory allocating planes array");
-	    DBGP("Out of memory allocating planes array");
-		return FAILURE;
-	  }
-      planes[validPlanes][0] = hyperPlanes[i][freeCoord[0]]/len;
-      planes[validPlanes][1] = hyperPlanes[i][freeCoord[1]]/len;
-      planes[validPlanes][2] = hyperPlanes[i][freeCoord[2]]/len;
-      planes[validPlanes][3] = (hyperPlanes[i][6] + 
-	                            hyperPlanes[i][fixedCoord[0]]*projCoords[fixedCoord[0]] +
-		                        hyperPlanes[i][fixedCoord[1]]*projCoords[fixedCoord[1]] +
-		                        hyperPlanes[i][fixedCoord[2]]*projCoords[fixedCoord[2]])/len;
-      
-      validPlanes++;
-	}
-  }
-
-  if (validPlanes<numHyperPlanes) {
-	  DBGP("Ignored " << numHyperPlanes-validPlanes << 
-		   " hyperplanes which did not intersect this 3-space");
-  }
-  if (!validPlanes) {
-	  DBGA("No valid planes in 3D projection!");
-	  return FAILURE;
-  }
-	   
-
-  //
-  // call qhull to do the halfspace intersection
-  //
-  coordT *array = new coordT[validPlanes*3];
-  coordT *p = &array[0];
-  
-  boolT zerodiv;
-  coordT *point, *normp, *coordp, **pointp, *feasiblep;
-  vertexT *vertex, **vertexp;
-
-#ifdef GRASPITDBG
-  printf("Calling qhull to perform a 3D halfspace intersection of %d planes...\n",validPlanes);
-#endif
-
-  ismalloc = False; 	// True if qh_freeqhull should 'free(array)'
-
-  // I want to get rid of this but qh_init needs some sort of file pointer
-  // for stdout and stderr
-  FILE *qhfp = fopen("logfile","w");
-
-  if (!qhfp) {
-	fprintf(stderr,"Could not open qhull logfile!\n");
-	qh_init_A(NULL, stdout, stderr, 0, NULL);
-  }
-  else
-   qh_init_A(NULL, qhfp, qhfp, 0, NULL);
-
-  if ((exitcode = setjmp(qh errexit))) {
-    delete [] array;
-	qh NOerrexit= True;
-	qh_freeqhull(!qh_ALL);
-	qh_memfreeshort (&curlong, &totlong);
-	if (curlong || totlong)  	/* optional */
-	   fprintf (stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
-		 totlong, curlong);
-    for (i=0;i<validPlanes;i++)
-      free(planes[i]);
-    free(planes);
-	if (qhfp) fclose(qhfp);
-	DBGP("Qhull forces the exit; probably no valid intersection");
-    return FAILURE; //exit(exitcode);
-  }
-  sprintf(options, "qhull -H0,0,0 Pp");
-  qh_initflags(options);
-  qh_setfeasible(3);
-  if (!(qh feasible_point)) printf("why is qh_qh NULL?\n");
-  for(i=0;i<validPlanes;i++) {
-    qh_sethalfspace (3, p, &p, planes[i],&(planes[i][3]), qh feasible_point);
-  }
-
-  qh_init_B(&array[0], validPlanes, 3, ismalloc);
-  qh_qhull();
-  qh_check_output();
-  if (qhfp) fclose(qhfp);
-
-  //
-  // Collect the vertices of the volume
-  //
-  hullCoords.clear();
-  numCoords = qh num_facets;
-  hullCoords.reserve(numCoords);
-  int *indices = new int[numCoords];
-
-  double scale = grasp->getMaxRadius(); // Hmm, is this right?
-
-  point= (pointT*)qh_memalloc (qh normal_size);
-
-  FORALLfacets {
-    coordp = point;
-	if (facet->offset > 0)
-      goto LABELprintinfinite;
-	
-    normp= facet->normal;
-    feasiblep= qh feasible_point;
-    if (facet->offset < -qh MINdenom) {
-      for (k= qh hull_dim; k--; )
-        *(coordp++)= (*(normp++) / - facet->offset) + *(feasiblep++);
-    }else {
-      for (k= qh hull_dim; k--; ) {
-        *(coordp++)= qh_divzero (*(normp++), facet->offset, qh MINdenom_1,&zerodiv) + *(feasiblep++);
-        if (zerodiv) {
-          goto LABELprintinfinite;
+    // determine which dimensions are free and which are fixed
+    // the set keeps things ordered
+    for (i = 0, j = 0, k = 0; i < 6; i++) {
+        if (fixedCoordSet.find(i) == fixedCoordSet.end()) {
+            freeCoord[k++] = i;
         }
-      }
-    }    
-    hullCoords.push_back(position(point[0]*scale,point[1]*scale,
-				  point[2]*scale));
-    continue;
+        else {
+            fixedCoord[j++] = i;
+        }
+    }
+
+    // project the hyperplanes to three dimensional planes
+    for (i = 0; i < numHyperPlanes; i++) {
+        double len = sqrt(hyperPlanes[i][freeCoord[0]] * hyperPlanes[i][freeCoord[0]] +
+                          hyperPlanes[i][freeCoord[1]] * hyperPlanes[i][freeCoord[1]] +
+                          hyperPlanes[i][freeCoord[2]] * hyperPlanes[i][freeCoord[2]]);
+
+        if (len > 1e-11) {
+            planes[validPlanes] = (double *) malloc(4 * sizeof(double));
+            if (!planes[validPlanes]) {
+                pr_error("Out of memory allocating planes array");
+                DBGP("Out of memory allocating planes array");
+                return FAILURE;
+            }
+            planes[validPlanes][0] = hyperPlanes[i][freeCoord[0]] / len;
+            planes[validPlanes][1] = hyperPlanes[i][freeCoord[1]] / len;
+            planes[validPlanes][2] = hyperPlanes[i][freeCoord[2]] / len;
+            planes[validPlanes][3] = (hyperPlanes[i][6] +
+                                      hyperPlanes[i][fixedCoord[0]] * projCoords[fixedCoord[0]] +
+                                      hyperPlanes[i][fixedCoord[1]] * projCoords[fixedCoord[1]] +
+                                      hyperPlanes[i][fixedCoord[2]] * projCoords[fixedCoord[2]]) / len;
+
+            validPlanes++;
+        }
+    }
+
+    if (validPlanes < numHyperPlanes) {
+        DBGP("Ignored " << numHyperPlanes - validPlanes <<
+             " hyperplanes which did not intersect this 3-space");
+    }
+    if (!validPlanes) {
+        DBGA("No valid planes in 3D projection!");
+        return FAILURE;
+    }
+
+
+    //
+    // call qhull to do the halfspace intersection
+    //
+    coordT *array = new coordT[validPlanes * 3];
+    coordT *p = &array[0];
+
+    boolT zerodiv;
+    coordT *point, *normp, *coordp, **pointp, *feasiblep;
+    vertexT *vertex, **vertexp;
+
+    #ifdef GRASPITDBG
+    printf("Calling qhull to perform a 3D halfspace intersection of %d planes...\n", validPlanes);
+    #endif
+
+    ismalloc = False;     // True if qh_freeqhull should 'free(array)'
+
+    // I want to get rid of this but qh_init needs some sort of file pointer
+    // for stdout and stderr
+    FILE *qhfp = fopen("logfile", "w");
+
+    if (!qhfp) {
+        fprintf(stderr, "Could not open qhull logfile!\n");
+        qh_init_A(NULL, stdout, stderr, 0, NULL);
+    }
+    else
+        qh_init_A(NULL, qhfp, qhfp, 0, NULL);
+
+    if ((exitcode = setjmp(qh errexit))) {
+        delete [] array;
+        qh NOerrexit = True;
+        qh_freeqhull(!qh_ALL);
+        qh_memfreeshort(&curlong, &totlong);
+        if (curlong || totlong)     /* optional */
+            fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
+                    totlong, curlong);
+        for (i = 0; i < validPlanes; i++)
+            free(planes[i]);
+        free(planes);
+        if (qhfp) fclose(qhfp);
+        DBGP("Qhull forces the exit; probably no valid intersection");
+        return FAILURE; //exit(exitcode);
+    }
+    sprintf(options, "qhull -H0,0,0 Pp");
+    qh_initflags(options);
+    qh_setfeasible(3);
+    if (!(qh feasible_point)) printf("why is qh_qh NULL?\n");
+    for (i = 0; i < validPlanes; i++) {
+        qh_sethalfspace(3, p, &p, planes[i], &(planes[i][3]), qh feasible_point);
+    }
+
+    qh_init_B(&array[0], validPlanes, 3, ismalloc);
+    qh_qhull();
+    qh_check_output();
+    if (qhfp) fclose(qhfp);
+
+    //
+    // Collect the vertices of the volume
+    //
+    hullCoords.clear();
+    numCoords = qh num_facets;
+    hullCoords.reserve(numCoords);
+    int *indices = new int[numCoords];
+
+    double scale = grasp->getMaxRadius(); // Hmm, is this right?
+
+    point = (pointT *)qh_memalloc(qh normal_size);
+
+    FORALLfacets {
+        coordp = point;
+        if (facet->offset > 0)
+            goto LABELprintinfinite;
+
+        normp = facet->normal;
+        feasiblep = qh feasible_point;
+        if (facet->offset < -qh MINdenom) {
+            for (k = qh hull_dim; k--;)
+                *(coordp++) = (*(normp++) / - facet->offset) + *(feasiblep++);
+        }
+        else {
+            for (k = qh hull_dim; k--;) {
+                *(coordp++) = qh_divzero(*(normp++), facet->offset, qh MINdenom_1, &zerodiv) + *(feasiblep++);
+                if (zerodiv) {
+                    goto LABELprintinfinite;
+                }
+            }
+        }
+        hullCoords.push_back(position(point[0]*scale, point[1]*scale,
+                                      point[2]*scale));
+        continue;
     LABELprintinfinite:
-    hullCoords.push_back(position(qh_INFINITE,qh_INFINITE,qh_INFINITE));
-    fprintf(stderr,"intersection at infinity!\n");
-  }
-  qh_memfree (point, qh normal_size);
+        hullCoords.push_back(position(qh_INFINITE, qh_INFINITE, qh_INFINITE));
+        fprintf(stderr, "intersection at infinity!\n");
+    }
+    qh_memfree(point, qh normal_size);
 
 
-  //
-  // use adjacency information to build faces of the volume
-  //
-  double dot;
-  vec3 testNormal, refNormal;
+    //
+    // use adjacency information to build faces of the volume
+    //
+    double dot;
+    vec3 testNormal, refNormal;
 
-  int numfacets, numsimplicial, numridges, totneighbors, numneighbors, numcoplanars;
-  setT *vertices, *vertex_points, *coplanar_points;
-  int numpoints= qh num_points + qh_setsize (qh other_points);
-  int vertex_i, vertex_n;
-  facetT *neighbor, **neighborp;
-  int unused_numnumtricoplanarsp; //added because countfacets takes more arguments in qhull 2012
-								  //FIXME - understand what this argument does. 
-  qh_countfacets (qh facet_list, NULL, !qh_ALL, &numfacets, &numsimplicial, 
-      &totneighbors, &numridges, &numcoplanars, &unused_numnumtricoplanarsp);  /* sets facet->visitid */
+    int numfacets, numsimplicial, numridges, totneighbors, numneighbors, numcoplanars;
+    setT *vertices, *vertex_points, *coplanar_points;
+    int numpoints = qh num_points + qh_setsize(qh other_points);
+    int vertex_i, vertex_n;
+    facetT *neighbor, **neighborp;
+    int unused_numnumtricoplanarsp; //added because countfacets takes more arguments in qhull 2012
+    //FIXME - understand what this argument does.
+    qh_countfacets(qh facet_list, NULL, !qh_ALL, &numfacets, &numsimplicial,
+                   &totneighbors, &numridges, &numcoplanars, &unused_numnumtricoplanarsp);  /* sets facet->visitid */
 
-  qh_vertexneighbors();
-  vertices= qh_facetvertices (qh facet_list, NULL, !qh_ALL);
-  vertex_points= qh_settemp (numpoints);
-  coplanar_points= qh_settemp (numpoints);
-  qh_setzero (vertex_points, 0, numpoints);
-  qh_setzero (coplanar_points, 0, numpoints);
-  FOREACHvertex_(vertices)
-    qh_point_add (vertex_points, vertex->point, vertex);
-  FORALLfacet_(qh facet_list) {
-    FOREACHpoint_(facet->coplanarset)
-      qh_point_add (coplanar_points, point, facet);
-  }
-
-  FOREACHvertex_i_(vertex_points) {
-    if (vertex) { 
-      numneighbors= qh_setsize (vertex->neighbors);
-
-      numInLoop = numneighbors;
-      qh_order_vertexneighbors (vertex);
-      j=0;
-      FOREACHneighbor_(vertex) {
-		if (!neighbor->visitid) {
-			fprintf(stderr,"Uh oh! neighbor->visitId==0, -neighbor->id: %d\n",-int(neighbor->id));
-			numInLoop--;
-		}
-		else
-			indices[j] = neighbor->visitid - 1;
-
-		if (j>0 && ((hullCoords[indices[j]]-hullCoords[indices[j-1]]).len() < IVTOL ||
-			(hullCoords[indices[j]]-hullCoords[indices[0]]).len() < IVTOL)) 
-		{
-			numInLoop--;
-		}
-		else j++;
-      }
-	} else if ((facet= SETelemt_(coplanar_points, vertex_i, facetT))) {
-      numInLoop=1;
-	} else {
-      numInLoop=0;
-      continue;
+    qh_vertexneighbors();
+    vertices = qh_facetvertices(qh facet_list, NULL, !qh_ALL);
+    vertex_points = qh_settemp(numpoints);
+    coplanar_points = qh_settemp(numpoints);
+    qh_setzero(vertex_points, 0, numpoints);
+    qh_setzero(coplanar_points, 0, numpoints);
+    FOREACHvertex_(vertices)
+    qh_point_add(vertex_points, vertex->point, vertex);
+    FORALLfacet_(qh facet_list) {
+        FOREACHpoint_(facet->coplanarset)
+        qh_point_add(coplanar_points, point, facet);
     }
 
-    if (numInLoop<3) {
-      DBGP("too few vertices to make a face. Ignoring ...");
-      continue;
+    FOREACHvertex_i_(vertex_points) {
+        if (vertex) {
+            numneighbors = qh_setsize(vertex->neighbors);
+
+            numInLoop = numneighbors;
+            qh_order_vertexneighbors(vertex);
+            j = 0;
+            FOREACHneighbor_(vertex) {
+                if (!neighbor->visitid) {
+                    fprintf(stderr, "Uh oh! neighbor->visitId==0, -neighbor->id: %d\n", -int(neighbor->id));
+                    numInLoop--;
+                }
+                else
+                    indices[j] = neighbor->visitid - 1;
+
+                if (j > 0 && ((hullCoords[indices[j]] - hullCoords[indices[j - 1]]).len() < IVTOL ||
+                              (hullCoords[indices[j]] - hullCoords[indices[0]]).len() < IVTOL)) {
+                    numInLoop--;
+                }
+                else j++;
+            }
+        }
+        else if ((facet = SETelemt_(coplanar_points, vertex_i, facetT))) {
+            numInLoop = 1;
+        }
+        else {
+            numInLoop = 0;
+            continue;
+        }
+
+        if (numInLoop < 3) {
+            DBGP("too few vertices to make a face. Ignoring ...");
+            continue;
+        }
+
+        // check if the current orientation of the face matches the plane's normal
+        testNormal = (hullCoords[indices[1]] - hullCoords[indices[0]]) * (hullCoords[indices[j - 1]] - hullCoords[indices[0]]);
+        refNormal = vec3(planes[vertex_i][0], planes[vertex_i][1], planes[vertex_i][2]);
+
+        if ((dot = testNormal % refNormal) > 0.0) {
+            for (j = 0; j < numInLoop; j++)
+                hullIndices.push_back(indices[j]);
+            hullIndices.push_back(-1);
+        }
+        else {
+            // reverse the vertex ordering
+            for (j = numInLoop - 1; j >= 0; j--)
+                hullIndices.push_back(indices[j]);
+            hullIndices.push_back(-1);
+        }
     }
 
-    // check if the current orientation of the face matches the plane's normal
-    testNormal = (hullCoords[indices[1]] - hullCoords[indices[0]]) * (hullCoords[indices[j-1]] - hullCoords[indices[0]]);
-	refNormal = vec3(planes[vertex_i][0],planes[vertex_i][1],planes[vertex_i][2]);
+    qh_settempfree(&coplanar_points);
+    qh_settempfree(&vertex_points);
+    qh_settempfree(&vertices);
 
-    if ((dot = testNormal % refNormal) > 0.0) {
-      for (j=0;j<numInLoop;j++)
-		hullIndices.push_back(indices[j]);
-      hullIndices.push_back(-1);
-    } else {
-      // reverse the vertex ordering
-      for (j=numInLoop-1;j>=0;j--)
-		hullIndices.push_back(indices[j]);
-      hullIndices.push_back(-1);
-    }
-  }
+    qh NOerrexit = True;
+    qh_freeqhull(!qh_ALL);
+    qh_memfreeshort(&curlong, &totlong);
+    if (curlong || totlong)   /* optional */
+        fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
+                totlong, curlong);
 
-  qh_settempfree (&coplanar_points);
-  qh_settempfree (&vertex_points);
-  qh_settempfree (&vertices);
+    for (i = 0; i < validPlanes; i++)
+        free(planes[i]);
+    free(planes);
 
-  qh NOerrexit= True;
-  qh_freeqhull(!qh_ALL);
-  qh_memfreeshort (&curlong, &totlong);
-  if (curlong || totlong)  	/* optional */
-     fprintf (stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
-        totlong, curlong);
-
-  for (i=0;i<validPlanes;i++)
-    free(planes[i]);
-  free(planes);
-
-  delete [] indices;
-  delete [] array;
-  DBGP("Succesfull completion of intersection task");
-  return SUCCESS;
+    delete [] indices;
+    delete [] array;
+    DBGP("Succesfull completion of intersection task");
+    return SUCCESS;
 }
 
 
 void
-GWS::setGravity(bool use, vec3 gd)
-{
-	useGravity = use;
-	if (!use) gravDirection = vec3(0,0,0);
-	else gravDirection = gd;
+GWS::setGravity(bool use, vec3 gd) {
+    useGravity = use;
+    if (!use) gravDirection = vec3(0, 0, 0);
+    else gravDirection = gd;
 }
 
-/*! Given a set of hyperplanes that have already been computed and stored 
-	internally in hyperPlanes, this will compute the metrics that we care
-	about: for now, the only computation is the min offset of a hyperplane
-	from the origin. The other metric, the volume of the hull, is computed
-	when a quality metric actually asks for it.
+/*! Given a set of hyperplanes that have already been computed and stored
+    internally in hyperPlanes, this will compute the metrics that we care
+    about: for now, the only computation is the min offset of a hyperplane
+    from the origin. The other metric, the volume of the hull, is computed
+    when a quality metric actually asks for it.
 
-	This also uses the min offset to tell the grasp to display the min
-	wrench that will break it.
+    This also uses the min offset to tell the grasp to display the min
+    wrench that will break it.
 */
 void
-GWS::computeHyperplaneMetrics()
-{
-	if (!numHyperPlanes) {
-		forceClosure = false;
-		return;
-	}
+GWS::computeHyperplaneMetrics() {
+    if (!numHyperPlanes) {
+        forceClosure = false;
+        return;
+    }
 
-	int posOffsets = 0;
-	int minIndex = 0;
-	double minOffset = -1.0;
+    int posOffsets = 0;
+    int minIndex = 0;
+    double minOffset = -1.0;
 
-	for (int i=0; i<numHyperPlanes; i++) {
-		if (hyperPlanes[i][6] > 0) posOffsets++;
-		if (minOffset == -1.0 || -hyperPlanes[i][6]<minOffset) {
-			minOffset = -hyperPlanes[i][6];
-			minIndex = i;
-		}
-	}
+    for (int i = 0; i < numHyperPlanes; i++) {
+        if (hyperPlanes[i][6] > 0) posOffsets++;
+        if (minOffset == -1.0 || -hyperPlanes[i][6] < minOffset) {
+            minOffset = -hyperPlanes[i][6];
+            minIndex = i;
+        }
+    }
 
-	grasp->setMinWrench(hyperPlanes[minIndex]);
+    grasp->setMinWrench(hyperPlanes[minIndex]);
 
-	if (posOffsets>0) {
-		DBGP("QUALITY: NON FORCE CLOSURE GRASP, late exit");
-		forceClosure = false;
-	}
-	else {
-		DBGP("FORCE CLOSURE GRASP");
-		forceClosure = true;
-	}
+    if (posOffsets > 0) {
+        DBGP("QUALITY: NON FORCE CLOSURE GRASP, late exit");
+        forceClosure = false;
+    }
+    else {
+        DBGP("FORCE CLOSURE GRASP");
+        forceClosure = true;
+    }
 }
 
 /*! Encapsulates the qhull calls to build the convex hull of a set of wrenches.
-	\a wr is a set of \a numWrenches wrenches, each of them having \a dimensions 
-	dimensions. The convex hull is computed as the intersection of a number of
-	halfspaces, each defined by a hyperplane. The hyperplanes are computed
-	using qhull and stored internally in the GWS class.
+    \a wr is a set of \a numWrenches wrenches, each of them having \a dimensions
+    dimensions. The convex hull is computed as the intersection of a number of
+    halfspaces, each defined by a hyperplane. The hyperplanes are computed
+    using qhull and stored internally in the GWS class.
 
-	\a useDimensions tells us which dimensions we use when building the hull.
-	The wrenches themselves are tightly packed, i.e. only contain the values for
-	those dimensions. As far as qhull is concerned, it does not matter which 
-	those directions are, only how many of them we have. But we need to know
-	which the dimensions are so we can store that information in the hyperplanes.
+    \a useDimensions tells us which dimensions we use when building the hull.
+    The wrenches themselves are tightly packed, i.e. only contain the values for
+    those dimensions. As far as qhull is concerned, it does not matter which
+    those directions are, only how many of them we have. But we need to know
+    which the dimensions are so we can store that information in the hyperplanes.
 */
-int 
-GWS::buildHyperplanesFromWrenches(void *wr, int numWrenches, 
-								  std::vector<int> useDimensions)
-{
-  DBGP("Qhull init on " << numWrenches << " wrenches"); 
+int
+GWS::buildHyperplanesFromWrenches(void *wr, int numWrenches,
+                                  std::vector<int> useDimensions) {
+    DBGP("Qhull init on " << numWrenches << " wrenches");
 
-  // qhull variables
-  coordT *wrenches = (coordT*)wr;
-  boolT ismalloc;
-  int curlong, totlong, exitcode;
-  char options[200];  
-  facetT *facet;
-  int i;
+    // qhull variables
+    coordT *wrenches = (coordT *)wr;
+    boolT ismalloc;
+    int curlong, totlong, exitcode;
+    char options[200];
+    facetT *facet;
+    int i;
 
-  ismalloc = False; 	// True if qh_freeqhull should 'free(array)'
-  FILE *qhfp = fopen("logfile-qhull","w");
-  if (!qhfp) {
-	fprintf(stderr,"Could not open qhull logfile!\n");
-	qh_init_A(NULL, stdout, stderr, 0, NULL);
-  }
-  else
-   qh_init_A(NULL, qhfp, qhfp, 0, NULL);
-
-
-  if ((exitcode = setjmp(qh errexit))) {
-    DBGP("QUALITY: 0 volume, quick exit");
-	qh NOerrexit= True;
-	qh_freeqhull(!qh_ALL);
-	qh_memfreeshort (&curlong, &totlong);
-	if (curlong || totlong)  	
-	   fprintf (stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
-		  totlong, curlong);
-	if (qhfp) fclose(qhfp);
-    return FAILURE;
-  }
-
-  int dimensions = 0;
-  for (int d=0; d<6; d++) {
-    if (useDimensions[d]) dimensions++;
-  }
-  
-  sprintf(options, "qhull Pp n Qx C-0.0001");
-  qh_initflags(options);
-  qh_init_B(&wrenches[0], numWrenches, dimensions, ismalloc);
-  qh_qhull();
-  qh_check_output();
-  qh_getarea(qh facet_list);
-  if (qhfp) fclose(qhfp);
-
-  hullArea = qh totarea;
-  hullVolume = qh totvol;
-  numHyperPlanes = qh num_facets;
-
-  hyperPlanes = new doublePtr[numHyperPlanes];
-  if (!hyperPlanes) {
-    DBGA("Out of memory allocating hyperPlanes array");
-    return FAILURE;
-  }
-
-  for (i=0;i<numHyperPlanes;i++) {
-    hyperPlanes[i] = new double[7];
-    if (!hyperPlanes[i]) {
-      DBGA("Out of memory allocating hyperPlanes array");
-      return FAILURE;
+    ismalloc = False;     // True if qh_freeqhull should 'free(array)'
+    FILE *qhfp = fopen("logfile-qhull", "w");
+    if (!qhfp) {
+        fprintf(stderr, "Could not open qhull logfile!\n");
+        qh_init_A(NULL, stdout, stderr, 0, NULL);
     }
-  }
+    else
+        qh_init_A(NULL, qhfp, qhfp, 0, NULL);
 
-  i=0;
 
-  mUsedDimensions = useDimensions;
-  FORALLfacets {
-	  int hd = 0;
-	  for (int d=0; d<6; d++) {
-		  if (useDimensions[d]) {
-			  hyperPlanes[i][d] = facet->normal[hd];
-			  hd++;
-		  } else {
-			  hyperPlanes[i][d] = 0;
-		  }
-	  }
-	  hyperPlanes[i][6] = facet->offset;  
-	  i++;
-  }
+    if ((exitcode = setjmp(qh errexit))) {
+        DBGP("QUALITY: 0 volume, quick exit");
+        qh NOerrexit = True;
+        qh_freeqhull(!qh_ALL);
+        qh_memfreeshort(&curlong, &totlong);
+        if (curlong || totlong)
+            fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
+                    totlong, curlong);
+        if (qhfp) fclose(qhfp);
+        return FAILURE;
+    }
 
-  qh NOerrexit= True;
-  qh_freeqhull(!qh_ALL);
-  qh_memfreeshort (&curlong, &totlong);
-  if (curlong || totlong) {
-     fprintf (stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
-        totlong, curlong);
-  }
-  DBGP("Qhull SUCCESS");
-  return SUCCESS;
+    int dimensions = 0;
+    for (int d = 0; d < 6; d++) {
+        if (useDimensions[d]) dimensions++;
+    }
+
+    sprintf(options, "qhull Pp n Qx C-0.0001");
+    qh_initflags(options);
+    qh_init_B(&wrenches[0], numWrenches, dimensions, ismalloc);
+    qh_qhull();
+    qh_check_output();
+    qh_getarea(qh facet_list);
+    if (qhfp) fclose(qhfp);
+
+    hullArea = qh totarea;
+    hullVolume = qh totvol;
+    numHyperPlanes = qh num_facets;
+
+    hyperPlanes = new doublePtr[numHyperPlanes];
+    if (!hyperPlanes) {
+        DBGA("Out of memory allocating hyperPlanes array");
+        return FAILURE;
+    }
+
+    for (i = 0; i < numHyperPlanes; i++) {
+        hyperPlanes[i] = new double[7];
+        if (!hyperPlanes[i]) {
+            DBGA("Out of memory allocating hyperPlanes array");
+            return FAILURE;
+        }
+    }
+
+    i = 0;
+
+    mUsedDimensions = useDimensions;
+    FORALLfacets {
+        int hd = 0;
+        for (int d = 0; d < 6; d++) {
+            if (useDimensions[d]) {
+                hyperPlanes[i][d] = facet->normal[hd];
+                hd++;
+            }
+            else {
+                hyperPlanes[i][d] = 0;
+            }
+        }
+        hyperPlanes[i][6] = facet->offset;
+        i++;
+    }
+
+    qh NOerrexit = True;
+    qh_freeqhull(!qh_ALL);
+    qh_memfreeshort(&curlong, &totlong);
+    if (curlong || totlong) {
+        fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory (%d pieces)\n",
+                totlong, curlong);
+    }
+    DBGP("Qhull SUCCESS");
+    return SUCCESS;
 }
 
 /*!
-  Builds an L1 GWS by simply taking the union of all the contact wrenches,
-  and using these as the input for the convex hull operation
-  (performed by qhull). The output of qhull is the list of equations of the
-  hyperplanes that bound the hull as well as the hull area and hull volume.
-  These are all saved within the GWS.
-  Returns FAILURE or SUCCESS.
+    Builds an L1 GWS by simply taking the union of all the contact wrenches,
+    and using these as the input for the convex hull operation
+    (performed by qhull). The output of qhull is the list of equations of the
+    hyperplanes that bound the hull as well as the hull area and hull volume.
+    These are all saved within the GWS.
+    Returns FAILURE or SUCCESS.
 
-  You can ask for the GWS to be built using only a subset of the 6 dimensions 
-  of force and torque normally available. These are, in this order: 
-  
-  fx, fy, fz, tx, ty, tz
+    You can ask for the GWS to be built using only a subset of the 6 dimensions
+    of force and torque normally available. These are, in this order:
 
-  If you want only a subset to be used, pass a vector of 6 ints with 1 for the
-  dimensions you want or 0 for those that you do not want. For example, if you
-  want a GWS that only uses fx, fy and tz, pass the following vector:
+    fx, fy, fz, tx, ty, tz
 
-  1, 1, 0, 0, 0, 1
+    If you want only a subset to be used, pass a vector of 6 ints with 1 for the
+    dimensions you want or 0 for those that you do not want. For example, if you
+    want a GWS that only uses fx, fy and tz, pass the following vector:
 
-  If you want to use all 6 dimensions, pass the default value of 
-  GWS::ALL_DIMENSIONS.
+    1, 1, 0, 0, 0, 1
+
+    If you want to use all 6 dimensions, pass the default value of
+    GWS::ALL_DIMENSIONS.
 */
 int
-L1GWS::build(std::vector<int> useDimensions)
-{
-	DBGP("in L1 gws build");
-	if (useGravity) {
-		DBGP("Gravity: " << gravDirection.x() << " " << gravDirection.y() 
-		  			     << " " << gravDirection.z());
-	} else {
-		DBGP("No gravity");
-	}
+L1GWS::build(std::vector<int> useDimensions) {
+    DBGP("in L1 gws build");
+    if (useGravity) {
+        DBGP("Gravity: " << gravDirection.x() << " " << gravDirection.y()
+             << " " << gravDirection.z());
+    }
+    else {
+        DBGP("No gravity");
+    }
 
-	clearGWS();
+    clearGWS();
 
-	if (!grasp->getNumContacts()) {
-		forceClosure = false;
-		DBGP(" No contacts, returning");
-		return SUCCESS;
-	}
+    if (!grasp->getNumContacts()) {
+        forceClosure = false;
+        DBGP(" No contacts, returning");
+        return SUCCESS;
+    }
 
-	int wrenchCount = 0;
-	for (int i=0;i<grasp->getNumContacts();i++) {
-		wrenchCount += grasp->getContact(i)->getMate()->numFrictionEdges;
-	}
+    int wrenchCount = 0;
+    for (int i = 0; i < grasp->getNumContacts(); i++) {
+        wrenchCount += grasp->getContact(i)->getMate()->numFrictionEdges;
+    }
 
-	//count the number of dimensions actually in use
-	int numDimensions = 0;
-	for (int d=0; d<6; d++) {
-		if (useDimensions[d]) {
-			numDimensions++;
-		}
-	}
-	DBGP("Building a " << numDimensions << "D L1 GWS");
+    //count the number of dimensions actually in use
+    int numDimensions = 0;
+    for (int d = 0; d < 6; d++) {
+        if (useDimensions[d]) {
+            numDimensions++;
+        }
+    }
+    DBGP("Building a " << numDimensions << "D L1 GWS");
 
-	if (numDimensions < 2) {
-		DBGA("At least 2 used dimensions needed");
-		return FAILURE;
-	}
-		
-	coordT *array = new coordT[wrenchCount*numDimensions];
-	if (!array) {
-		DBGA("Failed to allocate memory for wrenchCount" << wrenchCount);
-		return FAILURE;
-	}
+    if (numDimensions < 2) {
+        DBGA("At least 2 used dimensions needed");
+        return FAILURE;
+    }
 
-	coordT *p = &array[0];
-	for (int i=0; i<grasp->getNumContacts(); i++) {    
-		for (int w=0; w<grasp->getContact(i)->getMate()->numFrictionEdges; w++) {
+    coordT *array = new coordT[wrenchCount * numDimensions];
+    if (!array) {
+        DBGA("Failed to allocate memory for wrenchCount" << wrenchCount);
+        return FAILURE;
+    }
 
-			DBGP(" x: " << grasp->getContact(i)->getMate()->wrench[w].force.x() <<
-				 " y: " << grasp->getContact(i)->getMate()->wrench[w].force.y() << 
-				 " z: " << grasp->getContact(i)->getMate()->wrench[w].force.z() ); 
-			DBGP("tx: " << grasp->getContact(i)->getMate()->wrench[w].torque.x() <<
-				 " ty: " << grasp->getContact(i)->getMate()->wrench[w].torque.y() << 
-				 " tz: " << grasp->getContact(i)->getMate()->wrench[w].torque.z() );		  
+    coordT *p = &array[0];
+    for (int i = 0; i < grasp->getNumContacts(); i++) {
+        for (int w = 0; w < grasp->getContact(i)->getMate()->numFrictionEdges; w++) {
 
-			if (useDimensions[0]) *p++ = grasp->getContact(i)->getMate()->wrench[w].force.x();
-			if (useGravity) *(p-1) = *(p-1) + gravDirection.x();
-			if (useDimensions[1]) *p++ = grasp->getContact(i)->getMate()->wrench[w].force.y();
-			if (useGravity) *(p-1) = *(p-1) + gravDirection.y();
-			if (useDimensions[2]) *p++ = grasp->getContact(i)->getMate()->wrench[w].force.z();
-			if (useGravity) *(p-1) = *(p-1) + gravDirection.z();
+            DBGP(" x: " << grasp->getContact(i)->getMate()->wrench[w].force.x() <<
+                 " y: " << grasp->getContact(i)->getMate()->wrench[w].force.y() <<
+                 " z: " << grasp->getContact(i)->getMate()->wrench[w].force.z());
+            DBGP("tx: " << grasp->getContact(i)->getMate()->wrench[w].torque.x() <<
+                 " ty: " << grasp->getContact(i)->getMate()->wrench[w].torque.y() <<
+                 " tz: " << grasp->getContact(i)->getMate()->wrench[w].torque.z());
 
-			if (useDimensions[3]) *p++ = grasp->getContact(i)->getMate()->wrench[w].torque.x();
-			if (useDimensions[4]) *p++ = grasp->getContact(i)->getMate()->wrench[w].torque.y();
-			if (useDimensions[5]) *p++ = grasp->getContact(i)->getMate()->wrench[w].torque.z();
+            if (useDimensions[0]) *p++ = grasp->getContact(i)->getMate()->wrench[w].force.x();
+            if (useGravity) *(p - 1) = *(p - 1) + gravDirection.x();
+            if (useDimensions[1]) *p++ = grasp->getContact(i)->getMate()->wrench[w].force.y();
+            if (useGravity) *(p - 1) = *(p - 1) + gravDirection.y();
+            if (useDimensions[2]) *p++ = grasp->getContact(i)->getMate()->wrench[w].force.z();
+            if (useGravity) *(p - 1) = *(p - 1) + gravDirection.z();
 
-		}
-	}
+            if (useDimensions[3]) *p++ = grasp->getContact(i)->getMate()->wrench[w].torque.x();
+            if (useDimensions[4]) *p++ = grasp->getContact(i)->getMate()->wrench[w].torque.y();
+            if (useDimensions[5]) *p++ = grasp->getContact(i)->getMate()->wrench[w].torque.z();
 
-	//-----lock qhull access
-	qhull_mutex.lock();
+        }
+    }
 
-	int result;
-	try {
-		result = buildHyperplanesFromWrenches(array, wrenchCount, useDimensions);
-	} catch(...) {
-		DBGA("Build QHull failed!!!");
-		result = FAILURE;
-	}
+    //-----lock qhull access
+    qhull_mutex.lock();
 
-	//-----unlock qhull access
-	qhull_mutex.unlock();
+    int result;
+    try {
+        result = buildHyperplanesFromWrenches(array, wrenchCount, useDimensions);
+    }
+    catch (...) {
+        DBGA("Build QHull failed!!!");
+        result = FAILURE;
+    }
 
-	if (result == SUCCESS) {
-		computeHyperplaneMetrics();
-	} else{
-		clearGWS();
-	}
+    //-----unlock qhull access
+    qhull_mutex.unlock();
 
-	DBGP("HULL AREA: " << hullArea);
-	DBGP("HULL VOLUME: " << hullVolume);
+    if (result == SUCCESS) {
+        computeHyperplaneMetrics();
+    }
+    else {
+        clearGWS();
+    }
 
-	delete [] array;
-	return result;
+    DBGP("HULL AREA: " << hullArea);
+    DBGP("HULL VOLUME: " << hullVolume);
+
+    delete [] array;
+    return result;
 }
 
-/*! 
-  This computes the minkowski sum of the wrenches from a set of contacts.
-  The result is a m^n set of wrenches where m is the number of boundary
-  wrenches on each contact and n is the number of contacts.
+/*!
+    This computes the minkowski sum of the wrenches from a set of contacts.
+    The result is a m^n set of wrenches where m is the number of boundary
+    wrenches on each contact and n is the number of contacts.
 */
 void
 minkowskiSum(Grasp *g, int c, int &wrenchNum, coordT *wrenchArray, Wrench prevSum,
-			 std::vector<int> useDimensions)
-{
-	static Wrench sum;
+             std::vector<int> useDimensions) {
+    static Wrench sum;
 
-	int nd = 0;
-	for (int d=0; d<6; d++) {
-		if (useDimensions[d]) nd++;
-	}
-	if (c == g->getNumContacts()) {
-		if (useDimensions[0]) wrenchArray[ wrenchNum*nd + 0 ] = prevSum.force.x();
-		if (useDimensions[1]) wrenchArray[ wrenchNum*nd + 1 ] = prevSum.force.y();
-		if (useDimensions[2]) wrenchArray[ wrenchNum*nd + 2 ] = prevSum.force.z();
-		if (useDimensions[3]) wrenchArray[ wrenchNum*nd + 3 ] = prevSum.torque.x();
-		if (useDimensions[4]) wrenchArray[ wrenchNum*nd + 4 ] = prevSum.torque.y();
-		if (useDimensions[5]) wrenchArray[ wrenchNum*nd + 5 ] = prevSum.torque.z();
-		wrenchNum++;
-		return;
-	}
+    int nd = 0;
+    for (int d = 0; d < 6; d++) {
+        if (useDimensions[d]) nd++;
+    }
+    if (c == g->getNumContacts()) {
+        if (useDimensions[0]) wrenchArray[ wrenchNum * nd + 0 ] = prevSum.force.x();
+        if (useDimensions[1]) wrenchArray[ wrenchNum * nd + 1 ] = prevSum.force.y();
+        if (useDimensions[2]) wrenchArray[ wrenchNum * nd + 2 ] = prevSum.force.z();
+        if (useDimensions[3]) wrenchArray[ wrenchNum * nd + 3 ] = prevSum.torque.x();
+        if (useDimensions[4]) wrenchArray[ wrenchNum * nd + 4 ] = prevSum.torque.y();
+        if (useDimensions[5]) wrenchArray[ wrenchNum * nd + 5 ] = prevSum.torque.z();
+        wrenchNum++;
+        return;
+    }
 
-	// Perform a sum that doesn't include any contribution from this contact
-	minkowskiSum(g, c+1, wrenchNum, wrenchArray, prevSum, useDimensions);
+    // Perform a sum that doesn't include any contribution from this contact
+    minkowskiSum(g, c + 1, wrenchNum, wrenchArray, prevSum, useDimensions);
 
-	// perform a sum that includes all of this contact wrenches
-	for (int w=0; w < g->getContact(c)->numFrictionEdges; w++) {
+    // perform a sum that includes all of this contact wrenches
+    for (int w = 0; w < g->getContact(c)->numFrictionEdges; w++) {
 
-		sum.force = prevSum.force + g->getContact(c)->getMate()->wrench[w].force;
-		sum.torque = prevSum.torque + g->getContact(c)->getMate()->wrench[w].torque;
+        sum.force = prevSum.force + g->getContact(c)->getMate()->wrench[w].force;
+        sum.torque = prevSum.torque + g->getContact(c)->getMate()->wrench[w].torque;
 
-		minkowskiSum(g, c+1, wrenchNum, wrenchArray, sum, useDimensions);
-	}
+        minkowskiSum(g, c + 1, wrenchNum, wrenchArray, sum, useDimensions);
+    }
 }
 
 /*!
-  Builds an L Infinity GWS by finding the minkowski sum of the set of contact
-  wrenches, and using these as the input for the convex hull operation.
-  (performed by qhull). The output of qhull is the list of equations of the
-  hyperplanes that bound the hull as well as the hull area and hull volume.
-  These are all saved within the GWS.
-  Returns FAILURE or SUCCESS.
+    Builds an L Infinity GWS by finding the minkowski sum of the set of contact
+    wrenches, and using these as the input for the convex hull operation.
+    (performed by qhull). The output of qhull is the list of equations of the
+    hyperplanes that bound the hull as well as the hull area and hull volume.
+    These are all saved within the GWS.
+    Returns FAILURE or SUCCESS.
 
-  You can ask for the GWS to be built using only a subset of the 6 dimensions 
-  of force and torque normally available. These are, in this order: 
-  
-  fx, fy, fz, tx, ty, tz
+    You can ask for the GWS to be built using only a subset of the 6 dimensions
+    of force and torque normally available. These are, in this order:
 
-  If you want only a subset to be used, pass a vector of 6 ints with 1 for the
-  dimensions you want or 0 for those that you do not want. For example, if you
-  want a GWS that only uses fx, fy and tz, pass the following vector:
+    fx, fy, fz, tx, ty, tz
 
-  1, 1, 0, 0, 0, 1
+    If you want only a subset to be used, pass a vector of 6 ints with 1 for the
+    dimensions you want or 0 for those that you do not want. For example, if you
+    want a GWS that only uses fx, fy and tz, pass the following vector:
 
-  If you want to use all 6 dimensions, pass the default value of 
-  GWS::ALL_DIMENSIONS.
+    1, 1, 0, 0, 0, 1
+
+    If you want to use all 6 dimensions, pass the default value of
+    GWS::ALL_DIMENSIONS.
 */
 int
-LInfGWS::build(std::vector<int> useDimensions)
-{
-  clearGWS();
-  if (!grasp->getNumContacts()) {
-    forceClosure = false;
-    return SUCCESS;
-  }
+LInfGWS::build(std::vector<int> useDimensions) {
+    clearGWS();
+    if (!grasp->getNumContacts()) {
+        forceClosure = false;
+        return SUCCESS;
+    }
 
-  //count the number of dimensions actually in use
-  int numDimensions = 0;
-  for (int d=0; d<6; d++) {
-	  if (useDimensions[d]) {
-		  numDimensions++;
-	  }
-  }
+    //count the number of dimensions actually in use
+    int numDimensions = 0;
+    for (int d = 0; d < 6; d++) {
+        if (useDimensions[d]) {
+            numDimensions++;
+        }
+    }
 
-  int wrenchCount = 1;
-  for (int i=0; i<grasp->getNumContacts(); i++) {
-	  wrenchCount *= grasp->getContact(i)->getMate()->numFCWrenches + 1;
-	  if (wrenchCount > INT_MAX/6.0) {  //what is a reasonable threshold ?
-	    DBGA("Too many contacts to compute the Minkowski sum!");
+    int wrenchCount = 1;
+    for (int i = 0; i < grasp->getNumContacts(); i++) {
+        wrenchCount *= grasp->getContact(i)->getMate()->numFCWrenches + 1;
+        if (wrenchCount > INT_MAX / 6.0) { //what is a reasonable threshold ?
+            DBGA("Too many contacts to compute the Minkowski sum!");
+            return FAILURE;
+        }
+    }
+
+    coordT *array = new coordT[wrenchCount * 6];
+    if (!array) {
+        DBGA("Could not allocate wrench array in ComputeLInfHull. wrenchCount: " << wrenchCount);
         return FAILURE;
-      }
-  }
+    }
 
-  coordT *array = new coordT[wrenchCount*6];
-  if (!array) {
-	  DBGA("Could not allocate wrench array in ComputeLInfHull. wrenchCount: " << wrenchCount);
-      return FAILURE;
-  }
+    Wrench initSum;
+    initSum.force = vec3::ZERO;
+    initSum.torque = vec3::ZERO;
 
-  Wrench initSum;
-  initSum.force = vec3::ZERO;
-  initSum.torque = vec3::ZERO;
+    int wrenchNum = 0;
+    minkowskiSum(grasp, 0, wrenchNum, array, initSum, useDimensions);
 
-  int wrenchNum = 0;
-  minkowskiSum(grasp, 0, wrenchNum, array, initSum, useDimensions);
+    //-----lock qhull access
+    qhull_mutex.lock();
 
-  //-----lock qhull access
-  qhull_mutex.lock();
-  
-  int result;
-  try {
-	result = buildHyperplanesFromWrenches(array, wrenchCount, useDimensions);
-  } catch(...) {
-	DBGA("Build QHull 3D failed!!!");
-	result = FAILURE;
-  }
-  
-  //-----release qhull access
-  qhull_mutex.unlock();
+    int result;
+    try {
+        result = buildHyperplanesFromWrenches(array, wrenchCount, useDimensions);
+    }
+    catch (...) {
+        DBGA("Build QHull 3D failed!!!");
+        result = FAILURE;
+    }
 
-  if (result == SUCCESS) {
-	  computeHyperplaneMetrics();
-  } else{
-	  clearGWS();
-  }
+    //-----release qhull access
+    qhull_mutex.unlock();
 
-  DBGP("HULL VOLUME: " << hullVolume);
+    if (result == SUCCESS) {
+        computeHyperplaneMetrics();
+    }
+    else {
+        clearGWS();
+    }
 
-  delete [] array;
-  return result;
+    DBGP("HULL VOLUME: " << hullVolume);
+
+    delete [] array;
+    return result;
 }

--- a/src/gwsprojection.cpp
+++ b/src/gwsprojection.cpp
@@ -17,15 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: gwsprojection.cpp,v 1.9 2009/06/16 22:53:03 cmatei Exp $
 //
 //######################################################################
 
-/*! \file 
-  \brief Implements the grasp wrench space projection class.
- */
+/*! \file
+    \brief Implements the grasp wrench space projection class.
+*/
 
 #include "pointers.dat"
 #include "gwsprojection.h"
@@ -60,186 +60,182 @@
 #define HULLAXES_SCALE 50.0
 
 /*!
-  A GWS projection must be initialized with the a pointer to the mainWindow,
-  a pointer to the GWS being projected, a 6x1 projection coordinates vector,
-  \a c, and set specifiying which of these coordinates are fixed. 
+    A GWS projection must be initialized with the a pointer to the mainWindow,
+    a pointer to the GWS being projected, a 6x1 projection coordinates vector,
+    \a c, and set specifiying which of these coordinates are fixed.
 */
-GWSprojection::GWSprojection(SoQtExaminerViewer *mainViewer,GWS *g,double *c,
-			     std::set<int> whichFixed)
-{
-  gws = g;
-  GraspableBody *object = gws->getGrasp()->getObject();
+GWSprojection::GWSprojection(SoQtExaminerViewer *mainViewer, GWS *g, double *c,
+                             std::set<int> whichFixed) {
+    gws = g;
+    GraspableBody *object = gws->getGrasp()->getObject();
 
-  memcpy(projCoords,c,6*sizeof(double));
+    memcpy(projCoords, c, 6 * sizeof(double));
 
-  fixedCoordIndex = whichFixed;
+    fixedCoordIndex = whichFixed;
 
-  SoMaterial *mat = new SoMaterial;
-  SoShapeHints *myHints = new SoShapeHints;
-  myHints->shapeType = SoShapeHints::SOLID;
-  myHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
-  
-  mat->diffuseColor = SbColor(0,0.8f,0);
-  mat->ambientColor = SbColor(0,0.2f,0);
-  mat->transparency = 0.4f;
+    SoMaterial *mat = new SoMaterial;
+    SoShapeHints *myHints = new SoShapeHints;
+    myHints->shapeType = SoShapeHints::SOLID;
+    myHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
 
-  hullCoords = new SoCoordinate3;
-  hullIFS = new SoIndexedFaceSet;
-  hullSep = new SoSeparator;
-  hullSep->addChild(myHints);
-  hullSep->addChild(mat);
-  hullSep->addChild(hullCoords);
-  hullSep->addChild(hullIFS);
-  
-  SoInput in;
-  in.setBuffer((void *) pointersData, (size_t) sizeof(pointersData));
-  SoSeparator *pointers = SoDB::readAll(&in);
-  SoSeparator *hullaxes = (SoSeparator *)pointers->getChild(3);
-  SoScale *hasf = new SoScale;
-  double scale = gws->getGrasp()->getMaxRadius();
-  hasf->scaleFactor=SbVec3f(scale/HULLAXES_SCALE, scale/HULLAXES_SCALE, scale/HULLAXES_SCALE);
-  hullaxes->insertChild(hasf,0);
+    mat->diffuseColor = SbColor(0, 0.8f, 0);
+    mat->ambientColor = SbColor(0, 0.2f, 0);
+    mat->transparency = 0.4f;
 
-  SoRotation *lightDir = new SoRotation;
-  lightDir->rotation.connectFrom(&mainViewer->getCamera()->orientation);
-  SoTransformSeparator *lightSep = new SoTransformSeparator;
-  lightSep->addChild(lightDir);
-  lightSep->addChild(mainViewer->getHeadlight());
+    hullCoords = new SoCoordinate3;
+    hullIFS = new SoIndexedFaceSet;
+    hullSep = new SoSeparator;
+    hullSep->addChild(myHints);
+    hullSep->addChild(mat);
+    hullSep->addChild(hullCoords);
+    hullSep->addChild(hullIFS);
 
-  SoTransform *hullTran = new SoTransform;
-  if (!hullTran) printf("NULL hullTran!\n");
+    SoInput in;
+    in.setBuffer((void *) pointersData, (size_t) sizeof(pointersData));
+    SoSeparator *pointers = SoDB::readAll(&in);
+    SoSeparator *hullaxes = (SoSeparator *)pointers->getChild(3);
+    SoScale *hasf = new SoScale;
+    double scale = gws->getGrasp()->getMaxRadius();
+    hasf->scaleFactor = SbVec3f(scale / HULLAXES_SCALE, scale / HULLAXES_SCALE, scale / HULLAXES_SCALE);
+    hullaxes->insertChild(hasf, 0);
 
-  if (object!=NULL) {
-	hullTran->translation.connectFrom(&object->getIVTran()->translation);
-	hullTran->rotation.connectFrom(&object->getIVTran()->rotation);
-  } else {
-	  hullTran->translation = gws->getGrasp()->getCoG().toSbVec3f();
-  }
+    SoRotation *lightDir = new SoRotation;
+    lightDir->rotation.connectFrom(&mainViewer->getCamera()->orientation);
+    SoTransformSeparator *lightSep = new SoTransformSeparator;
+    lightSep->addChild(lightDir);
+    lightSep->addChild(mainViewer->getHeadlight());
 
-  sg = new SoSeparator;
-  // create our own camera so it has better clipping planes
-  SoPerspectiveCamera *camera = new SoPerspectiveCamera();
-  if (!camera->position.connectFrom( &mainViewer->getCamera()->position )) 
-	  fprintf(stderr,"Projection camera connection 1 failed!\n");
-  if (!camera->orientation.connectFrom( &mainViewer->getCamera()->orientation ))
-	  fprintf(stderr,"Projection camera connection 2 failed!\n");
-  camera->nearDistance = 5;
-  camera->farDistance = 1000;
-  sg->addChild(camera);
-  // original code just re-used main camera
-  //sg->addChild( mainViewer->getCamera() );
+    SoTransform *hullTran = new SoTransform;
+    if (!hullTran) printf("NULL hullTran!\n");
 
-  sg->addChild(lightSep);   
-  sg->addChild(hullTran);
-  sg->addChild(hullaxes);
-  sg->addChild(hullSep); 
-
-  pointers->ref();
-  pointers->unref();
-
-
-  projectionViewer = new SoQtRenderArea();
-  projectionViewer->setTransparencyType(SoGLRenderAction::SORTED_OBJECT_BLEND);
-  projectionViewer->setBackgroundColor(SbColor(1,1,1));
-  projectionViewer->setSceneGraph(sg);
-  if (projectionViewer->isTopLevelShell()) printf("TOP LEVEL SHELL\n");
-  else printf("NOT TOP LEVEL SHELL\n");
-  projectionViewer->setWindowCloseCallback(Grasp::destroyProjection,this);
-
-  projectionViewer->show();
-  setWinTitle();
-  projWin = projectionViewer->getParentWidget();
-
-  update();
-
-}
-
-/*!
-  Removes 1 reference to a GWS (if refcount goes to 0 it will be deleted).
-  If the window still exists, delete it.  Delete the projection viewer.
-*/
-GWSprojection::~GWSprojection()
-{
-  gws->getGrasp()->removeGWS(gws);
-  if (projectionViewer->getShellWidget()) {
-	projectionViewer->setWindowCloseCallback(NULL);
-	delete projectionViewer->getShellWidget();
-  }
-  delete projectionViewer;
-}
-
-/*!
-  Sets the window title of the projection window after the viewer is created.
-  The title is specifies the type of GWS and the coordinate values of
-  fixed coordinates.
-  (i.e. "L1 GWS projection (0, 0, 0, *, *, *)" is a projection into torque-
-  space)
-*/
-void
-GWSprojection::setWinTitle()
-{
-  int i;
-  char titleStr[100],element[6];
-
-  sprintf(titleStr,"%s GWS projection (",gws->getType());
-  for (i=0;i<6;i++) {
-    if (fixedCoordIndex.find(i) == fixedCoordIndex.end())
-      strcat(titleStr," * ");
+    if (object != NULL) {
+        hullTran->translation.connectFrom(&object->getIVTran()->translation);
+        hullTran->rotation.connectFrom(&object->getIVTran()->rotation);
+    }
     else {
-      sprintf(element,"%4.1f",projCoords[i]);
-      strcat(titleStr,element);
+        hullTran->translation = gws->getGrasp()->getCoG().toSbVec3f();
     }
 
-    if (i<5)
-      strcat(titleStr,",");
-  }
-  strcat(titleStr,")");
+    sg = new SoSeparator;
+    // create our own camera so it has better clipping planes
+    SoPerspectiveCamera *camera = new SoPerspectiveCamera();
+    if (!camera->position.connectFrom(&mainViewer->getCamera()->position))
+        fprintf(stderr, "Projection camera connection 1 failed!\n");
+    if (!camera->orientation.connectFrom(&mainViewer->getCamera()->orientation))
+        fprintf(stderr, "Projection camera connection 2 failed!\n");
+    camera->nearDistance = 5;
+    camera->farDistance = 1000;
+    sg->addChild(camera);
+    // original code just re-used main camera
+    //sg->addChild( mainViewer->getCamera() );
 
-  projectionViewer->setTitle(titleStr);
+    sg->addChild(lightSep);
+    sg->addChild(hullTran);
+    sg->addChild(hullaxes);
+    sg->addChild(hullSep);
+
+    pointers->ref();
+    pointers->unref();
+
+
+    projectionViewer = new SoQtRenderArea();
+    projectionViewer->setTransparencyType(SoGLRenderAction::SORTED_OBJECT_BLEND);
+    projectionViewer->setBackgroundColor(SbColor(1, 1, 1));
+    projectionViewer->setSceneGraph(sg);
+    if (projectionViewer->isTopLevelShell()) printf("TOP LEVEL SHELL\n");
+    else printf("NOT TOP LEVEL SHELL\n");
+    projectionViewer->setWindowCloseCallback(Grasp::destroyProjection, this);
+
+    projectionViewer->show();
+    setWinTitle();
+    projWin = projectionViewer->getParentWidget();
+
+    update();
+
 }
 
 /*!
-  Updates the 3D hull by calling the projection routine of the associated
-  GWS.  The new hull geometry is then created.
+    Removes 1 reference to a GWS (if refcount goes to 0 it will be deleted).
+    If the window still exists, delete it.  Delete the projection viewer.
 */
-void
-GWSprojection::update()
-{
-  int i;
-  std::vector<position> coords;
-  std::vector<int> indices;
-
-  if (gws->isForceClosure() || gws->hasPositiveVolume() )
-    gws->projectTo3D(projCoords,fixedCoordIndex,coords,indices);
-
-  hullCoords->point.deleteValues(0);
-  hullIFS->coordIndex.deleteValues(0);
-
-  int numCoords = coords.size();
-  for (i=0;i<numCoords;i++) {
-    hullCoords->point.set1Value(i,(float)coords[i].x(),(float)coords[i].y(),
-				(float)coords[i].z());
-  }
-
-  int numIndices = indices.size();
-  for (i=0;i<numIndices;i++) {
-    hullIFS->coordIndex.set1Value(i,indices[i]);
-  }
-  
-  coords.clear();
-  indices.clear();
+GWSprojection::~GWSprojection() {
+    gws->getGrasp()->removeGWS(gws);
+    if (projectionViewer->getShellWidget()) {
+        projectionViewer->setWindowCloseCallback(NULL);
+        delete projectionViewer->getShellWidget();
+    }
+    delete projectionViewer;
 }
 
 /*!
-  Replaces 3D hull geometry with an empty node.
+    Sets the window title of the projection window after the viewer is created.
+    The title is specifies the type of GWS and the coordinate values of
+    fixed coordinates.
+    (i.e. "L1 GWS projection (0, 0, 0, *, *, *)" is a projection into torque-
+    space)
 */
 void
-GWSprojection::deleteHull()
-{
-  hullSep->removeChild(2);
-  hullSep->removeChild(2);
-  hullCoords = new SoCoordinate3;
-  hullIFS = new SoIndexedFaceSet;
-  hullSep->addChild(hullCoords);
-  hullSep->addChild(hullIFS);
+GWSprojection::setWinTitle() {
+    int i;
+    char titleStr[100], element[6];
+
+    sprintf(titleStr, "%s GWS projection (", gws->getType());
+    for (i = 0; i < 6; i++) {
+        if (fixedCoordIndex.find(i) == fixedCoordIndex.end())
+            strcat(titleStr, " * ");
+        else {
+            sprintf(element, "%4.1f", projCoords[i]);
+            strcat(titleStr, element);
+        }
+
+        if (i < 5)
+            strcat(titleStr, ",");
+    }
+    strcat(titleStr, ")");
+
+    projectionViewer->setTitle(titleStr);
+}
+
+/*!
+    Updates the 3D hull by calling the projection routine of the associated
+    GWS.  The new hull geometry is then created.
+*/
+void
+GWSprojection::update() {
+    int i;
+    std::vector<position> coords;
+    std::vector<int> indices;
+
+    if (gws->isForceClosure() || gws->hasPositiveVolume())
+        gws->projectTo3D(projCoords, fixedCoordIndex, coords, indices);
+
+    hullCoords->point.deleteValues(0);
+    hullIFS->coordIndex.deleteValues(0);
+
+    int numCoords = coords.size();
+    for (i = 0; i < numCoords; i++) {
+        hullCoords->point.set1Value(i, (float)coords[i].x(), (float)coords[i].y(),
+                                    (float)coords[i].z());
+    }
+
+    int numIndices = indices.size();
+    for (i = 0; i < numIndices; i++) {
+        hullIFS->coordIndex.set1Value(i, indices[i]);
+    }
+
+    coords.clear();
+    indices.clear();
+}
+
+/*!
+    Replaces 3D hull geometry with an empty node.
+*/
+void
+GWSprojection::deleteHull() {
+    hullSep->removeChild(2);
+    hullSep->removeChild(2);
+    hullCoords = new SoCoordinate3;
+    hullIFS = new SoIndexedFaceSet;
+    hullSep->addChild(hullCoords);
+    hullSep->addChild(hullIFS);
 }

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: ivmgr.cpp,v 1.65 2009/11/20 23:03:32 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Implements the IVmgr class which handles 3D user interaction.
+    \brief Implements the IVmgr class which handles 3D user interaction.
 */
 
 #include <map>
@@ -112,7 +112,7 @@
 
 #ifdef USE_DMALLOC
 include "dmalloc.h"
-#endif 
+#endif
 
 #define FORCE_SCALE 5.0
 
@@ -121,1757 +121,1708 @@ extern FILE *debugfile;
 #endif
 
 //! Keeps track of Inventor draggers attached to worldElements or DOF's
-/*! 
-  A dragger is an Inventor object which allows the user to use the mouse to
-  move worldElements or DOF's.  Each time a dragger is created, a new instance
-  of this structure is create to keep track of the dragger and information
-  related to it.  There are 4 types of draggers currently used:
-  <ul>
-  <li>For moving the base of a robot, an object or an obstacle:
-  <ul>
-  <li>A handlebox allows 3D translation of the element
-  <li>A centerball allows 3D rotation of the element about an arbitrary point
-  </ul>
-  <li>For moving a DOF:
-  <ul>
-  <li>An arrow allows translation of prismatic DOF's
-  <li>A disc allows rotation of revolute DOF's
-  </ul>
-  </ul>
+/*!
+    A dragger is an Inventor object which allows the user to use the mouse to
+    move worldElements or DOF's.  Each time a dragger is created, a new instance
+    of this structure is create to keep track of the dragger and information
+    related to it.  There are 4 types of draggers currently used:
+    <ul>
+    <li>For moving the base of a robot, an object or an obstacle:
+    <ul>
+    <li>A handlebox allows 3D translation of the element
+    <li>A centerball allows 3D rotation of the element about an arbitrary point
+    </ul>
+    <li>For moving a DOF:
+    <ul>
+    <li>An arrow allows translation of prismatic DOF's
+    <li>A disc allows rotation of revolute DOF's
+    </ul>
+    </ul>
 */
 struct DraggerInfo {
-  //! Points to the associated robot or object for handleboxes and centerballs 
-  WorldElement *selectedElement;
+    //! Points to the associated robot or object for handleboxes and centerballs
+    WorldElement *selectedElement;
 
-  //! Points to the associated DOF for DOF draggers
-  DOF *dof;
+    //! Points to the associated DOF for DOF draggers
+    DOF *dof;
 
-  //! Points to the Inventor root of the dragger sub-tree.
-  SoSeparator *draggerSep;
+    //! Points to the Inventor root of the dragger sub-tree.
+    SoSeparator *draggerSep;
 
-  //! Points to the dragger itself
-  SoDragger *dragger;
+    //! Points to the dragger itself
+    SoDragger *dragger;
 
-  //! Points to the Inventor transform controlling the position of the dragger relative to
-  SoTransform *draggerTran;
+    //! Points to the Inventor transform controlling the position of the dragger relative to
+    SoTransform *draggerTran;
 
-  //! The last recorded translation of a handlebox dragger
-  SbVec3f lastTran;
+    //! The last recorded translation of a handlebox dragger
+    SbVec3f lastTran;
 
-  //! The last recorded rotation of a centerball dragger
-  SbRotation lastRot;
+    //! The last recorded rotation of a centerball dragger
+    SbRotation lastRot;
 
-  //! The last recorded center of rotation of a centerball dragger
-  SbVec3f lastCent;
-  
-  //! The current translation of a centerball dragger
-  vec3 centerballTransl;
+    //! The last recorded center of rotation of a centerball dragger
+    SbVec3f lastCent;
 
-  //! The last recorded angle or distance for DOF draggers
-  double lastVal;
+    //! The current translation of a centerball dragger
+    vec3 centerballTransl;
+
+    //! The last recorded angle or distance for DOF draggers
+    double lastVal;
 };
 
-//! A list of the current draggers and their related info 
+//! A list of the current draggers and their related info
 std::list<DraggerInfo *> draggerInfoList;
 
 
 void
-StereoViewer::computeSeekFinalOrientation()
-{
-	float f = getCamera()->focalDistance.getValue();
-	float sb = mFocalPlane / f;
-	getCamera()->setBalanceAdjustment( sb );
+StereoViewer::computeSeekFinalOrientation() {
+    float f = getCamera()->focalDistance.getValue();
+    float sb = mFocalPlane / f;
+    getCamera()->setBalanceAdjustment(sb);
 }
 
 
-void StereoViewer::setStereo(bool s)
-{
-	if (s) {
-		stereoOn = true;
-		setStereoType( SoQtViewer::STEREO_QUADBUFFER );
-		getCamera()->setStereoAdjustment(100.0);
-		setStereoOffset(10.0);
-		computeSeekFinalOrientation();
-	} else {
-		stereoOn = false;
-		setStereoType( SoQtViewer::STEREO_NONE );
-	}
+void StereoViewer::setStereo(bool s) {
+    if (s) {
+        stereoOn = true;
+        setStereoType(SoQtViewer::STEREO_QUADBUFFER);
+        getCamera()->setStereoAdjustment(100.0);
+        setStereoOffset(10.0);
+        computeSeekFinalOrientation();
+    }
+    else {
+        stereoOn = false;
+        setStereoType(SoQtViewer::STEREO_NONE);
+    }
 }
 
-StereoViewer::StereoViewer(QWidget *parent) : SoQtExaminerViewer(parent) 
-{
-	stereoOn = false;
-	mFocalPlane = 200.0;
+StereoViewer::StereoViewer(QWidget *parent) : SoQtExaminerViewer(parent) {
+    stereoOn = false;
+    mFocalPlane = 200.0;
 }
 
 IVmgr *IVmgr::ivmgr = 0;
 
 
 /*!
-  Initializes the IVmgr instance.  It creates a new World that is the main
-  world that the user interacts with.  It creates the examiner viewer that
-  allows the user to navigate within the world and interact with it. It sets
-  up the root of the entire Inventor scene graph tree as well as sub-nodes
-  that handle callbacks for user selections and key presses.  Sub-tree roots
-  for draggers and wireframe models, which indicate when bodies are selected,
-  are also created.
+    Initializes the IVmgr instance.  It creates a new World that is the main
+    world that the user interacts with.  It creates the examiner viewer that
+    allows the user to navigate within the world and interact with it. It sets
+    up the root of the entire Inventor scene graph tree as well as sub-nodes
+    that handle callbacks for user selections and key presses.  Sub-tree roots
+    for draggers and wireframe models, which indicate when bodies are selected,
+    are also created.
 */
-IVmgr::IVmgr(QWidget *parent, const char *name, Qt::WFlags f) : 
-  QWidget(parent,name,f)
-{
-  ivmgr = this;
-  camerafp = NULL;
-  CtrlDown = FALSE;
-  ShiftDown = FALSE;
-  dynForceMat = NULL;
+IVmgr::IVmgr(QWidget *parent, const char *name, Qt::WFlags f) :
+    QWidget(parent, name, f) {
+    ivmgr = this;
+    camerafp = NULL;
+    CtrlDown = FALSE;
+    ShiftDown = FALSE;
+    dynForceMat = NULL;
 
-  currTool = TRANSLATE_TOOL;
+    currTool = TRANSLATE_TOOL;
 
-#ifdef GRASPITDBG
-  printf("Starting Inventor...\n");
-#endif
+    #ifdef GRASPITDBG
+    printf("Starting Inventor...\n");
+    #endif
 
-  // Initialize the main world
-  world = new World(NULL,"mainWorld", this);
-  setupPointers();
+    // Initialize the main world
+    world = new World(NULL, "mainWorld", this);
+    setupPointers();
 
-  // Create the viewer
-  myViewer = new StereoViewer(parent);
+    // Create the viewer
+    myViewer = new StereoViewer(parent);
 
-  //this->setFocusProxy(myViewer->getWidget());
+    //this->setFocusProxy(myViewer->getWidget());
 
-  sceneRoot = new SoSeparator;
-  sceneRoot->ref();
+    sceneRoot = new SoSeparator;
+    sceneRoot->ref();
 
-  //add this before the mouseEventCB which otherwise captures the click!
-  draggerRoot = new SoSeparator;
-  sceneRoot->addChild(draggerRoot);
+    //add this before the mouseEventCB which otherwise captures the click!
+    draggerRoot = new SoSeparator;
+    sceneRoot->addChild(draggerRoot);
 
-  //add keyboard callback
-  SoEventCallback *keyEventNode = new SoEventCallback;
-  keyEventNode->addEventCallback(SoKeyboardEvent::getClassTypeId(), keyPressedCB,NULL);
-  sceneRoot->addChild(keyEventNode);
+    //add keyboard callback
+    SoEventCallback *keyEventNode = new SoEventCallback;
+    keyEventNode->addEventCallback(SoKeyboardEvent::getClassTypeId(), keyPressedCB, NULL);
+    sceneRoot->addChild(keyEventNode);
 
-  // Add callback to detect if modifier keys are held down during mouse clicks
-  SoEventCallback *mouseEventCB = new SoEventCallback;
-  mouseEventCB->addEventCallback(SoMouseButtonEvent::getClassTypeId(), shiftOrCtrlDownCB);
-  sceneRoot->addChild(mouseEventCB);
+    // Add callback to detect if modifier keys are held down during mouse clicks
+    SoEventCallback *mouseEventCB = new SoEventCallback;
+    mouseEventCB->addEventCallback(SoMouseButtonEvent::getClassTypeId(), shiftOrCtrlDownCB);
+    sceneRoot->addChild(mouseEventCB);
 
-  // an empty separator used in the make handlebox routine
-  junk = new SoSeparator; junk->ref(); 
+    // an empty separator used in the make handlebox routine
+    junk = new SoSeparator;
+    junk->ref();
 
-  // create and set up the selection node
-  selectionRoot = new SoSelection;
-  sceneRoot->addChild(selectionRoot);
+    // create and set up the selection node
+    selectionRoot = new SoSelection;
+    sceneRoot->addChild(selectionRoot);
 
-  // Add selection and deselection callbacks
-  selectionRoot->addSelectionCallback(selectionCB, NULL);
-  selectionRoot->addDeselectionCallback(deselectionCB, NULL);
-  selectionRoot->setPickFilterCallback(pickFilterCB, NULL);
-  selectionRoot->addChild(world->getIVRoot());
+    // Add selection and deselection callbacks
+    selectionRoot->addSelectionCallback(selectionCB, NULL);
+    selectionRoot->addDeselectionCallback(deselectionCB, NULL);
+    selectionRoot->setPickFilterCallback(pickFilterCB, NULL);
+    selectionRoot->addChild(world->getIVRoot());
 
-  wireFrameRoot = new SoSeparator;
-  sceneRoot->addChild(wireFrameRoot);
+    wireFrameRoot = new SoSeparator;
+    sceneRoot->addChild(wireFrameRoot);
 
-  //comment these out if only single-threaded operation will be used
-  //myViewer->setRenderMutex(&mRenderMutex);
-  //world->setRenderMutex(&mRenderMutex);
+    //comment these out if only single-threaded operation will be used
+    //myViewer->setRenderMutex(&mRenderMutex);
+    //world->setRenderMutex(&mRenderMutex);
 
-  myViewer->show();
-  myViewer->setSceneGraph(sceneRoot);
-  myViewer->setTransparencyType(SoGLRenderAction::DELAYED_BLEND);
-  myViewer->setBackgroundColor(SbColor(1,1,1));
+    myViewer->show();
+    myViewer->setSceneGraph(sceneRoot);
+    myViewer->setTransparencyType(SoGLRenderAction::DELAYED_BLEND);
+    myViewer->setBackgroundColor(SbColor(1, 1, 1));
 
-  myViewer->viewAll();
-  mDBMgr = NULL;
-  mDBMgr = NULL;
+    myViewer->viewAll();
+    mDBMgr = NULL;
+    mDBMgr = NULL;
 }
 
 //! Not used right now
 void
-IVmgr::setStereoWindow(QWidget *parent)
-{
-	StereoViewer *sViewer = new StereoViewer(parent);
-	sViewer->show();
-	sViewer->setSceneGraph(sceneRoot);
-	sViewer->setTransparencyType(SoGLRenderAction::DELAYED_BLEND);
-	sViewer->setBackgroundColor(SbColor(1,1,1));
-	//sViewer->setCamera( myViewer->getCamera() );
-	sViewer->viewAll();
-	sViewer->setDecoration(false);
+IVmgr::setStereoWindow(QWidget *parent) {
+    StereoViewer *sViewer = new StereoViewer(parent);
+    sViewer->show();
+    sViewer->setSceneGraph(sceneRoot);
+    sViewer->setTransparencyType(SoGLRenderAction::DELAYED_BLEND);
+    sViewer->setBackgroundColor(SbColor(1, 1, 1));
+    //sViewer->setCamera( myViewer->getCamera() );
+    sViewer->viewAll();
+    sViewer->setDecoration(false);
 }
 
 /*!
-  Deselects all elements, and deletes the main world.  Deletes the remaining
-  Inventor scene graph and deletes the Inventor viewer.
+    Deselects all elements, and deletes the main world.  Deletes the remaining
+    Inventor scene graph and deletes the Inventor viewer.
 */
-IVmgr::~IVmgr()
-{
-  if (camerafp) fclose(camerafp);
-  std::cout << "deleting IVmgr" << std::endl;
-  selectionRoot->deselectAll();
-  delete world;
-  junk->unref();
-  if (dynForceMat) dynForceMat->unref();
-  pointers->unref();
-  sceneRoot->unref();
-  delete myViewer;
+IVmgr::~IVmgr() {
+    if (camerafp) fclose(camerafp);
+    std::cout << "deleting IVmgr" << std::endl;
+    selectionRoot->deselectAll();
+    delete world;
+    junk->unref();
+    if (dynForceMat) dynForceMat->unref();
+    pointers->unref();
+    sceneRoot->unref();
+    delete myViewer;
 }
 
 /*!
-  Deselects all world elements, deletes the world, and creates a new world.
+    Deselects all world elements, deletes the world, and creates a new world.
 */
 void
-IVmgr::emptyWorld()
-{
-  selectionRoot->deselectAll();
-  selectionRoot->removeChild(world->getIVRoot());
-  delete world;
-  world = new World(NULL, "MainWorld", this);
-  //comment out here and where another world is created to stop using mutexes
-  //world->setRenderMutex(&mRenderMutex);
-  selectionRoot->addChild(world->getIVRoot());
+IVmgr::emptyWorld() {
+    selectionRoot->deselectAll();
+    selectionRoot->removeChild(world->getIVRoot());
+    delete world;
+    world = new World(NULL, "MainWorld", this);
+    //comment out here and where another world is created to stop using mutexes
+    //world->setRenderMutex(&mRenderMutex);
+    selectionRoot->addChild(world->getIVRoot());
 }
 
 /*!
-  Deselects all elements and sets the current tool type.
+    Deselects all elements and sets the current tool type.
 */
-void IVmgr::setTool(ToolType newTool)
-{
-  selectionRoot->deselectAll();
-  currTool = newTool;
+void IVmgr::setTool(ToolType newTool) {
+    selectionRoot->deselectAll();
+    currTool = newTool;
 }
 
 /*!
-  Tells Inventor to read the binary data stored in the static pointersData to
-  create a model of the arrow used in the coordinate axes and force pointers,
-  and a model of the torque pointer.
+    Tells Inventor to read the binary data stored in the static pointersData to
+    create a model of the arrow used in the coordinate axes and force pointers,
+    and a model of the torque pointer.
 */
 void
-IVmgr::setupPointers()
-{
-  SoInput in;
-  in.setBuffer((void *) pointersData, (size_t) sizeof(pointersData));
-  pointers = SoDB::readAll(&in);
-  //pointers = new SoSeparator;
-  pointers->ref();
+IVmgr::setupPointers() {
+    SoInput in;
+    in.setBuffer((void *) pointersData, (size_t) sizeof(pointersData));
+    pointers = SoDB::readAll(&in);
+    //pointers = new SoSeparator;
+    pointers->ref();
 }
 
 /*!
-  Starts the main event loop.
+    Starts the main event loop.
 */
 void
-IVmgr::beginMainLoop()
-{
-  //SoQt::show(MainWindow);
-  SoQt::mainLoop();
+IVmgr::beginMainLoop() {
+    //SoQt::show(MainWindow);
+    SoQt::mainLoop();
 }
 
 /*!
-	Draws the force pointers that show the resultant static forces applied
-	to objects as a result of coupled robot dofs touching them.
+    Draws the force pointers that show the resultant static forces applied
+    to objects as a result of coupled robot dofs touching them.
 */
 void
-IVmgr::drawUnbalancedForces()
-{
-	for (int b=0; b<world->getNumGB(); b++) {
-		drawBodyWrench( world->getGB(b), world->getGB(b)->getExtWrenchAcc() );
-	}
+IVmgr::drawUnbalancedForces() {
+    for (int b = 0; b < world->getNumGB(); b++) {
+        drawBodyWrench(world->getGB(b), world->getGB(b)->getExtWrenchAcc());
+    }
 }
 
 /*!
-  Draws the force and torque pointers that indicate the relative size and 
-  orientation of the force and torque components of the worst case disturbance
-  wrench for each grasped object.  The pointers are added to the object's
-  Inventor sub-graph.
- */
+    Draws the force and torque pointers that indicate the relative size and
+    orientation of the force and torque components of the worst case disturbance
+    wrench for each grasped object.  The pointers are added to the object's
+    Inventor sub-graph.
+*/
 void
-IVmgr::drawWorstCaseWrenches()
-{
-  Grasp *grasp;
-  double minWrench[6];
+IVmgr::drawWorstCaseWrenches() {
+    Grasp *grasp;
+    double minWrench[6];
 
-  for (int h=0;h<world->getNumHands();h++) {
-    grasp = world->getHand(h)->getGrasp();
-	if (!grasp->getObject()) continue;
+    for (int h = 0; h < world->getNumHands(); h++) {
+        grasp = world->getHand(h)->getGrasp();
+        if (!grasp->getObject()) continue;
 
-    // Get the grasp wrench most difficult for this grasp to apply
-    grasp->getMinWrench(minWrench);
+        // Get the grasp wrench most difficult for this grasp to apply
+        grasp->getMinWrench(minWrench);
 
-	//normalise the wrench to be sure we can see it
-	double forceScale  = minWrench[0]*minWrench[0] + minWrench[1]*minWrench[1] + minWrench[2]*minWrench[2];
-	forceScale = sqrt(forceScale);
-	double torqueScale = minWrench[3]*minWrench[3] + minWrench[4]*minWrench[4] + minWrench[5]*minWrench[5];
-	torqueScale = sqrt(torqueScale);
-	double scale = 5.0 / std::max(forceScale, torqueScale);
+        //normalise the wrench to be sure we can see it
+        double forceScale  = minWrench[0] * minWrench[0] + minWrench[1] * minWrench[1] + minWrench[2] * minWrench[2];
+        forceScale = sqrt(forceScale);
+        double torqueScale = minWrench[3] * minWrench[3] + minWrench[4] * minWrench[4] + minWrench[5] * minWrench[5];
+        torqueScale = sqrt(torqueScale);
+        double scale = 5.0 / std::max(forceScale, torqueScale);
 
-    // The worst case disturbance wrench is the opposite of the minWrench
-	for (int i=0; i<6; i++) {
-		minWrench[i] = -scale * minWrench[i];
-	}
+        // The worst case disturbance wrench is the opposite of the minWrench
+        for (int i = 0; i < 6; i++) {
+            minWrench[i] = -scale * minWrench[i];
+        }
 
-	drawBodyWrench( grasp->getObject(), minWrench );
-  }
+        drawBodyWrench(grasp->getObject(), minWrench);
+    }
 }
 
 void
-IVmgr::drawBodyWrench(GraspableBody *body, const double *wrench)
-{
+IVmgr::drawBodyWrench(GraspableBody *body, const double *wrench) {
     SoSeparator *fSep = NULL;
     SoSeparator *tSep = NULL;
     body->getIVWorstCase()->removeAllChildren();
- 
-    SbVec3f forceDir(wrench[0],wrench[1],wrench[2]);
+
+    SbVec3f forceDir(wrench[0], wrench[1], wrench[2]);
     if (forceDir.length() > 0.0) {
-      SoArrow *forcePtr = new SoArrow;
-      forcePtr->height = forceDir.length()*FORCE_SCALE;
-	  if (forceDir.length()*FORCE_SCALE > 200.0) {
-		  DBGP("Too long.");
-		  forcePtr->height = 200.0;
-	  }
-      
-      SoRotation *fRot = new SoRotation;
-      fRot->rotation.setValue(SbRotation(SbVec3f(0,1,0),forceDir));
-      
-      fSep = new SoSeparator;
-      fSep->addChild(fRot);
-      fSep->addChild(forcePtr);
-    }
-    
-    SbVec3f torqueDir(wrench[3],wrench[4],wrench[5]);
-    if (torqueDir.length() > 0.0) {
-      SoTorquePointer *torquePtr = new SoTorquePointer;  
-      torquePtr->height = torqueDir.length()*FORCE_SCALE;
-	  if (torqueDir.length()*FORCE_SCALE > 200.0) {
-		  DBGP("Too long.");
-		  torquePtr->height = 200.0;
-	  }
-      
-      SoRotation *tRot = new SoRotation;
-      tRot->rotation.setValue(SbRotation(SbVec3f(0,1,0),torqueDir));
-      
-      tSep = new SoSeparator;
-      tSep->addChild(tRot);
-      tSep->addChild(torquePtr);
-    }
-    
-    if (fSep || tSep) {
-      SoMaterial *mat = new SoMaterial;  
-      mat->diffuseColor = SbColor(0.8f,0,0.8f);
-      mat->ambientColor = SbColor(0.2f,0,0.2f);
-      mat->emissiveColor = SbColor(0.4f,0,0.4f);
-      
-      SoSeparator *pointerRoot = new SoSeparator;
-      pointerRoot->addChild(mat);
-      if (fSep) pointerRoot->addChild(fSep);
-      if (tSep) pointerRoot->addChild(tSep);
-      
-      // Remove previous worstcase pointers from the object and add new ones
-      body->getIVWorstCase()->addChild(pointerRoot);
-    }
-}
-
-/*!
-  This routine adds arrows within each of the friction cones that indicate
-  the size of the dynamic contact forces that were solved for.
-  This still doesn't handle the display of any torsional forces at soft
-  finger contacts.  If dynamics are not on, blinker nodes are added so that
-  when a contact force is selected from the list the associated contact force
-  indicator will blink.
-*/
-void
-IVmgr::drawDynamicForces()
-{
-	std::list<Contact *> contactList;
-	std::list<Contact *>::iterator cp;
-	SbVec3f forceVec;
-	double *contactForce;
-
-	if (!dynForceMat) {
-		dynForceMat = new SoMaterial;
-		dynForceMat->diffuseColor = SbColor(0.8f,0.8f,0);
-		dynForceMat->ambientColor = SbColor(0.2f,0.2f,0);
-		//dynForceMat->emissiveColor = SbColor(0.8,0.8,0);
-		dynForceMat->ref();
-	}
-
-	int numContacts=0;
-	if (!world->dynamicsAreOn()) {
-		//count the number of contacts
-		for (int b=0; b<world->getNumGB(); b++) {
-			int sz = world->getGB(b)->getContacts().size();
-			numContacts += sz;
-			int numChildren = world->getGB(b)->getIVContactIndicators()->getNumChildren();
-			for (int i=numChildren-1; i>=sz; i--){
-				world->getGB(b)->getIVContactIndicators()->removeChild(i);
-			}
-		}
-		contactForceBlinkerVec.clear();
-		if (numContacts == 0) return;
-		contactForceBlinkerVec.reserve(numContacts);
-	}
-
-	for (int b=0; b<world->getNumGB(); b++) {
-		contactList = world->getGB(b)->getContacts();
-		for (cp=contactList.begin();cp!=contactList.end();cp++) {
-			contactForce = (*cp)->getDynamicContactWrench();   
-			forceVec.setValue(contactForce[0],contactForce[1],contactForce[2]);
-			forceVec *= FORCE_SCALE;
-			//don't add large arrows because they mess up the OpenGL clipping planes
-			if (forceVec.length() > 200) {
-				forceVec *= 200.0 / forceVec.length();
-			}
-			SoArrow *arrow = new SoArrow;
-			arrow->height = forceVec.length();
-			arrow->cylRadius = 0.25;
-			arrow->coneRadius = 0.5;
-			if (arrow->height.getValue() < arrow->coneHeight.getValue()) {
-				arrow->coneHeight = arrow->height.getValue() / 2.0;
-			}     
-			SoTransform *tran = new SoTransform;
-			(*cp)->getContactFrame().toSoTransform(tran);      
-			SoRotation *rot = new SoRotation;
-			rot->rotation.setValue(SbRotation(SbVec3f(0,1,0),forceVec));
-            
-			SoSeparator *ptr = new SoSeparator;    
-			ptr->addChild(tran);
-			ptr->addChild(rot);
-			ptr->addChild(dynForceMat);
-			ptr->addChild(arrow);
-
-			int lastChild = world->getGB(b)->getIVContactIndicators()->getNumChildren();
-			if (world->dynamicsAreOn()) {
-				world->getGB(b)->getIVContactIndicators()->insertChild(ptr, lastChild);
-			} else {
-				contactForceBlinkerVec.push_back(new SoBlinker);
-				contactForceBlinkerVec.back()->addChild(ptr);
-				contactForceBlinkerVec.back()->on = false;
-				contactForceBlinkerVec.back()->whichChild = 0;
-				world->getGB(b)->getIVContactIndicators()->insertChild(
-					contactForceBlinkerVec.back(),lastChild);
-			}
-		}
-	}
-}
-
-/*!
-  Called when a contact is selected from the contact list, and causes the
-  associated contact force indicator to blink.
-*/
-void
-IVmgr::hilightObjContact(int contactNum)
-{
-	if ((int)contactForceBlinkerVec.size() > contactNum) {
-		contactForceBlinkerVec[contactNum]->on = true;
-	} else {
-		DBGA("Highlight blinker " << contactNum << " requested, but only " 
-			<< contactForceBlinkerVec.size() << " present.");
-	}
-}
-
-/*!
-  Called when a contact is deselected from the contact list, and causes the
-  associated contact force indicator to stop blinking.
-*/
-void
-IVmgr::unhilightObjContact(int contactNum)
-{
-	if ((int)contactForceBlinkerVec.size() > contactNum) {
-		contactForceBlinkerVec[contactNum]->on = false;
-		contactForceBlinkerVec[contactNum]->whichChild = 0;
-	} else {
-		DBGA("Unhighlight blinker " << contactNum << " requested, but only " 
-			<< contactForceBlinkerVec.size() << " present.");
-	}
-}
-
-/*!
-  This is a callback routine that is invoked anytime a handlebox or centerball
-  is manipulated by the user. It requires a pointer to the draggerInfo
-  structure of the manipulated dragger.  If the center of centerball was
-  changed, it simply updates the variable tracking the centerball translation.
-  If a handlebox is moved or a centerball is rotated this computes the new
-  body transform and calls the worldElement::moveTo routine.  After the move
-  is completed or a contact prevents further motion, it asks the world to
-  update all grasps, and sets the new dragger position.
-*/
-void
-IVmgr::transRot(DraggerInfo *dInfo)
-{
-	//static int count = 0;
-	//DBGA("Callback " << count++);
-	
-	SoCenterballDragger *myCenterball;
-	SoHandleBoxDragger *myHandleBox;
-	bool translating;
-
-	Quaternion origRotation,desiredRotation;
-	vec3 origTranslation,desiredTranslation, center,scale;
-	transf newTran;
-
-	//is it a handlebox dragger (translating) or a centerball (rotating)
-	if (dInfo->dragger->isOfType(SoHandleBoxDragger::getClassTypeId())) {
-		myHandleBox = (SoHandleBoxDragger *)dInfo->dragger;
-		translating = true;
-	} else {
-		myCenterball = (SoCenterballDragger *)dInfo->dragger;
-		translating = false;
-	}
-  
-	// if this callback is due to a recentering of the centerball dragger,
-	// then no actual movement is performed but hand's current translation
-	// and rotation values need to be recomputed.
-	if (!translating) {
-		SbVec3f centerTran = myCenterball->center.getValue() - dInfo->lastCent;
-		if (centerTran.length() > 1.0e-3) {
-			DBGP("RECENTERING");
-			DBGP("current center: " << myCenterball->center.getValue()[0] << " " <<
-									myCenterball->center.getValue()[1] << " " <<
-									myCenterball->center.getValue()[2]);
-			DBGP("last center: " << dInfo->lastCent[0] << " " << 
-									dInfo->lastCent[1] << " " << 
-									dInfo->lastCent[2]);
-			scale.set(dInfo->draggerTran->scaleFactor.getValue());    
-			center.set(myCenterball->center.getValue());
-			center*=scale[0];    
-			transf recenterTran = translate_transf(center)*
-								dInfo->selectedElement->getTran() * translate_transf(-center);
-			dInfo->centerballTransl = recenterTran.translation();
-			dInfo->lastCent = myCenterball->center.getValue();
-			return;
-		}
-	}
-	
-	// disable the callback while we are moving things
-	//this is no longer needed since we replaced the valueChanged callback 
-	//with a motion callback
-	//SbBool enabled = dInfo->dragger->enableValueChangedCallbacks(FALSE);
-    
-	origTranslation = dInfo->selectedElement->getTran().translation();
-	origRotation = dInfo->selectedElement->getTran().rotation();
-
-	// save the desired position or orientation and set what percent of the 
-	// desired moved will be accomplished in each step
-	if (translating) {
-		if ((myHandleBox->translation.getValue() - dInfo->lastTran).length()<0.00001) {
-			myHandleBox->translation.setValue(dInfo->lastTran); 
-			//if (enabled) myHandleBox->enableValueChangedCallbacks(TRUE);
-			return;
-		}
-		desiredTranslation.set(myHandleBox->translation.getValue());
-		scale.set(dInfo->draggerTran->scaleFactor.getValue());
-		desiredTranslation[0] *= scale[0];
-		desiredTranslation[1] *= scale[1];
-		desiredTranslation[2] *= scale[2];
-		//origRotation.set(dInfo->draggerTran->rotation.getValue());
-		desiredTranslation = origRotation*desiredTranslation;
-
-		DBGP("desired Translation: " << desiredTranslation);
-		//not needed?
-		//if ((desiredTranslation - origTranslation).len() == 0.0) return;
-		newTran = transf(origRotation,desiredTranslation);
-	} else {
-		if (myCenterball->rotation.getValue().equals(dInfo->lastRot,0.00001f)) {
-			myCenterball->rotation.setValue(dInfo->lastRot); 
-			//if (enabled) myCenterball->enableValueChangedCallbacks(TRUE);
-			return;
-		}
-		desiredRotation.set(myCenterball->rotation.getValue());
-		scale.set(dInfo->draggerTran->scaleFactor.getValue());    
-		center.set(myCenterball->center.getValue());
-		center*=scale[0];    
-		//this does not work if the centerball has been recentered
-		//hope to fix this at some point
-		newTran = translate_transf(-center) * transf(desiredRotation,vec3::ZERO) *
-				  translate_transf(center) * translate_transf(dInfo->centerballTransl);
-	}
-	dInfo->selectedElement->moveTo(newTran,50*Contact::THRESHOLD,M_PI/36.0);
-	world->updateGrasps();
-
-	DBGP("new pos: "<<dInfo->selectedElement->getTran());
-	if (translating) {
-		SbVec3f newPos = (origRotation.inverse() * dInfo->selectedElement->getTran().translation()).toSbVec3f();
-		newPos[0]/=scale[0];
-		newPos[1]/=scale[1];
-		newPos[2]/=scale[2];
-		dInfo->lastTran = newPos;
-		myHandleBox->translation.setValue(newPos);
-	} else {
-		SbRotation newRot = dInfo->selectedElement->getTran().rotation().toSbRotation();
-		dInfo->lastRot = newRot;
-		myCenterball->rotation.setValue(newRot);
-#ifdef GRASPITDBG
-		SbVec3f ax;
-		float ang;
-		newRot.getValue(ax,ang);
-		desiredRotation.set(myCenterball->rotation.getValue());
-		std::cout << "setting ball to: "<<desiredRotation<<std::endl;
-#endif
-	}
-
-	//if (enabled) dInfo->dragger->enableValueChangedCallbacks(TRUE);
-}
-
-void 
-IVmgr::revoluteJointClicked(DraggerInfo *dInfo)
-{
-  SbVec3f axis;
-  float angle;
-  SoRotateDiscDragger *dragger = (SoRotateDiscDragger *)dInfo->dragger;
-  dragger->rotation.getValue(axis,angle);
-  dInfo->lastVal = angle;
-
-  Robot *robot = (Robot *) dInfo->selectedElement;
-  robot->emitUserInteractionStart();
-}
-
-void 
-IVmgr::revoluteJointFinished(DraggerInfo *dInfo)
-{
-  Robot *robot = (Robot *) dInfo->selectedElement;
-  robot->emitUserInteractionEnd();
-}
-
-/*!
-  The callback routine is invoked whenever a disc dragger controlling a
-  revolute DOF is moved by the user.  It requires a pointer to the dragger's
-  associated info structure.  It prevents the user from moving the dragger
-  past the minimum or maximum DOF limits.  It calls the associated robot's
-  moveDOFto routine to peform the move, and after it is completed or a contact
-  prevents further motion it asks the world to update the grasps and sets the
-  current angle of the disc dragger.
-*/
-void 
-IVmgr::revoluteJointChanged(DraggerInfo *dInfo)
-{
-  SbVec3f axis;
-  float angle;
-  double desiredAngle;
-  Robot *robot = (Robot *)dInfo->selectedElement;
-  SoRotateDiscDragger *dragger = (SoRotateDiscDragger *)dInfo->dragger;
-  DOF *dof = dInfo->dof;
-  double *dofVals= new double[robot->getNumDOF()];
-  double *stepBy = new double[robot->getNumDOF()];
-  int d;
-
-
-#ifdef GRASPITDBG
-  printf("in jointChangedCB\n");
-#endif
-
-  SbBool enabled = dragger->enableValueChangedCallbacks(FALSE);
-
-  dragger->rotation.getValue(axis,angle);
-  
-  if (fabs(angle - dInfo->lastVal) < 0.00001) {
-      dragger->rotation.setValue(axis,dInfo->lastVal);
-      if (enabled) dragger->enableValueChangedCallbacks(TRUE);
-      return;
-  }
-  
-//  desiredAngle = (double) (axis[2] * angle);
-
-  double relAngle = (double)axis[2] * (angle - dInfo->lastVal);
-  if (relAngle > M_PI) relAngle -= 2 * M_PI;
-  if (relAngle <= -M_PI) relAngle += 2 * M_PI;
-  desiredAngle = dof->getVal() + (double)(relAngle);
-  dInfo->lastVal = angle;
-
-#ifdef GRASPITDBG
-  printf("axis[2]: %f angle: %f\n",axis[2],angle);
-#endif
-
-  // Check that the desired angle has not exceeded the DOF limits
-  //if (desiredAngle - dof->getVal() > M_PI)
-  //  desiredAngle -= 2*M_PI; 
-  if (desiredAngle > dof->getMax())
-    desiredAngle = dof->getMax();
-  else if (desiredAngle < dof->getMin())
-    desiredAngle = dof->getMin();
-
-  robot->getDOFVals(dofVals);
-
-#ifdef GRASPITDBG
-  printf("desiredDOFVal: %.1f deg -- %15.15lf rad\n",desiredAngle * 180.0 / M_PI, desiredAngle);
-#endif
-  
-  dofVals[dof->getDOFNum()] = desiredAngle;
-  for(d=0;d<robot->getNumDOF();d++) {
-//    stepBy[d]=0.0;
-	  stepBy[d] = M_PI/36.0;
-#if 0
-    printf("dof %d, to: %lf\n",d,dofVals[d]);
-#endif
-  }
-  stepBy[dof->getDOFNum()] = M_PI/36.0;
-  
-  // Perform the move
-  robot->moveDOFToContacts(dofVals,stepBy,true);
-  //this is just so that a potential eigen grasp dialog knows about this
-  robot->emitConfigChange();
-  world->updateGrasps();
-
-#ifdef GRASPITDBG
-  printf("newDOFVal: %15.15lf\n",dof->getVal());
-#endif
-  
-  angle = (float) dof->getVal();
-  //if (dof->getVal() >= 0.0 && (dof->getVal() % (2*M_PI)) < M_PI) {
-  //    axis[2] = 1.0f;
-  //    angle = (float)dof->getVal();
-  //  }
-  //  else {
-  //    axis[2] = -1.0f;
-  //    angle = (float) -dof->getVal();
-  //  }
-
-  angle = dof->getVal() / axis[2];
-//  dInfo->lastVal = angle;
-#ifdef GRASPITDBG
-  printf("setting axis[2]: %f angle: %f dof val: %f\n",axis[2],angle,dof->getVal());
-#endif
-
-  dragger->rotation.setValue(axis,angle);
-  
-  if (enabled)
-    dragger->enableValueChangedCallbacks(TRUE);
-
-  delete [] dofVals;
-  delete [] stepBy;
-}
-
-/*!
-  The callback routine is invoked whenever an arrow dragger controlling a
-  prismatic DOF is moved by the user.  It requires a pointer to the dragger's
-  associated info structure.  It prevents the user from moving the dragger
-  past the minimum or maximum DOF limits.  It calls the associated robot's
-  moveDOFto routine to peform the move, and after it is completed or a contact
-  prevents further motion it asks the world to update the grasps and sets the
-  current translation of the arrow dragger.
-*/
-void
-IVmgr::prismaticJointChanged(DraggerInfo *dInfo)
-{
-  SbVec3f transl(0,0,0);
-  double desiredTransl;
-  SoTranslate1Dragger *dragger = (SoTranslate1Dragger *)dInfo->dragger;
-  Robot *robot = (Robot *)dInfo->selectedElement;
-  DOF *dof = dInfo->dof;
-  double *dofVals = new double[robot->getNumDOF()];
-  double *stepBy = new double[robot->getNumDOF()];
-
-  SbBool enabled = dragger->enableValueChangedCallbacks(FALSE);
-
-  float scale=robot->getDOFDraggerScale(dof->getDOFNum());
-
-  // Must multiply the dragger value by its scale
-  desiredTransl = (double) (dragger->translation.getValue()[0] * scale);
-
-  if (desiredTransl > dof->getMax()) {
-    desiredTransl = dof->getMax();
-  }
-  else if (desiredTransl < dof->getMin()) {
-    desiredTransl = dof->getMin();
-  }
-
-  robot->getDOFVals(dofVals);
-
-#ifdef GRASPITDBG
-  printf("desiredDOFVal: %le\n",desiredTransl);
-#endif
-  
-  dofVals[dof->getDOFNum()] = desiredTransl;
-  for(int d=0;d<robot->getNumDOF();d++) stepBy[d]=0.0;
-  stepBy[dof->getDOFNum()] = 50*Contact::THRESHOLD;
-  
-  // Perform the move
-  robot->moveDOFToContacts(dofVals,stepBy,true);
-  //this is just so that a potential eigen grasp dialog knows about this
-  robot->emitConfigChange();
-  world->updateGrasps();
-
-  transl[0] = (float) dof->getVal()/scale;
-  dragger->translation.setValue(transl);
-
-  if (enabled)
-    dragger->enableValueChangedCallbacks(TRUE);
-
-  delete [] dofVals;
-  delete [] stepBy;
-}
-
-/*! 
-  Creates a centerball dragger for the provided worldElement around the
-  body surroundMe, and sets up the value changed callback for the dragger.
-  For a free body, the worldElement and surroundMe point to the same body.
-  For a robot, the worldElement points to the robot and surround me points
-  to the base link of the robot.
- */
-void
-IVmgr::makeCenterball(WorldElement *selectedElement,Body *surroundMe)
-{
-	SoCenterballDragger *myCenterball = new SoCenterballDragger;
-	SoSeparator *sep = new SoSeparator;
-	SoTransform *draggerTran = new SoTransform;
-  
-	// Compute the bounding box of the surroundMe body
-	SoGetBoundingBoxAction *bba = new SoGetBoundingBoxAction(myViewer->getViewportRegion());
-	bba->apply(surroundMe->getIVGeomRoot());
-	float maxRad = (bba->getBoundingBox().getMax() - bba->getBoundingBox().getMin()).length();
-	delete bba;
-
-	maxRad /= 2.0;
-  
-	draggerTran->translation = selectedElement->getTran().translation().toSbVec3f();
-	draggerTran->scaleFactor.setValue(maxRad,maxRad,maxRad);
-	myCenterball->rotation = selectedElement->getTran().rotation().toSbRotation();
-
-	sep->addChild(draggerTran);
-	sep->addChild(myCenterball);
-	draggerRoot->addChild(sep);
-
-	// Create the dragger info structure
-	DraggerInfo *dInfo = new DraggerInfo;
-	dInfo->draggerSep = sep;
-	dInfo->dragger = myCenterball;
-	dInfo->draggerTran = draggerTran;
-	dInfo->selectedElement = selectedElement;
-	dInfo->lastCent = myCenterball->center.getValue();
-	DBGP("lastCent " << dInfo->lastCent[0] << " "<<dInfo->lastCent[1]<<" "<<dInfo->lastCent[2]);
-	
-	dInfo->centerballTransl = selectedElement->getTran().translation();
-	draggerInfoList.push_back(dInfo);
-	DBGP("NUM DRAGGER INFOS "<<draggerInfoList.size());
-
-	//the value changed callback is behaving strangely so we replaced it
-	//with motion callback which is a lot more stable. if you need the 
-	//functionality of the valueChanged callback, beware of erratic
-	//behavior where the callback is called again and again for no reason.
-	//myCenterball->addValueChangedCallback(transRotCB,dInfo);  
-	myCenterball->addMotionCallback(transRotCB,dInfo);  
-}
-
-/*! 
-  Creates a handlebox dragger for the provided worldElement around the
-  body surroundMe, and sets up the value changed callback for the dragger.
-  For a free body, the worldElement and surroundMe point to the same body.
-  For a robot, the worldElement points to the robot and surround me points
-  to the base link of the robot.
- */
-void
-IVmgr::makeHandleBox(WorldElement *selectedElement,Body *surroundMe)
-{
-  SoSeparator *sep = new SoSeparator;
-  draggerRoot->addChild(sep);
-
-  // Elminate many parts of the handlebox that would allow body scaling etc...
-  SoHandleBoxDragger *myHandleBox = new SoHandleBoxDragger;
-  myHandleBox->setPart("extruder1",new SoSeparator);
-  myHandleBox->setPart("extruder2",new SoSeparator);
-  myHandleBox->setPart("extruder3",new SoSeparator);
-  myHandleBox->setPart("extruder4",new SoSeparator);
-  myHandleBox->setPart("extruder5",new SoSeparator);
-  myHandleBox->setPart("extruder6",new SoSeparator);
-  myHandleBox->setPart("uniform1",new SoSeparator);
-  myHandleBox->setPart("uniform2",new SoSeparator);
-  myHandleBox->setPart("uniform3",new SoSeparator);
-  myHandleBox->setPart("uniform4",new SoSeparator);
-  myHandleBox->setPart("uniform5",new SoSeparator);
-  myHandleBox->setPart("uniform6",new SoSeparator);
-  myHandleBox->setPart("uniform7",new SoSeparator);
-  myHandleBox->setPart("uniform8",new SoSeparator);
-  myHandleBox->setPart("extruder1Active",new SoSeparator);
-  myHandleBox->setPart("extruder2Active",new SoSeparator);
-  myHandleBox->setPart("extruder3Active",new SoSeparator);
-  myHandleBox->setPart("extruder4Active",new SoSeparator);
-  myHandleBox->setPart("extruder5Active",new SoSeparator);
-  myHandleBox->setPart("extruder6Active",new SoSeparator);
-  myHandleBox->setPart("uniform1Active",new SoSeparator);
-  myHandleBox->setPart("uniform2Active",new SoSeparator);
-  myHandleBox->setPart("uniform3Active",new SoSeparator);
-  myHandleBox->setPart("uniform4Active",new SoSeparator);
-  myHandleBox->setPart("uniform5Active",new SoSeparator);
-  myHandleBox->setPart("uniform6Active",new SoSeparator);
-  myHandleBox->setPart("uniform7Active",new SoSeparator);
-  myHandleBox->setPart("uniform8Active",new SoSeparator);
-  
-  // compute the bounding box of the body  
-  SoGetBoundingBoxAction *bba = new SoGetBoundingBoxAction(myViewer->getViewportRegion());
-  bba->apply(surroundMe->getIVGeomRoot());
-  SbVec3f bbmin,bbmax;
-  bba->getBoundingBox().getBounds(bbmin,bbmax);
-  delete bba;
-
-   // make the dragger (a 2x2x2 box) slightly bigger than the bounding box.
-  SbVec3f scale = ((bbmax - bbmin)/1.9f);
-  double maxScale = MAX(MAX(scale[0],scale[1]),scale[2]);
-  if (maxScale == 0.0) {   // not good, object has 0 volume bbox!
-    DBGP( "0 volume bounding box!");
-    return;
-  }
-
-  // prevent any of the sides from having a dimension much smaller than another
-  for (int i=0;i<3;i++) {
-    if (scale[i]/maxScale < .01) {
-      scale[i] = 0.01 * maxScale;
-	}
-  }
-
-  SbRotation rot = selectedElement->getTran().rotation().toSbRotation();
-
-  SbVec3f transl =
-    (selectedElement->getTran().rotation().inverse()*
-     selectedElement->getTran().translation()).toSbVec3f();
-
-  transl[0] = transl[0] / scale[0];
-  transl[1] = transl[1] / scale[1];
-  transl[2] = transl[2] / scale[2];
-
-  // compute the offset from the body's frame to the dragger's center
-  SbVec3f offsetTransl;
-  rot.multVec((bbmax+bbmin)/2.0f,offsetTransl);
-
-  SoTransform *draggerTran = new SoTransform;
-
-  myHandleBox->translation= transl;
-  draggerTran->scaleFactor.setValue(scale);
-  draggerTran->rotation = rot;
-  draggerTran->translation = offsetTransl;
-
-  sep->addChild(draggerTran);
-  sep->addChild(myHandleBox);
-
-  DraggerInfo *dInfo = new DraggerInfo;
-  dInfo->draggerSep = sep;
-  dInfo->dragger = myHandleBox;
-  dInfo->draggerTran = draggerTran;
-  dInfo->selectedElement = selectedElement;
-  draggerInfoList.push_back(dInfo);
-
-  DBGP("Callback added");
-  //the value changed callback is behaving strangely so we replaced it
-  //with motion callback which is a lot more stable. if you need the 
-  //functionality of the valueChanged callback, beware of erratic
-  //behavior where the callback is called again and again for no reason.
-  //  myHandleBox->addValueChangedCallback(transRotCB,dInfo);
-  myHandleBox->addMotionCallback(transRotCB,dInfo);  
-}
-
-/*! 
-  Creates the joint draggers for each DOF in the provided kinematic chain,
-  and sets up the value changed callback for each dragger.  Only the first
-  joint in the chain associated with a given DOF has a dragger connected to
-  it.  In other words, passive joints don't have draggers.  The scale of
-  the joint dragger is controlled by a parameter found in the joints section
-  of the robot configuration file.
- */
-void
-IVmgr::makeJointDraggers(Robot *robot,KinematicChain *chain)
-{
-  int j,d;
-  int *activeDOFs = new int[robot->getNumDOF()];
-  SoSeparator *jointDraggerSep = new SoSeparator;
-  DraggerInfo *dInfo;
-  bool firstDragger=true;
-
-  //jointDraggerSep->ref();
-  jointDraggerSep->addChild(robot->getBase()->getIVTran());
-  DBGP("make draggers; value: " << chain->getIVTran()->translation.getValue()[0]);
-  jointDraggerSep->addChild(chain->getIVTran());
-
-  for (d=0;d<robot->getNumDOF();d++)
-    activeDOFs[d] = -1;
-
-  for (j=chain->getNumJoints()-1;j>=0;j--)
-    activeDOFs[chain->getJoint(j)->getDOFNum()] = j;
-	
-  for(d=0;d<robot->getNumDOF();d++) {
-    if ((j=activeDOFs[d]) != -1) {
-      SoSeparator *sep = new SoSeparator;
-      dInfo = new DraggerInfo;
-      dInfo->selectedElement = robot;
-      dInfo->dof = robot->getDOF(d);
-      
-      // add the parent separator for all the joint draggers to the
-      // first draggerInfo, because it includes not only the draggers
-      // but also the transforms between them, and we'll delete them
-      // all at once.
-      if (firstDragger) {
-        dInfo->draggerSep = jointDraggerSep;
-        firstDragger=false;
-      }
-      else
-        dInfo->draggerSep = NULL;
-      
-      //      for (l=0;l<chain->getNumLinks();l++)
-      //	if (j<=chain->getLastJoint(l)) break;
-
-      if (chain->getJoint(j)->getType() == REVOLUTE) {
-        SoScale *dialSize = new SoScale;
-        SoRotateDiscDragger *myDisc = new SoRotateDiscDragger;
-        
-        float scale = robot->getDOFDraggerScale(d);
-        dialSize->scaleFactor.setValue(SbVec3f(scale,scale,scale));
-       	SoTranslation *dTrans = new SoTranslation;
-        dTrans->translation.setValue(0,0,chain->getJoint(j)->getDH()->getD());
-        
-        //sep->addChild(dTrans);
-        sep->addChild(dialSize);
-        sep->addChild(myDisc);
-	
-        myDisc->rotation.setValue(SbVec3f(0.0,0.0,1.0),(float) robot->getDOF(d)->getVal());
-        //dInfo->lastVal = (float) robot->getDOF(d)->getVal();
-        myDisc->addStartCallback(revoluteJointClickedCB,dInfo);
-        myDisc->addValueChangedCallback(revoluteJointChangedCB,dInfo);
-        myDisc->addFinishCallback(revoluteJointFinishedCB,dInfo);
-        dInfo->dragger = myDisc;
-      }
-      else { // prismatic
-        SoTransform *arrowTran = new SoTransform;
-        SoTranslate1Dragger *myArrow = new SoTranslate1Dragger;
-        SoBaseColor *arrowBC = new SoBaseColor;
-        float scale = robot->getDOFDraggerScale(d);
-        arrowBC->rgb.setValue(1,1,1);
-        arrowTran->scaleFactor.setValue(SbVec3f(scale,scale,scale));
-        arrowTran->rotation.setValue(SbVec3f(0,1,0),(float)-M_PI/2.0f);
-        arrowTran->translation.setValue(SbVec3f(0,-scale,0));
-        sep->addChild(arrowBC);
-        sep->addChild(arrowTran);
-        sep->addChild(myArrow);
-	
-        myArrow->translation.setValue(SbVec3f((float)robot->getDOF(d)->getVal()/scale,0,0));
-        dInfo->lastVal = (float) robot->getDOF(d)->getVal()/scale;
-        myArrow->addValueChangedCallback(prismaticJointChangedCB,dInfo);
-        dInfo->dragger = myArrow;
-      }
-      // now it will update its IVTran whenever it moves
-      chain->getJoint(j)->setDraggerAttached(true);
-      
-      jointDraggerSep->addChild(sep);
-      jointDraggerSep->addChild(chain->getJoint(j)->getIVTran());
-      draggerInfoList.push_back(dInfo);
-    }
-  }
-  draggerRoot->addChild(jointDraggerSep);
-
-#ifdef GRASPITDBG
-  std::cout << "NUM DRAGGER INFOS "<<draggerInfoList.size()<<std::endl;
-#endif
-  delete activeDOFs;
-}
-
-/*!
-  Creates a white wireframe copy of the model sub-tree passed to it in
-  elementRoot, and adds it to the wireframe root.  This is used to provide
-  a visual indication when a body has been selected by the user.
- */
-void
-IVmgr::drawWireFrame(SoSeparator *elementRoot)
-{
-  SoLightModel *lm = new SoLightModel;
-  lm->model = SoLightModel::BASE_COLOR;
-
-  SoDrawStyle *ds = new SoDrawStyle;
-  ds->style = SoDrawStyle::LINES;
-  ds->setOverride(TRUE);
-
-  SoBaseColor *bc = new SoBaseColor;
-  bc->rgb.setValue(1,1,1);
-  bc->setOverride(TRUE);
-
-  SoSeparator *sep = new SoSeparator;
-  sep->addChild(lm);
-  sep->addChild(ds);
-  sep->addChild(bc);
-  sep->addChild(elementRoot);
-
-  wireFrameRoot->addChild(sep);
-}
-
-/*!
-  This callback routine is invoked when a user clicks within the scene and
-  controls what Inventor body is picked.  If a dragger is clicked, a empty
-  path is returned because we don't want the dragger to be selected in the
-  Inventor sense.  If the translate or rotate tool is currently being used
-  and a link of a kinematic chain is clicked, pick the whole chain.
-  If the base of a robot is clicked, pick the whole robot.  If the current
-  tool is the select tool, and a link is clicked that has already been
-  selected, pick the whole robot.  Otherwise pick the body that was clicked.
-*/
-SoPath *
-IVmgr::pickFilter(const SoPickedPoint *pick)
-{
-  int i,l,r,f,b;
-  SoPath *p = pick->getPath();
-  Robot *robot;
-
-  if (p->getTail()->isOfType(SoDragger::getClassTypeId())||
-      p->getTail()->isOfType(SoTransformManip::getClassTypeId()))
-    {
-	  DBGP("dragger or manip picked");
-      SoPath *newP = new SoPath(sceneRoot);
-      return newP;
-    }
-  
-  for (i=p->getLength() - 1; i>=0; i--) {
-    SoNode *n = p->getNode(i);
-    for (r=0;r<world->getNumRobots(); r++) {
-      robot = world->getRobot(r);
-      
-      if (currTool != SELECT_TOOL) {
-		for (f=0;f<robot->getNumChains();f++)
-		  if (n == robot->getChain(f)->getIVRoot())
-			return p->copy(0,i+1);                  // select the chain
-
-		if (n == robot->getBase()->getIVRoot())
-		return p->copy(0,i);                      // select the whole robot
-
-		if (robot->inherits("HumanHand"))
-		{
-			for (f=0; f<((HumanHand*)robot)->getNumTendons(); f++)
-				if ( n == ((HumanHand*)robot)->getTendon(f)->getIVRoot() )
-					return p->copy(0,i+1);
-		}
-
-	  }
-      else {
-		if (n == robot->getBase()->getIVRoot() && world->isSelected(robot->getBase())) 
-			return p->copy(0,i);                      // select the whole robot
-  
-		for (f=0;f<robot->getNumChains();f++)
-		  for (l=0;l<robot->getChain(f)->getNumLinks();l++)
-			 if (n == robot->getChain(f)->getLink(l)->getIVRoot()&&	world->isSelected(robot->getChain(f)->getLink(l)))
-				return p->copy(0,i-1);                // select the whole robot
-
-		if (robot->inherits("HumanHand"))
-		{
-			for (f=0; f<((HumanHand*)robot)->getNumTendons(); f++)
-				if ( n == ((HumanHand*)robot)->getTendon(f)->getIVRoot() )
-					return p->copy(0,i+1);
-		}
-
-	  }
-    }
-  }
-  
-  for (i=p->getLength() - 1; i>=0; i--) {
-    SoNode *n = p->getNode(i);
-    for(b=0;b<world->getNumBodies();b++)      
-      if (n == world->getBody(b)->getIVRoot()) {
-	  #ifdef GRAPSITDBG
-		printf("pickfilter: body %s picked\n",world->getBody(b)->getName());
-	  #endif
-	  return p->copy(0,i+1);                      // select body
-      }
-  }
-  
-  return NULL;
-}
-
-/*!
-  This callback routine is invoked whenever an Inventor selection occurs.
-  When this routine is called because of a user click, the path sent to this
-  routine is determined by the pickFilter.  The action that occurs upon
-  selection depends on the current tool selected.  If a kinematic chain is
-  selected, and the rotate or translate tool is selected, joint draggers are
-  created.  Otherwise, if the rotate tool is being used, then a centerball is
-  created around the chosen body.  If the translate tool is being used, then
-  a handlebox is created around the chosen body.  If the select tool is being
-  used, the chosen body is selected within GraspIt! and a wireframe version
-  of the body is drawn to indicate the selection.
-*/
-void 
-IVmgr::handleSelection(SoPath *p)
-{
-  int r,b,f;
-  bool selectionFound=false;
-  Robot *robot;
-
-#ifdef GRASPITDBG	  
-  printf("in selectionCB: \n");
-  fprintf(stderr,"in selectionCB: \n");
-  
-  fprintf(stderr,"*************NUM SELECTED %d*****************\n",selectionRoot->getNumSelected());
-#endif
-
-  if (p->getTail()->isOfType(SoDragger::getClassTypeId())) {
-#ifdef GRASPITDBG
-    printf("selection path tail is dragger\n");
-#endif
-    return;
-  }
-  else if (p->getTail() == sceneRoot) {
-#ifdef GRASPITDBG
-    printf("selection path tail is sceneRoot\n");
-#endif
-    return;
-  }
-  else {
-    for (r=0;r<world->getNumRobots();r++) {
-      robot = world->getRobot(r);      
-      if (p->getTail() == robot->getIVRoot()) {
-#ifdef GRASPITDBG
-        printf("robot selected\n");
-#endif
-        selectionFound = true;
-        if (currTool == ROTATE_TOOL)
-          makeCenterball(robot,robot->getBase());
-        else if (currTool == TRANSLATE_TOOL)
-          makeHandleBox(robot,robot->getBase());
-        else if (currTool == SELECT_TOOL) {
-          world->selectElement(robot);
-          drawWireFrame(robot->getIVRoot());
+        SoArrow *forcePtr = new SoArrow;
+        forcePtr->height = forceDir.length() * FORCE_SCALE;
+        if (forceDir.length()*FORCE_SCALE > 200.0) {
+            DBGP("Too long.");
+            forcePtr->height = 200.0;
         }
-      }
-      else {
-        for (f=0;f<robot->getNumChains();f++)
-          if (p->getTail() == robot->getChain(f)->getIVRoot()) {
-            selectionFound = true;
-            makeJointDraggers(robot,robot->getChain(f));
-          }
-        if ( robot->inherits("HumanHand") )
-        {
-          for (f=0; f< ((HumanHand*)robot)->getNumTendons(); f++)
-            if (p->getTail() == ((HumanHand*)robot)->getTendon(f)->getIVRoot())
-            {
-              selectionFound = true;
-              world->selectTendon( ((HumanHand*)robot)->getTendon(f));
+
+        SoRotation *fRot = new SoRotation;
+        fRot->rotation.setValue(SbRotation(SbVec3f(0, 1, 0), forceDir));
+
+        fSep = new SoSeparator;
+        fSep->addChild(fRot);
+        fSep->addChild(forcePtr);
+    }
+
+    SbVec3f torqueDir(wrench[3], wrench[4], wrench[5]);
+    if (torqueDir.length() > 0.0) {
+        SoTorquePointer *torquePtr = new SoTorquePointer;
+        torquePtr->height = torqueDir.length() * FORCE_SCALE;
+        if (torqueDir.length()*FORCE_SCALE > 200.0) {
+            DBGP("Too long.");
+            torquePtr->height = 200.0;
+        }
+
+        SoRotation *tRot = new SoRotation;
+        tRot->rotation.setValue(SbRotation(SbVec3f(0, 1, 0), torqueDir));
+
+        tSep = new SoSeparator;
+        tSep->addChild(tRot);
+        tSep->addChild(torquePtr);
+    }
+
+    if (fSep || tSep) {
+        SoMaterial *mat = new SoMaterial;
+        mat->diffuseColor = SbColor(0.8f, 0, 0.8f);
+        mat->ambientColor = SbColor(0.2f, 0, 0.2f);
+        mat->emissiveColor = SbColor(0.4f, 0, 0.4f);
+
+        SoSeparator *pointerRoot = new SoSeparator;
+        pointerRoot->addChild(mat);
+        if (fSep) pointerRoot->addChild(fSep);
+        if (tSep) pointerRoot->addChild(tSep);
+
+        // Remove previous worstcase pointers from the object and add new ones
+        body->getIVWorstCase()->addChild(pointerRoot);
+    }
+}
+
+/*!
+    This routine adds arrows within each of the friction cones that indicate
+    the size of the dynamic contact forces that were solved for.
+    This still doesn't handle the display of any torsional forces at soft
+    finger contacts.  If dynamics are not on, blinker nodes are added so that
+    when a contact force is selected from the list the associated contact force
+    indicator will blink.
+*/
+void
+IVmgr::drawDynamicForces() {
+    std::list<Contact *> contactList;
+    std::list<Contact *>::iterator cp;
+    SbVec3f forceVec;
+    double *contactForce;
+
+    if (!dynForceMat) {
+        dynForceMat = new SoMaterial;
+        dynForceMat->diffuseColor = SbColor(0.8f, 0.8f, 0);
+        dynForceMat->ambientColor = SbColor(0.2f, 0.2f, 0);
+        //dynForceMat->emissiveColor = SbColor(0.8,0.8,0);
+        dynForceMat->ref();
+    }
+
+    int numContacts = 0;
+    if (!world->dynamicsAreOn()) {
+        //count the number of contacts
+        for (int b = 0; b < world->getNumGB(); b++) {
+            int sz = world->getGB(b)->getContacts().size();
+            numContacts += sz;
+            int numChildren = world->getGB(b)->getIVContactIndicators()->getNumChildren();
+            for (int i = numChildren - 1; i >= sz; i--) {
+                world->getGB(b)->getIVContactIndicators()->removeChild(i);
             }
         }
-      }
+        contactForceBlinkerVec.clear();
+        if (numContacts == 0) return;
+        contactForceBlinkerVec.reserve(numContacts);
     }
-    if (!selectionFound) {
-      // check if one of the objects was selected
-      for (b=0;b<world->getNumBodies();b++) {
-	if (p->getTail() == world->getBody(b)->getIVRoot()) {
-          //#ifdef GRASPITDBG
-	  printf("body %s selected\n",world->getBody(b)->getName().latin1());
-          //#endif
-	  selectionFound = true;
-	  if (currTool == ROTATE_TOOL)
-	    makeCenterball(world->getBody(b),world->getBody(b));
-	  else if (currTool == TRANSLATE_TOOL)
-	    makeHandleBox(world->getBody(b),world->getBody(b));
-	  else if (currTool == SELECT_TOOL) {
-	    world->selectElement(world->getBody(b));
-	    drawWireFrame(world->getBody(b)->getIVRoot());
-	  }
-	  break;
-	}
-      }
-    }    
-  }
+
+    for (int b = 0; b < world->getNumGB(); b++) {
+        contactList = world->getGB(b)->getContacts();
+        for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+            contactForce = (*cp)->getDynamicContactWrench();
+            forceVec.setValue(contactForce[0], contactForce[1], contactForce[2]);
+            forceVec *= FORCE_SCALE;
+            //don't add large arrows because they mess up the OpenGL clipping planes
+            if (forceVec.length() > 200) {
+                forceVec *= 200.0 / forceVec.length();
+            }
+            SoArrow *arrow = new SoArrow;
+            arrow->height = forceVec.length();
+            arrow->cylRadius = 0.25;
+            arrow->coneRadius = 0.5;
+            if (arrow->height.getValue() < arrow->coneHeight.getValue()) {
+                arrow->coneHeight = arrow->height.getValue() / 2.0;
+            }
+            SoTransform *tran = new SoTransform;
+            (*cp)->getContactFrame().toSoTransform(tran);
+            SoRotation *rot = new SoRotation;
+            rot->rotation.setValue(SbRotation(SbVec3f(0, 1, 0), forceVec));
+
+            SoSeparator *ptr = new SoSeparator;
+            ptr->addChild(tran);
+            ptr->addChild(rot);
+            ptr->addChild(dynForceMat);
+            ptr->addChild(arrow);
+
+            int lastChild = world->getGB(b)->getIVContactIndicators()->getNumChildren();
+            if (world->dynamicsAreOn()) {
+                world->getGB(b)->getIVContactIndicators()->insertChild(ptr, lastChild);
+            }
+            else {
+                contactForceBlinkerVec.push_back(new SoBlinker);
+                contactForceBlinkerVec.back()->addChild(ptr);
+                contactForceBlinkerVec.back()->on = false;
+                contactForceBlinkerVec.back()->whichChild = 0;
+                world->getGB(b)->getIVContactIndicators()->insertChild(
+                    contactForceBlinkerVec.back(), lastChild);
+            }
+        }
+    }
 }
 
 /*!
-  This callback routine is invoked whenever an Inventor deselection occurs.
-  If the select tool is being used this deselects the element within GraspIt!
-  and deletes the wireframe.  Otherwise this removes the draggers, from the
-  deselected body or robot.
+    Called when a contact is selected from the contact list, and causes the
+    associated contact force indicator to blink.
 */
 void
-IVmgr::handleDeselection(SoPath *p)
-{
-  int r,b,f,j;
-  Robot *robot;
-  WorldElement *deselectedElement=NULL;
-  std::list<DraggerInfo *>::iterator dp;
-
-#ifdef GRASPITDBG	  
-  printf("in deselectionCB: \n");
-#endif
-
-
-#ifdef GRASPITDBG	  
-  if (p->getTail()->isOfType(SoDragger::getClassTypeId()))
-    printf("deselecting dragger\n");
-#endif
-  
-  for (r=0;r<world->getNumRobots() && !deselectedElement;r++) {
-    robot = world->getRobot(r);
-
-    // check if the base was deselected
-    if (p->getTail() == robot->getIVRoot()) {
-      deselectedElement = robot;
-    } else {
-      // check if a chain was deselected
-	  for (f=0;f<robot->getNumChains() && !deselectedElement;f++) {
-		if (p->getTail() == robot->getChain(f)->getIVRoot()) {
-			DBGP("deselecting chain " << f);
-			for (j=0;j<robot->getChain(f)->getNumJoints();j++)
-				robot->getChain(f)->getJoint(j)->setDraggerAttached(false);
-			deselectedElement = robot;
-		}
-	  }
-	  if ( robot->inherits("HumanHand") ){
-			for (f=0; f< ((HumanHand*)robot)->getNumTendons(); f++)
-				if (p->getTail() == ((HumanHand*)robot)->getTendon(f)->getIVRoot())	{
-					deselectedElement = robot;
-					//let's keep the tendon selected so we can play with robot joints 
-					//and see how it affeccts the tendon
-					//world->deselectTendon();
-				}
-		}
-
-	}
-  }
-
-  for (b=0;b<world->getNumBodies() && !deselectedElement;b++)
-    if (p->getTail() == world->getBody(b)->getIVRoot()) {
-      DBGP("deselecting body " << world->getBody(b)->getName().latin1());
-      deselectedElement = world->getBody(b);
+IVmgr::hilightObjContact(int contactNum) {
+    if ((int)contactForceBlinkerVec.size() > contactNum) {
+        contactForceBlinkerVec[contactNum]->on = true;
     }
-
-  if (deselectedElement) {
-    if (currTool == SELECT_TOOL) {
-      world->deselectElement(deselectedElement);
-      for (b=0;b<wireFrameRoot->getNumChildren();b++) {
-		SoSeparator *wfSep = (SoSeparator *)wireFrameRoot->getChild(b);
-		if (wfSep->getChild(wfSep->getNumChildren()-1) ==  deselectedElement->getIVRoot()) {
-			wireFrameRoot->removeChild(b);
-			break;
-		}
-      }
-	}
     else {
-      dp=draggerInfoList.begin();
-      while (dp!=draggerInfoList.end()) {
-		if ((*dp)->selectedElement == deselectedElement) {
-		  if ((*dp)->draggerSep) {
-			draggerRoot->removeChild((*dp)->draggerSep);
-		  }
-		  delete *dp;
-		  dp = draggerInfoList.erase(dp);
-		  DBGP("removing dragger info");
-		} else {
-		  dp++;
-		}
-	  }
+        DBGA("Highlight blinker " << contactNum << " requested, but only "
+             << contactForceBlinkerVec.size() << " present.");
     }
-  }
 }
 
 /*!
-  If the select tool is currently being used and the user hits the delete key,
-  then all currently selected bodies will be deleted.  This routine does not
-  allow links of robots to be deleted, because of the change it would
-  require in the robot structure.  Sometime in the future we'll deal with that.
-  However, if the whole robot is selected, it will be deleted.
+    Called when a contact is deselected from the contact list, and causes the
+    associated contact force indicator to stop blinking.
 */
 void
-IVmgr::deleteSelections()
-{
-  int i,r,b;
-
-  // If a whole robot is selected, delete it
-  for (i=selectionRoot->getNumSelected()-1;i>=0;i--) {
-    for (r=0;r<world->getNumRobots();r++)
-      if (selectionRoot->getPath(i)->getTail() ==
-	  world->getRobot(r)->getIVRoot()) {
-	selectionRoot->deselect(i);
-	world->destroyElement(world->getRobot(r));
-	break;
-      }
-  }
-
-  // If a body is selected, first make sure it isn't a link before deleting it.
-  // Later, we'll want to be able to delete links, but for now it's too
-  // complicated, and would mean the robot structure would have to change
-  // dynamically
-  for (i=selectionRoot->getNumSelected()-1;i>=0;i--) {
-    for (b=0;b<world->getNumBodies();b++)
-      if (selectionRoot->getPath(i)->getTail() ==
-	  world->getBody(b)->getIVRoot()) {
-	if (!world->getBody(b)->inherits("Link")) {
-	  selectionRoot->deselect(i);
-	  world->destroyElement(world->getBody(b));
-	}
-	break;
-      }
-  }
-}
-
-void
-IVmgr::deselectBody(Body *b)
-{
-	int i;
-	for (i=selectionRoot->getNumSelected()-1;i>=0;i--) {
-		if (selectionRoot->getPath(i)->getTail() == b->getIVRoot()) {
-			if (!b->inherits("Link")) {
-				selectionRoot->deselect(i);
-			}
-		break;
-		}
-	}
-}
-/*!
-  Given a filename with an appropriate image format file extension, this
-  will render the current scene to an image file.  It currently uses a white
-  background and performs anti-aliasing by blending the images from 5 slightly
-  different camera angles.  One camera headlight is used for lighting.
- */
-void 
-IVmgr::saveImage(QString filename)
-{
-  SoQtRenderArea *renderArea;
-  SoNode *sg;                // scene graph
-  const SbColor white(1, 1, 1);
-  //  const SbColor black(0,0,0);
-  SoGLRenderAction *glRend;
-  SoOffscreenRenderer *myRenderer;
-
-  renderArea = myViewer;
-  sg = sceneRoot;
-
-  glRend = new SoGLRenderAction(renderArea->getViewportRegion());
-  glRend->setSmoothing(TRUE);
-  glRend->setNumPasses(5);
-  glRend->setTransparencyType(SoGLRenderAction::SORTED_OBJECT_SORTED_TRIANGLE_BLEND);
-  
-  myRenderer = new SoOffscreenRenderer(glRend);
-  myRenderer->setBackgroundColor(white);
-
-#ifdef GRASPITDBG
-  if (myRenderer->isWriteSupported("jpg"))
-	std::cout << " supports jpg" << std::endl;
-  else
-	std::cout << "no jpg support" << std::endl;
-#endif  
-
-  SoSeparator *renderRoot = new SoSeparator;
-  renderRoot->ref();
-  renderRoot->addChild(myViewer->getCamera());
-  SoTransformSeparator *lightSep = new SoTransformSeparator;
-  SoRotation *lightDir = new SoRotation;
-  lightDir->rotation.connectFrom(&myViewer->getCamera()->orientation);
-  lightSep->addChild(lightDir);
-  lightSep->addChild(myViewer->getHeadlight());
-  
-  renderRoot->addChild(lightSep);  
-  renderRoot->addChild(sg);
-  
-  myRenderer->render(renderRoot);
-  
-
-  myRenderer->writeToFile(SbString(filename.latin1()),
-                          SbName(filename.section('.',-1)));
-  
-  renderRoot->unref();
-  delete myRenderer;
+IVmgr::unhilightObjContact(int contactNum) {
+    if ((int)contactForceBlinkerVec.size() > contactNum) {
+        contactForceBlinkerVec[contactNum]->on = false;
+        contactForceBlinkerVec[contactNum]->whichChild = 0;
+    }
+    else {
+        DBGA("Unhighlight blinker " << contactNum << " requested, but only "
+             << contactForceBlinkerVec.size() << " present.");
+    }
 }
 
 /*!
-  Given a base filename this will save an image of the scene after every
-  completed step of the dynamics.  The filename should have a %1 in it, which
-  will be replaced by the simulation time in seconds with a precision of 4
-  places after the decimal point.  The fileStr should also have a valid image
-  format file extension such as .jpg.
- */
-void
-IVmgr::saveImageSequence(const char *fileStr)
-{
-  imgSeqStr = fileStr;
-  imgSeqCounter = 1;
-  connect(world,SIGNAL(dynamicStepTaken()),this,SLOT(saveNextImage()));
-
-}
-
-/*!
-  This calls saveImage after substituting the current world simulation time
-  into the filename.
+    This is a callback routine that is invoked anytime a handlebox or centerball
+    is manipulated by the user. It requires a pointer to the draggerInfo
+    structure of the manipulated dragger.  If the center of centerball was
+    changed, it simply updates the variable tracking the centerball translation.
+    If a handlebox is moved or a centerball is rotated this computes the new
+    body transform and calls the worldElement::moveTo routine.  After the move
+    is completed or a contact prevents further motion, it asks the world to
+    update all grasps, and sets the new dragger position.
 */
 void
-IVmgr::saveNextImage()
-{  
-  saveImage(QString(imgSeqStr).
-	    arg(world->getWorldTime(),0,'f',4));
+IVmgr::transRot(DraggerInfo *dInfo) {
+    //static int count = 0;
+    //DBGA("Callback " << count++);
+
+    SoCenterballDragger *myCenterball;
+    SoHandleBoxDragger *myHandleBox;
+    bool translating;
+
+    Quaternion origRotation, desiredRotation;
+    vec3 origTranslation, desiredTranslation, center, scale;
+    transf newTran;
+
+    //is it a handlebox dragger (translating) or a centerball (rotating)
+    if (dInfo->dragger->isOfType(SoHandleBoxDragger::getClassTypeId())) {
+        myHandleBox = (SoHandleBoxDragger *)dInfo->dragger;
+        translating = true;
+    }
+    else {
+        myCenterball = (SoCenterballDragger *)dInfo->dragger;
+        translating = false;
+    }
+
+    // if this callback is due to a recentering of the centerball dragger,
+    // then no actual movement is performed but hand's current translation
+    // and rotation values need to be recomputed.
+    if (!translating) {
+        SbVec3f centerTran = myCenterball->center.getValue() - dInfo->lastCent;
+        if (centerTran.length() > 1.0e-3) {
+            DBGP("RECENTERING");
+            DBGP("current center: " << myCenterball->center.getValue()[0] << " " <<
+                 myCenterball->center.getValue()[1] << " " <<
+                 myCenterball->center.getValue()[2]);
+            DBGP("last center: " << dInfo->lastCent[0] << " " <<
+                 dInfo->lastCent[1] << " " <<
+                 dInfo->lastCent[2]);
+            scale.set(dInfo->draggerTran->scaleFactor.getValue());
+            center.set(myCenterball->center.getValue());
+            center *= scale[0];
+            transf recenterTran = translate_transf(center) *
+                                  dInfo->selectedElement->getTran() * translate_transf(-center);
+            dInfo->centerballTransl = recenterTran.translation();
+            dInfo->lastCent = myCenterball->center.getValue();
+            return;
+        }
+    }
+
+    // disable the callback while we are moving things
+    //this is no longer needed since we replaced the valueChanged callback
+    //with a motion callback
+    //SbBool enabled = dInfo->dragger->enableValueChangedCallbacks(FALSE);
+
+    origTranslation = dInfo->selectedElement->getTran().translation();
+    origRotation = dInfo->selectedElement->getTran().rotation();
+
+    // save the desired position or orientation and set what percent of the
+    // desired moved will be accomplished in each step
+    if (translating) {
+        if ((myHandleBox->translation.getValue() - dInfo->lastTran).length() < 0.00001) {
+            myHandleBox->translation.setValue(dInfo->lastTran);
+            //if (enabled) myHandleBox->enableValueChangedCallbacks(TRUE);
+            return;
+        }
+        desiredTranslation.set(myHandleBox->translation.getValue());
+        scale.set(dInfo->draggerTran->scaleFactor.getValue());
+        desiredTranslation[0] *= scale[0];
+        desiredTranslation[1] *= scale[1];
+        desiredTranslation[2] *= scale[2];
+        //origRotation.set(dInfo->draggerTran->rotation.getValue());
+        desiredTranslation = origRotation * desiredTranslation;
+
+        DBGP("desired Translation: " << desiredTranslation);
+        //not needed?
+        //if ((desiredTranslation - origTranslation).len() == 0.0) return;
+        newTran = transf(origRotation, desiredTranslation);
+    }
+    else {
+        if (myCenterball->rotation.getValue().equals(dInfo->lastRot, 0.00001f)) {
+            myCenterball->rotation.setValue(dInfo->lastRot);
+            //if (enabled) myCenterball->enableValueChangedCallbacks(TRUE);
+            return;
+        }
+        desiredRotation.set(myCenterball->rotation.getValue());
+        scale.set(dInfo->draggerTran->scaleFactor.getValue());
+        center.set(myCenterball->center.getValue());
+        center *= scale[0];
+        //this does not work if the centerball has been recentered
+        //hope to fix this at some point
+        newTran = translate_transf(-center) * transf(desiredRotation, vec3::ZERO) *
+                  translate_transf(center) * translate_transf(dInfo->centerballTransl);
+    }
+    dInfo->selectedElement->moveTo(newTran, 50 * Contact::THRESHOLD, M_PI / 36.0);
+    world->updateGrasps();
+
+    DBGP("new pos: " << dInfo->selectedElement->getTran());
+    if (translating) {
+        SbVec3f newPos = (origRotation.inverse() * dInfo->selectedElement->getTran().translation()).toSbVec3f();
+        newPos[0] /= scale[0];
+        newPos[1] /= scale[1];
+        newPos[2] /= scale[2];
+        dInfo->lastTran = newPos;
+        myHandleBox->translation.setValue(newPos);
+    }
+    else {
+        SbRotation newRot = dInfo->selectedElement->getTran().rotation().toSbRotation();
+        dInfo->lastRot = newRot;
+        myCenterball->rotation.setValue(newRot);
+        #ifdef GRASPITDBG
+        SbVec3f ax;
+        float ang;
+        newRot.getValue(ax, ang);
+        desiredRotation.set(myCenterball->rotation.getValue());
+        std::cout << "setting ball to: " << desiredRotation << std::endl;
+        #endif
+    }
+
+    //if (enabled) dInfo->dragger->enableValueChangedCallbacks(TRUE);
+}
+
+void
+IVmgr::revoluteJointClicked(DraggerInfo *dInfo) {
+    SbVec3f axis;
+    float angle;
+    SoRotateDiscDragger *dragger = (SoRotateDiscDragger *)dInfo->dragger;
+    dragger->rotation.getValue(axis, angle);
+    dInfo->lastVal = angle;
+
+    Robot *robot = (Robot *) dInfo->selectedElement;
+    robot->emitUserInteractionStart();
+}
+
+void
+IVmgr::revoluteJointFinished(DraggerInfo *dInfo) {
+    Robot *robot = (Robot *) dInfo->selectedElement;
+    robot->emitUserInteractionEnd();
 }
 
 /*!
-  Given a filename, this will save the current camera position after each
-  completed step of the dynamics.  This allows the user to move the camera
-  during a dynamics simulation, and have each position saved so that when the
-  simulation is performed again to make an image sequence, the camera will
-  follow the saved trajectory.
+    The callback routine is invoked whenever a disc dragger controlling a
+    revolute DOF is moved by the user.  It requires a pointer to the dragger's
+    associated info structure.  It prevents the user from moving the dragger
+    past the minimum or maximum DOF limits.  It calls the associated robot's
+    moveDOFto routine to peform the move, and after it is completed or a contact
+    prevents further motion it asks the world to update the grasps and sets the
+    current angle of the disc dragger.
+*/
+void
+IVmgr::revoluteJointChanged(DraggerInfo *dInfo) {
+    SbVec3f axis;
+    float angle;
+    double desiredAngle;
+    Robot *robot = (Robot *)dInfo->selectedElement;
+    SoRotateDiscDragger *dragger = (SoRotateDiscDragger *)dInfo->dragger;
+    DOF *dof = dInfo->dof;
+    double *dofVals = new double[robot->getNumDOF()];
+    double *stepBy = new double[robot->getNumDOF()];
+    int d;
+
+
+    #ifdef GRASPITDBG
+    printf("in jointChangedCB\n");
+    #endif
+
+    SbBool enabled = dragger->enableValueChangedCallbacks(FALSE);
+
+    dragger->rotation.getValue(axis, angle);
+
+    if (fabs(angle - dInfo->lastVal) < 0.00001) {
+        dragger->rotation.setValue(axis, dInfo->lastVal);
+        if (enabled) dragger->enableValueChangedCallbacks(TRUE);
+        return;
+    }
+
+    //  desiredAngle = (double) (axis[2] * angle);
+
+    double relAngle = (double)axis[2] * (angle - dInfo->lastVal);
+    if (relAngle > M_PI) relAngle -= 2 * M_PI;
+    if (relAngle <= -M_PI) relAngle += 2 * M_PI;
+    desiredAngle = dof->getVal() + (double)(relAngle);
+    dInfo->lastVal = angle;
+
+    #ifdef GRASPITDBG
+    printf("axis[2]: %f angle: %f\n", axis[2], angle);
+    #endif
+
+    // Check that the desired angle has not exceeded the DOF limits
+    //if (desiredAngle - dof->getVal() > M_PI)
+    //  desiredAngle -= 2*M_PI;
+    if (desiredAngle > dof->getMax())
+        desiredAngle = dof->getMax();
+    else if (desiredAngle < dof->getMin())
+        desiredAngle = dof->getMin();
+
+    robot->getDOFVals(dofVals);
+
+    #ifdef GRASPITDBG
+    printf("desiredDOFVal: %.1f deg -- %15.15lf rad\n", desiredAngle * 180.0 / M_PI, desiredAngle);
+    #endif
+
+    dofVals[dof->getDOFNum()] = desiredAngle;
+    for (d = 0; d < robot->getNumDOF(); d++) {
+        //    stepBy[d]=0.0;
+        stepBy[d] = M_PI / 36.0;
+        #if 0
+        printf("dof %d, to: %lf\n", d, dofVals[d]);
+        #endif
+    }
+    stepBy[dof->getDOFNum()] = M_PI / 36.0;
+
+    // Perform the move
+    robot->moveDOFToContacts(dofVals, stepBy, true);
+    //this is just so that a potential eigen grasp dialog knows about this
+    robot->emitConfigChange();
+    world->updateGrasps();
+
+    #ifdef GRASPITDBG
+    printf("newDOFVal: %15.15lf\n", dof->getVal());
+    #endif
+
+    angle = (float) dof->getVal();
+    //if (dof->getVal() >= 0.0 && (dof->getVal() % (2*M_PI)) < M_PI) {
+    //    axis[2] = 1.0f;
+    //    angle = (float)dof->getVal();
+    //  }
+    //  else {
+    //    axis[2] = -1.0f;
+    //    angle = (float) -dof->getVal();
+    //  }
+
+    angle = dof->getVal() / axis[2];
+    //  dInfo->lastVal = angle;
+    #ifdef GRASPITDBG
+    printf("setting axis[2]: %f angle: %f dof val: %f\n", axis[2], angle, dof->getVal());
+    #endif
+
+    dragger->rotation.setValue(axis, angle);
+
+    if (enabled)
+        dragger->enableValueChangedCallbacks(TRUE);
+
+    delete [] dofVals;
+    delete [] stepBy;
+}
+
+/*!
+    The callback routine is invoked whenever an arrow dragger controlling a
+    prismatic DOF is moved by the user.  It requires a pointer to the dragger's
+    associated info structure.  It prevents the user from moving the dragger
+    past the minimum or maximum DOF limits.  It calls the associated robot's
+    moveDOFto routine to peform the move, and after it is completed or a contact
+    prevents further motion it asks the world to update the grasps and sets the
+    current translation of the arrow dragger.
+*/
+void
+IVmgr::prismaticJointChanged(DraggerInfo *dInfo) {
+    SbVec3f transl(0, 0, 0);
+    double desiredTransl;
+    SoTranslate1Dragger *dragger = (SoTranslate1Dragger *)dInfo->dragger;
+    Robot *robot = (Robot *)dInfo->selectedElement;
+    DOF *dof = dInfo->dof;
+    double *dofVals = new double[robot->getNumDOF()];
+    double *stepBy = new double[robot->getNumDOF()];
+
+    SbBool enabled = dragger->enableValueChangedCallbacks(FALSE);
+
+    float scale = robot->getDOFDraggerScale(dof->getDOFNum());
+
+    // Must multiply the dragger value by its scale
+    desiredTransl = (double)(dragger->translation.getValue()[0] * scale);
+
+    if (desiredTransl > dof->getMax()) {
+        desiredTransl = dof->getMax();
+    }
+    else if (desiredTransl < dof->getMin()) {
+        desiredTransl = dof->getMin();
+    }
+
+    robot->getDOFVals(dofVals);
+
+    #ifdef GRASPITDBG
+    printf("desiredDOFVal: %le\n", desiredTransl);
+    #endif
+
+    dofVals[dof->getDOFNum()] = desiredTransl;
+    for (int d = 0; d < robot->getNumDOF(); d++) stepBy[d] = 0.0;
+    stepBy[dof->getDOFNum()] = 50 * Contact::THRESHOLD;
+
+    // Perform the move
+    robot->moveDOFToContacts(dofVals, stepBy, true);
+    //this is just so that a potential eigen grasp dialog knows about this
+    robot->emitConfigChange();
+    world->updateGrasps();
+
+    transl[0] = (float) dof->getVal() / scale;
+    dragger->translation.setValue(transl);
+
+    if (enabled)
+        dragger->enableValueChangedCallbacks(TRUE);
+
+    delete [] dofVals;
+    delete [] stepBy;
+}
+
+/*!
+    Creates a centerball dragger for the provided worldElement around the
+    body surroundMe, and sets up the value changed callback for the dragger.
+    For a free body, the worldElement and surroundMe point to the same body.
+    For a robot, the worldElement points to the robot and surround me points
+    to the base link of the robot.
+*/
+void
+IVmgr::makeCenterball(WorldElement *selectedElement, Body *surroundMe) {
+    SoCenterballDragger *myCenterball = new SoCenterballDragger;
+    SoSeparator *sep = new SoSeparator;
+    SoTransform *draggerTran = new SoTransform;
+
+    // Compute the bounding box of the surroundMe body
+    SoGetBoundingBoxAction *bba = new SoGetBoundingBoxAction(myViewer->getViewportRegion());
+    bba->apply(surroundMe->getIVGeomRoot());
+    float maxRad = (bba->getBoundingBox().getMax() - bba->getBoundingBox().getMin()).length();
+    delete bba;
+
+    maxRad /= 2.0;
+
+    draggerTran->translation = selectedElement->getTran().translation().toSbVec3f();
+    draggerTran->scaleFactor.setValue(maxRad, maxRad, maxRad);
+    myCenterball->rotation = selectedElement->getTran().rotation().toSbRotation();
+
+    sep->addChild(draggerTran);
+    sep->addChild(myCenterball);
+    draggerRoot->addChild(sep);
+
+    // Create the dragger info structure
+    DraggerInfo *dInfo = new DraggerInfo;
+    dInfo->draggerSep = sep;
+    dInfo->dragger = myCenterball;
+    dInfo->draggerTran = draggerTran;
+    dInfo->selectedElement = selectedElement;
+    dInfo->lastCent = myCenterball->center.getValue();
+    DBGP("lastCent " << dInfo->lastCent[0] << " " << dInfo->lastCent[1] << " " << dInfo->lastCent[2]);
+
+    dInfo->centerballTransl = selectedElement->getTran().translation();
+    draggerInfoList.push_back(dInfo);
+    DBGP("NUM DRAGGER INFOS " << draggerInfoList.size());
+
+    //the value changed callback is behaving strangely so we replaced it
+    //with motion callback which is a lot more stable. if you need the
+    //functionality of the valueChanged callback, beware of erratic
+    //behavior where the callback is called again and again for no reason.
+    //myCenterball->addValueChangedCallback(transRotCB,dInfo);
+    myCenterball->addMotionCallback(transRotCB, dInfo);
+}
+
+/*!
+    Creates a handlebox dragger for the provided worldElement around the
+    body surroundMe, and sets up the value changed callback for the dragger.
+    For a free body, the worldElement and surroundMe point to the same body.
+    For a robot, the worldElement points to the robot and surround me points
+    to the base link of the robot.
+*/
+void
+IVmgr::makeHandleBox(WorldElement *selectedElement, Body *surroundMe) {
+    SoSeparator *sep = new SoSeparator;
+    draggerRoot->addChild(sep);
+
+    // Elminate many parts of the handlebox that would allow body scaling etc...
+    SoHandleBoxDragger *myHandleBox = new SoHandleBoxDragger;
+    myHandleBox->setPart("extruder1", new SoSeparator);
+    myHandleBox->setPart("extruder2", new SoSeparator);
+    myHandleBox->setPart("extruder3", new SoSeparator);
+    myHandleBox->setPart("extruder4", new SoSeparator);
+    myHandleBox->setPart("extruder5", new SoSeparator);
+    myHandleBox->setPart("extruder6", new SoSeparator);
+    myHandleBox->setPart("uniform1", new SoSeparator);
+    myHandleBox->setPart("uniform2", new SoSeparator);
+    myHandleBox->setPart("uniform3", new SoSeparator);
+    myHandleBox->setPart("uniform4", new SoSeparator);
+    myHandleBox->setPart("uniform5", new SoSeparator);
+    myHandleBox->setPart("uniform6", new SoSeparator);
+    myHandleBox->setPart("uniform7", new SoSeparator);
+    myHandleBox->setPart("uniform8", new SoSeparator);
+    myHandleBox->setPart("extruder1Active", new SoSeparator);
+    myHandleBox->setPart("extruder2Active", new SoSeparator);
+    myHandleBox->setPart("extruder3Active", new SoSeparator);
+    myHandleBox->setPart("extruder4Active", new SoSeparator);
+    myHandleBox->setPart("extruder5Active", new SoSeparator);
+    myHandleBox->setPart("extruder6Active", new SoSeparator);
+    myHandleBox->setPart("uniform1Active", new SoSeparator);
+    myHandleBox->setPart("uniform2Active", new SoSeparator);
+    myHandleBox->setPart("uniform3Active", new SoSeparator);
+    myHandleBox->setPart("uniform4Active", new SoSeparator);
+    myHandleBox->setPart("uniform5Active", new SoSeparator);
+    myHandleBox->setPart("uniform6Active", new SoSeparator);
+    myHandleBox->setPart("uniform7Active", new SoSeparator);
+    myHandleBox->setPart("uniform8Active", new SoSeparator);
+
+    // compute the bounding box of the body
+    SoGetBoundingBoxAction *bba = new SoGetBoundingBoxAction(myViewer->getViewportRegion());
+    bba->apply(surroundMe->getIVGeomRoot());
+    SbVec3f bbmin, bbmax;
+    bba->getBoundingBox().getBounds(bbmin, bbmax);
+    delete bba;
+
+    // make the dragger (a 2x2x2 box) slightly bigger than the bounding box.
+    SbVec3f scale = ((bbmax - bbmin) / 1.9f);
+    double maxScale = MAX(MAX(scale[0], scale[1]), scale[2]);
+    if (maxScale == 0.0) {   // not good, object has 0 volume bbox!
+        DBGP("0 volume bounding box!");
+        return;
+    }
+
+    // prevent any of the sides from having a dimension much smaller than another
+    for (int i = 0; i < 3; i++) {
+        if (scale[i] / maxScale < .01) {
+            scale[i] = 0.01 * maxScale;
+        }
+    }
+
+    SbRotation rot = selectedElement->getTran().rotation().toSbRotation();
+
+    SbVec3f transl =
+        (selectedElement->getTran().rotation().inverse() *
+         selectedElement->getTran().translation()).toSbVec3f();
+
+    transl[0] = transl[0] / scale[0];
+    transl[1] = transl[1] / scale[1];
+    transl[2] = transl[2] / scale[2];
+
+    // compute the offset from the body's frame to the dragger's center
+    SbVec3f offsetTransl;
+    rot.multVec((bbmax + bbmin) / 2.0f, offsetTransl);
+
+    SoTransform *draggerTran = new SoTransform;
+
+    myHandleBox->translation = transl;
+    draggerTran->scaleFactor.setValue(scale);
+    draggerTran->rotation = rot;
+    draggerTran->translation = offsetTransl;
+
+    sep->addChild(draggerTran);
+    sep->addChild(myHandleBox);
+
+    DraggerInfo *dInfo = new DraggerInfo;
+    dInfo->draggerSep = sep;
+    dInfo->dragger = myHandleBox;
+    dInfo->draggerTran = draggerTran;
+    dInfo->selectedElement = selectedElement;
+    draggerInfoList.push_back(dInfo);
+
+    DBGP("Callback added");
+    //the value changed callback is behaving strangely so we replaced it
+    //with motion callback which is a lot more stable. if you need the
+    //functionality of the valueChanged callback, beware of erratic
+    //behavior where the callback is called again and again for no reason.
+    //  myHandleBox->addValueChangedCallback(transRotCB,dInfo);
+    myHandleBox->addMotionCallback(transRotCB, dInfo);
+}
+
+/*!
+    Creates the joint draggers for each DOF in the provided kinematic chain,
+    and sets up the value changed callback for each dragger.  Only the first
+    joint in the chain associated with a given DOF has a dragger connected to
+    it.  In other words, passive joints don't have draggers.  The scale of
+    the joint dragger is controlled by a parameter found in the joints section
+    of the robot configuration file.
+*/
+void
+IVmgr::makeJointDraggers(Robot *robot, KinematicChain *chain) {
+    int j, d;
+    int *activeDOFs = new int[robot->getNumDOF()];
+    SoSeparator *jointDraggerSep = new SoSeparator;
+    DraggerInfo *dInfo;
+    bool firstDragger = true;
+
+    //jointDraggerSep->ref();
+    jointDraggerSep->addChild(robot->getBase()->getIVTran());
+    DBGP("make draggers; value: " << chain->getIVTran()->translation.getValue()[0]);
+    jointDraggerSep->addChild(chain->getIVTran());
+
+    for (d = 0; d < robot->getNumDOF(); d++)
+        activeDOFs[d] = -1;
+
+    for (j = chain->getNumJoints() - 1; j >= 0; j--)
+        activeDOFs[chain->getJoint(j)->getDOFNum()] = j;
+
+    for (d = 0; d < robot->getNumDOF(); d++) {
+        if ((j = activeDOFs[d]) != -1) {
+            SoSeparator *sep = new SoSeparator;
+            dInfo = new DraggerInfo;
+            dInfo->selectedElement = robot;
+            dInfo->dof = robot->getDOF(d);
+
+            // add the parent separator for all the joint draggers to the
+            // first draggerInfo, because it includes not only the draggers
+            // but also the transforms between them, and we'll delete them
+            // all at once.
+            if (firstDragger) {
+                dInfo->draggerSep = jointDraggerSep;
+                firstDragger = false;
+            }
+            else
+                dInfo->draggerSep = NULL;
+
+            //      for (l=0;l<chain->getNumLinks();l++)
+            //    if (j<=chain->getLastJoint(l)) break;
+
+            if (chain->getJoint(j)->getType() == REVOLUTE) {
+                SoScale *dialSize = new SoScale;
+                SoRotateDiscDragger *myDisc = new SoRotateDiscDragger;
+
+                float scale = robot->getDOFDraggerScale(d);
+                dialSize->scaleFactor.setValue(SbVec3f(scale, scale, scale));
+                SoTranslation *dTrans = new SoTranslation;
+                dTrans->translation.setValue(0, 0, chain->getJoint(j)->getDH()->getD());
+
+                //sep->addChild(dTrans);
+                sep->addChild(dialSize);
+                sep->addChild(myDisc);
+
+                myDisc->rotation.setValue(SbVec3f(0.0, 0.0, 1.0), (float) robot->getDOF(d)->getVal());
+                //dInfo->lastVal = (float) robot->getDOF(d)->getVal();
+                myDisc->addStartCallback(revoluteJointClickedCB, dInfo);
+                myDisc->addValueChangedCallback(revoluteJointChangedCB, dInfo);
+                myDisc->addFinishCallback(revoluteJointFinishedCB, dInfo);
+                dInfo->dragger = myDisc;
+            }
+            else { // prismatic
+                SoTransform *arrowTran = new SoTransform;
+                SoTranslate1Dragger *myArrow = new SoTranslate1Dragger;
+                SoBaseColor *arrowBC = new SoBaseColor;
+                float scale = robot->getDOFDraggerScale(d);
+                arrowBC->rgb.setValue(1, 1, 1);
+                arrowTran->scaleFactor.setValue(SbVec3f(scale, scale, scale));
+                arrowTran->rotation.setValue(SbVec3f(0, 1, 0), (float) - M_PI / 2.0f);
+                arrowTran->translation.setValue(SbVec3f(0, -scale, 0));
+                sep->addChild(arrowBC);
+                sep->addChild(arrowTran);
+                sep->addChild(myArrow);
+
+                myArrow->translation.setValue(SbVec3f((float)robot->getDOF(d)->getVal() / scale, 0, 0));
+                dInfo->lastVal = (float) robot->getDOF(d)->getVal() / scale;
+                myArrow->addValueChangedCallback(prismaticJointChangedCB, dInfo);
+                dInfo->dragger = myArrow;
+            }
+            // now it will update its IVTran whenever it moves
+            chain->getJoint(j)->setDraggerAttached(true);
+
+            jointDraggerSep->addChild(sep);
+            jointDraggerSep->addChild(chain->getJoint(j)->getIVTran());
+            draggerInfoList.push_back(dInfo);
+        }
+    }
+    draggerRoot->addChild(jointDraggerSep);
+
+    #ifdef GRASPITDBG
+    std::cout << "NUM DRAGGER INFOS " << draggerInfoList.size() << std::endl;
+    #endif
+    delete activeDOFs;
+}
+
+/*!
+    Creates a white wireframe copy of the model sub-tree passed to it in
+    elementRoot, and adds it to the wireframe root.  This is used to provide
+    a visual indication when a body has been selected by the user.
+*/
+void
+IVmgr::drawWireFrame(SoSeparator *elementRoot) {
+    SoLightModel *lm = new SoLightModel;
+    lm->model = SoLightModel::BASE_COLOR;
+
+    SoDrawStyle *ds = new SoDrawStyle;
+    ds->style = SoDrawStyle::LINES;
+    ds->setOverride(TRUE);
+
+    SoBaseColor *bc = new SoBaseColor;
+    bc->rgb.setValue(1, 1, 1);
+    bc->setOverride(TRUE);
+
+    SoSeparator *sep = new SoSeparator;
+    sep->addChild(lm);
+    sep->addChild(ds);
+    sep->addChild(bc);
+    sep->addChild(elementRoot);
+
+    wireFrameRoot->addChild(sep);
+}
+
+/*!
+    This callback routine is invoked when a user clicks within the scene and
+    controls what Inventor body is picked.  If a dragger is clicked, a empty
+    path is returned because we don't want the dragger to be selected in the
+    Inventor sense.  If the translate or rotate tool is currently being used
+    and a link of a kinematic chain is clicked, pick the whole chain.
+    If the base of a robot is clicked, pick the whole robot.  If the current
+    tool is the select tool, and a link is clicked that has already been
+    selected, pick the whole robot.  Otherwise pick the body that was clicked.
+*/
+SoPath *
+IVmgr::pickFilter(const SoPickedPoint *pick) {
+    int i, l, r, f, b;
+    SoPath *p = pick->getPath();
+    Robot *robot;
+
+    if (p->getTail()->isOfType(SoDragger::getClassTypeId()) ||
+            p->getTail()->isOfType(SoTransformManip::getClassTypeId())) {
+        DBGP("dragger or manip picked");
+        SoPath *newP = new SoPath(sceneRoot);
+        return newP;
+    }
+
+    for (i = p->getLength() - 1; i >= 0; i--) {
+        SoNode *n = p->getNode(i);
+        for (r = 0; r < world->getNumRobots(); r++) {
+            robot = world->getRobot(r);
+
+            if (currTool != SELECT_TOOL) {
+                for (f = 0; f < robot->getNumChains(); f++)
+                    if (n == robot->getChain(f)->getIVRoot())
+                        return p->copy(0, i + 1);               // select the chain
+
+                if (n == robot->getBase()->getIVRoot())
+                    return p->copy(0, i);                     // select the whole robot
+
+                if (robot->inherits("HumanHand")) {
+                    for (f = 0; f < ((HumanHand *)robot)->getNumTendons(); f++)
+                        if (n == ((HumanHand *)robot)->getTendon(f)->getIVRoot())
+                            return p->copy(0, i + 1);
+                }
+
+            }
+            else {
+                if (n == robot->getBase()->getIVRoot() && world->isSelected(robot->getBase()))
+                    return p->copy(0, i);                     // select the whole robot
+
+                for (f = 0; f < robot->getNumChains(); f++)
+                    for (l = 0; l < robot->getChain(f)->getNumLinks(); l++)
+                        if (n == robot->getChain(f)->getLink(l)->getIVRoot() && world->isSelected(robot->getChain(f)->getLink(l)))
+                            return p->copy(0, i - 1);             // select the whole robot
+
+                if (robot->inherits("HumanHand")) {
+                    for (f = 0; f < ((HumanHand *)robot)->getNumTendons(); f++)
+                        if (n == ((HumanHand *)robot)->getTendon(f)->getIVRoot())
+                            return p->copy(0, i + 1);
+                }
+
+            }
+        }
+    }
+
+    for (i = p->getLength() - 1; i >= 0; i--) {
+        SoNode *n = p->getNode(i);
+        for (b = 0; b < world->getNumBodies(); b++)
+            if (n == world->getBody(b)->getIVRoot()) {
+                #ifdef GRAPSITDBG
+                printf("pickfilter: body %s picked\n", world->getBody(b)->getName());
+                #endif
+                return p->copy(0, i + 1);                   // select body
+            }
+    }
+
+    return NULL;
+}
+
+/*!
+    This callback routine is invoked whenever an Inventor selection occurs.
+    When this routine is called because of a user click, the path sent to this
+    routine is determined by the pickFilter.  The action that occurs upon
+    selection depends on the current tool selected.  If a kinematic chain is
+    selected, and the rotate or translate tool is selected, joint draggers are
+    created.  Otherwise, if the rotate tool is being used, then a centerball is
+    created around the chosen body.  If the translate tool is being used, then
+    a handlebox is created around the chosen body.  If the select tool is being
+    used, the chosen body is selected within GraspIt! and a wireframe version
+    of the body is drawn to indicate the selection.
+*/
+void
+IVmgr::handleSelection(SoPath *p) {
+    int r, b, f;
+    bool selectionFound = false;
+    Robot *robot;
+
+    #ifdef GRASPITDBG
+    printf("in selectionCB: \n");
+    fprintf(stderr, "in selectionCB: \n");
+
+    fprintf(stderr, "*************NUM SELECTED %d*****************\n", selectionRoot->getNumSelected());
+    #endif
+
+    if (p->getTail()->isOfType(SoDragger::getClassTypeId())) {
+        #ifdef GRASPITDBG
+        printf("selection path tail is dragger\n");
+        #endif
+        return;
+    }
+    else if (p->getTail() == sceneRoot) {
+        #ifdef GRASPITDBG
+        printf("selection path tail is sceneRoot\n");
+        #endif
+        return;
+    }
+    else {
+        for (r = 0; r < world->getNumRobots(); r++) {
+            robot = world->getRobot(r);
+            if (p->getTail() == robot->getIVRoot()) {
+                #ifdef GRASPITDBG
+                printf("robot selected\n");
+                #endif
+                selectionFound = true;
+                if (currTool == ROTATE_TOOL)
+                    makeCenterball(robot, robot->getBase());
+                else if (currTool == TRANSLATE_TOOL)
+                    makeHandleBox(robot, robot->getBase());
+                else if (currTool == SELECT_TOOL) {
+                    world->selectElement(robot);
+                    drawWireFrame(robot->getIVRoot());
+                }
+            }
+            else {
+                for (f = 0; f < robot->getNumChains(); f++)
+                    if (p->getTail() == robot->getChain(f)->getIVRoot()) {
+                        selectionFound = true;
+                        makeJointDraggers(robot, robot->getChain(f));
+                    }
+                if (robot->inherits("HumanHand")) {
+                    for (f = 0; f < ((HumanHand *)robot)->getNumTendons(); f++)
+                        if (p->getTail() == ((HumanHand *)robot)->getTendon(f)->getIVRoot()) {
+                            selectionFound = true;
+                            world->selectTendon(((HumanHand *)robot)->getTendon(f));
+                        }
+                }
+            }
+        }
+        if (!selectionFound) {
+            // check if one of the objects was selected
+            for (b = 0; b < world->getNumBodies(); b++) {
+                if (p->getTail() == world->getBody(b)->getIVRoot()) {
+                    //#ifdef GRASPITDBG
+                    printf("body %s selected\n", world->getBody(b)->getName().latin1());
+                    //#endif
+                    selectionFound = true;
+                    if (currTool == ROTATE_TOOL)
+                        makeCenterball(world->getBody(b), world->getBody(b));
+                    else if (currTool == TRANSLATE_TOOL)
+                        makeHandleBox(world->getBody(b), world->getBody(b));
+                    else if (currTool == SELECT_TOOL) {
+                        world->selectElement(world->getBody(b));
+                        drawWireFrame(world->getBody(b)->getIVRoot());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/*!
+    This callback routine is invoked whenever an Inventor deselection occurs.
+    If the select tool is being used this deselects the element within GraspIt!
+    and deletes the wireframe.  Otherwise this removes the draggers, from the
+    deselected body or robot.
+*/
+void
+IVmgr::handleDeselection(SoPath *p) {
+    int r, b, f, j;
+    Robot *robot;
+    WorldElement *deselectedElement = NULL;
+    std::list<DraggerInfo *>::iterator dp;
+
+    #ifdef GRASPITDBG
+    printf("in deselectionCB: \n");
+    #endif
+
+
+    #ifdef GRASPITDBG
+    if (p->getTail()->isOfType(SoDragger::getClassTypeId()))
+        printf("deselecting dragger\n");
+    #endif
+
+    for (r = 0; r < world->getNumRobots() && !deselectedElement; r++) {
+        robot = world->getRobot(r);
+
+        // check if the base was deselected
+        if (p->getTail() == robot->getIVRoot()) {
+            deselectedElement = robot;
+        }
+        else {
+            // check if a chain was deselected
+            for (f = 0; f < robot->getNumChains() && !deselectedElement; f++) {
+                if (p->getTail() == robot->getChain(f)->getIVRoot()) {
+                    DBGP("deselecting chain " << f);
+                    for (j = 0; j < robot->getChain(f)->getNumJoints(); j++)
+                        robot->getChain(f)->getJoint(j)->setDraggerAttached(false);
+                    deselectedElement = robot;
+                }
+            }
+            if (robot->inherits("HumanHand")) {
+                for (f = 0; f < ((HumanHand *)robot)->getNumTendons(); f++)
+                    if (p->getTail() == ((HumanHand *)robot)->getTendon(f)->getIVRoot()) {
+                        deselectedElement = robot;
+                        //let's keep the tendon selected so we can play with robot joints
+                        //and see how it affeccts the tendon
+                        //world->deselectTendon();
+                    }
+            }
+
+        }
+    }
+
+    for (b = 0; b < world->getNumBodies() && !deselectedElement; b++)
+        if (p->getTail() == world->getBody(b)->getIVRoot()) {
+            DBGP("deselecting body " << world->getBody(b)->getName().latin1());
+            deselectedElement = world->getBody(b);
+        }
+
+    if (deselectedElement) {
+        if (currTool == SELECT_TOOL) {
+            world->deselectElement(deselectedElement);
+            for (b = 0; b < wireFrameRoot->getNumChildren(); b++) {
+                SoSeparator *wfSep = (SoSeparator *)wireFrameRoot->getChild(b);
+                if (wfSep->getChild(wfSep->getNumChildren() - 1) ==  deselectedElement->getIVRoot()) {
+                    wireFrameRoot->removeChild(b);
+                    break;
+                }
+            }
+        }
+        else {
+            dp = draggerInfoList.begin();
+            while (dp != draggerInfoList.end()) {
+                if ((*dp)->selectedElement == deselectedElement) {
+                    if ((*dp)->draggerSep) {
+                        draggerRoot->removeChild((*dp)->draggerSep);
+                    }
+                    delete *dp;
+                    dp = draggerInfoList.erase(dp);
+                    DBGP("removing dragger info");
+                }
+                else {
+                    dp++;
+                }
+            }
+        }
+    }
+}
+
+/*!
+    If the select tool is currently being used and the user hits the delete key,
+    then all currently selected bodies will be deleted.  This routine does not
+    allow links of robots to be deleted, because of the change it would
+    require in the robot structure.  Sometime in the future we'll deal with that.
+    However, if the whole robot is selected, it will be deleted.
+*/
+void
+IVmgr::deleteSelections() {
+    int i, r, b;
+
+    // If a whole robot is selected, delete it
+    for (i = selectionRoot->getNumSelected() - 1; i >= 0; i--) {
+        for (r = 0; r < world->getNumRobots(); r++)
+            if (selectionRoot->getPath(i)->getTail() ==
+                    world->getRobot(r)->getIVRoot()) {
+                selectionRoot->deselect(i);
+                world->destroyElement(world->getRobot(r));
+                break;
+            }
+    }
+
+    // If a body is selected, first make sure it isn't a link before deleting it.
+    // Later, we'll want to be able to delete links, but for now it's too
+    // complicated, and would mean the robot structure would have to change
+    // dynamically
+    for (i = selectionRoot->getNumSelected() - 1; i >= 0; i--) {
+        for (b = 0; b < world->getNumBodies(); b++)
+            if (selectionRoot->getPath(i)->getTail() ==
+                    world->getBody(b)->getIVRoot()) {
+                if (!world->getBody(b)->inherits("Link")) {
+                    selectionRoot->deselect(i);
+                    world->destroyElement(world->getBody(b));
+                }
+                break;
+            }
+    }
+}
+
+void
+IVmgr::deselectBody(Body *b) {
+    int i;
+    for (i = selectionRoot->getNumSelected() - 1; i >= 0; i--) {
+        if (selectionRoot->getPath(i)->getTail() == b->getIVRoot()) {
+            if (!b->inherits("Link")) {
+                selectionRoot->deselect(i);
+            }
+            break;
+        }
+    }
+}
+/*!
+    Given a filename with an appropriate image format file extension, this
+    will render the current scene to an image file.  It currently uses a white
+    background and performs anti-aliasing by blending the images from 5 slightly
+    different camera angles.  One camera headlight is used for lighting.
+*/
+void
+IVmgr::saveImage(QString filename) {
+    SoQtRenderArea *renderArea;
+    SoNode *sg;                // scene graph
+    const SbColor white(1, 1, 1);
+    //  const SbColor black(0,0,0);
+    SoGLRenderAction *glRend;
+    SoOffscreenRenderer *myRenderer;
+
+    renderArea = myViewer;
+    sg = sceneRoot;
+
+    glRend = new SoGLRenderAction(renderArea->getViewportRegion());
+    glRend->setSmoothing(TRUE);
+    glRend->setNumPasses(5);
+    glRend->setTransparencyType(SoGLRenderAction::SORTED_OBJECT_SORTED_TRIANGLE_BLEND);
+
+    myRenderer = new SoOffscreenRenderer(glRend);
+    myRenderer->setBackgroundColor(white);
+
+    #ifdef GRASPITDBG
+    if (myRenderer->isWriteSupported("jpg"))
+        std::cout << " supports jpg" << std::endl;
+    else
+        std::cout << "no jpg support" << std::endl;
+    #endif
+
+    SoSeparator *renderRoot = new SoSeparator;
+    renderRoot->ref();
+    renderRoot->addChild(myViewer->getCamera());
+    SoTransformSeparator *lightSep = new SoTransformSeparator;
+    SoRotation *lightDir = new SoRotation;
+    lightDir->rotation.connectFrom(&myViewer->getCamera()->orientation);
+    lightSep->addChild(lightDir);
+    lightSep->addChild(myViewer->getHeadlight());
+
+    renderRoot->addChild(lightSep);
+    renderRoot->addChild(sg);
+
+    myRenderer->render(renderRoot);
+
+
+    myRenderer->writeToFile(SbString(filename.latin1()),
+                            SbName(filename.section('.', -1)));
+
+    renderRoot->unref();
+    delete myRenderer;
+}
+
+/*!
+    Given a base filename this will save an image of the scene after every
+    completed step of the dynamics.  The filename should have a %1 in it, which
+    will be replaced by the simulation time in seconds with a precision of 4
+    places after the decimal point.  The fileStr should also have a valid image
+    format file extension such as .jpg.
+*/
+void
+IVmgr::saveImageSequence(const char *fileStr) {
+    imgSeqStr = fileStr;
+    imgSeqCounter = 1;
+    connect(world, SIGNAL(dynamicStepTaken()), this, SLOT(saveNextImage()));
+
+}
+
+/*!
+    This calls saveImage after substituting the current world simulation time
+    into the filename.
+*/
+void
+IVmgr::saveNextImage() {
+    saveImage(QString(imgSeqStr).
+              arg(world->getWorldTime(), 0, 'f', 4));
+}
+
+/*!
+    Given a filename, this will save the current camera position after each
+    completed step of the dynamics.  This allows the user to move the camera
+    during a dynamics simulation, and have each position saved so that when the
+    simulation is performed again to make an image sequence, the camera will
+    follow the saved trajectory.
 */
 int
-IVmgr::saveCameraPositions(const char *filename)
-{
-  if (!(camerafp=fopen(filename,"w"))) return FAILURE;
-  connect(world,SIGNAL(dynamicStepTaken()),this,SLOT(saveCameraPos()));
-  return SUCCESS;
+IVmgr::saveCameraPositions(const char *filename) {
+    if (!(camerafp = fopen(filename, "w"))) return FAILURE;
+    connect(world, SIGNAL(dynamicStepTaken()), this, SLOT(saveCameraPos()));
+    return SUCCESS;
 }
 
 /*!
-  Given a filename to read camera positions from, this will set the camera
-  position after each completed step of the dynamics.  This is useful when
-  saving an image sequence to a file, because due to delays, the camera
-  cannot easily be controlled directly.
+    Given a filename to read camera positions from, this will set the camera
+    position after each completed step of the dynamics.  This is useful when
+    saving an image sequence to a file, because due to delays, the camera
+    cannot easily be controlled directly.
 */
 int
-IVmgr::useSavedCameraPositions(const char *filename)
-{
-  if (!(camerafp=fopen(filename,"r"))) return FAILURE;
-  connect(world,SIGNAL(dynamicStepTaken()),this,SLOT(restoreCameraPos()));
-  return SUCCESS;
+IVmgr::useSavedCameraPositions(const char *filename) {
+    if (!(camerafp = fopen(filename, "r"))) return FAILURE;
+    connect(world, SIGNAL(dynamicStepTaken()), this, SLOT(restoreCameraPos()));
+    return SUCCESS;
 }
 
 /*!
-  Saves the current camera position as a line in the currently open camera
-  position file.
+    Saves the current camera position as a line in the currently open camera
+    position file.
 */
 void
-IVmgr::saveCameraPos()
-{
-  float x,y,z;
-  float q1,q2,q3,q4;
-  
-  myViewer->getCamera()->position.getValue().getValue(x,y,z);
-  myViewer->getCamera()->orientation.getValue().getValue(q1,q2,q3,q4);
-  fprintf(camerafp,"%f %f %f %f %f %f %f\n",x,y,z,q1,q2,q3,q4);  
+IVmgr::saveCameraPos() {
+    float x, y, z;
+    float q1, q2, q3, q4;
+
+    myViewer->getCamera()->position.getValue().getValue(x, y, z);
+    myViewer->getCamera()->orientation.getValue().getValue(q1, q2, q3, q4);
+    fprintf(camerafp, "%f %f %f %f %f %f %f\n", x, y, z, q1, q2, q3, q4);
 }
 
 /*!
-  Reads a camera position from the currently open camera position file and
-  sets the viewer camera to that position.
+    Reads a camera position from the currently open camera position file and
+    sets the viewer camera to that position.
 */
 void
-IVmgr::restoreCameraPos()
-{
-  float x,y,z;
-  float q1,q2,q3,q4;
- 
-  if(fscanf(camerafp,"%f %f %f %f %f %f %f\n",&x,&y,&z,&q1,&q2,&q3,&q4) <= 0) {
-    DBGA("restoreCameraPos - Failed to read camera pose");
-    return;
-  }  
-  myViewer->getCamera()->position.setValue(x,y,z);
-  myViewer->getCamera()->orientation.setValue(q1,q2,q3,q4);
+IVmgr::restoreCameraPos() {
+    float x, y, z;
+    float q1, q2, q3, q4;
+
+    if (fscanf(camerafp, "%f %f %f %f %f %f %f\n", &x, &y, &z, &q1, &q2, &q3, &q4) <= 0) {
+        DBGA("restoreCameraPos - Failed to read camera pose");
+        return;
+    }
+    myViewer->getCamera()->position.setValue(x, y, z);
+    myViewer->getCamera()->orientation.setValue(q1, q2, q3, q4);
 }
 
-void 
-IVmgr::setCamera(double px, double py, double pz, double q1, double q2, double q3, double q4, double fd)
-{
-  myViewer->getCamera()->position.setValue(px,py,pz);
-  myViewer->getCamera()->orientation.setValue(q1,q2,q3,q4);
-  myViewer->getCamera()->focalDistance.setValue(fd);
+void
+IVmgr::setCamera(double px, double py, double pz, double q1, double q2, double q3, double q4, double fd) {
+    myViewer->getCamera()->position.setValue(px, py, pz);
+    myViewer->getCamera()->orientation.setValue(q1, q2, q3, q4);
+    myViewer->getCamera()->focalDistance.setValue(fd);
 }
 
-void 
-IVmgr::getCamera(float &px, float &py, float &pz, float &q1, float &q2, float &q3, float &q4, float &fd)
-{
-  myViewer->getCamera()->position.getValue().getValue(px,py,pz);
-  myViewer->getCamera()->orientation.getValue().getValue(q1,q2,q3,q4);
-  fd = myViewer->getCamera()->focalDistance.getValue();
+void
+IVmgr::getCamera(float &px, float &py, float &pz, float &q1, float &q2, float &q3, float &q4, float &fd) {
+    myViewer->getCamera()->position.getValue().getValue(px, py, pz);
+    myViewer->getCamera()->orientation.getValue().getValue(q1, q2, q3, q4);
+    fd = myViewer->getCamera()->focalDistance.getValue();
 }
 
-void 
-IVmgr::setCameraTransf(transf tr)
-{
-	const vec3 t = tr.translation();
-	const Quaternion q = tr.rotation();
-	myViewer->getCamera()->position.setValue( t.x(), t.y(), t.z() );
-	myViewer->getCamera()->orientation.setValue( q.x, q.y, q.z, q.w );
+void
+IVmgr::setCameraTransf(transf tr) {
+    const vec3 t = tr.translation();
+    const Quaternion q = tr.rotation();
+    myViewer->getCamera()->position.setValue(t.x(), t.y(), t.z());
+    myViewer->getCamera()->orientation.setValue(q.x, q.y, q.z, q.w);
 }
 
 transf
-IVmgr::getCameraTransf()
-{
-	transf tr;
-	float px, py, pz, qx, qy, qz, qw;
-	myViewer->getCamera()->position.getValue().getValue(px,py,pz);
-	myViewer->getCamera()->orientation.getValue().getValue(qx,qy,qz,qw);
-	Quaternion q = Quaternion(qw,qx,qy,qz);
-	tr.set( q, vec3(px,py,pz) );
-	return tr;
+IVmgr::getCameraTransf() {
+    transf tr;
+    float px, py, pz, qx, qy, qz, qw;
+    myViewer->getCamera()->position.getValue().getValue(px, py, pz);
+    myViewer->getCamera()->orientation.getValue().getValue(qx, qy, qz, qw);
+    Quaternion q = Quaternion(qw, qx, qy, qz);
+    tr.set(q, vec3(px, py, pz));
+    return tr;
 }
 
 /*!
-  This callback routine is invoked when the user presses a key while the
-  arrow (not the hand) viewer tool is selected.  The space bar toggles the
-  state of the dynamics.  The delete key deletes currently selected bodies.
-  The G key starts an autograps of the current hand.
+    This callback routine is invoked when the user presses a key while the
+    arrow (not the hand) viewer tool is selected.  The space bar toggles the
+    state of the dynamics.  The delete key deletes currently selected bodies.
+    The G key starts an autograps of the current hand.
 */
 void
-IVmgr::keyPressed(SoEventCallback *eventCB)
-{
-  const SoEvent *event = eventCB->getEvent();
+IVmgr::keyPressed(SoEventCallback *eventCB) {
+    const SoEvent *event = eventCB->getEvent();
 
-  if (SO_KEY_RELEASE_EVENT(event,SPACE)) {
-    if (world->dynamicsAreOn()) world->turnOffDynamics();
-    else world->turnOnDynamics();
-  }
-
-  //can't use simple macro with DELETE because win32 headers define DELETE
-  if (SoKeyboardEvent::isKeyReleaseEvent(event, SoKeyboardEvent::KEY_DELETE)) {
-    if (currTool == SELECT_TOOL)
-      ivmgr->deleteSelections();
-  }
-
-  if (SO_KEY_RELEASE_EVENT(event,G)) {
-    if (world->getCurrentHand()) {
-	  fprintf(stderr,"Autograsp!\n");
-	  world->getCurrentHand()->approachToContact(30);
-      world->getCurrentHand()->autoGrasp(true);
-      world->updateGrasps();
+    if (SO_KEY_RELEASE_EVENT(event, SPACE)) {
+        if (world->dynamicsAreOn()) world->turnOffDynamics();
+        else world->turnOnDynamics();
     }
-  }
 
-  if (SO_KEY_RELEASE_EVENT(event,R)) {
-	  world->getCurrentHand()->restoreState();
-  }
+    //can't use simple macro with DELETE because win32 headers define DELETE
+    if (SoKeyboardEvent::isKeyReleaseEvent(event, SoKeyboardEvent::KEY_DELETE)) {
+        if (currTool == SELECT_TOOL)
+            ivmgr->deleteSelections();
+    }
 
-  if (SO_KEY_RELEASE_EVENT(event,C)) {
-	  Hand *h = world->getCurrentHand();
-	  Hand *clone = new Hand(world, "Hand clone");
-	  clone->cloneFrom(h);
-	  clone->setRenderGeometry(false);
-	  clone->showVirtualContacts(false);
-	  world->addRobot(clone);
-	  world->toggleCollisions(false, h, clone);
-	  clone->setTran( h->getTran() );
-  }
+    if (SO_KEY_RELEASE_EVENT(event, G)) {
+        if (world->getCurrentHand()) {
+            fprintf(stderr, "Autograsp!\n");
+            world->getCurrentHand()->approachToContact(30);
+            world->getCurrentHand()->autoGrasp(true);
+            world->updateGrasps();
+        }
+    }
 
-  if (SO_KEY_RELEASE_EVENT(event,S)) {
-          world->getCurrentHand()->saveState();
-	  /*
-	  if (myViewer->isStereoOn())
-		  graspItGUI->getMainWindow()->stereoOff();
-	  else
-		  graspItGUI->getMainWindow()->stereoOn();
-		  */
-  }
+    if (SO_KEY_RELEASE_EVENT(event, R)) {
+        world->getCurrentHand()->restoreState();
+    }
 
-  if (SoKeyboardEvent::isKeyReleaseEvent(event,SoKeyboardEvent::PAD_ADD)) {
-	  if (myViewer->isStereoOn()) {
-		myViewer->mFocalPlane += 50.0;
-		myViewer->setStereo(true);
-	  }
-  }
-  if (SoKeyboardEvent::isKeyReleaseEvent(event,SoKeyboardEvent::PAD_SUBTRACT)) {
-	  if (myViewer->isStereoOn()) {
-		  myViewer->mFocalPlane -= 50.0;
-		  myViewer->setStereo(true);
-	  }
-  }
-  
-  //static bool left = true;  
+    if (SO_KEY_RELEASE_EVENT(event, C)) {
+        Hand *h = world->getCurrentHand();
+        Hand *clone = new Hand(world, "Hand clone");
+        clone->cloneFrom(h);
+        clone->setRenderGeometry(false);
+        clone->showVirtualContacts(false);
+        world->addRobot(clone);
+        world->toggleCollisions(false, h, clone);
+        clone->setTran(h->getTran());
+    }
 
-  static SoSeparator *indicators = NULL;
-  if (SO_KEY_RELEASE_EVENT(event,V)) {
-	  fprintf(stderr,"Distance test\n");
-	  if (!indicators) {
-		  indicators = new SoSeparator();
-		  world->getIVRoot()->addChild(indicators);
-	  }
-	  indicators->removeAllChildren();
-	  if (world->getNumGB() < 2) return;
-	  Body *b1 = world->getGB(0);
-	  Body *b2 = world->getGB(1);
-	  position p1, p2;
-	  world->getDist(b1, b2, p1, p2);
-	  p1 = p1 * b1->getTran();
-	  p2 = p2 * b2->getTran();
+    if (SO_KEY_RELEASE_EVENT(event, S)) {
+        world->getCurrentHand()->saveState();
+        /*
+            if (myViewer->isStereoOn())
+            graspItGUI->getMainWindow()->stereoOff();
+            else
+            graspItGUI->getMainWindow()->stereoOn();
+        */
+    }
 
-	  //vec3 v3 = world->pointDistanceToBody(p1, b2);
-	  //v3 = (p1 - position::ORIGIN) + v3;
-	  //p2 = position( v3.x(), v3.y(), v3.z());
+    if (SoKeyboardEvent::isKeyReleaseEvent(event, SoKeyboardEvent::PAD_ADD)) {
+        if (myViewer->isStereoOn()) {
+            myViewer->mFocalPlane += 50.0;
+            myViewer->setStereo(true);
+        }
+    }
+    if (SoKeyboardEvent::isKeyReleaseEvent(event, SoKeyboardEvent::PAD_SUBTRACT)) {
+        if (myViewer->isStereoOn()) {
+            myViewer->mFocalPlane -= 50.0;
+            myViewer->setStereo(true);
+        }
+    }
 
-	  SoSphere *sphere = new SoSphere();
-	  sphere->radius = 2;
+    //static bool left = true;
 
-	  SoSeparator *sep1 = new SoSeparator();
-	  SoTransform *tran1 = new SoTransform();
-	  tran1->translation.setValue(p1.x(), p1.y(), p1.z());
-	  sep1->addChild(tran1);
-	  sep1->addChild(sphere);
-	  indicators->addChild(sep1);
+    static SoSeparator *indicators = NULL;
+    if (SO_KEY_RELEASE_EVENT(event, V)) {
+        fprintf(stderr, "Distance test\n");
+        if (!indicators) {
+            indicators = new SoSeparator();
+            world->getIVRoot()->addChild(indicators);
+        }
+        indicators->removeAllChildren();
+        if (world->getNumGB() < 2) return;
+        Body *b1 = world->getGB(0);
+        Body *b2 = world->getGB(1);
+        position p1, p2;
+        world->getDist(b1, b2, p1, p2);
+        p1 = p1 * b1->getTran();
+        p2 = p2 * b2->getTran();
 
-	  SoSeparator *sep2 = new SoSeparator();
-	  SoTransform *tran2 = new SoTransform();
-	  tran2->translation.setValue(p2.x(), p2.y(), p2.z());
-	  sep2->addChild(tran2);
-	  sep2->addChild(sphere);
-	  indicators->addChild(sep2);
-  }
+        //vec3 v3 = world->pointDistanceToBody(p1, b2);
+        //v3 = (p1 - position::ORIGIN) + v3;
+        //p2 = position( v3.x(), v3.y(), v3.z());
+
+        SoSphere *sphere = new SoSphere();
+        sphere->radius = 2;
+
+        SoSeparator *sep1 = new SoSeparator();
+        SoTransform *tran1 = new SoTransform();
+        tran1->translation.setValue(p1.x(), p1.y(), p1.z());
+        sep1->addChild(tran1);
+        sep1->addChild(sphere);
+        indicators->addChild(sep1);
+
+        SoSeparator *sep2 = new SoSeparator();
+        SoTransform *tran2 = new SoTransform();
+        tran2->translation.setValue(p2.x(), p2.y(), p2.z());
+        sep2->addChild(tran2);
+        sep2->addChild(sphere);
+        indicators->addChild(sep2);
+    }
 
 }
 
 // static callback routines
 void
-IVmgr::keyPressedCB(void *,SoEventCallback *eventCB)
-{
-  ivmgr->keyPressed(eventCB);
+IVmgr::keyPressedCB(void *, SoEventCallback *eventCB) {
+    ivmgr->keyPressed(eventCB);
 }
 
 void
-IVmgr::transRotCB(void *dInfo,SoDragger *dragger)
-{ 
-  ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
-  ivmgr->transRot((DraggerInfo *)dInfo);
+IVmgr::transRotCB(void *dInfo, SoDragger *dragger) {
+    ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
+    ivmgr->transRot((DraggerInfo *)dInfo);
 }
 
 void
-IVmgr::revoluteJointChangedCB(void *dInfo,SoDragger *dragger)
-{
-  ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
-  ivmgr->revoluteJointChanged((DraggerInfo *)dInfo);
+IVmgr::revoluteJointChangedCB(void *dInfo, SoDragger *dragger) {
+    ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
+    ivmgr->revoluteJointChanged((DraggerInfo *)dInfo);
 }
 
 void
-IVmgr::revoluteJointClickedCB(void *dInfo,SoDragger *dragger)
-{
-  ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
-  ivmgr->revoluteJointClicked((DraggerInfo *)dInfo);
+IVmgr::revoluteJointClickedCB(void *dInfo, SoDragger *dragger) {
+    ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
+    ivmgr->revoluteJointClicked((DraggerInfo *)dInfo);
 }
 
 void
-IVmgr::revoluteJointFinishedCB(void *dInfo,SoDragger *dragger)
-{
-  ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
-  ivmgr->revoluteJointFinished((DraggerInfo *)dInfo);
+IVmgr::revoluteJointFinishedCB(void *dInfo, SoDragger *dragger) {
+    ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
+    ivmgr->revoluteJointFinished((DraggerInfo *)dInfo);
 }
 
 void
-IVmgr::prismaticJointChangedCB(void *dInfo,SoDragger *dragger)
-{
-  ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
-  ivmgr->prismaticJointChanged((DraggerInfo *)dInfo);
+IVmgr::prismaticJointChangedCB(void *dInfo, SoDragger *dragger) {
+    ((DraggerInfo *)dInfo)->dragger = dragger;  //to avoid compiler warning
+    ivmgr->prismaticJointChanged((DraggerInfo *)dInfo);
 }
 
 void
-IVmgr::shiftOrCtrlDownCB(void *,SoEventCallback *eventCB)
-{
-  const SoEvent *event = eventCB->getEvent();
-  if (SO_MOUSE_RELEASE_EVENT(event,BUTTON1))
-      ivmgr->setCtrlDown(event->wasCtrlDown());
-  if (SO_MOUSE_PRESS_EVENT(event,BUTTON1)) 
-      ivmgr->setShiftDown(event->wasShiftDown());
+IVmgr::shiftOrCtrlDownCB(void *, SoEventCallback *eventCB) {
+    const SoEvent *event = eventCB->getEvent();
+    if (SO_MOUSE_RELEASE_EVENT(event, BUTTON1))
+        ivmgr->setCtrlDown(event->wasCtrlDown());
+    if (SO_MOUSE_PRESS_EVENT(event, BUTTON1))
+        ivmgr->setShiftDown(event->wasShiftDown());
 }
 
-SoPath*
-IVmgr::pickFilterCB(void *,const SoPickedPoint *pick)
-{
-  return ivmgr->pickFilter(pick);
-}
-
-void
-IVmgr::selectionCB(void *,SoPath *path)
-{
-  ivmgr->handleSelection(path);
+SoPath *
+IVmgr::pickFilterCB(void *, const SoPickedPoint *pick) {
+    return ivmgr->pickFilter(pick);
 }
 
 void
-IVmgr::deselectionCB(void *,SoPath *path)
-{
-  ivmgr->handleDeselection(path);
+IVmgr::selectionCB(void *, SoPath *path) {
+    ivmgr->handleSelection(path);
 }
 
-void IVmgr::setStereo(bool s)
-{
-	myViewer->setStereo(s);
+void
+IVmgr::deselectionCB(void *, SoPath *path) {
+    ivmgr->handleDeselection(path);
 }
 
-void IVmgr::flipStereo()
-{
+void IVmgr::setStereo(bool s) {
+    myViewer->setStereo(s);
+}
+
+void IVmgr::flipStereo() {
 }

--- a/src/jacobian.cpp
+++ b/src/jacobian.cpp
@@ -26,78 +26,105 @@
 #include "jacobian.h"
 #include <math.h>
 
-void jacobian(double t1, double t2, double t3, double t4, double px, double py, double pz, double *J)
-{
-	double dxdt1 = -52.11*cos(t2)*sin(t1) - 40.76*cos(t2)*cos(t3)*sin(t1) + py*(0.7193709695451316*cos(t1) - 0.6946260923516316*sin(t1)*sin(t2)) + 
-  40.76*(0.6946260923516316*cos(t1) + 0.7193709695451316*sin(t1)*sin(t2))*sin(t3) + 
-  px*(cos(t4)*((0.6946260923516316*cos(t1) + 0.7193709695451316*sin(t1)*sin(t2))*sin(t3) - cos(t2)*cos(t3)*sin(t1)) + 
-    (cos(t3)*(0.6946260923516316*cos(t1) + 0.7193709695451316*sin(t1)*sin(t2)) + cos(t2)*sin(t1)*sin(t3))*sin(t4)) + 
-  pz*(((0.6946260923516316*cos(t1) + 0.7193709695451316*sin(t1)*sin(t2))*sin(t3) - cos(t2)*cos(t3)*sin(t1))*sin(t4) - 
-    cos(t4)*(cos(t3)*(0.6946260923516316*cos(t1) + 0.7193709695451316*sin(t1)*sin(t2)) + cos(t2)*sin(t1)*sin(t3)));
+void jacobian(double t1, double t2, double t3, double t4, double px, double py, double pz, double *J) {
+    double dxdt1 = -52.11 * cos(t2) * sin(t1) - 40.76 * cos(t2) * cos(t3) * sin(t1) + py * (0.7193709695451316 * cos(t1) - 0.6946260923516316 * sin(t1) * sin(t2)) +
+                   40.76 * (0.6946260923516316 * cos(t1) + 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3) +
+                   px * (cos(t4) * ((0.6946260923516316 * cos(t1) + 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3) - cos(t2) * cos(t3) * sin(t1)) +
+                         (cos(t3) * (0.6946260923516316 * cos(t1) + 0.7193709695451316 * sin(t1) * sin(t2)) + cos(t2) * sin(t1) * sin(t3)) * sin(t4)) +
+                   pz * (((0.6946260923516316 * cos(t1) + 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3) - cos(t2) * cos(t3) * sin(t1)) * sin(t4) -
+                         cos(t4) * (cos(t3) * (0.6946260923516316 * cos(t1) + 0.7193709695451316 * sin(t1) * sin(t2)) + cos(t2) * sin(t1) * sin(t3)));
 
-	double dxdt2 = 0.6946260923516316*py*cos(t1)*cos(t2) - 29.321560718659562*cos(t1)*sin(t3)*cos(t2) - 52.11*cos(t1)*sin(t2) - 40.76*cos(t1)*cos(t3)*sin(t2) + 
-  pz*(((-cos(t1))*cos(t3)*sin(t2) - 0.7193709695451316*cos(t1)*cos(t2)*sin(t3))*sin(t4) - 
-    cos(t4)*(cos(t1)*sin(t2)*sin(t3) - 0.7193709695451316*cos(t1)*cos(t2)*cos(t3))) + 
-  px*(cos(t4)*((-cos(t1))*cos(t3)*sin(t2) - 0.7193709695451316*cos(t1)*cos(t2)*sin(t3)) + (cos(t1)*sin(t2)*sin(t3) - 0.7193709695451316*cos(t1)*cos(t2)*cos(t3))*
-     sin(t4));
+    double dxdt2 = 0.6946260923516316 * py * cos(t1) * cos(t2) - 29.321560718659562 * cos(t1) * sin(t3) * cos(t2) - 52.11 * cos(t1) * sin(t2) - 40.76 * cos(t1) * cos(t3) * sin(t2) +
+                   pz * (((-cos(t1)) * cos(t3) * sin(t2) - 0.7193709695451316 * cos(t1) * cos(t2) * sin(t3)) * sin(t4) -
+                         cos(t4) * (cos(t1) * sin(t2) * sin(t3) - 0.7193709695451316 * cos(t1) * cos(t2) * cos(t3))) +
+                   px * (cos(t4) * ((-cos(t1)) * cos(t3) * sin(t2) - 0.7193709695451316 * cos(t1) * cos(t2) * sin(t3)) + (cos(t1) * sin(t2) * sin(t3) - 0.7193709695451316 * cos(t1) * cos(t2) * cos(t3)) *
+                         sin(t4));
 
-	double dxdt3 = 40.76*cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - 40.76*cos(t1)*cos(t2)*sin(t3) + 
-  pz*((cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - cos(t1)*cos(t2)*sin(t3))*sin(t4) - 
-    cos(t4)*((-cos(t1))*cos(t2)*cos(t3) - (0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3))) + 
-  px*(cos(t4)*(cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - cos(t1)*cos(t2)*sin(t3)) + 
-    ((-cos(t1))*cos(t2)*cos(t3) - (0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3))*sin(t4));
+    double dxdt3 = 40.76 * cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - 40.76 * cos(t1) * cos(t2) * sin(t3) +
+                   pz * ((cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - cos(t1) * cos(t2) * sin(t3)) * sin(t4) -
+                         cos(t4) * ((-cos(t1)) * cos(t2) * cos(t3) - (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3))) +
+                   px * (cos(t4) * (cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - cos(t1) * cos(t2) * sin(t3)) +
+                         ((-cos(t1)) * cos(t2) * cos(t3) - (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3)) * sin(t4));
 
-	double dxdt4 = pz*(cos(t4)*(cos(t1)*cos(t2)*cos(t3) + (0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3)) + 
-    (cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - cos(t1)*cos(t2)*sin(t3))*sin(t4)) + 
-  px*(cos(t4)*(cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - cos(t1)*cos(t2)*sin(t3)) - 
-    (cos(t1)*cos(t2)*cos(t3) + (0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3))*sin(t4));
+    double dxdt4 = pz * (cos(t4) * (cos(t1) * cos(t2) * cos(t3) + (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3)) +
+                         (cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - cos(t1) * cos(t2) * sin(t3)) * sin(t4)) +
+                   px * (cos(t4) * (cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - cos(t1) * cos(t2) * sin(t3)) -
+                         (cos(t1) * cos(t2) * cos(t3) + (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3)) * sin(t4));
 
-	double dydt1 = 52.11*cos(t1)*cos(t2) + 40.76*cos(t1)*cos(t3)*cos(t2) + py*(0.7193709695451316*sin(t1) + 0.6946260923516316*cos(t1)*sin(t2)) + 
-  40.76*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3) + 
-  px*(cos(t4)*(cos(t1)*cos(t2)*cos(t3) + (0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3)) + 
-    (cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - cos(t1)*cos(t2)*sin(t3))*sin(t4)) + 
-  pz*((cos(t1)*cos(t2)*cos(t3) + (0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2))*sin(t3))*sin(t4) - 
-    cos(t4)*(cos(t3)*(0.6946260923516316*sin(t1) - 0.7193709695451316*cos(t1)*sin(t2)) - cos(t1)*cos(t2)*sin(t3)));
+    double dydt1 = 52.11 * cos(t1) * cos(t2) + 40.76 * cos(t1) * cos(t3) * cos(t2) + py * (0.7193709695451316 * sin(t1) + 0.6946260923516316 * cos(t1) * sin(t2)) +
+                   40.76 * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3) +
+                   px * (cos(t4) * (cos(t1) * cos(t2) * cos(t3) + (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3)) +
+                         (cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - cos(t1) * cos(t2) * sin(t3)) * sin(t4)) +
+                   pz * ((cos(t1) * cos(t2) * cos(t3) + (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) * sin(t3)) * sin(t4) -
+                         cos(t4) * (cos(t3) * (0.6946260923516316 * sin(t1) - 0.7193709695451316 * cos(t1) * sin(t2)) - cos(t1) * cos(t2) * sin(t3)));
 
-	double dydt2 = 0.6946260923516316*py*cos(t2)*sin(t1) - 40.76*cos(t3)*sin(t2)*sin(t1) - 52.11*sin(t2)*sin(t1) - 29.321560718659562*cos(t2)*sin(t3)*sin(t1) + 
-  pz*(((-cos(t3))*sin(t1)*sin(t2) - 0.7193709695451316*cos(t2)*sin(t1)*sin(t3))*sin(t4) - 
-    cos(t4)*(sin(t1)*sin(t2)*sin(t3) - 0.7193709695451316*cos(t2)*cos(t3)*sin(t1))) + 
-  px*(cos(t4)*((-cos(t3))*sin(t1)*sin(t2) - 0.7193709695451316*cos(t2)*sin(t1)*sin(t3)) + (sin(t1)*sin(t2)*sin(t3) - 0.7193709695451316*cos(t2)*cos(t3)*sin(t1))*
-     sin(t4));
+    double dydt2 = 0.6946260923516316 * py * cos(t2) * sin(t1) - 40.76 * cos(t3) * sin(t2) * sin(t1) - 52.11 * sin(t2) * sin(t1) - 29.321560718659562 * cos(t2) * sin(t3) * sin(t1) +
+                   pz * (((-cos(t3)) * sin(t1) * sin(t2) - 0.7193709695451316 * cos(t2) * sin(t1) * sin(t3)) * sin(t4) -
+                         cos(t4) * (sin(t1) * sin(t2) * sin(t3) - 0.7193709695451316 * cos(t2) * cos(t3) * sin(t1))) +
+                   px * (cos(t4) * ((-cos(t3)) * sin(t1) * sin(t2) - 0.7193709695451316 * cos(t2) * sin(t1) * sin(t3)) + (sin(t1) * sin(t2) * sin(t3) - 0.7193709695451316 * cos(t2) * cos(t3) * sin(t1)) *
+                         sin(t4));
 
-	double dydt3 = 40.76*cos(t3)*(-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2)) - 40.76*cos(t2)*sin(t1)*sin(t3) + 
-  pz*((cos(t3)*(-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2)) - cos(t2)*sin(t1)*sin(t3))*sin(t4) - 
-    cos(t4)*((-cos(t2))*cos(t3)*sin(t1) - (-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2))*sin(t3))) + 
-  px*(cos(t4)*(cos(t3)*(-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2)) - cos(t2)*sin(t1)*sin(t3)) + 
-    ((-cos(t2))*cos(t3)*sin(t1) - (-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2))*sin(t3))*sin(t4));
+    double dydt3 = 40.76 * cos(t3) * (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) - 40.76 * cos(t2) * sin(t1) * sin(t3) +
+                   pz * ((cos(t3) * (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) - cos(t2) * sin(t1) * sin(t3)) * sin(t4) -
+                         cos(t4) * ((-cos(t2)) * cos(t3) * sin(t1) - (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3))) +
+                   px * (cos(t4) * (cos(t3) * (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) - cos(t2) * sin(t1) * sin(t3)) +
+                         ((-cos(t2)) * cos(t3) * sin(t1) - (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3)) * sin(t4));
 
-	double dydt4 = pz*(cos(t4)*(cos(t2)*cos(t3)*sin(t1) + (-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2))*sin(t3)) + 
-    (cos(t3)*(-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2)) - cos(t2)*sin(t1)*sin(t3))*sin(t4)) + 
-  px*(cos(t4)*(cos(t3)*(-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2)) - cos(t2)*sin(t1)*sin(t3)) - 
-    (cos(t2)*cos(t3)*sin(t1) + (-0.6946260923516316*cos(t1) - 0.7193709695451316*sin(t1)*sin(t2))*sin(t3))*sin(t4));
+    double dydt4 = pz * (cos(t4) * (cos(t2) * cos(t3) * sin(t1) + (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3)) +
+                         (cos(t3) * (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) - cos(t2) * sin(t1) * sin(t3)) * sin(t4)) +
+                   px * (cos(t4) * (cos(t3) * (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) - cos(t2) * sin(t1) * sin(t3)) -
+                         (cos(t2) * cos(t3) * sin(t1) + (-0.6946260923516316 * cos(t1) - 0.7193709695451316 * sin(t1) * sin(t2)) * sin(t3)) * sin(t4));
 
-	double dzdt1 = 0;
+    double dzdt1 = 0;
 
-	double dzdt2 = 40.76*cos(t3)*cos(t2) + 52.11*cos(t2) + 0.6946260923516316*py*sin(t2) - 29.321560718659562*sin(t2)*sin(t3) + 
-  px*(cos(t4)*(cos(t2)*cos(t3) - 0.7193709695451316*sin(t2)*sin(t3)) + (-0.7193709695451316*cos(t3)*sin(t2) - cos(t2)*sin(t3))*sin(t4)) + 
-  pz*((cos(t2)*cos(t3) - 0.7193709695451316*sin(t2)*sin(t3))*sin(t4) - cos(t4)*(-0.7193709695451316*cos(t3)*sin(t2) - cos(t2)*sin(t3)));
+    double dzdt2 = 40.76 * cos(t3) * cos(t2) + 52.11 * cos(t2) + 0.6946260923516316 * py * sin(t2) - 29.321560718659562 * sin(t2) * sin(t3) +
+                   px * (cos(t4) * (cos(t2) * cos(t3) - 0.7193709695451316 * sin(t2) * sin(t3)) + (-0.7193709695451316 * cos(t3) * sin(t2) - cos(t2) * sin(t3)) * sin(t4)) +
+                   pz * ((cos(t2) * cos(t3) - 0.7193709695451316 * sin(t2) * sin(t3)) * sin(t4) - cos(t4) * (-0.7193709695451316 * cos(t3) * sin(t2) - cos(t2) * sin(t3)));
 
-	double dzdt3 = 29.321560718659562*cos(t2)*cos(t3) - 40.76*sin(t2)*sin(t3) + px*(cos(t4)*(0.7193709695451316*cos(t2)*cos(t3) - sin(t2)*sin(t3)) + 
-    ((-cos(t3))*sin(t2) - 0.7193709695451316*cos(t2)*sin(t3))*sin(t4)) + pz*((0.7193709695451316*cos(t2)*cos(t3) - sin(t2)*sin(t3))*sin(t4) - 
-    cos(t4)*((-cos(t3))*sin(t2) - 0.7193709695451316*cos(t2)*sin(t3)));
+    double dzdt3 = 29.321560718659562 * cos(t2) * cos(t3) - 40.76 * sin(t2) * sin(t3) + px * (cos(t4) * (0.7193709695451316 * cos(t2) * cos(t3) - sin(t2) * sin(t3)) +
+                                                                                              ((-cos(t3)) * sin(t2) - 0.7193709695451316 * cos(t2) * sin(t3)) * sin(t4)) + pz * ((0.7193709695451316 * cos(t2) * cos(t3) - sin(t2) * sin(t3)) * sin(t4) -
+                                                                                                      cos(t4) * ((-cos(t3)) * sin(t2) - 0.7193709695451316 * cos(t2) * sin(t3)));
 
-	double dzdt4 = px*(cos(t4)*(0.7193709695451316*cos(t2)*cos(t3) - sin(t2)*sin(t3)) - (cos(t3)*sin(t2) + 0.7193709695451316*cos(t2)*sin(t3))*sin(t4)) + 
-  pz*(cos(t4)*(cos(t3)*sin(t2) + 0.7193709695451316*cos(t2)*sin(t3)) + (0.7193709695451316*cos(t2)*cos(t3) - sin(t2)*sin(t3))*sin(t4));
+    double dzdt4 = px * (cos(t4) * (0.7193709695451316 * cos(t2) * cos(t3) - sin(t2) * sin(t3)) - (cos(t3) * sin(t2) + 0.7193709695451316 * cos(t2) * sin(t3)) * sin(t4)) +
+                   pz * (cos(t4) * (cos(t3) * sin(t2) + 0.7193709695451316 * cos(t2) * sin(t3)) + (0.7193709695451316 * cos(t2) * cos(t3) - sin(t2) * sin(t3)) * sin(t4));
 
-	J[0] = dxdt1;   J[3] = dxdt2;   J[6] = dxdt3;   J[9]  = dxdt4;
-	J[1] = dydt1;   J[4] = dydt2;   J[7] = dydt3;   J[10] = dydt4;
-	J[2] = dzdt1;   J[5] = dzdt2;   J[8] = dzdt3;   J[11] = dzdt4;
+    J[0] = dxdt1;
+    J[3] = dxdt2;
+    J[6] = dxdt3;
+    J[9]  = dxdt4;
+    J[1] = dydt1;
+    J[4] = dydt2;
+    J[7] = dydt3;
+    J[10] = dydt4;
+    J[2] = dzdt1;
+    J[5] = dzdt2;
+    J[8] = dzdt3;
+    J[11] = dzdt4;
 }
 
-void compute_dTdG(double s0, double s1, double s2, double s3, double *dTdG)
-{
-	dTdG[0] = s0;	dTdG[4] = s1;	dTdG[8] =   0;	dTdG[12] =  0;	dTdG[16] =  0;	dTdG[20] =  0;
-	dTdG[1] =  0;	dTdG[5] =  0;	dTdG[9] =  s0;	dTdG[13] = s1;	dTdG[17] =  0;	dTdG[21] =  0;
-	dTdG[2] =  0;	dTdG[6] =  0;	dTdG[10] =  0;	dTdG[14] =  0;	dTdG[18] = s2;	dTdG[22] =  0;
-	dTdG[3] =  0;	dTdG[7] =  0;	dTdG[11] =  0;	dTdG[15] =  0;	dTdG[19] =  0;	dTdG[23] = s3;
+void compute_dTdG(double s0, double s1, double s2, double s3, double *dTdG) {
+    dTdG[0] = s0;
+    dTdG[4] = s1;
+    dTdG[8] =   0;
+    dTdG[12] =  0;
+    dTdG[16] =  0;
+    dTdG[20] =  0;
+    dTdG[1] =  0;
+    dTdG[5] =  0;
+    dTdG[9] =  s0;
+    dTdG[13] = s1;
+    dTdG[17] =  0;
+    dTdG[21] =  0;
+    dTdG[2] =  0;
+    dTdG[6] =  0;
+    dTdG[10] =  0;
+    dTdG[14] =  0;
+    dTdG[18] = s2;
+    dTdG[22] =  0;
+    dTdG[3] =  0;
+    dTdG[7] =  0;
+    dTdG[11] =  0;
+    dTdG[15] =  0;
+    dTdG[19] =  0;
+    dTdG[23] = s3;
 }

--- a/src/joint.cpp
+++ b/src/joint.cpp
@@ -23,8 +23,8 @@
 //
 //######################################################################
 
-/*! \file 
-\brief Implements the classes: DHTransform, DOF, RevoluteJoint, and PrismaticJoint.
+/*! \file
+    \brief Implements the classes: DHTransform, DOF, RevoluteJoint, and PrismaticJoint.
 */
 
 /* standard C includes */
@@ -59,330 +59,319 @@
 #include "debug.h"
 
 /*! Initializes the DHTransform with the 4 DH parameters. */
-DHTransform::DHTransform(double thval,double dval,double aval,double alval) :
-theta(thval),d(dval),a(aval),alpha(alval)
-{
-  computeTran();
+DHTransform::DHTransform(double thval, double dval, double aval, double alval) :
+    theta(thval), d(dval), a(aval), alpha(alval) {
+    computeTran();
 }
 
-void DHTransform::computeTran()
-{
-  transf tr3,tr4;
-  
-  dtrans[0] = 0.0;
-  dtrans[1] = 0.0;
-  dtrans[2] = d;
-  
-  atrans[0] = a;
-  atrans[1] = 0.0;
-  atrans[2] = 0.0;
-  
-  tr1 = rotate_transf(theta,vec3(0,0,1));
-  tr2 = translate_transf(dtrans);
-  tr3 = translate_transf(atrans);
-  tr4 = rotate_transf(alpha,vec3(1,0,0));
-  tr4TimesTr3 = tr4 * tr3;
-  
-  tran = tr4TimesTr3 * tr2 * tr1;
-}
+void DHTransform::computeTran() {
+    transf tr3, tr4;
 
-/*!
-Sets a new d value for prismatic joints and recomputes the current value
-of the transform.
-*/
-void DHTransform::setD(double q)
-{
-  d = q;
-  dtrans[2] = d;
-  tr2 = translate_transf(dtrans);
-  
-  tran = tr4TimesTr3 * tr2 * tr1;
+    dtrans[0] = 0.0;
+    dtrans[1] = 0.0;
+    dtrans[2] = d;
+
+    atrans[0] = a;
+    atrans[1] = 0.0;
+    atrans[2] = 0.0;
+
+    tr1 = rotate_transf(theta, vec3(0, 0, 1));
+    tr2 = translate_transf(dtrans);
+    tr3 = translate_transf(atrans);
+    tr4 = rotate_transf(alpha, vec3(1, 0, 0));
+    tr4TimesTr3 = tr4 * tr3;
+
+    tran = tr4TimesTr3 * tr2 * tr1;
 }
 
 /*!
-Sets a new theta value for revolute joints and recomputes the current value
-of the transform.
+    Sets a new d value for prismatic joints and recomputes the current value
+    of the transform.
 */
-void DHTransform::setTheta(double q)
-{
-  theta = q;
-  tr1 = rotate_transf(theta,vec3(0,0,1));
-  
-  tran = tr4TimesTr3 * tr2 * tr1;
+void DHTransform::setD(double q) {
+    d = q;
+    dtrans[2] = d;
+    tr2 = translate_transf(dtrans);
+
+    tran = tr4TimesTr3 * tr2 * tr1;
 }
 
 /*!
-Unreferences the associated Inventor transform, and deletes the DHTransform
-associated with this joint.
+    Sets a new theta value for revolute joints and recomputes the current value
+    of the transform.
 */
-Joint::~Joint()
-{
-	IVTran->unref(); delete DH;
+void DHTransform::setTheta(double q) {
+    theta = q;
+    tr1 = rotate_transf(theta, vec3(0, 0, 1));
+
+    tran = tr4TimesTr3 * tr2 * tr1;
+}
+
+/*!
+    Unreferences the associated Inventor transform, and deletes the DHTransform
+    associated with this joint.
+*/
+Joint::~Joint() {
+    IVTran->unref();
+    delete DH;
 }
 
 void
-Joint::cloneFrom(const Joint *original)
-{
-	DOFnum  = original->DOFnum;
-	jointNum = original->jointNum;
-	minVal = original->minVal;
-	maxVal = original->maxVal;
-	mCouplingRatio = original->mCouplingRatio;
-	c = original->c;
-	f1 = original->f1;
-	f0 = original->f0;
-	mK = original->mK;
-	mRestVal = original->mRestVal;
-	worldAxis = original->worldAxis;
-	DH = new DHTransform(original->DH);
-	DH->getTran().toSoTransform(IVTran);
+Joint::cloneFrom(const Joint *original) {
+    DOFnum  = original->DOFnum;
+    jointNum = original->jointNum;
+    minVal = original->minVal;
+    maxVal = original->maxVal;
+    mCouplingRatio = original->mCouplingRatio;
+    c = original->c;
+    f1 = original->f1;
+    f0 = original->f0;
+    mK = original->mK;
+    mRestVal = original->mRestVal;
+    worldAxis = original->worldAxis;
+    DH = new DHTransform(original->DH);
+    DH->getTran().toSoTransform(IVTran);
 }
 
 int
-Joint::getChainNum() const
-{
-	return owner->getNum();
+Joint::getChainNum() const {
+    return owner->getNum();
 }
 
 void
-Joint::applyPassiveInternalWrenches()
-{
-	double f = getFriction();
-	DBGP("Friction coeffs: " << f0 << " " << f1);
-	DBGP("Friction force: " << f);
-	if (f != 0.0) applyInternalWrench(f);
+Joint::applyPassiveInternalWrenches() {
+    double f = getFriction();
+    DBGP("Friction coeffs: " << f0 << " " << f1);
+    DBGP("Friction force: " << f);
+    if (f != 0.0) applyInternalWrench(f);
 
-	f = getSpringForce();
-	DBGP("Spring force: " << f);
-	applyInternalWrench(-f);
+    f = getSpringForce();
+    DBGP("Spring force: " << f);
+    applyInternalWrench(-f);
 }
 
 /*! Assumes a linear spring with the rest value specified*/
 double
-Joint::getSpringForce() const 
-{
-    DBGP( "mK: " << mK << " getDisplacement(): " << getDisplacement() << std::endl);
-	return mK * getDisplacement();
+Joint::getSpringForce() const {
+    DBGP("mK: " << mK << " getDisplacement(): " << getDisplacement() << std::endl);
+    return mK * getDisplacement();
 }
 
 /*! The joint Jacobian is a 6x1 matrix that relates movement of a joint
-(1 DOF) to movement (translation and rotation) of a point in 3D space 
-placed at world coordinates	\a toTarget. If worldCoords is true, the 
-jacobian is expressed in world coordinate system; otherwise, it is
-expressed in the local coordinate system of the target point.
+    (1 DOF) to movement (translation and rotation) of a point in 3D space
+    placed at world coordinates \a toTarget. If worldCoords is true, the
+    jacobian is expressed in world coordinate system; otherwise, it is
+    expressed in the local coordinate system of the target point.
 */
-Matrix 
-Joint::jacobian(const Joint *joint, const transf &jointTran, 
-				const transf &toTarget, bool worldCoords)
-{
-	transf T;
-	if (worldCoords) {
-		// the translation from joint coordinate system to world coordinate system
-		T = transf(Quaternion::IDENTITY, toTarget.translation()) * jointTran.inverse();
-	} else {
-		T = toTarget * jointTran.inverse();	
-	}
-	double M[36];
-	T.jacobian(M);
-	Matrix fullJ(M,6,6,true);
-	Matrix J(Matrix::ZEROES<Matrix>(6,1));
-	if (joint->getType() == REVOLUTE) {
-		//keep rotation against z
-		J.copySubBlock(0, 0, 6, 1, fullJ, 0, 5);
-	} else if (joint->getType() == PRISMATIC) {
-		//keep translation along z
-		J.copySubBlock(0, 0, 6, 1, fullJ, 0, 2);
-	} else {
-		assert(0);
-	}
-	return J;
+Matrix
+Joint::jacobian(const Joint *joint, const transf &jointTran,
+                const transf &toTarget, bool worldCoords) {
+    transf T;
+    if (worldCoords) {
+        // the translation from joint coordinate system to world coordinate system
+        T = transf(Quaternion::IDENTITY, toTarget.translation()) * jointTran.inverse();
+    }
+    else {
+        T = toTarget * jointTran.inverse();
+    }
+    double M[36];
+    T.jacobian(M);
+    Matrix fullJ(M, 6, 6, true);
+    Matrix J(Matrix::ZEROES<Matrix>(6, 1));
+    if (joint->getType() == REVOLUTE) {
+        //keep rotation against z
+        J.copySubBlock(0, 0, 6, 1, fullJ, 0, 5);
+    }
+    else if (joint->getType() == PRISMATIC) {
+        //keep translation along z
+        J.copySubBlock(0, 0, 6, 1, fullJ, 0, 2);
+    }
+    else {
+        assert(0);
+    }
+    return J;
 }
 
-/*! Initializes a prismatic joint from an XML DOM read from the robot 
-	configuration file.  Returns FAILURE if it could not read all the 
-	necessary values from the provided XML, otherwise it returns SUCESS.
+/*! Initializes a prismatic joint from an XML DOM read from the robot
+    configuration file.  Returns FAILURE if it could not read all the
+    necessary values from the provided XML, otherwise it returns SUCESS.
 */
 int
-PrismaticJoint::initJointFromXml(const TiXmlElement* root, int jnum)
-{
-	char dStr[40],num[40],*tmp;
-	QString dQStr;
-	double theta,d,a,alpha;
-	jointNum = jnum;
-	const TiXmlElement* element = findXmlElement(root,"d");
-	if(element){
-		dQStr = element->GetText();
-		dQStr = dQStr.stripWhiteSpace();
-		strcpy(dStr,dQStr.toStdString().c_str());
-	} else {
-		return FAILURE;
-	}
-	if(!getDouble(root,"theta", theta)) return FAILURE;
-	if(!getDouble(root,"a", a)) return FAILURE;
-	if(!getDouble(root,"alpha", alpha)) return FAILURE;
-	if(!getDouble(root,"minValue", minVal)) return FAILURE;
-	if(!getDouble(root,"maxValue", maxVal))	return FAILURE;
-    if (!getDouble(root,"viscousFriction", f1)) f1 = 0.0;
-	if (!getDouble(root,"CoulombFriction", f0)) f0 = 0.0;
-    if (!getDouble(root,"springStiffness", mK)) mK = 0.0;
-	if (!getDouble(root,"restValue", mRestVal)) mRestVal = 0.0;
+PrismaticJoint::initJointFromXml(const TiXmlElement *root, int jnum) {
+    char dStr[40], num[40], *tmp;
+    QString dQStr;
+    double theta, d, a, alpha;
+    jointNum = jnum;
+    const TiXmlElement *element = findXmlElement(root, "d");
+    if (element) {
+        dQStr = element->GetText();
+        dQStr = dQStr.stripWhiteSpace();
+        strcpy(dStr, dQStr.toStdString().c_str());
+    }
+    else {
+        return FAILURE;
+    }
+    if (!getDouble(root, "theta", theta)) return FAILURE;
+    if (!getDouble(root, "a", a)) return FAILURE;
+    if (!getDouble(root, "alpha", alpha)) return FAILURE;
+    if (!getDouble(root, "minValue", minVal)) return FAILURE;
+    if (!getDouble(root, "maxValue", maxVal)) return FAILURE;
+    if (!getDouble(root, "viscousFriction", f1)) f1 = 0.0;
+    if (!getDouble(root, "CoulombFriction", f0)) f0 = 0.0;
+    if (!getDouble(root, "springStiffness", mK)) mK = 0.0;
+    if (!getDouble(root, "restValue", mRestVal)) mRestVal = 0.0;
 
-	DBGP("thStr: " << theta << " d: " << dStr << " a: " << a << " alpha: " 
-		<< alpha << " minVal: " << minVal << " maxVal: " << maxVal << " f1: " 
-		<< f1 << " f0:" << f0 << " mK: " << mK << " mRestVal: " << mRestVal);
+    DBGP("thStr: " << theta << " d: " << dStr << " a: " << a << " alpha: "
+         << alpha << " minVal: " << minVal << " maxVal: " << maxVal << " f1: "
+         << f1 << " f0:" << f0 << " mK: " << mK << " mRestVal: " << mRestVal);
 
-	//convert to graspit force units which for now seem to be the
-	//rather strange N * 1.0e6
-	mK *= 1.0e6; 
+    //convert to graspit force units which for now seem to be the
+    //rather strange N * 1.0e6
+    mK *= 1.0e6;
 
-	theta *= M_PI/180.0;
-	alpha *= M_PI/180.0;
+    theta *= M_PI / 180.0;
+    alpha *= M_PI / 180.0;
 
-	d = 0.0;
-	tmp = dStr+1;
-	sscanf(tmp,"%[0-9]",num);
-	DOFnum = atoi(num);
-	tmp += strlen(num);
-	if (DOFnum > owner->getOwner()->getNumDOF()) {
-		pr_error("DOF number is out of range\n");
-		return FAILURE;
-	}
-	if (*tmp=='*') {
-		tmp++;
-		sscanf(tmp,"%[0-9.-]",num);
-		tmp += strlen(num);
-		mCouplingRatio = atof(num);
-	}
-	if (*tmp=='+') {
-		tmp++;
-		sscanf(tmp,"%lf",&c);
-	}
-
-	DH = new DHTransform(theta,d+c,a,alpha);  
-	DH->getTran().toSoTransform(IVTran);
-
-	return SUCCESS;
-}
-
-/*!
-Sets the current joint value to \a q.  The \a d value of the DHTransform
-is then set to \a q + the joint offset \a c. 
-*/
-int
-PrismaticJoint::setVal(double q)
-{
-	DH->setD(q+c);
-	DH->getTran().toSoTransform(IVTran);
-	return SUCCESS;  
-}
-
-/*!
-Applies equal and opposite forces of magnitude \a f along the axis
-\a worldAxis to the two links connected to this joint.
-*/
-void
-PrismaticJoint::applyInternalWrench(double magnitude)
-{
-	dynJoint->getPrevLink()->addForce(-magnitude * worldAxis);
-	dynJoint->getNextLink()->addForce(magnitude * worldAxis);
-}
-
-/*! Initializes a revolute joint from an XML DOM read from the robot 
-	configuration file. This returns FAILURE if it could not read all 
-	the necessary values from the provided string, otherwise it 
-	returns SUCESS.
-*/
-int
-RevoluteJoint::initJointFromXml(const TiXmlElement* root, int jnum)
-{
-
-  QString thQStr;
-  char thStr[40],num[40],*tmp;
-  double theta,d,a,alpha;
-  jointNum = jnum;
-  const TiXmlElement* element = findXmlElement(root,"theta");
-  if(element){
-    thQStr = element->GetText();
-    thQStr = thQStr.stripWhiteSpace();
-    strcpy(thStr,thQStr.toStdString().c_str());
-  }
-  else
-    return FAILURE;
-  if(!getDouble(root,"d", d)) return FAILURE;
-  if(!getDouble(root,"a", a)) return FAILURE;
-  if(!getDouble(root,"alpha", alpha)) return FAILURE;
-  if(!getDouble(root,"minValue", minVal)) return FAILURE;
-  if(!getDouble(root,"maxValue", maxVal)) return FAILURE;
-  if(!getDouble(root,"viscousFriction", f1)) f1 = 0.0;
-  if(!getDouble(root,"CoulombFriction", f0)) f0 = 0.0;
-  if(!getDouble(root,"springStiffness", mK)) mK = 0.0;
-  if(!getDouble(root,"restValue", mRestVal)) mRestVal = 0.0;
-  
-  DBGP("thStr: " << thStr << " d: " << d << " a: " << a << " alpha: " 
-       << alpha << " minVal: " << minVal << " maxVal: " << maxVal << " f1: " 
-       << f1 << " f0:" << f0 << " mK: " << mK << " mRestVal: " << mRestVal);
-  
-  if (mK < 0) {
-    DBGA("Negative spring stiffness");
-    return FAILURE;
-  }
-  
-  //convert to graspit units which for now seem to be the
-  //rather strange Nmm * 1.0e6
-  mK *= 1.0e6; 
-
-  
-  alpha *= M_PI/180.0;
-  minVal *= M_PI/180.0;
-  maxVal *= M_PI/180.0;
-  
-  theta = 0.0;
-  tmp = thStr+1;
-  sscanf(tmp,"%[0-9]",num);
-  DOFnum = atoi(num);
-  tmp += strlen(num);
-  
-  if (DOFnum > owner->getOwner()->getNumDOF()) {
-    pr_error("DOF number is out of range\n");
-    return FAILURE;
-  }
-  
-  if (*tmp=='*') {
-    tmp++;
-    sscanf(tmp,"%[0-9.-]",num);
+    d = 0.0;
+    tmp = dStr + 1;
+    sscanf(tmp, "%[0-9]", num);
+    DOFnum = atoi(num);
     tmp += strlen(num);
-    mCouplingRatio = atof(num);
-  }
-  if (*tmp=='+') {
-    tmp++;
-    sscanf(tmp,"%lf",&c);
-    c *= M_PI/180.0;
-  }
-  
-  DH = new DHTransform(theta+c,d,a,alpha);  
-  DH->getTran().toSoTransform(IVTran);
-  return SUCCESS;
+    if (DOFnum > owner->getOwner()->getNumDOF()) {
+        pr_error("DOF number is out of range\n");
+        return FAILURE;
+    }
+    if (*tmp == '*') {
+        tmp++;
+        sscanf(tmp, "%[0-9.-]", num);
+        tmp += strlen(num);
+        mCouplingRatio = atof(num);
+    }
+    if (*tmp == '+') {
+        tmp++;
+        sscanf(tmp, "%lf", &c);
+    }
+
+    DH = new DHTransform(theta, d + c, a, alpha);
+    DH->getTran().toSoTransform(IVTran);
+
+    return SUCCESS;
 }
 
 /*!
-Sets the current joint value to \a q.  The \a theta value of the DHTransform
-is then set to \a q + the joint offset \a c.  
+    Sets the current joint value to \a q.  The \a d value of the DHTransform
+    is then set to \a q + the joint offset \a c.
 */
 int
-RevoluteJoint::setVal(double q)
-{
-  DH->setTheta(q+c);
-  DH->getTran().toSoTransform(IVTran);
-  return SUCCESS;  
+PrismaticJoint::setVal(double q) {
+    DH->setD(q + c);
+    DH->getTran().toSoTransform(IVTran);
+    return SUCCESS;
 }
 
 /*!
-Applies equal and opposite torques of magnitude \a f about the axis
-\a worldAxis to the two links connected to this joint.
+    Applies equal and opposite forces of magnitude \a f along the axis
+    \a worldAxis to the two links connected to this joint.
 */
 void
-RevoluteJoint::applyInternalWrench(double magnitude)
-{
-  dynJoint->getPrevLink()->addTorque(-magnitude * worldAxis);
-  dynJoint->getNextLink()->addTorque(magnitude * worldAxis);
+PrismaticJoint::applyInternalWrench(double magnitude) {
+    dynJoint->getPrevLink()->addForce(-magnitude * worldAxis);
+    dynJoint->getNextLink()->addForce(magnitude * worldAxis);
+}
+
+/*! Initializes a revolute joint from an XML DOM read from the robot
+    configuration file. This returns FAILURE if it could not read all
+    the necessary values from the provided string, otherwise it
+    returns SUCESS.
+*/
+int
+RevoluteJoint::initJointFromXml(const TiXmlElement *root, int jnum) {
+
+    QString thQStr;
+    char thStr[40], num[40], *tmp;
+    double theta, d, a, alpha;
+    jointNum = jnum;
+    const TiXmlElement *element = findXmlElement(root, "theta");
+    if (element) {
+        thQStr = element->GetText();
+        thQStr = thQStr.stripWhiteSpace();
+        strcpy(thStr, thQStr.toStdString().c_str());
+    }
+    else
+        return FAILURE;
+    if (!getDouble(root, "d", d)) return FAILURE;
+    if (!getDouble(root, "a", a)) return FAILURE;
+    if (!getDouble(root, "alpha", alpha)) return FAILURE;
+    if (!getDouble(root, "minValue", minVal)) return FAILURE;
+    if (!getDouble(root, "maxValue", maxVal)) return FAILURE;
+    if (!getDouble(root, "viscousFriction", f1)) f1 = 0.0;
+    if (!getDouble(root, "CoulombFriction", f0)) f0 = 0.0;
+    if (!getDouble(root, "springStiffness", mK)) mK = 0.0;
+    if (!getDouble(root, "restValue", mRestVal)) mRestVal = 0.0;
+
+    DBGP("thStr: " << thStr << " d: " << d << " a: " << a << " alpha: "
+         << alpha << " minVal: " << minVal << " maxVal: " << maxVal << " f1: "
+         << f1 << " f0:" << f0 << " mK: " << mK << " mRestVal: " << mRestVal);
+
+    if (mK < 0) {
+        DBGA("Negative spring stiffness");
+        return FAILURE;
+    }
+
+    //convert to graspit units which for now seem to be the
+    //rather strange Nmm * 1.0e6
+    mK *= 1.0e6;
+
+
+    alpha *= M_PI / 180.0;
+    minVal *= M_PI / 180.0;
+    maxVal *= M_PI / 180.0;
+
+    theta = 0.0;
+    tmp = thStr + 1;
+    sscanf(tmp, "%[0-9]", num);
+    DOFnum = atoi(num);
+    tmp += strlen(num);
+
+    if (DOFnum > owner->getOwner()->getNumDOF()) {
+        pr_error("DOF number is out of range\n");
+        return FAILURE;
+    }
+
+    if (*tmp == '*') {
+        tmp++;
+        sscanf(tmp, "%[0-9.-]", num);
+        tmp += strlen(num);
+        mCouplingRatio = atof(num);
+    }
+    if (*tmp == '+') {
+        tmp++;
+        sscanf(tmp, "%lf", &c);
+        c *= M_PI / 180.0;
+    }
+
+    DH = new DHTransform(theta + c, d, a, alpha);
+    DH->getTran().toSoTransform(IVTran);
+    return SUCCESS;
+}
+
+/*!
+    Sets the current joint value to \a q.  The \a theta value of the DHTransform
+    is then set to \a q + the joint offset \a c.
+*/
+int
+RevoluteJoint::setVal(double q) {
+    DH->setTheta(q + c);
+    DH->getTran().toSoTransform(IVTran);
+    return SUCCESS;
+}
+
+/*!
+    Applies equal and opposite torques of magnitude \a f about the axis
+    \a worldAxis to the two links connected to this joint.
+*/
+void
+RevoluteJoint::applyInternalWrench(double magnitude) {
+    dynJoint->getPrevLink()->addTorque(-magnitude * worldAxis);
+    dynJoint->getNextLink()->addTorque(magnitude * worldAxis);
 }

--- a/src/kinematicChain.cpp
+++ b/src/kinematicChain.cpp
@@ -49,708 +49,716 @@
 //#define GRASPITDBG
 #include "debug.h"
 
-KinematicChain::KinematicChain(Robot *r,int chainNumber, int jointNum) : owner(r),chainNum(chainNumber), firstJointNum(jointNum),
-									 numJoints(0),numLinks(0),lastJoint(NULL), IVRoot(NULL),numChildren(0)
-{
+KinematicChain::KinematicChain(Robot *r, int chainNumber, int jointNum) : owner(r), chainNum(chainNumber), firstJointNum(jointNum),
+    numJoints(0), numLinks(0), lastJoint(NULL), IVRoot(NULL), numChildren(0) {
 }
 
 /*!
-  The destructor deletes each of the joints in this chain, and asks the
-  world to delete each of the links in the chain.  It also detaches any
-  connected robots.
+    The destructor deletes each of the joints in this chain, and asks the
+    world to delete each of the links in the chain.  It also detaches any
+    connected robots.
 */
-KinematicChain::~KinematicChain()
-{
-  int i;
-  IVTran->unref();
+KinematicChain::~KinematicChain() {
+    int i;
+    IVTran->unref();
 
-  delete [] lastJoint;
+    delete [] lastJoint;
 
-  for (i=0;i<numJoints;i++)
-    if (jointVec[i]) delete jointVec[i];
+    for (i = 0; i < numJoints; i++)
+        if (jointVec[i]) delete jointVec[i];
 
-    for (i=0;i<numLinks;i++)
-      if (linkVec[i]) owner->getWorld()->destroyElement(linkVec[i]);
-	
+    for (i = 0; i < numLinks; i++)
+        if (linkVec[i]) owner->getWorld()->destroyElement(linkVec[i]);
 
-  // go in reverse order becase these operations will delete elements from
-  // the children vector
-  for (i=numChildren-1;i>=0;i--)
-    owner->detachRobot(children[i]);
+
+    // go in reverse order becase these operations will delete elements from
+    // the children vector
+    for (i = numChildren - 1; i >= 0; i--)
+        owner->detachRobot(children[i]);
 }
 
 /*! Creates dynamic joints for each of the links in the chain. A dynamic joint
-	can be a collection of one or more regular joints, so dynamic joints are
-	only created when all the links and the regular joints are already in place.
-	The vector of dynamic joint types tells us what kind of dynamic joint
-	each link is connected to, and the dynamic joint is then constructed
-	based on the appropriate number of regular joints.
+    can be a collection of one or more regular joints, so dynamic joints are
+    only created when all the links and the regular joints are already in place.
+    The vector of dynamic joint types tells us what kind of dynamic joint
+    each link is connected to, and the dynamic joint is then constructed
+    based on the appropriate number of regular joints.
 
-	See the DynJoint class for details.
+    See the DynJoint class for details.
 */
 int
-KinematicChain::createDynamicJoints(const std::vector<int> &dynJointTypes)
-{
-  Link* prevLink = owner->getBase();
-  for (int l=0; l<numLinks; l++){
-    transf dynJointTran = transf::IDENTITY;
-    if(l==0) dynJointTran = tran;
-    
-    if (dynJointTypes[l] == DynJoint::BALL) {
-      linkVec[l]->setDynJoint(new BallDynJoint(
-                                               jointVec[lastJoint[l]-2],
-                                               jointVec[lastJoint[l]-1],jointVec[lastJoint[l]],
-                                               prevLink,linkVec[l], 
-                                               dynJointTran, jointVec[lastJoint[l]]->getTran().inverse()));
-      jointVec[lastJoint[l]-2]->setDynJoint(linkVec[l]->getDynJoint());
-      jointVec[lastJoint[l]-1]->setDynJoint(linkVec[l]->getDynJoint());
-      jointVec[lastJoint[l]-0]->setDynJoint(linkVec[l]->getDynJoint());
-    } else if (dynJointTypes[l] == DynJoint::UNIVERSAL) {
-      linkVec[l]->setDynJoint(new UniversalDynJoint(
-                                                    jointVec[lastJoint[l]-1], jointVec[lastJoint[l]],
-                                                    prevLink, linkVec[l], 
-                                                    dynJointTran, jointVec[lastJoint[l]]->getTran().inverse()));
-      jointVec[lastJoint[l]-1]->setDynJoint( linkVec[l]->getDynJoint());
-      jointVec[lastJoint[l]-0]->setDynJoint( linkVec[l]->getDynJoint());
-    } else if (dynJointTypes[l] == DynJoint::REVOLUTE) {
-      linkVec[l]->setDynJoint(new RevoluteDynJoint(jointVec[lastJoint[l]],
-                                                   prevLink,linkVec[l],dynJointTran));
-      jointVec[lastJoint[l]]->setDynJoint(linkVec[l]->getDynJoint());
-    } else if (dynJointTypes[l] == DynJoint::PRISMATIC) {
-      linkVec[l]->setDynJoint(new RevoluteDynJoint(jointVec[lastJoint[l]],
-                                                   prevLink,linkVec[l],dynJointTran));
-      jointVec[lastJoint[l]]->setDynJoint(linkVec[l]->getDynJoint());
-    } else if (dynJointTypes[l] == DynJoint::FIXED) {
-      DBGA("FIXED dynamic joints not yet fully supported");
-      return FAILURE;
-      //linkVec[l]->setDynJoint(new FixedDynJoint(prevLink, linkVec[l], dynJointTran));
-    } else {
-      DBGA("Unknown joint type requested");
-      return FAILURE;
+KinematicChain::createDynamicJoints(const std::vector<int> &dynJointTypes) {
+    Link *prevLink = owner->getBase();
+    for (int l = 0; l < numLinks; l++) {
+        transf dynJointTran = transf::IDENTITY;
+        if (l == 0) dynJointTran = tran;
+
+        if (dynJointTypes[l] == DynJoint::BALL) {
+            linkVec[l]->setDynJoint(new BallDynJoint(
+                                        jointVec[lastJoint[l] - 2],
+                                        jointVec[lastJoint[l] - 1], jointVec[lastJoint[l]],
+                                        prevLink, linkVec[l],
+                                        dynJointTran, jointVec[lastJoint[l]]->getTran().inverse()));
+            jointVec[lastJoint[l] - 2]->setDynJoint(linkVec[l]->getDynJoint());
+            jointVec[lastJoint[l] - 1]->setDynJoint(linkVec[l]->getDynJoint());
+            jointVec[lastJoint[l] - 0]->setDynJoint(linkVec[l]->getDynJoint());
+        }
+        else if (dynJointTypes[l] == DynJoint::UNIVERSAL) {
+            linkVec[l]->setDynJoint(new UniversalDynJoint(
+                                        jointVec[lastJoint[l] - 1], jointVec[lastJoint[l]],
+                                        prevLink, linkVec[l],
+                                        dynJointTran, jointVec[lastJoint[l]]->getTran().inverse()));
+            jointVec[lastJoint[l] - 1]->setDynJoint(linkVec[l]->getDynJoint());
+            jointVec[lastJoint[l] - 0]->setDynJoint(linkVec[l]->getDynJoint());
+        }
+        else if (dynJointTypes[l] == DynJoint::REVOLUTE) {
+            linkVec[l]->setDynJoint(new RevoluteDynJoint(jointVec[lastJoint[l]],
+                                                         prevLink, linkVec[l], dynJointTran));
+            jointVec[lastJoint[l]]->setDynJoint(linkVec[l]->getDynJoint());
+        }
+        else if (dynJointTypes[l] == DynJoint::PRISMATIC) {
+            linkVec[l]->setDynJoint(new RevoluteDynJoint(jointVec[lastJoint[l]],
+                                                         prevLink, linkVec[l], dynJointTran));
+            jointVec[lastJoint[l]]->setDynJoint(linkVec[l]->getDynJoint());
+        }
+        else if (dynJointTypes[l] == DynJoint::FIXED) {
+            DBGA("FIXED dynamic joints not yet fully supported");
+            return FAILURE;
+            //linkVec[l]->setDynJoint(new FixedDynJoint(prevLink, linkVec[l], dynJointTran));
+        }
+        else {
+            DBGA("Unknown joint type requested");
+            return FAILURE;
+        }
+        prevLink = linkVec[l];
     }
-    prevLink = linkVec[l];
-  }
-  return SUCCESS;
+    return SUCCESS;
 }
 
 /*!
-  Sets up the chain given a XML DOM from a currently open robot
-  configuration file.  It reads the number of joints and the number of links
-  and allocates space for those vectors, then it reads in the base transform
-  of the chain.  Next, it reads a node for each joint and creates a
-  prismatic or revolute joint which is initialized with the kinematic data
-  in that node. \a linkDir should be the path to the directory where the link
-  body files are kept (usually rootPath/iv).
-*/ 
+    Sets up the chain given a XML DOM from a currently open robot
+    configuration file.  It reads the number of joints and the number of links
+    and allocates space for those vectors, then it reads in the base transform
+    of the chain.  Next, it reads a node for each joint and creates a
+    prismatic or revolute joint which is initialized with the kinematic data
+    in that node. \a linkDir should be the path to the directory where the link
+    body files are kept (usually rootPath/iv).
+*/
 int
-KinematicChain::initChainFromXml(const TiXmlElement* root,QString &linkDir)
-{
-  numJoints = countXmlElements(root,"joint");
-  if (numJoints < 1) {
-    DBGA("number of joints < 1");
-    return FAILURE;
-  }
-  
-  numLinks = countXmlElements(root,"link");
-  if (numLinks < 1) {
-    DBGA("Number of links < 1");
-    return FAILURE;
-  }
-  
-  jointVec.resize(numJoints, NULL);
-  linkVec.resize(numLinks, NULL);  
-  
-  lastJoint = new int[numLinks];
-  
-  IVRoot = new SoSeparator;
-  IVTran = new SoTransform;
-  IVTran->ref();
-  
-  /* read in the finger transformation */
-  const TiXmlElement* element = findXmlElement(root,"transform");
-  if(element){
-    if(!getTransform(element,tran)){
-      QTWARNING("Fail to perform transformation");
-      return FAILURE;
+KinematicChain::initChainFromXml(const TiXmlElement *root, QString &linkDir) {
+    numJoints = countXmlElements(root, "joint");
+    if (numJoints < 1) {
+        DBGA("number of joints < 1");
+        return FAILURE;
     }
-  }
-  tran.toSoTransform(IVTran);
-  
-  DBGA("  Creating joints");
-  numDOF = 0;
-  std::list<const TiXmlElement*> elementList = findAllXmlElements(root, "joint");
-  std::list<const TiXmlElement*>::iterator p;
-  int j;
-  for(p = elementList.begin(), j=0; p!=elementList.end(); p++,j++){
-    DBGA("   Joint " << j);
-    QString type = (*p)->Attribute("type");
-    if(type.isNull()){
-      QTWARNING("No Joint Type Specified");
-      return FAILURE;
+
+    numLinks = countXmlElements(root, "link");
+    if (numLinks < 1) {
+        DBGA("Number of links < 1");
+        return FAILURE;
     }
-    if(type == "Revolute"){
-      jointVec[j] = new RevoluteJoint(this);
-    } else if(type == "Prismatic"){
-      jointVec[j] = new PrismaticJoint (this);
-    } else {
-      DBGA("Unknown joint type requested");
-      return FAILURE;
+
+    jointVec.resize(numJoints, NULL);
+    linkVec.resize(numLinks, NULL);
+
+    lastJoint = new int[numLinks];
+
+    IVRoot = new SoSeparator;
+    IVTran = new SoTransform;
+    IVTran->ref();
+
+    /* read in the finger transformation */
+    const TiXmlElement *element = findXmlElement(root, "transform");
+    if (element) {
+        if (!getTransform(element, tran)) {
+            QTWARNING("Fail to perform transformation");
+            return FAILURE;
+        }
     }
-    if (jointVec[j]->initJointFromXml(*p, firstJointNum+j) == FAILURE) {
-      DBGA("Failed to initialize joint");
-      return FAILURE;
+    tran.toSoTransform(IVTran);
+
+    DBGA("  Creating joints");
+    numDOF = 0;
+    std::list<const TiXmlElement *> elementList = findAllXmlElements(root, "joint");
+    std::list<const TiXmlElement *>::iterator p;
+    int j;
+    for (p = elementList.begin(), j = 0; p != elementList.end(); p++, j++) {
+        DBGA("   Joint " << j);
+        QString type = (*p)->Attribute("type");
+        if (type.isNull()) {
+            QTWARNING("No Joint Type Specified");
+            return FAILURE;
+        }
+        if (type == "Revolute") {
+            jointVec[j] = new RevoluteJoint(this);
+        }
+        else if (type == "Prismatic") {
+            jointVec[j] = new PrismaticJoint(this);
+        }
+        else {
+            DBGA("Unknown joint type requested");
+            return FAILURE;
+        }
+        if (jointVec[j]->initJointFromXml(*p, firstJointNum + j) == FAILURE) {
+            DBGA("Failed to initialize joint");
+            return FAILURE;
+        }
     }
-  }
-  
-  DBGA("  Creating links");
-  std::vector<int> dynJointTypes;
-  int lastJointNum = -1;
-  elementList = findAllXmlElements(root, "link");
-  int l;
-  for (l=0, p=elementList.begin(); p!=elementList.end(); p++,l++){
-    DBGA("   Link " << l);
-    QString jointType=(*p)->Attribute("dynamicJointType");
-    if(jointType.isNull()){
-      QTWARNING("No Dynamic Joint Type Specified");
-      return FAILURE;
+
+    DBGA("  Creating links");
+    std::vector<int> dynJointTypes;
+    int lastJointNum = -1;
+    elementList = findAllXmlElements(root, "link");
+    int l;
+    for (l = 0, p = elementList.begin(); p != elementList.end(); p++, l++) {
+        DBGA("   Link " << l);
+        QString jointType = (*p)->Attribute("dynamicJointType");
+        if (jointType.isNull()) {
+            QTWARNING("No Dynamic Joint Type Specified");
+            return FAILURE;
+        }
+        jointType = jointType.stripWhiteSpace();
+        if (jointType == "Revolute") {
+            dynJointTypes.push_back(DynJoint::REVOLUTE);
+            lastJointNum += 1;
+        }
+        else if (jointType == "Ball") {
+            dynJointTypes.push_back(DynJoint::BALL);
+            lastJointNum += 3;
+        }
+        else if (jointType == "Universal") {
+            dynJointTypes.push_back(DynJoint::UNIVERSAL);
+            lastJointNum += 2;
+        }
+        else if (jointType == "Prismatic") {
+            dynJointTypes.push_back(DynJoint::PRISMATIC);
+            lastJointNum += 1;
+        }
+        else if (jointType == "Fixed") {
+            dynJointTypes.push_back(DynJoint::FIXED);
+        }
+        else {
+            DBGA("Unknown joint type requested");
+            return FAILURE;
+        }
+
+        QString linkFilename = (*p)->GetText();
+        linkFilename = linkFilename.stripWhiteSpace();
+        QString linkName = QString(owner->name()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
+        linkVec[l] = new Link(owner, chainNum, l, owner->getWorld(), linkName.latin1());
+        if (linkVec[l]->load(linkDir + linkFilename) == FAILURE) {
+            delete linkVec[l];
+            linkVec[l] = NULL;
+            DBGA("Failed to load file for link " << l);
+            return FAILURE;
+        }
+        /*  Handle collision rule settings:
+            Common case is NULL - collisions are on except for adjacent links.
+            Off - turn off collisions for this link globally, do not enter this body
+            into the collision engine at all.
+            OverlappingPair - turn off collisions between two particular links
+        */
+        QString collisionRule = (*p)->Attribute("collisionRule");
+
+        if (!collisionRule.isNull()) {
+            collisionRule = collisionRule.stripWhiteSpace();
+            if (collisionRule == "Off") {
+                linkVec[l]->addToIvc(true);
+                linkVec[l]->myWorld->toggleCollisions(false, linkVec[l], NULL);
+                DBGA("Collisions off for link " << l);
+            }
+            else if (collisionRule == "OverlappingPair") {
+                /*  targetChain - specifies the chain of the target link to disable
+                    collisions for.  No attribute implies current chain.
+                    Base implies robot base.
+                    targetLink - specifies link number in target chain
+                */
+                linkVec[l]->addToIvc();
+                QString targetChain = (*p)->Attribute("targetChain");
+                targetChain = targetChain.stripWhiteSpace();
+                if (targetChain == "base")
+                    linkVec[l]->myWorld->toggleCollisions(false, linkVec[l], owner->getBase());
+                else {
+
+                    QString targetLink = (*p)->Attribute("targetLink");
+                    if (!targetLink.isNull()) {
+                        bool ok = TRUE;
+                        int linkNum = targetLink.toInt(&ok);
+                        if (!ok) {
+                            DBGA("targetLink not a valid input");
+                            return FAILURE;
+                        }
+
+                        if (targetChain.isNull())
+                            linkVec[l]->myWorld->toggleCollisions(false, linkVec[l], linkVec[linkNum]);
+                        else {
+                            int chainNum = targetChain.toInt(&ok);
+                            if (!ok) {
+                                DBGA("targetChain not a valid input");
+                                return FAILURE;
+                            }
+                            linkVec[l]->myWorld->toggleCollisions(false, linkVec[l], owner->getChain(chainNum)->linkVec[linkNum]);
+                        }
+                    }
+                }
+            }
+            else {
+                DBGA("Unknown Collision Rule");
+                return FAILURE;
+            }
+        }
+        else {
+            linkVec[l]->addToIvc();
+        }
+
+
+        lastJoint[l] = lastJointNum;
+        if (lastJoint[l] >= numJoints) {
+            DBGA("Wrong last joint value: " << lastJoint[l]);
+            return FAILURE;
+        }
+
+        IVRoot->addChild(linkVec[l]->getIVRoot());
     }
-    jointType = jointType.stripWhiteSpace();
-    if (jointType == "Revolute") {
-      dynJointTypes.push_back(DynJoint::REVOLUTE);
-      lastJointNum += 1;
-    } else if (jointType == "Ball") {
-      dynJointTypes.push_back(DynJoint::BALL);
-      lastJointNum += 3;
-    } else if (jointType == "Universal") {
-      dynJointTypes.push_back(DynJoint::UNIVERSAL);
-      lastJointNum += 2;
-    } else if (jointType == "Prismatic") {
-      dynJointTypes.push_back(DynJoint::PRISMATIC);
-      lastJointNum += 1;
-    } else if (jointType == "Fixed") {
-      dynJointTypes.push_back(DynJoint::FIXED);
-    } else {
-      DBGA("Unknown joint type requested");
-      return FAILURE;
+
+    DBGA("  Creating dynamic joints");
+    if (createDynamicJoints(dynJointTypes) == FAILURE) {
+        DBGA("Failed to create dynamic joints");
+        return FAILURE;
     }
-    
-    QString linkFilename = (*p)->GetText();
-    linkFilename = linkFilename.stripWhiteSpace();
-    QString linkName = QString(owner->name()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
-    linkVec[l] = new Link(owner,chainNum,l,owner->getWorld(),linkName.latin1());
-    if (linkVec[l]->load(linkDir + linkFilename)==FAILURE) {
-      delete linkVec[l]; linkVec[l] = NULL;
-      DBGA("Failed to load file for link " << l);
-      return FAILURE;
-    }
-    /*Handle collision rule settings:
-     *Common case is NULL - collisions are on except for adjacent links.
-     *Off - turn off collisions for this link globally, do not enter this body
-     *into the collision engine at all.
-     *OverlappingPair - turn off collisions between two particular links
-     */
-    QString collisionRule=(*p)->Attribute("collisionRule");
-    
-    if(!collisionRule.isNull()){
-      collisionRule = collisionRule.stripWhiteSpace();
-      if (collisionRule == "Off"){
-	linkVec[l]->addToIvc(true);
-	linkVec[l]->myWorld->toggleCollisions(false, linkVec[l],NULL);
-	DBGA("Collisions off for link " << l);
-      }else if (collisionRule == "OverlappingPair"){
-	/*targetChain - specifies the chain of the target link to disable
-	 *collisions for.  No attribute implies current chain.  
-	 *Base implies robot base.
-	 *targetLink - specifies link number in target chain
-	 */
-	linkVec[l]->addToIvc();
-	QString targetChain=(*p)->Attribute("targetChain");
-	targetChain = targetChain.stripWhiteSpace();
-	if (targetChain == "base")
-	  linkVec[l]->myWorld->toggleCollisions(false, linkVec[l],owner->getBase());
-	else{
-	  
-	  QString targetLink = (*p)->Attribute("targetLink");
-	  if (!targetLink.isNull()){
-	    bool ok = TRUE;
-	    int linkNum = targetLink.toInt(&ok);
-	    if (!ok){
-	      DBGA("targetLink not a valid input");
-	      return FAILURE;
-	    }
-	    
-	    if(targetChain.isNull())
-	      linkVec[l]->myWorld->toggleCollisions(false, linkVec[l],linkVec[linkNum]);
-	    else{
-	      int chainNum = targetChain.toInt(&ok);
-	      if (!ok){
-		DBGA("targetChain not a valid input");
-		return FAILURE;
-	      }
-	      linkVec[l]->myWorld->toggleCollisions(false, linkVec[l],owner->getChain(chainNum)->linkVec[linkNum]);	
-	    }
-	  }
-	}				
-      }
-      else{
-	DBGA("Unknown Collision Rule");
-	return FAILURE;
-      }
-    }else{
-      linkVec[l]->addToIvc();
-    }
-    
-    
-    lastJoint[l] = lastJointNum;
-    if (lastJoint[l] >= numJoints) {
-      DBGA("Wrong last joint value: " << lastJoint[l]);
-      return FAILURE;
-    }
-    
-    IVRoot->addChild(linkVec[l]->getIVRoot());
-  }
-  
-  DBGA("  Creating dynamic joints");
-  if (createDynamicJoints(dynJointTypes) == FAILURE) {
-    DBGA("Failed to create dynamic joints");
-    return FAILURE;
-  }
-  
-  jointsMoved = true;
-  updateLinkPoses();
-  owner->getWorld()->tendonChange();
-  owner->getIVRoot()->addChild(IVRoot);
-  
-  return SUCCESS;
+
+    jointsMoved = true;
+    updateLinkPoses();
+    owner->getWorld()->tendonChange();
+    owner->getIVRoot()->addChild(IVRoot);
+
+    return SUCCESS;
 }
 
 
 /*! Copies this chain structure from an existing chain. All joints are
-	set to independent copies of the original chain. All links are created
-	as clones of the links from the original chain.
+    set to independent copies of the original chain. All links are created
+    as clones of the links from the original chain.
 */
 void
-KinematicChain::cloneFrom(const KinematicChain *original)
-{
-	IVRoot = new SoSeparator;
-	IVTran = new SoTransform;
-	IVTran->ref();
-	tran = original->getTran();
-	tran.toSoTransform(IVTran);
-	
-	numJoints = original->getNumJoints();
-	numLinks = original->getNumLinks();
-	jointVec.resize(numJoints,NULL);
-	linkVec.resize(numLinks,NULL);  
-	lastJoint = new int[numLinks];
+KinematicChain::cloneFrom(const KinematicChain *original) {
+    IVRoot = new SoSeparator;
+    IVTran = new SoTransform;
+    IVTran->ref();
+    tran = original->getTran();
+    tran.toSoTransform(IVTran);
 
-	numDOF = 0;
-	for (int j=0; j<numJoints; j++){
-		if (original->getJoint(j)->getType() == REVOLUTE) {
-			jointVec[j] = new RevoluteJoint(this);
-		}else if (original->getJoint(j)->getType() == PRISMATIC) {
-			jointVec[j] = new PrismaticJoint(this);
-		}
-		jointVec[j]->cloneFrom( original->getJoint(j) );
-	}
-	
-	std::vector<int> dynJointTypes;
-	for (int l=0; l<numLinks; l++){
-		lastJoint[l] = original->getLastJoint(l);
-		QString linkName =  QString(owner->name())+QString("_chain%1_link%2").arg(chainNum).arg(l);
-		linkVec[l] = new Link(owner,chainNum,l,owner->getWorld(),linkName);
-		linkVec[l]->cloneFrom( original->getLink(l) );
-		//linkVec[l]->setTransparency(0.5);
-		IVRoot->addChild(linkVec[l]->getIVRoot());
-		dynJointTypes.push_back( original->getLink(l)->getDynJoint()->getType() );
-	}
-	createDynamicJoints(dynJointTypes);
+    numJoints = original->getNumJoints();
+    numLinks = original->getNumLinks();
+    jointVec.resize(numJoints, NULL);
+    linkVec.resize(numLinks, NULL);
+    lastJoint = new int[numLinks];
 
-	jointsMoved = true;
-	owner->getIVRoot()->addChild(IVRoot);
+    numDOF = 0;
+    for (int j = 0; j < numJoints; j++) {
+        if (original->getJoint(j)->getType() == REVOLUTE) {
+            jointVec[j] = new RevoluteJoint(this);
+        }
+        else if (original->getJoint(j)->getType() == PRISMATIC) {
+            jointVec[j] = new PrismaticJoint(this);
+        }
+        jointVec[j]->cloneFrom(original->getJoint(j));
+    }
+
+    std::vector<int> dynJointTypes;
+    for (int l = 0; l < numLinks; l++) {
+        lastJoint[l] = original->getLastJoint(l);
+        QString linkName =  QString(owner->name()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
+        linkVec[l] = new Link(owner, chainNum, l, owner->getWorld(), linkName);
+        linkVec[l]->cloneFrom(original->getLink(l));
+        //linkVec[l]->setTransparency(0.5);
+        IVRoot->addChild(linkVec[l]->getIVRoot());
+        dynJointTypes.push_back(original->getLink(l)->getDynJoint()->getType());
+    }
+    createDynamicJoints(dynJointTypes);
+
+    jointsMoved = true;
+    owner->getIVRoot()->addChild(IVRoot);
 }
 
 /*!
-  Given a pointer to another robot and an offset transform of the base
-  frame of the robot with respect to the end transform of the link of
-  this chain.
+    Given a pointer to another robot and an offset transform of the base
+    frame of the robot with respect to the end transform of the link of
+    this chain.
 */
 void
-KinematicChain::attachRobot(Robot *r,const transf &offsetTr)
-{
-  children.push_back(r);
-  childOffsetTran.push_back(offsetTr);
-  numChildren++;
+KinematicChain::attachRobot(Robot *r, const transf &offsetTr) {
+    children.push_back(r);
+    childOffsetTran.push_back(offsetTr);
+    numChildren++;
 
-  if (r->getMountPiece())
-    r->getMountPiece()->
-      setDynJoint(new FixedDynJoint(linkVec[numLinks-1],r->getMountPiece(), offsetTr));
-  else
-    r->getBase()->
-      setDynJoint(new FixedDynJoint(linkVec[numLinks-1],r->getBase(), offsetTr));
+    if (r->getMountPiece())
+        r->getMountPiece()->
+        setDynJoint(new FixedDynJoint(linkVec[numLinks - 1], r->getMountPiece(), offsetTr));
+    else
+        r->getBase()->
+        setDynJoint(new FixedDynJoint(linkVec[numLinks - 1], r->getBase(), offsetTr));
 }
 
 /*!
-  This separates the robot pointed to by r from this kinematic chain,
-  allowing them to move independently.
+    This separates the robot pointed to by r from this kinematic chain,
+    allowing them to move independently.
 */
 void
-KinematicChain::detachRobot(Robot *r)
-{
-  int i,j;
-  std::vector<transf>::iterator tp;
-  std::vector<Robot *>::iterator rp;
+KinematicChain::detachRobot(Robot *r) {
+    int i, j;
+    std::vector<transf>::iterator tp;
+    std::vector<Robot *>::iterator rp;
 
-  for (i=0,rp=children.begin();rp!=children.end();i++,rp++)
-    if (*rp==r) {children.erase(rp); break;}
+    for (i = 0, rp = children.begin(); rp != children.end(); i++, rp++)
+        if (*rp == r) {
+            children.erase(rp);
+            break;
+        }
 
-  for (j=0,tp=childOffsetTran.begin();tp!=childOffsetTran.end();j++,tp++)
-    if (j==i) {childOffsetTran.erase(tp); break;}
+    for (j = 0, tp = childOffsetTran.begin(); tp != childOffsetTran.end(); j++, tp++)
+        if (j == i) {
+            childOffsetTran.erase(tp);
+            break;
+        }
 
-  numChildren--;
+    numChildren--;
 }
 
-std::list<Joint*> 
-KinematicChain::getJoints()
-{
-	std::list<Joint*> joints;
-	for (int j=0; j<numJoints; j++) {
-		joints.push_back(jointVec[j]);
-	}
-	return joints;
+std::list<Joint *>
+KinematicChain::getJoints() {
+    std::list<Joint *> joints;
+    for (int j = 0; j < numJoints; j++) {
+        joints.push_back(jointVec[j]);
+    }
+    return joints;
 }
 /*! Filters a collision report and keeps only collisions of a particular chain
-	For now it also throws out collisions between robot parts, as those are 
-	giving us problems.
+    For now it also throws out collisions between robot parts, as those are
+    giving us problems.
 */
-void KinematicChain::filterCollisionReport(CollisionReport &colReport)
-{
-	//only keep in the collision report those collision that interest this chain
-	CollisionReport::iterator it = colReport.begin();
-	bool keep;
-	while ( it != colReport.end() ) {
+void KinematicChain::filterCollisionReport(CollisionReport &colReport) {
+    //only keep in the collision report those collision that interest this chain
+    CollisionReport::iterator it = colReport.begin();
+    bool keep;
+    while (it != colReport.end()) {
 
-		if ( (*it).first->getOwner() != owner ) {
-			if ( (*it).second->getOwner() != owner ) {
-				keep = false;
-			} else {
-				if ( ((Link*)(*it).second)->getChainNum() == chainNum )
-					keep = true;
-				else
-					keep = false;
-			}
-		} else if ( (*it).second->getOwner() != owner ) {
-			if ( ((Link*)(*it).first)->getChainNum() == chainNum )
-				keep = true;
-			else
-				keep = false;			
-		} else {
-			keep = false;
-		}
-		if (!keep) {
-			it = colReport.erase(it);
-		} else {
-			it++;
-		}
-	}
+        if ((*it).first->getOwner() != owner) {
+            if ((*it).second->getOwner() != owner) {
+                keep = false;
+            }
+            else {
+                if (((Link *)(*it).second)->getChainNum() == chainNum)
+                    keep = true;
+                else
+                    keep = false;
+            }
+        }
+        else if ((*it).second->getOwner() != owner) {
+            if (((Link *)(*it).first)->getChainNum() == chainNum)
+                keep = true;
+            else
+                keep = false;
+        }
+        else {
+            keep = false;
+        }
+        if (!keep) {
+            it = colReport.erase(it);
+        }
+        else {
+            it++;
+        }
+    }
 }
 
 /*! Reads in the current values of the joints in this chain, and uses
-	them to populate the vector \a jointVals. This vector is ordered to
-	contain all the joints of the robot (not only of this chain) and
-	joints are indexed by their number in the robot structure, not in
-	this chain's struture.
+    them to populate the vector \a jointVals. This vector is ordered to
+    contain all the joints of the robot (not only of this chain) and
+    joints are indexed by their number in the robot structure, not in
+    this chain's struture.
 */
 void
-KinematicChain::getJointValues(double *jointVals) const
-{
-	for (int j=0; j<numJoints; j++) {
-		jointVals[firstJointNum + j] = jointVec[j]->getVal();
-	}
+KinematicChain::getJointValues(double *jointVals) const {
+    for (int j = 0; j < numJoints; j++) {
+        jointVals[firstJointNum + j] = jointVec[j]->getVal();
+    }
 }
 
-/*! Sets the current joint values from the vector \a jointVals. This 
-	vector is ordered to contain all the joints of the robot (not only 
-	of this chain) and joints are indexed by their number in the robot 
-	structure, not in this chain's struture.
+/*! Sets the current joint values from the vector \a jointVals. This
+    vector is ordered to contain all the joints of the robot (not only
+    of this chain) and joints are indexed by their number in the robot
+    structure, not in this chain's struture.
 */
 void
-KinematicChain::setJointValues(const double *jointVals)
-{
-	for (int j=0; j<numJoints; j++) {
-		jointVec[j]->setVal( jointVals[firstJointNum + j] );
-	}
+KinematicChain::setJointValues(const double *jointVals) {
+    for (int j = 0; j < numJoints; j++) {
+        jointVec[j]->setVal(jointVals[firstJointNum + j]);
+    }
 }
 
 /*! Computes forward kinematics for the current joint values, then
-	sets the link transforms accordingly. This is the only way that 
-	robot links should ever be moved (the robot asks the dof' for
-	joint values, tells the chains to set those values then tells
-	the chains to update link poses).
+    sets the link transforms accordingly. This is the only way that
+    robot links should ever be moved (the robot asks the dof' for
+    joint values, tells the chains to set those values then tells
+    the chains to update link poses).
 */
 void
-KinematicChain::updateLinkPoses()
-{
-	std::vector<transf> newLinkTranVec;
-	newLinkTranVec.resize(numLinks, transf::IDENTITY);
-	fwdKinematics(NULL, newLinkTranVec);
+KinematicChain::updateLinkPoses() {
+    std::vector<transf> newLinkTranVec;
+    newLinkTranVec.resize(numLinks, transf::IDENTITY);
+    fwdKinematics(NULL, newLinkTranVec);
 
-	for (int l=0;l<numLinks;l++) {
-		linkVec[l]->setTran(newLinkTranVec[l]);
-	}
+    for (int l = 0; l < numLinks; l++) {
+        linkVec[l]->setTran(newLinkTranVec[l]);
+    }
 
-	for (int j=0;j<numChildren;j++) {
-		children[j]->simpleSetTran(childOffsetTran[j]*newLinkTranVec[numLinks-1]);
-	}
+    for (int j = 0; j < numChildren; j++) {
+        children[j]->simpleSetTran(childOffsetTran[j]*newLinkTranVec[numLinks - 1]);
+    }
 
-	if ( owner->inherits("HumanHand") ){
-		((HumanHand*)owner)->updateTendonGeometry();
-		owner->getWorld()->tendonChange();
-	}
+    if (owner->inherits("HumanHand")) {
+        ((HumanHand *)owner)->updateTendonGeometry();
+        owner->getWorld()->tendonChange();
+    }
 }
 
 /*! Given a array of joint values for each joint in the chain, this method
-	will compute the transforms for each link in the chain with respect to
-	world coordinates.  It does not affect the chain itself.
+    will compute the transforms for each link in the chain with respect to
+    world coordinates.  It does not affect the chain itself.
 
-	The array of joint values is assumed to contain all the joints in the
-	robot, numbered as in the robot's numbering scheme. Alternatively,
-	you can pass NULL instead, in which case the current joint values are
-	used.
+    The array of joint values is assumed to contain all the joints in the
+    robot, numbered as in the robot's numbering scheme. Alternatively,
+    you can pass NULL instead, in which case the current joint values are
+    used.
 */
 void
-KinematicChain::fwdKinematics(const double *jointVals, std::vector<transf> &newLinkTranVec) const
-{
-	transf total = tran * owner->getTran();
-	int l=0;
-	for (int j=0;j<numJoints;j++) {    
-		if (!jointVals) {
-			total = jointVec[j]->getTran( jointVec[j]->getVal() ) * total;
-		} else {
-			total = jointVec[j]->getTran( jointVals[firstJointNum + j] ) * total;
-		}
-		if (l<numLinks && lastJoint[l]==j) {
-			newLinkTranVec[l] = total;
-			l++;
-		}
-	}
+KinematicChain::fwdKinematics(const double *jointVals, std::vector<transf> &newLinkTranVec) const {
+    transf total = tran * owner->getTran();
+    int l = 0;
+    for (int j = 0; j < numJoints; j++) {
+        if (!jointVals) {
+            total = jointVec[j]->getTran(jointVec[j]->getVal()) * total;
+        }
+        else {
+            total = jointVec[j]->getTran(jointVals[firstJointNum + j]) * total;
+        }
+        if (l < numLinks && lastJoint[l] == j) {
+            newLinkTranVec[l] = total;
+            l++;
+        }
+    }
 }
 
 /*! Given an array of joint values for each joint in the chain, it will compute
-	the location and orientations of all the joints in the chain, w.r.t. world
-	coordinates. This is somewhat similar to fwd kinematics, but instead of 
-	computing link transforms it computes joint transforms. This is different 
-	for two reasons. First, a joint's coordinate system is the chained transform 
-	*before* that joint, not after the joint (as it would be for a link that 
-	comes after the joint). Also, we can have multiple joints between two links.
+    the location and orientations of all the joints in the chain, w.r.t. world
+    coordinates. This is somewhat similar to fwd kinematics, but instead of
+    computing link transforms it computes joint transforms. This is different
+    for two reasons. First, a joint's coordinate system is the chained transform
+     before* that joint, not after the joint (as it would be for a link that
+    comes after the joint). Also, we can have multiple joints between two links.
 
-	Also remember two GraspIt conventions: for any joint, the joint axis (for 
-	rotation or translation) is the z axis of the joint transform returned here.
-	Also, the origin of a link is the same as the transform *after* the last joint
-	that comes before it.
+    Also remember two GraspIt conventions: for any joint, the joint axis (for
+    rotation or translation) is the z axis of the joint transform returned here.
+    Also, the origin of a link is the same as the transform *after* the last joint
+    that comes before it.
 
-	The array of joint values is assumed to contain all the joints in the
-	robot, numbered as in the robot's numbering scheme. Alternatively,
-	you can pass NULL instead, in which case the current joint values are
-	used.
+    The array of joint values is assumed to contain all the joints in the
+    robot, numbered as in the robot's numbering scheme. Alternatively,
+    you can pass NULL instead, in which case the current joint values are
+    used.
 */
 void
-KinematicChain::getJointLocations(const double *jointVals, std::vector<transf> &jointTranVec) const
-{
-	transf total = tran * owner->getTran();
-	for (int j=0;j<numJoints;j++) {    
-		jointTranVec[j] = total;
-		if (!jointVals) {
-			total = jointVec[j]->getTran( jointVec[j]->getVal() ) * total;
-		} else {
-			total = jointVec[j]->getTran( jointVals[firstJointNum + j] ) * total;
-		}
-	}	
+KinematicChain::getJointLocations(const double *jointVals, std::vector<transf> &jointTranVec) const {
+    transf total = tran * owner->getTran();
+    for (int j = 0; j < numJoints; j++) {
+        jointTranVec[j] = total;
+        if (!jointVals) {
+            total = jointVec[j]->getTran(jointVec[j]->getVal()) * total;
+        }
+        else {
+            total = jointVec[j]->getTran(jointVals[firstJointNum + j]) * total;
+        }
+    }
 }
 
 /*! Given an array of desired joint values, this computed an infinitesimal motion
-	of each link as motion *from the current values* towards the desired values is 
-	started. Used mainly to	see if any contacts prevent this motion.
+    of each link as motion *from the current values* towards the desired values is
+    started. Used mainly to see if any contacts prevent this motion.
 */
 void
-KinematicChain::infinitesimalMotion(const double *jointVals, std::vector<transf> &newLinkTranVec) const
-{
-	//start with the link jacobian in local link coordinates
-	//but keep just the actuated part
-	Matrix J(actuatedJacobian(linkJacobian(false)));
-	//joint values matrix
-	Matrix theta(numJoints, 1);
-	//a very small motion
-	//either 0.1 radians or 0.1 mm, should be small enough
-	double inf = 0.1;
-	//a very small threshold
-	double eps = 1.0e-6;
-	for(int j=0; j<numJoints; j++) {
-		int sign;
-		if ( jointVals[firstJointNum + j] + eps < jointVec[j]->getVal() ) {
-			sign = -1;
-		} else if ( jointVals[firstJointNum + j] > jointVec[j]->getVal() + eps ) {
-			sign = 1;
-		} else {
-			sign = 0;
-		}
-		theta.elem(j,0) = sign * inf;
-	}
-	//compute infinitesimal motion
-	Matrix dm(6*numLinks, 1);
-	matrixMultiply(J, theta, dm);
-	//and convert it to transforms
-	for (int l=0; l<numLinks; l++) {
-		transf tr = rotXYZ( dm.elem(6*l+3, 0), dm.elem(6*l+4, 0), dm.elem(6*l+5, 0) ) * 
-					translate_transf( vec3( dm.elem(6*l+0, 0), dm.elem(6*l+1, 0), dm.elem(6*l+2, 0) ) );
-		newLinkTranVec[l] = tr;
-	}
+KinematicChain::infinitesimalMotion(const double *jointVals, std::vector<transf> &newLinkTranVec) const {
+    //start with the link jacobian in local link coordinates
+    //but keep just the actuated part
+    Matrix J(actuatedJacobian(linkJacobian(false)));
+    //joint values matrix
+    Matrix theta(numJoints, 1);
+    //a very small motion
+    //either 0.1 radians or 0.1 mm, should be small enough
+    double inf = 0.1;
+    //a very small threshold
+    double eps = 1.0e-6;
+    for (int j = 0; j < numJoints; j++) {
+        int sign;
+        if (jointVals[firstJointNum + j] + eps < jointVec[j]->getVal()) {
+            sign = -1;
+        }
+        else if (jointVals[firstJointNum + j] > jointVec[j]->getVal() + eps) {
+            sign = 1;
+        }
+        else {
+            sign = 0;
+        }
+        theta.elem(j, 0) = sign * inf;
+    }
+    //compute infinitesimal motion
+    Matrix dm(6 * numLinks, 1);
+    matrixMultiply(J, theta, dm);
+    //and convert it to transforms
+    for (int l = 0; l < numLinks; l++) {
+        transf tr = rotXYZ(dm.elem(6 * l + 3, 0), dm.elem(6 * l + 4, 0), dm.elem(6 * l + 5, 0)) *
+                    translate_transf(vec3(dm.elem(6 * l + 0, 0), dm.elem(6 * l + 1, 0), dm.elem(6 * l + 2, 0)));
+        newLinkTranVec[l] = tr;
+    }
 }
 
-void 
-KinematicChain::getDynamicJoints(std::vector<DynJoint*> *dj) const
-{
-	DynJoint *lastDynJoint = NULL;
-	for(int j=0; j<numJoints; j++) {
+void
+KinematicChain::getDynamicJoints(std::vector<DynJoint *> *dj) const {
+    DynJoint *lastDynJoint = NULL;
+    for (int j = 0; j < numJoints; j++) {
         if (jointVec[j]->getDynJoint() == lastDynJoint) continue;
         lastDynJoint = jointVec[j]->getDynJoint();
-		dj->push_back(lastDynJoint);
-	}
+        dj->push_back(lastDynJoint);
+    }
 }
 
 /*! The link jacobian relates joint angle changes to link movement.
-	Its transpose relates forces applied to link to forces applied
-	to joints. If \a worldCoords is false, the jacobian is computed
-	in each link's coordinate system.
+    Its transpose relates forces applied to link to forces applied
+    to joints. If \a worldCoords is false, the jacobian is computed
+    in each link's coordinate system.
 */
 Matrix
-KinematicChain::linkJacobian(bool worldCoords) const
-{
-	Matrix J(Matrix::ZEROES<Matrix>(numLinks * 6, numLinks * 6));
-	Matrix indJ(6,6);
-	for (int l=0; l<numLinks; l++) {
-		for (int dl=0; dl<=l; dl++) {
-			DynJoint *dynJoint = linkVec[dl]->getDynJoint();
-			dynJoint->jacobian(linkVec[l]->getTran(), &indJ, worldCoords);
-			J.copySubMatrix(6*l, 6*dl, indJ);
-		}
-	}
-	return J;
+KinematicChain::linkJacobian(bool worldCoords) const {
+    Matrix J(Matrix::ZEROES<Matrix>(numLinks * 6, numLinks * 6));
+    Matrix indJ(6, 6);
+    for (int l = 0; l < numLinks; l++) {
+        for (int dl = 0; dl <= l; dl++) {
+            DynJoint *dynJoint = linkVec[dl]->getDynJoint();
+            dynJoint->jacobian(linkVec[l]->getTran(), &indJ, worldCoords);
+            J.copySubMatrix(6 * l, 6 * dl, indJ);
+        }
+    }
+    return J;
 }
 
 /*! The active link jacobian will build the regular link Jacobian, then
-	only keep the rows that correspond to links that have at least one
-	contact (as links with no contacts can not balance actuation forces 
-	applied	to them).
+    only keep the rows that correspond to links that have at least one
+    contact (as links with no contacts can not balance actuation forces
+    applied to them).
 */
 Matrix
-KinematicChain::activeLinkJacobian(bool worldCoords)
-{
-	Matrix J(linkJacobian(worldCoords));
-	if (!J.rows() || !J.cols()) return Matrix(0,0);
-	int activeLinks = 0;
-	for (int l=0; l<numLinks; l++) {
-		if (linkVec[l]->getNumContacts()) {
-			activeLinks++;
-		}
-	}
-	if (!activeLinks) {
-		DBGA("Active link Jac requested, but no active links!");
-		return Matrix::ZEROES<Matrix>(0,0);
-	}
-	int activeRows = 6*activeLinks;
-	Matrix activeJ(activeRows, J.cols());
-	int linkCount = 0;
-	//only keep rows that correspond to links that have at least one contact
-	for (int l=0; l<numLinks; l++) {
-		if (!linkVec[l]->getNumContacts()) continue;
-		activeJ.copySubBlock(6*linkCount, 0, 6, J.cols(), J, 6*l, 0);
-		linkCount++;
-	}
-	return activeJ;
+KinematicChain::activeLinkJacobian(bool worldCoords) {
+    Matrix J(linkJacobian(worldCoords));
+    if (!J.rows() || !J.cols()) return Matrix(0, 0);
+    int activeLinks = 0;
+    for (int l = 0; l < numLinks; l++) {
+        if (linkVec[l]->getNumContacts()) {
+            activeLinks++;
+        }
+    }
+    if (!activeLinks) {
+        DBGA("Active link Jac requested, but no active links!");
+        return Matrix::ZEROES<Matrix>(0, 0);
+    }
+    int activeRows = 6 * activeLinks;
+    Matrix activeJ(activeRows, J.cols());
+    int linkCount = 0;
+    //only keep rows that correspond to links that have at least one contact
+    for (int l = 0; l < numLinks; l++) {
+        if (!linkVec[l]->getNumContacts()) continue;
+        activeJ.copySubBlock(6 * linkCount, 0, 6, J.cols(), J, 6 * l, 0);
+        linkCount++;
+    }
+    return activeJ;
 }
 
 /*! This function takes a Jacobian with all columns (6dof per joint
-	and returns a version that has only those columns that correspond
-	to the actuated dofs in each joint (e.g. the z axis for revolute 
-	joints) 
+    and returns a version that has only those columns that correspond
+    to the actuated dofs in each joint (e.g. the z axis for revolute
+    joints)
 */
 Matrix
-KinematicChain::actuatedJacobian(const Matrix &fullColumnJ) const
-{
-	std::vector<DynJoint*> dynJoints;
-	getDynamicJoints(&dynJoints);
-	int activeRows = fullColumnJ.rows();
-	if (!activeRows) return Matrix(0,0);
-	//first count the constraints
-	int numConstrained = 0;
-	int numActuated = 0;
-	for(int dj=0; dj<(int)dynJoints.size(); dj++) {
-		numConstrained += dynJoints[dj]->getNumConstraints();
-		numActuated += 6 - dynJoints[dj]->getNumConstraints();
-	}
-	assert(numActuated + numConstrained == 6*numLinks);
-	assert(fullColumnJ.cols() == 6*numLinks);
-	Matrix blockJ(activeRows, numActuated);
-	//then copy only actuated columns in the block jacobian.
-	int actIndex = 0;
-	for(int dj=0; dj<(int)dynJoints.size(); dj++) {
-		char constraints[6];
-		dynJoints[dj]->getConstraints(constraints);
-		for (int c=0; c<6; c++) {
-			if (!constraints[c]) {
-				//actuated direction
-				blockJ.copySubBlock(0, actIndex, activeRows, 1, fullColumnJ, 0, 6*dj+c);
-				actIndex++;
-			}
-		}
-	}
-	assert(actIndex == numActuated);
-	return blockJ;
+KinematicChain::actuatedJacobian(const Matrix &fullColumnJ) const {
+    std::vector<DynJoint *> dynJoints;
+    getDynamicJoints(&dynJoints);
+    int activeRows = fullColumnJ.rows();
+    if (!activeRows) return Matrix(0, 0);
+    //first count the constraints
+    int numConstrained = 0;
+    int numActuated = 0;
+    for (int dj = 0; dj < (int)dynJoints.size(); dj++) {
+        numConstrained += dynJoints[dj]->getNumConstraints();
+        numActuated += 6 - dynJoints[dj]->getNumConstraints();
+    }
+    assert(numActuated + numConstrained == 6 * numLinks);
+    assert(fullColumnJ.cols() == 6 * numLinks);
+    Matrix blockJ(activeRows, numActuated);
+    //then copy only actuated columns in the block jacobian.
+    int actIndex = 0;
+    for (int dj = 0; dj < (int)dynJoints.size(); dj++) {
+        char constraints[6];
+        dynJoints[dj]->getConstraints(constraints);
+        for (int c = 0; c < 6; c++) {
+            if (!constraints[c]) {
+                //actuated direction
+                blockJ.copySubBlock(0, actIndex, activeRows, 1, fullColumnJ, 0, 6 * dj + c);
+                actIndex++;
+            }
+        }
+    }
+    assert(actIndex == numActuated);
+    return blockJ;
 }
 
-/*! Given a matrix with all the joint torques of the robot, numbered as in the 
-	the robot scheme, this extracts a vector of chain joint torques, in the order
-	in which they appear in this chain
+/*! Given a matrix with all the joint torques of the robot, numbered as in the
+    the robot scheme, this extracts a vector of chain joint torques, in the order
+    in which they appear in this chain
 */
-Matrix 
-KinematicChain::jointTorquesVector(Matrix fullRobotTorques)
-{
-	assert(fullRobotTorques.cols() == 1);
-	Matrix tau(numJoints,1);
-	for (int j=0; j<numJoints; j++) {
-		tau.elem(j,0) = fullRobotTorques.elem(jointVec[j]->getNum(), 0);
-	}
-	return tau;
+Matrix
+KinematicChain::jointTorquesVector(Matrix fullRobotTorques) {
+    assert(fullRobotTorques.cols() == 1);
+    Matrix tau(numJoints, 1);
+    for (int j = 0; j < numJoints; j++) {
+        tau.elem(j, 0) = fullRobotTorques.elem(jointVec[j]->getNum(), 0);
+    }
+    return tau;
 }
 
 /*! Returns the number of contacts between the links of this chain and the object
-	\a body. If \a body == NULL, returns the total number of contacts, regardless
-	of what object they are against.
-	Todo: what about self-colision?
+    \a body. If \a body == NULL, returns the total number of contacts, regardless
+    of what object they are against.
+    Todo: what about self-colision?
 */
-int  
-KinematicChain::getNumContacts(Body *body)
-{
-	int numContacts = 0;
-	for (int l=0; l<numLinks; l++) {
-		numContacts += linkVec[l]->getNumContacts(body);
-	}
-	return numContacts;
+int
+KinematicChain::getNumContacts(Body *body) {
+    int numContacts = 0;
+    for (int l = 0; l < numLinks; l++) {
+        numContacts += linkVec[l]->getNumContacts(body);
+    }
+    return numContacts;
 }
 
 /*! Returns a list of the contacts between the links of this chain and the object
-	\a body. If \a body == NULL, returns all the contacts, regardless of what object 
-	they are against.
-	Todo: what about self-colision?
+    \a body. If \a body == NULL, returns all the contacts, regardless of what object
+    they are against.
+    Todo: what about self-colision?
 */
-std::list<Contact*>
-KinematicChain::getContacts(Body *body)
-{
-	std::list<Contact*> contacts;
-	for (int l=0; l<numLinks; l++) {
-		std::list<Contact*> linkContacts = linkVec[l]->getContacts(body);
-		contacts.insert(contacts.end(), linkContacts.begin(), linkContacts.end());
-	}
-	return contacts;
+std::list<Contact *>
+KinematicChain::getContacts(Body *body) {
+    std::list<Contact *> contacts;
+    for (int l = 0; l < numLinks; l++) {
+        std::list<Contact *> linkContacts = linkVec[l]->getContacts(body);
+        contacts.insert(contacts.end(), linkContacts.begin(), linkContacts.end());
+    }
+    return contacts;
 }

--- a/src/lmiOptimizer.cpp
+++ b/src/lmiOptimizer.cpp
@@ -43,1272 +43,1319 @@ bool errorOccurred = false;
 double LMIOptimizer::GFO_WEIGHT_FACTOR = 1.0;
 
 //print out error message and exit
-void FatalErrMsg(char* s)
-{
-  fprintf(stderr,"error: %s\n",s);
-  exit(-1);
+void FatalErrMsg(char *s) {
+    fprintf(stderr, "error: %s\n", s);
+    exit(-1);
 }
 
 #define errMsg(S_)                 \
-{                                  \
-  fprintf(stderr,"error: %s\n",S_);\
-  errorOccurred = true;            \
-  return;                          \
-} 
+    {                                  \
+        fprintf(stderr,"error: %s\n",S_);\
+        errorOccurred = true;            \
+        return;                          \
+    }
 
 /*!
-  Create a diagonal-block identity matrix
+    Create a diagonal-block identity matrix
 */
-double * block_Identity(int numBlocks, int * blockSizes, int pkSize)
-{
+double *block_Identity(int numBlocks, int *blockSizes, int pkSize) {
 
-  int i, j, itemIndex, blockDim;
-  double db0=0.0,*identity= (double*) malloc(pkSize*sizeof(double));
-  
-  dcopy(pkSize,&db0, 0, identity, 1);
-  itemIndex=0;
-  for(i=0;i<numBlocks; i++){
-    blockDim=blockSizes[i];
-    for(j=0;j<blockDim;j++){
-      identity[itemIndex]=1.0;
-      itemIndex+=blockDim-j;
+    int i, j, itemIndex, blockDim;
+    double db0 = 0.0, *identity = (double *) malloc(pkSize * sizeof(double));
+
+    dcopy(pkSize, &db0, 0, identity, 1);
+    itemIndex = 0;
+    for (i = 0; i < numBlocks; i++) {
+        blockDim = blockSizes[i];
+        for (j = 0; j < blockDim; j++) {
+            identity[itemIndex] = 1.0;
+            itemIndex += blockDim - j;
+        }
     }
-  }
-  return(identity);
+    return (identity);
 }
 
 /*!
-  Constructs the hand jacobian.  It currently assumes there is no palm motion,
-  hence the matrix is \c numDOF x \c numWrenches (\c numWrenches = 3 *
-  \c mGrasp->numContacts when each contact is PCWF.  This jacobian relates joint
-  velocities to contact velocities and its transpose relates contact forces
-  to joint torques.  
+    Constructs the hand jacobian.  It currently assumes there is no palm motion,
+    hence the matrix is \c numDOF x \c numWrenches (\c numWrenches = 3 *
+    \c mGrasp->numContacts when each contact is PCWF.  This jacobian relates joint
+    velocities to contact velocities and its transpose relates contact forces
+    to joint torques.
 
-  Distances used to be in meters. Now they are in millimeters.
+    Distances used to be in meters. Now they are in millimeters.
 */
 void
-LMIOptimizer::buildJacobian()
-{
-	double db0=0.0;
-	int i,f,l,blkOffset,rowOffset;
-	transf Tec;
-	double *Jee,*Tv_ec,*J;
-	std::list<Contact *>::iterator cp;
-	std::list<Contact *> contactList;
-  
-	numDOF = mGrasp->hand->getNumDOF();   // +6 for palm motion
+LMIOptimizer::buildJacobian() {
+    double db0 = 0.0;
+    int i, f, l, blkOffset, rowOffset;
+    transf Tec;
+    double *Jee, *Tv_ec, *J;
+    std::list<Contact *>::iterator cp;
+    std::list<Contact *> contactList;
 
-	if (externalTorques) delete [] externalTorques;
-	externalTorques = new double[numDOF];
-	for (i=0;i<numDOF;i++) {
-		externalTorques[i] = mGrasp->hand->getDOF(i)->getExtForce();
-	}
+    numDOF = mGrasp->hand->getNumDOF();   // +6 for palm motion
 
-	if (Jacobian) delete [] Jacobian;
-	Jacobian = new double[numDOF*numWrenches];
-	dcopy(numDOF*numWrenches,&db0,0,Jacobian,1);
-	blkOffset = 0;
+    if (externalTorques) delete [] externalTorques;
+    externalTorques = new double[numDOF];
+    for (i = 0; i < numDOF; i++) {
+        externalTorques[i] = mGrasp->hand->getDOF(i)->getExtForce();
+    }
 
-	// J is an individual contact jacobian
-	J = new double[6*numDOF];
+    if (Jacobian) delete [] Jacobian;
+    Jacobian = new double[numDOF * numWrenches];
+    dcopy(numDOF * numWrenches, &db0, 0, Jacobian, 1);
+    blkOffset = 0;
 
-	for (f=0;f<mGrasp->hand->getNumFingers();f++) {
-		for (l=0;l<mGrasp->hand->getFinger(f)->getNumLinks();l++) {
-   			contactList = mGrasp->hand->getFinger(f)->getLink(l)->getContacts();
-			if (contactList.empty()) continue;
+    // J is an individual contact jacobian
+    J = new double[6 * numDOF];
 
-			Jee = mGrasp->getLinkJacobian(f,l);
+    for (f = 0; f < mGrasp->hand->getNumFingers(); f++) {
+        for (l = 0; l < mGrasp->hand->getFinger(f)->getNumLinks(); l++) {
+            contactList = mGrasp->hand->getFinger(f)->getLink(l)->getContacts();
+            if (contactList.empty()) continue;
 
-			for (cp=contactList.begin();cp!=contactList.end();cp++) {
-				if ((*cp)->getBody2() != mGrasp->object) continue;
-				dcopy(6*numDOF,&db0,0,J,1);
+            Jee = mGrasp->getLinkJacobian(f, l);
 
-				// Tec: tranform from link base to contact point
-				Tec = rotate_transf(M_PI,vec3(1,0,0)) * (*cp)->getContactFrame();
-				Tv_ec = new double[36];
-				Tec.jacobian(Tv_ec);
-				// J = Tv_ec * Jee;
-				dgemm("N","N",6,numDOF,6,1.0,Tv_ec,6,Jee,6,0.0,J,6);
-   				delete [] Tv_ec;
+            for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+                if ((*cp)->getBody2() != mGrasp->object) continue;
+                dcopy(6 * numDOF, &db0, 0, J, 1);
 
-				// we only want to include the portion of J that is admissible
-				// by the contact type
-	    
-				rowOffset = 0;
-	    
-				if ((*cp)->getContactDim() >= 3) {
-					// copy the first row of J (dx/dtheta)
-					dcopy(numDOF,J,6,Jacobian+blkOffset+rowOffset,numWrenches);
-					rowOffset++;
-      				// copy the second row of J (dy/dtheta)
-					dcopy(numDOF,J+1,6,Jacobian+blkOffset+rowOffset,numWrenches);
-					rowOffset++;
-				}
-   
-				// copy the third row of J (dz/dtheta)
-				dcopy(numDOF,J+2,6,Jacobian+blkOffset+rowOffset,numWrenches);
-				rowOffset++;
-    
-				if ((*cp)->getContactDim() > 3) {
-					// copy the sixth row of J (drz/dtheta)
-					dcopy(numDOF,J+5,6,Jacobian+blkOffset+rowOffset,numWrenches);
-					rowOffset++;
-				}
-	    		blkOffset += rowOffset;
-			}
-			delete [] Jee;
-		}
-	}  
-	delete [] J;
+                // Tec: tranform from link base to contact point
+                Tec = rotate_transf(M_PI, vec3(1, 0, 0)) * (*cp)->getContactFrame();
+                Tv_ec = new double[36];
+                Tec.jacobian(Tv_ec);
+                // J = Tv_ec * Jee;
+                dgemm("N", "N", 6, numDOF, 6, 1.0, Tv_ec, 6, Jee, 6, 0.0, J, 6);
+                delete [] Tv_ec;
 
-#ifdef GRASPDEBUG
-	printf("JACOBIAN:\n");
-	disp_mat(stdout,Jacobian,numWrenches,numDOF,0);
-#endif
+                // we only want to include the portion of J that is admissible
+                // by the contact type
+
+                rowOffset = 0;
+
+                if ((*cp)->getContactDim() >= 3) {
+                    // copy the first row of J (dx/dtheta)
+                    dcopy(numDOF, J, 6, Jacobian + blkOffset + rowOffset, numWrenches);
+                    rowOffset++;
+                    // copy the second row of J (dy/dtheta)
+                    dcopy(numDOF, J + 1, 6, Jacobian + blkOffset + rowOffset, numWrenches);
+                    rowOffset++;
+                }
+
+                // copy the third row of J (dz/dtheta)
+                dcopy(numDOF, J + 2, 6, Jacobian + blkOffset + rowOffset, numWrenches);
+                rowOffset++;
+
+                if ((*cp)->getContactDim() > 3) {
+                    // copy the sixth row of J (drz/dtheta)
+                    dcopy(numDOF, J + 5, 6, Jacobian + blkOffset + rowOffset, numWrenches);
+                    rowOffset++;
+                }
+                blkOffset += rowOffset;
+            }
+            delete [] Jee;
+        }
+    }
+    delete [] J;
+
+    #ifdef GRASPDEBUG
+    printf("JACOBIAN:\n");
+    disp_mat(stdout, Jacobian, numWrenches, numDOF, 0);
+    #endif
 
 }
 
 
 /*!
-  Constructs the grasp map matrix.  This is a 6 x \c numWrenches
-  (\c numWrenches = 3 * \c mGrasp->numContacts, when each contact is PCWF) matrix
-  that computes the net object wrench given a vector of magnitudes for
-  the contact wrenches.  
+    Constructs the grasp map matrix.  This is a 6 x \c numWrenches
+    (\c numWrenches = 3 * \c mGrasp->numContacts, when each contact is PCWF) matrix
+    that computes the net object wrench given a vector of magnitudes for
+    the contact wrenches.
 */
 void
-LMIOptimizer::buildGraspMap()
-{
-  int i,curLoc = 0;
+LMIOptimizer::buildGraspMap() {
+    int i, curLoc = 0;
 
-  if (graspMap) delete [] graspMap;
-  graspMap = NULL;
+    if (graspMap) delete [] graspMap;
+    graspMap = NULL;
 
-  // count the total number of wrenches contributed by all the contacts
-  numWrenches = 0;
-  for(i=0;i<mGrasp->numContacts;i++)
-    numWrenches += mGrasp->contactVec[i]->getContactDim();
+    // count the total number of wrenches contributed by all the contacts
+    numWrenches = 0;
+    for (i = 0; i < mGrasp->numContacts; i++)
+        numWrenches += mGrasp->contactVec[i]->getContactDim();
 
-  if (mGrasp->numContacts) {
-    graspCounter++;
-    graspMap = new double[6*numWrenches];
+    if (mGrasp->numContacts) {
+        graspCounter++;
+        graspMap = new double[6 * numWrenches];
 
-    /*
-      This code has not been verified in a long time. Please check that the frictionEdges
-      below indeed do what you expect them to
-    */
-    fprintf(stderr,"Unverified code! Check me first!\n");
-    // add the basis wrenches of each contact to the grasp map
-    for (i=0;i<mGrasp->numContacts;i++) {
-      dcopy(6*mGrasp->contactVec[i]->numFrictionEdges,
-	    mGrasp->contactVec[i]->getMate()->frictionEdges,1,graspMap+curLoc,1);
-	  curLoc += 6 * mGrasp->contactVec[i]->getContactDim();
+        /*
+            This code has not been verified in a long time. Please check that the frictionEdges
+            below indeed do what you expect them to
+        */
+        fprintf(stderr, "Unverified code! Check me first!\n");
+        // add the basis wrenches of each contact to the grasp map
+        for (i = 0; i < mGrasp->numContacts; i++) {
+            dcopy(6 * mGrasp->contactVec[i]->numFrictionEdges,
+                  mGrasp->contactVec[i]->getMate()->frictionEdges, 1, graspMap + curLoc, 1);
+            curLoc += 6 * mGrasp->contactVec[i]->getContactDim();
+        }
+        #ifdef GRASPDEBUG
+        printf("Built GraspMap (6x%d):\n", numWrenches);
+        disp_mat(stdout, graspMap, 6, numWrenches, 1);
+        #endif
+
     }
-#ifdef GRASPDEBUG
-    printf("Built GraspMap (6x%d):\n",numWrenches);
-    disp_mat(stdout,graspMap,6,numWrenches,1);
-#endif
-
-  }
 }
 
 /*!
-  Computes the null space of the grasp map.
-  Adapted from Li Han's code.
+    Computes the null space of the grasp map.
+    Adapted from Li Han's code.
 */
 void
 LMIOptimizer::computeNullSpace() {
 
-  double *tempGraspMap, *work;
-  double *leftSV, *singularValues, *rightSV, *checkNull, *checkRSV;
-  double db0=0.0;
-  int lwork, rank, info;
-  int numGElements, numCheck, i;
-  int row = 6, col = numWrenches;
-  
-  rank=row;
-  nullDim=col-rank;
-  if (nullDim <= 0) return;
+    double *tempGraspMap, *work;
+    double *leftSV, *singularValues, *rightSV, *checkNull, *checkRSV;
+    double db0 = 0.0;
+    int lwork, rank, info;
+    int numGElements, numCheck, i;
+    int row = 6, col = numWrenches;
 
-  if (nullSpace) free(nullSpace);
+    rank = row;
+    nullDim = col - rank;
+    if (nullDim <= 0) return;
 
-  numGElements = row*col;
-  tempGraspMap=(double*) malloc(numGElements*sizeof(double));
-  dcopy(numGElements,graspMap,1, tempGraspMap,1);
-  
-  lwork=MAX(MAX(1,3*MIN(row,col)+ MAX(row,col)),5*MIN(row,col));  //-4
-  work=(double*) malloc(lwork*sizeof(double));
-  singularValues=(double*)malloc(MIN(row,col)*sizeof(double));
-  leftSV=(double*)malloc(row*row*sizeof(double));
-  rightSV=(double*)malloc(col*col*sizeof(double));
+    if (nullSpace) free(nullSpace);
 
-#ifdef GRASPDEBUG  
-  printf("--------- tempGraspMap ------------ \n");
-  disp_mat(stdout,tempGraspMap,row,col,0);
-#endif
-  
-  dgesvd("A","A", row, col,tempGraspMap, row, singularValues, leftSV, row,
-	 rightSV, col, work, lwork, &info);
-  if(info==0){
+    numGElements = row * col;
+    tempGraspMap = (double *) malloc(numGElements * sizeof(double));
+    dcopy(numGElements, graspMap, 1, tempGraspMap, 1);
 
-#ifdef GRASPDEBUG  
-      printf("--------- singular values ------------ \n");
-      disp_mat(stdout,singularValues,1,MIN(row,col),0);
-      
-      printf("--------- Left Singular Vectors -------- \n");
-      disp_mat(stdout, leftSV, row, row,0);
-      printf("--------- Right Singular Vectors -------- \n");
-      disp_mat(stdout, rightSV, col, col,0);
-      
-      printf("-------- GraspMap*RightSV ------------ \n");
-#endif
+    lwork = MAX(MAX(1, 3 * MIN(row, col) + MAX(row, col)), 5 * MIN(row, col)); //-4
+    work = (double *) malloc(lwork * sizeof(double));
+    singularValues = (double *)malloc(MIN(row, col) * sizeof(double));
+    leftSV = (double *)malloc(row * row * sizeof(double));
+    rightSV = (double *)malloc(col * col * sizeof(double));
 
-      checkRSV=(double*)malloc(col*col*sizeof(double));
-      dcopy(numGElements,graspMap,1, tempGraspMap,1);
-      dgemm("N","T",row,col,col,1.0,tempGraspMap,row,rightSV,col,0.0,
-      checkRSV,col);
-#ifdef GRASPDEBUG  
-      disp_mat(stdout, checkRSV, col, col,0);
-#endif
-      free(checkRSV);
+    #ifdef GRASPDEBUG
+    printf("--------- tempGraspMap ------------ \n");
+    disp_mat(stdout, tempGraspMap, row, col, 0);
+    #endif
 
-    nullSpace=(double *)malloc(col* nullDim *sizeof(double));
-    for (i=row;i<col;i++)
-      dcopy(col,rightSV+i,col,nullSpace+(i-row)*col,1);
-    
-#ifdef GRASPDEBUG  
-      printf("---------- Null Space -----------------\n");
-      disp_mat(stdout, nullSpace, col, nullDim,0);
-      
-      printf("---------- check null space --------- \n");
-#endif
-      numCheck=row*nullDim;
-      checkNull=(double*)malloc(numCheck*sizeof(double));
-      dcopy(numCheck, &db0, 0,checkNull,1);
-      dcopy(numGElements,graspMap,1, tempGraspMap,1);
-      dgemm("N","N", row, nullDim, col, 1.0, tempGraspMap, row,
-      nullSpace,col, 0.0, checkNull,row);
-#ifdef GRASPDEBUG  
-      disp_mat(stdout, checkNull, row, nullDim, 0);
-#endif
-      free(checkNull);
+    dgesvd("A", "A", row, col, tempGraspMap, row, singularValues, leftSV, row,
+           rightSV, col, work, lwork, &info);
+    if (info == 0) {
 
-    free(tempGraspMap);free(work); 
-    free(leftSV); free(singularValues); free(rightSV);
-  }
-  else {
-    free(tempGraspMap);free(work);
-    free(leftSV); free(singularValues); free(rightSV);    
-    errMsg("error in SVD of grasp map");
-  }
-}
+        #ifdef GRASPDEBUG
+        printf("--------- singular values ------------ \n");
+        disp_mat(stdout, singularValues, 1, MIN(row, col), 0);
 
-/*! 
-  Find the minimal norm solution to the object wrench equilibirum equation.
-  Adapted from Li Han's Code - I changed the sign of the object wrench.
+        printf("--------- Left Singular Vectors -------- \n");
+        disp_mat(stdout, leftSV, row, row, 0);
+        printf("--------- Right Singular Vectors -------- \n");
+        disp_mat(stdout, rightSV, col, col, 0);
 
-  The solution to the linear equation \f$ G x + F_{ext} = 0 \f$
-  is \f$ x = x_0 + V z \f$
-  where \f$ x_0 = G^+ * F_{ext} \f$ is the minimal normal solution.
+        printf("-------- GraspMap*RightSV ------------ \n");
+        #endif
 
-  Grasp map:   \f$G\f$. \n
-  minNormSln:  \f$x_0\f$.\n
-  nullSpace:   \f$V\f$. \n
-*/
-void
-LMIOptimizer::minimalNorm()
-{
-  double *tempGraspMap, *work, *incForce;
-  int lwork, info;
-  int numGElements, ldx0, i;
-  int row = 6, col = numWrenches, nrhs = 1;
+        checkRSV = (double *)malloc(col * col * sizeof(double));
+        dcopy(numGElements, graspMap, 1, tempGraspMap, 1);
+        dgemm("N", "T", row, col, col, 1.0, tempGraspMap, row, rightSV, col, 0.0,
+              checkRSV, col);
+        #ifdef GRASPDEBUG
+        disp_mat(stdout, checkRSV, col, col, 0);
+        #endif
+        free(checkRSV);
 
-  if (minNormSln) free(minNormSln);
+        nullSpace = (double *)malloc(col * nullDim * sizeof(double));
+        for (i = row; i < col; i++)
+            dcopy(col, rightSV + i, col, nullSpace + (i - row)*col, 1);
 
-  incForce=(double*)malloc(row*sizeof(double));
-  dcopy(row,mGrasp->object->getExtWrenchAcc(),1,incForce,1);
+        #ifdef GRASPDEBUG
+        printf("---------- Null Space -----------------\n");
+        disp_mat(stdout, nullSpace, col, nullDim, 0);
 
-  // Grasp should generate the _negative_ object wrench
-  dscal(row,-1.0,incForce,1);
+        printf("---------- check null space --------- \n");
+        #endif
+        numCheck = row * nullDim;
+        checkNull = (double *)malloc(numCheck * sizeof(double));
+        dcopy(numCheck, &db0, 0, checkNull, 1);
+        dcopy(numGElements, graspMap, 1, tempGraspMap, 1);
+        dgemm("N", "N", row, nullDim, col, 1.0, tempGraspMap, row,
+              nullSpace, col, 0.0, checkNull, row);
+        #ifdef GRASPDEBUG
+        disp_mat(stdout, checkNull, row, nullDim, 0);
+        #endif
+        free(checkNull);
 
-#ifdef GRASPDEBUG  
-  printf("---------- Object Wrench --------------------- \n");
-  disp_mat(stdout, mGrasp->object->getExtWrenchAcc(), row, 1,0);
-#endif
-
-  minNormSln = (double*) malloc(MAX(row,col)*nrhs*sizeof(double));
-  //lwork for dgels_ 
-  lwork=MAX(1,MIN(row,col)+MAX(row, MAX(col,nrhs)));
-  work= (double*)malloc(lwork*sizeof(double));
-  
-  numGElements = row*col;
-  tempGraspMap=(double*) malloc(numGElements*sizeof(double));
-  dcopy(numGElements,graspMap,1, tempGraspMap,1);
-  
-  ldx0=MAX(row,col);
-  for (i=0; i<nrhs;i++)
-    dcopy(row,incForce+i*row, 1, minNormSln+i*ldx0, 1);
-  
-  dgels("N", row, col, nrhs, tempGraspMap, row, minNormSln, ldx0, work,
-	 lwork, &info);
-  
-  if(info==0){
-#ifdef GRASPDEBUG
-    printf("preset work length: %d, optimal length: %f \n", lwork, work[0]);
-    printf("---------- Minimal Norm/Error Solution ---------- \n");
-    disp_mat(stdout, minNormSln, nrhs, ldx0,0);
-#endif
-    free(work); free(tempGraspMap); free(incForce);
-  }
-  else {
-    free(work); free(tempGraspMap); free(minNormSln); free(incForce);
-    minNormSln = NULL;
-    errMsg(" no exact solution exists");
-  }    
+        free(tempGraspMap);
+        free(work);
+        free(leftSV);
+        free(singularValues);
+        free(rightSV);
+    }
+    else {
+        free(tempGraspMap);
+        free(work);
+        free(leftSV);
+        free(singularValues);
+        free(rightSV);
+        errMsg("error in SVD of grasp map");
+    }
 }
 
 /*!
-  This sets up the contact limits lmi.  It requires the Grasp map null space,
-  the minimum norm solution and the lower and upper bounds of each null space
-  dimension.
-    
-  Adapted from Li Han's Code.
+    Find the minimal norm solution to the object wrench equilibirum equation.
+    Adapted from Li Han's Code - I changed the sign of the object wrench.
+
+    The solution to the linear equation \f$ G x + F_{ext} = 0 \f$
+    is \f$ x = x_0 + V z \f$
+    where \f$ x_0 = G^+ * F_{ext} \f$ is the minimal normal solution.
+
+    Grasp map:   \f$G\f$. \n
+    minNormSln:  \f$x_0\f$.\n
+    nullSpace:   \f$V\f$. \n
+*/
+void
+LMIOptimizer::minimalNorm() {
+    double *tempGraspMap, *work, *incForce;
+    int lwork, info;
+    int numGElements, ldx0, i;
+    int row = 6, col = numWrenches, nrhs = 1;
+
+    if (minNormSln) free(minNormSln);
+
+    incForce = (double *)malloc(row * sizeof(double));
+    dcopy(row, mGrasp->object->getExtWrenchAcc(), 1, incForce, 1);
+
+    // Grasp should generate the _negative_ object wrench
+    dscal(row, -1.0, incForce, 1);
+
+    #ifdef GRASPDEBUG
+    printf("---------- Object Wrench --------------------- \n");
+    disp_mat(stdout, mGrasp->object->getExtWrenchAcc(), row, 1, 0);
+    #endif
+
+    minNormSln = (double *) malloc(MAX(row, col) * nrhs * sizeof(double));
+    //lwork for dgels_
+    lwork = MAX(1, MIN(row, col) + MAX(row, MAX(col, nrhs)));
+    work = (double *)malloc(lwork * sizeof(double));
+
+    numGElements = row * col;
+    tempGraspMap = (double *) malloc(numGElements * sizeof(double));
+    dcopy(numGElements, graspMap, 1, tempGraspMap, 1);
+
+    ldx0 = MAX(row, col);
+    for (i = 0; i < nrhs; i++)
+        dcopy(row, incForce + i * row, 1, minNormSln + i * ldx0, 1);
+
+    dgels("N", row, col, nrhs, tempGraspMap, row, minNormSln, ldx0, work,
+          lwork, &info);
+
+    if (info == 0) {
+        #ifdef GRASPDEBUG
+        printf("preset work length: %d, optimal length: %f \n", lwork, work[0]);
+        printf("---------- Minimal Norm/Error Solution ---------- \n");
+        disp_mat(stdout, minNormSln, nrhs, ldx0, 0);
+        #endif
+        free(work);
+        free(tempGraspMap);
+        free(incForce);
+    }
+    else {
+        free(work);
+        free(tempGraspMap);
+        free(minNormSln);
+        free(incForce);
+        minNormSln = NULL;
+        errMsg(" no exact solution exists");
+    }
+}
+
+/*!
+    This sets up the contact limits lmi.  It requires the Grasp map null space,
+    the minimum norm solution and the lower and upper bounds of each null space
+    dimension.
+
+    Adapted from Li Han's Code.
 */
 double *
-lmiContactLimits(int numForces, int nullDim,  double* nullSpace,
-			 double * minNormSln, double* lowerBounds,
-			 double* upperBounds)
-{
-  double *LmiLinear, *tempLower, *tempUpper;
-  int row, col, nullSpaceSize;
-  int i;
-  
-  tempLower=(double*)malloc(numForces*sizeof(double));
-  dcopy(numForces, lowerBounds, 1, tempLower, 1);
-  daxpy(numForces, -1.0, minNormSln, 1, tempLower, 1);  //lower-minNormSln
-  dscal(numForces,-1.0,tempLower, 1);			 //-(lower-minNormSln)
-  
-  tempUpper=(double*)malloc(numForces*sizeof(double));	
-  dcopy(numForces, upperBounds, 1, tempUpper, 1);
-  daxpy(numForces, -1.0, minNormSln, 1, tempUpper, 1);  // upper - minNormSln
-  
-  row=2*numForces;   col=nullDim+1; 
-  LmiLinear=(double*)malloc(row*col*sizeof(double));
-  dcopy(numForces, tempLower, 1, LmiLinear, 1);
-  dcopy(numForces, tempUpper, 1, LmiLinear+numForces, 1);
-  
-  for(i=0;i<nullDim; i++)
-    dcopy(numForces, nullSpace+i*numForces, 1, LmiLinear+(i+1)*row,1);
-  nullSpaceSize=numForces*nullDim;
-  dscal(nullSpaceSize,-1.0, nullSpace, 1);
-  for(i=0;i<nullDim; i++)
-    dcopy(numForces, nullSpace+i*numForces, 1, LmiLinear+(i+1)*row+numForces,1);
-  
-  dscal(nullSpaceSize,-1.0, nullSpace, 1);
-  free(tempLower); free(tempUpper);
-  return(LmiLinear);
+lmiContactLimits(int numForces, int nullDim,  double *nullSpace,
+                 double *minNormSln, double *lowerBounds,
+                 double *upperBounds) {
+    double *LmiLinear, *tempLower, *tempUpper;
+    int row, col, nullSpaceSize;
+    int i;
+
+    tempLower = (double *)malloc(numForces * sizeof(double));
+    dcopy(numForces, lowerBounds, 1, tempLower, 1);
+    daxpy(numForces, -1.0, minNormSln, 1, tempLower, 1);  //lower-minNormSln
+    dscal(numForces, -1.0, tempLower, 1);          //-(lower-minNormSln)
+
+    tempUpper = (double *)malloc(numForces * sizeof(double));
+    dcopy(numForces, upperBounds, 1, tempUpper, 1);
+    daxpy(numForces, -1.0, minNormSln, 1, tempUpper, 1);  // upper - minNormSln
+
+    row = 2 * numForces;
+    col = nullDim + 1;
+    LmiLinear = (double *)malloc(row * col * sizeof(double));
+    dcopy(numForces, tempLower, 1, LmiLinear, 1);
+    dcopy(numForces, tempUpper, 1, LmiLinear + numForces, 1);
+
+    for (i = 0; i < nullDim; i++)
+        dcopy(numForces, nullSpace + i * numForces, 1, LmiLinear + (i + 1)*row, 1);
+    nullSpaceSize = numForces * nullDim;
+    dscal(nullSpaceSize, -1.0, nullSpace, 1);
+    for (i = 0; i < nullDim; i++)
+        dcopy(numForces, nullSpace + i * numForces, 1, LmiLinear + (i + 1)*row + numForces, 1);
+
+    dscal(nullSpaceSize, -1.0, nullSpace, 1);
+    free(tempLower);
+    free(tempUpper);
+    return (LmiLinear);
 }
 
-/*! 
-  Adapted from Li Han's Code.  
+/*!
+    Adapted from Li Han's Code.
 */
 double *
-LMIOptimizer::lmiTorqueLimits()
-{
-  double  db0=0.0,*tildeJ, *tildeExternalTrq;
-  int i,tildeJDim=numDOF*nullDim;
-  double *lmi,*lowerBounds,*upperBounds;
+LMIOptimizer::lmiTorqueLimits() {
+    double  db0 = 0.0, *tildeJ, *tildeExternalTrq;
+    int i, tildeJDim = numDOF * nullDim;
+    double *lmi, *lowerBounds, *upperBounds;
 
-  /*  L=2*numWrenches;
-  F_blkszs= (int *) malloc(L*sizeof(int));
-  for (int i=0;i<L;i++) F_blkszs[i]=1;
-  */
+    /*  L=2*numWrenches;
+        F_blkszs= (int *) malloc(L*sizeof(int));
+        for (int i=0;i<L;i++) F_blkszs[i]=1;
+    */
 
-  L=2*numDOF;
-  F_blkszs= (int *) malloc(L*sizeof(int));
-  for (i=0;i<L;i++) F_blkszs[i]=1;
+    L = 2 * numDOF;
+    F_blkszs = (int *) malloc(L * sizeof(int));
+    for (i = 0; i < L; i++) F_blkszs[i] = 1;
 
-  lowerBounds = (double*) malloc(numDOF*sizeof(double));
-  upperBounds = (double*) malloc(numDOF*sizeof(double));
-  for (i=0;i<mGrasp->hand->getNumDOF();i++) {
-    upperBounds[i] = mGrasp->hand->getDOF(i)->getMaxForce()*1.0e-9;
-    lowerBounds[i] = - mGrasp->hand->getDOF(i)->getMaxForce()*1.0e-9;
-  }
+    lowerBounds = (double *) malloc(numDOF * sizeof(double));
+    upperBounds = (double *) malloc(numDOF * sizeof(double));
+    for (i = 0; i < mGrasp->hand->getNumDOF(); i++) {
+        upperBounds[i] = mGrasp->hand->getDOF(i)->getMaxForce() * 1.0e-9;
+        lowerBounds[i] = - mGrasp->hand->getDOF(i)->getMaxForce() * 1.0e-9;
+    }
 
-  tildeJ=(double*) malloc(tildeJDim*sizeof(double));
-  dcopy(tildeJDim, &db0, 0, tildeJ,1);
+    tildeJ = (double *) malloc(tildeJDim * sizeof(double));
+    dcopy(tildeJDim, &db0, 0, tildeJ, 1);
 
-  dgemm("T","N", numDOF, nullDim, numWrenches, 1.0, Jacobian, numWrenches,
-	 nullSpace, numWrenches, 0.0, tildeJ, numDOF);
+    dgemm("T", "N", numDOF, nullDim, numWrenches, 1.0, Jacobian, numWrenches,
+          nullSpace, numWrenches, 0.0, tildeJ, numDOF);
 
-  tildeExternalTrq=(double*) malloc(numDOF*sizeof(double));
-  dcopy(numDOF, externalTorques, 1, tildeExternalTrq, 1);
-  
-  dgemv("T", numWrenches, numDOF, 1.0, Jacobian, numWrenches, minNormSln, 1,
-	 1.0, tildeExternalTrq, 1);
+    tildeExternalTrq = (double *) malloc(numDOF * sizeof(double));
+    dcopy(numDOF, externalTorques, 1, tildeExternalTrq, 1);
 
-#ifdef GRASPDEBUG  
-  printf("tildeExternalTrq:\n");
-  disp_mat(stdout,tildeExternalTrq,1,numDOF,0);
-#endif
+    dgemv("T", numWrenches, numDOF, 1.0, Jacobian, numWrenches, minNormSln, 1,
+          1.0, tildeExternalTrq, 1);
 
-  lmi = lmiContactLimits(numDOF, nullDim, tildeJ, tildeExternalTrq,
-		       lowerBounds, upperBounds);
+    #ifdef GRASPDEBUG
+    printf("tildeExternalTrq:\n");
+    disp_mat(stdout, tildeExternalTrq, 1, numDOF, 0);
+    #endif
 
-  free(tildeJ); free(tildeExternalTrq);  free(lowerBounds); free(upperBounds);
-  return(lmi);
+    lmi = lmiContactLimits(numDOF, nullDim, tildeJ, tildeExternalTrq,
+                           lowerBounds, upperBounds);
+
+    free(tildeJ);
+    free(tildeExternalTrq);
+    free(lowerBounds);
+    free(upperBounds);
+    return (lmi);
 }
 
 void
-LMIOptimizer::lmiFL(double *lmi,int rowInit, int colInit, int totalRow)
-{
-  int x3_post=colInit*totalRow+rowInit;
-  lmi[x3_post]=1.0;
+LMIOptimizer::lmiFL(double *lmi, int rowInit, int colInit, int totalRow) {
+    int x3_post = colInit * totalRow + rowInit;
+    lmi[x3_post] = 1.0;
 }
 
 void
-LMIOptimizer::lmiPCWF(double cof, double *lmi,int rowInit, int colInit,
-		    int totalRow)
-{
-  int x1_post, x2_post, x3_post;
+LMIOptimizer::lmiPCWF(double cof, double *lmi, int rowInit, int colInit,
+                      int totalRow) {
+    int x1_post, x2_post, x3_post;
 
-  x1_post=colInit*totalRow+rowInit+2;
-  lmi[x1_post]=1.0;
-  
-  x2_post=(colInit+1)*totalRow+rowInit+4;
-  lmi[x2_post]=1.0;
-  
-  x3_post=(colInit+2)*totalRow+rowInit;
-  lmi[x3_post]=cof;
-  lmi[x3_post+3]=cof;
-  lmi[x3_post+5]=cof;
+    x1_post = colInit * totalRow + rowInit + 2;
+    lmi[x1_post] = 1.0;
+
+    x2_post = (colInit + 1) * totalRow + rowInit + 4;
+    lmi[x2_post] = 1.0;
+
+    x3_post = (colInit + 2) * totalRow + rowInit;
+    lmi[x3_post] = cof;
+    lmi[x3_post + 3] = cof;
+    lmi[x3_post + 5] = cof;
 }
 
 void
-LMIOptimizer::lmiSFCE(double cof, double cof_t,double *lmi,int rowInit,
-		    int colInit, int totalRow)
-{
-  int x1_post, x2_post, x3_post, x4_post;
-  double alpha, beta;
-  
-  alpha=1.0/sqrt(cof);
-  beta =1.0/sqrt(cof_t);
-  
-  x1_post=colInit*totalRow+rowInit+3;
-  lmi[x1_post]=alpha;
-  
-  x2_post=(colInit+1)*totalRow+rowInit+6;
-  lmi[x2_post]=alpha;
-  
-  x3_post=(colInit+2)*totalRow+rowInit;
-  lmi[x3_post]=1.0;
-  lmi[x3_post+4]=1.0;
-  lmi[x3_post+7]=1.0;
-  lmi[x3_post+9]=1.0;
+LMIOptimizer::lmiSFCE(double cof, double cof_t, double *lmi, int rowInit,
+                      int colInit, int totalRow) {
+    int x1_post, x2_post, x3_post, x4_post;
+    double alpha, beta;
 
-  x4_post=(colInit+3)*totalRow+rowInit+8;
-  lmi[x4_post]=beta;
+    alpha = 1.0 / sqrt(cof);
+    beta = 1.0 / sqrt(cof_t);
+
+    x1_post = colInit * totalRow + rowInit + 3;
+    lmi[x1_post] = alpha;
+
+    x2_post = (colInit + 1) * totalRow + rowInit + 6;
+    lmi[x2_post] = alpha;
+
+    x3_post = (colInit + 2) * totalRow + rowInit;
+    lmi[x3_post] = 1.0;
+    lmi[x3_post + 4] = 1.0;
+    lmi[x3_post + 7] = 1.0;
+    lmi[x3_post + 9] = 1.0;
+
+    x4_post = (colInit + 3) * totalRow + rowInit + 8;
+    lmi[x4_post] = beta;
 }
 
 void
-LMIOptimizer::lmiSFCL(double cof, double cof_t,double *lmi,int rowInit,
-		    int colInit, int totalRow)
-{
-  int colFirst;
-  double ratio = cof/cof_t;
+LMIOptimizer::lmiSFCL(double cof, double cof_t, double *lmi, int rowInit,
+                      int colInit, int totalRow) {
+    int colFirst;
+    double ratio = cof / cof_t;
 
-  // The 1 dimensional index for the first item of this LMI block
-  // in the x_i column
+    // The 1 dimensional index for the first item of this LMI block
+    // in the x_i column
 
-  //x_1
-  colFirst=colInit* totalRow+rowInit;
-  lmi[colFirst+9]=1.0;
-  lmi[colFirst+24]=1.0;
-  
-  //x_2
-  colFirst=(colInit+1)*totalRow+rowInit;
-  lmi[colFirst+14]=1.0;
-  lmi[colFirst+26]=1.0;
-    
-  //x_3
-  colFirst=(colInit+2)*totalRow+rowInit;
-  lmi[colFirst]   =1.0;
-  lmi[colFirst+7] =cof;
-  lmi[colFirst+13]=cof;
-  lmi[colFirst+18]=cof;
-  lmi[colFirst+22]=cof;
-  lmi[colFirst+25]=cof;
-  lmi[colFirst+27]=cof;
-  
-  //x_4
-  colFirst=(colInit+3)*totalRow+rowInit;
-  lmi[colFirst+7] =ratio;
-  lmi[colFirst+13]=ratio;
-  lmi[colFirst+18]=ratio;
-  lmi[colFirst+22]=-ratio;
-  lmi[colFirst+25]=-ratio;
-  lmi[colFirst+27]=-ratio;
+    //x_1
+    colFirst = colInit * totalRow + rowInit;
+    lmi[colFirst + 9] = 1.0;
+    lmi[colFirst + 24] = 1.0;
+
+    //x_2
+    colFirst = (colInit + 1) * totalRow + rowInit;
+    lmi[colFirst + 14] = 1.0;
+    lmi[colFirst + 26] = 1.0;
+
+    //x_3
+    colFirst = (colInit + 2) * totalRow + rowInit;
+    lmi[colFirst]   = 1.0;
+    lmi[colFirst + 7] = cof;
+    lmi[colFirst + 13] = cof;
+    lmi[colFirst + 18] = cof;
+    lmi[colFirst + 22] = cof;
+    lmi[colFirst + 25] = cof;
+    lmi[colFirst + 27] = cof;
+
+    //x_4
+    colFirst = (colInit + 3) * totalRow + rowInit;
+    lmi[colFirst + 7] = ratio;
+    lmi[colFirst + 13] = ratio;
+    lmi[colFirst + 18] = ratio;
+    lmi[colFirst + 22] = -ratio;
+    lmi[colFirst + 25] = -ratio;
+    lmi[colFirst + 27] = -ratio;
 }
 
 // note that LMI is stored in a packed form where the whole lower triangle of
 // each P_i is stored as a single column (remember: column-major format)
 //
 double *
-LMIOptimizer::lmiFrictionCones()
-{
-  double db0=0.0,*initLMI, *finalLMI;
-  int lmiDim;
-  int row=0, col=0, *blockRowIndex, *blockColIndex;
-  int i, initSize, finalSize;
+LMIOptimizer::lmiFrictionCones() {
+    double db0 = 0.0, *initLMI, *finalLMI;
+    int lmiDim;
+    int row = 0, col = 0, *blockRowIndex, *blockColIndex;
+    int i, initSize, finalSize;
 
-  blockRowIndex = new int[mGrasp->numContacts];
-  blockColIndex = new int[mGrasp->numContacts];
+    blockRowIndex = new int[mGrasp->numContacts];
+    blockColIndex = new int[mGrasp->numContacts];
 
-  K=mGrasp->numContacts;
-  G_blkszs=(int *)malloc(K*sizeof(int));
+    K = mGrasp->numContacts;
+    G_blkszs = (int *)malloc(K * sizeof(int));
 
-  for (i=0;i<mGrasp->numContacts;i++) {
-    blockRowIndex[i]=row;
-    blockColIndex[i]=col;
-    lmiDim = mGrasp->contactVec[i]->getLmiDim();
-    row += lmiDim*(lmiDim+1)/2;  // size of the lower triangle
-    col += mGrasp->contactVec[i]->getContactDim();
-    G_blkszs[i]=lmiDim;
-  }
-
-  initSize=row*col;
-  initLMI=(double*)malloc(initSize*sizeof(double));
-  dcopy(initSize,&db0, 0, initLMI, 1);
-
-  for (i=0;i<mGrasp->numContacts;i++) {
-    switch(mGrasp->contactVec[i]->getFrictionType()) {
-      case FL:   lmiFL(initLMI,blockRowIndex[i],blockColIndex[i], row);
-	         break;
-      case PCWF: lmiPCWF(mGrasp->contactVec[i]->getCof(),initLMI,blockRowIndex[i],
-			 blockColIndex[i], row);
-                 break;
-      case SFCE: assert(0); //not handled
-			 //lmiSFCE(mGrasp->contactVec[i]->getCof(),
-			 //mGrasp->contactVec[i]->getTorsionalCof(),initLMI,
-			 //blockRowIndex[i], blockColIndex[i], row);
-                 break;
-      case SFCL: assert(0); //not handled
-		     //lmiSFCL(mGrasp->contactVec[i]->getCof(),
-			 //mGrasp->contactVec[i]->getTorsionalCof(),initLMI,
-			 //blockRowIndex[i], blockColIndex[i], row);
+    for (i = 0; i < mGrasp->numContacts; i++) {
+        blockRowIndex[i] = row;
+        blockColIndex[i] = col;
+        lmiDim = mGrasp->contactVec[i]->getLmiDim();
+        row += lmiDim * (lmiDim + 1) / 2; // size of the lower triangle
+        col += mGrasp->contactVec[i]->getContactDim();
+        G_blkszs[i] = lmiDim;
     }
-  }
-#ifdef GRASPDEBUG  
-  printf("------------- Init LMI(%-dx%-d) ----------------------\n",row, col);
-  disp_mat(stdout, initLMI, row, col,0);
-#endif
 
-  finalSize=row*(nullDim+1);
-  
-  finalLMI = (double*) malloc(finalSize*sizeof(double));
-  dcopy(finalSize,&db0, 0, finalLMI, 1);
-  dgemm("N","N",row, nullDim, col, 1.0, initLMI, row, nullSpace, col, 
-	 0.0,finalLMI+row, row);
-  dgemv("N",row,col, 1.0, initLMI, row, minNormSln, 1, 0.0, finalLMI, 1);
-  free(initLMI);
-  delete [] blockRowIndex;
-  delete [] blockColIndex;
-  GPkRow = row;
-  return(finalLMI);
+    initSize = row * col;
+    initLMI = (double *)malloc(initSize * sizeof(double));
+    dcopy(initSize, &db0, 0, initLMI, 1);
+
+    for (i = 0; i < mGrasp->numContacts; i++) {
+        switch (mGrasp->contactVec[i]->getFrictionType()) {
+            case FL:
+                lmiFL(initLMI, blockRowIndex[i], blockColIndex[i], row);
+                break;
+            case PCWF:
+                lmiPCWF(mGrasp->contactVec[i]->getCof(), initLMI, blockRowIndex[i],
+                        blockColIndex[i], row);
+                break;
+            case SFCE:
+                assert(0); //not handled
+                //lmiSFCE(mGrasp->contactVec[i]->getCof(),
+                //mGrasp->contactVec[i]->getTorsionalCof(),initLMI,
+                //blockRowIndex[i], blockColIndex[i], row);
+                break;
+            case SFCL:
+                assert(0); //not handled
+                //lmiSFCL(mGrasp->contactVec[i]->getCof(),
+                //mGrasp->contactVec[i]->getTorsionalCof(),initLMI,
+                //blockRowIndex[i], blockColIndex[i], row);
+        }
+    }
+    #ifdef GRASPDEBUG
+    printf("------------- Init LMI(%-dx%-d) ----------------------\n", row, col);
+    disp_mat(stdout, initLMI, row, col, 0);
+    #endif
+
+    finalSize = row * (nullDim + 1);
+
+    finalLMI = (double *) malloc(finalSize * sizeof(double));
+    dcopy(finalSize, &db0, 0, finalLMI, 1);
+    dgemm("N", "N", row, nullDim, col, 1.0, initLMI, row, nullSpace, col,
+          0.0, finalLMI + row, row);
+    dgemv("N", row, col, 1.0, initLMI, row, minNormSln, 1, 0.0, finalLMI, 1);
+    free(initLMI);
+    delete [] blockRowIndex;
+    delete [] blockColIndex;
+    GPkRow = row;
+    return (finalLMI);
 }
 
 double *
-LMIOptimizer::weightVec()
-{
-  double  db0=0.0,*initWeights, *finalWeights;
-  int i,dim,blockIndex=0;
-  
-  initWeights=(double*)malloc(numWrenches*sizeof(double));
-  for (i=0;i<mGrasp->numContacts;i++) {
-    dim = mGrasp->contactVec[i]->getContactDim();
-    dcopy(dim,&db0,1,initWeights+blockIndex,1);
+LMIOptimizer::weightVec() {
+    double  db0 = 0.0, *initWeights, *finalWeights;
+    int i, dim, blockIndex = 0;
 
-    // temporary preset weights
-    if (dim==1)
-      *(initWeights+blockIndex) = LMIOptimizer::GFO_WEIGHT_FACTOR;
-    else
-      *(initWeights+blockIndex+2) = LMIOptimizer::GFO_WEIGHT_FACTOR;
-    
-    blockIndex += dim;
-  }
+    initWeights = (double *)malloc(numWrenches * sizeof(double));
+    for (i = 0; i < mGrasp->numContacts; i++) {
+        dim = mGrasp->contactVec[i]->getContactDim();
+        dcopy(dim, &db0, 1, initWeights + blockIndex, 1);
 
-#ifdef GRASPDEBUG
-  printf("------------ Init Weight Vector(%d) -------------\n",numWrenches);
-  disp_mat(stdout, initWeights,1,numWrenches,0);
-  
-      printf("---------- Null Space -----------------\n");
-      disp_mat(stdout, nullSpace, numWrenches, nullDim,0);
-#endif
-      
-  finalWeights=(double*)malloc(nullDim*sizeof(double));
-  dcopy(nullDim,&db0,0,finalWeights,1);
-  dgemv("T",numWrenches,nullDim,1.0,nullSpace,numWrenches,initWeights,1,
-	0.0,finalWeights, 1);
-  
-  constOffset = ddot(numWrenches,initWeights,1,minNormSln,1);
+        // temporary preset weights
+        if (dim == 1)
+            *(initWeights + blockIndex) = LMIOptimizer::GFO_WEIGHT_FACTOR;
+        else
+            *(initWeights + blockIndex + 2) = LMIOptimizer::GFO_WEIGHT_FACTOR;
 
-#ifdef GRASPDEBUG
-  printf("------------ Final Weight Vector(%d) for new variables z & %lf -------------\n",nullDim, constOffset);
-  disp_mat(stdout, finalWeights,1,nullDim,0);
-#endif
+        blockIndex += dim;
+    }
 
-  free(initWeights);
-  return(finalWeights);
+    #ifdef GRASPDEBUG
+    printf("------------ Init Weight Vector(%d) -------------\n", numWrenches);
+    disp_mat(stdout, initWeights, 1, numWrenches, 0);
+
+    printf("---------- Null Space -----------------\n");
+    disp_mat(stdout, nullSpace, numWrenches, nullDim, 0);
+    #endif
+
+    finalWeights = (double *)malloc(nullDim * sizeof(double));
+    dcopy(nullDim, &db0, 0, finalWeights, 1);
+    dgemv("T", numWrenches, nullDim, 1.0, nullSpace, numWrenches, initWeights, 1,
+          0.0, finalWeights, 1);
+
+    constOffset = ddot(numWrenches, initWeights, 1, minNormSln, 1);
+
+    #ifdef GRASPDEBUG
+    printf("------------ Final Weight Vector(%d) for new variables z & %lf -------------\n", nullDim, constOffset);
+    disp_mat(stdout, finalWeights, 1, nullDim, 0);
+    #endif
+
+    free(initWeights);
+    return (finalWeights);
 }
 
 /*!
-  Combines LMIs \a lmi1 >0 and \a lmi2 >0 into the LMI \n
-  [lmi1    0]\n
-  [0    lmi2] > 0
+    Combines LMIs \a lmi1 >0 and \a lmi2 >0 into the LMI \n
+    [lmi1    0]\n
+    [0    lmi2] > 0
 */
 double *
-combineLMIs(int numVariables, double* lmi1, int lmi1RowSz, double * lmi2,
-	    int lmi2RowSz) {
+combineLMIs(int numVariables, double *lmi1, int lmi1RowSz, double *lmi2,
+            int lmi2RowSz) {
 
-  double * combinedLMI;
-  int numElements, totalRowSz;
-  int i;
-  
-  totalRowSz=lmi1RowSz+lmi2RowSz;
-  numElements=(numVariables+1)*totalRowSz;
-  combinedLMI=(double*)malloc(numElements*sizeof(double));
-  for(i=0;i<=numVariables;i++){
-    dcopy(lmi1RowSz,lmi1+i*lmi1RowSz,1,combinedLMI+i*totalRowSz,1);
-    dcopy(lmi2RowSz,lmi2+i*lmi2RowSz,1,combinedLMI+i*totalRowSz+lmi1RowSz,1);
-  }
-  return(combinedLMI);
+    double *combinedLMI;
+    int numElements, totalRowSz;
+    int i;
+
+    totalRowSz = lmi1RowSz + lmi2RowSz;
+    numElements = (numVariables + 1) * totalRowSz;
+    combinedLMI = (double *)malloc(numElements * sizeof(double));
+    for (i = 0; i <= numVariables; i++) {
+        dcopy(lmi1RowSz, lmi1 + i * lmi1RowSz, 1, combinedLMI + i * totalRowSz, 1);
+        dcopy(lmi2RowSz, lmi2 + i * lmi2RowSz, 1, combinedLMI + i * totalRowSz + lmi1RowSz, 1);
+    }
+    return (combinedLMI);
 }
 
 /*!
-  Prepare the parameters used by maxdet package and
-  use it to solve the maxdet optimization problem.
+    Prepare the parameters used by maxdet package and
+    use it to solve the maxdet optimization problem.
 */
-double * maxdet_wrap(int m, int L, double *F, int *F_blkszs,
-                   int K, double *G, int *G_blkszs,
-                   double *c, double *z0, double *Z, double *W,
-                   double gamma, double abstol, double reltol,
-                   int * pNTiters, int negativeFlag, FILE* pRstFile)
+double *maxdet_wrap(int m, int L, double *F, int *F_blkszs,
+                    int K, double *G, int *G_blkszs,
+                    double *c, double *z0, double *Z, double *W,
+                    double gamma, double abstol, double reltol,
+                    int *pNTiters, int negativeFlag, FILE *pRstFile)
 
 
 {
-  Q_UNUSED(pRstFile);
-  register int i;
-  int    n, l, max_n, max_l, F_sz, G_sz;  
-  int    ptr_size;
-  
-  int *iwork, lwork;
-  double db0=0.0,ul[2], *hist, *truncatedHist, *work;
-  int m3, m2, sourceCol, destCol, destSize;
-  int info, info2;
-  
-  
-  //  struct tms before,after;
-  
-  for (i=0; i<L; i++) {
-    if (F_blkszs[i] <= 0) {
-      pr_error("Elements of F_blkszs must be positive.\n");
-      errorOccurred = true;
-      return NULL;
-    }
-  }
-  for (i=0; i<K; i++) {
-    if (G_blkszs[i] <= 0) {
-      pr_error("Elements of G_blkszs must be positive.\n");
-      errorOccurred = true;
-      return NULL;
-    }
-  }
-  
-  /* various dimensions
-   * n, l: dimensions
-   * F_sz, G_sz: length in packed storage
-   * F_upsz, G_upsz: length in unpacked storage
-   * max_n, max_l: max block size */
-  for (i=0, n=0, F_sz=0, max_n=0; i<L; i++) {
-    n += F_blkszs[i];
-    F_sz += (F_blkszs[i]*(F_blkszs[i]+1))/2;
-    max_n = MAX(max_n, F_blkszs[i]);
-  }
-  for (i=0, l=0, G_sz=0, max_l=0; i<K; i++) {
-    l += G_blkszs[i];
-    G_sz += (G_blkszs[i]*(G_blkszs[i]+1))/2;
-    max_l = MAX(max_l, G_blkszs[i]);
-  }
-  
-  /* hist (5th output argument) */
-  ptr_size =(3+m)*(*pNTiters);
-  //    ptr_size =(3+m)*(NTiters);
-  hist=(double *) malloc(ptr_size*sizeof(double));
-  dcopy(ptr_size,&db0, 0, hist, 1);
-  
-  /* allocate work space */
-  lwork = (2*m+5)*(F_sz+G_sz) + 2*(n+l) +
-    MAX(m+(F_sz+G_sz)*NB,MAX(3*(m+SQR(m)+MAX(G_sz,F_sz)),
-			     MAX(3*(MAX(max_l,max_n)+MAX(G_sz,F_sz)),
-				 MAX(G_sz+3*max_l,F_sz+3*max_n))));
-  work = (double *) malloc(lwork*sizeof(double));
-  dcopy(lwork,&db0,0,work,1);
-  iwork = (int *) malloc(10*m*sizeof(int));
-  for(i=0;i<10*m;i++)	iwork[i]=0;
-  
-  //  times(&before);
-  info2=maxdet(m,L, (double*)F,(int *) F_blkszs,K,(double *) G,
-	       (int *) G_blkszs,(double *)c,(double *)z0,(double *)Z,
-	       (double *)W, (double *)ul, (double*)hist,gamma,abstol,reltol,
-	       pNTiters,work,lwork,iwork,&info,negativeFlag);
-  
-  if (info2) {
-      free(work); free(iwork); free(hist);
-      errorOccurred = true;
-      pr_error("Error in maxdet.\n");
-      return NULL;
-  }
-  
-  // times(&after);
-  
-  //#ifndef REAL_RUN
-  //  fprintf(pRstFile,"times:  User time: %f seconds\n",(float) (after.tms_utime-before.tms_utime)/sysconf(CLK_TCK));
-  //#endif
-  
-  // infostr 
-#ifdef GRASPDEBUG
-  switch (info) {
-  case 1:
-    fprintf(pRstFile, "  maximum Newton iteration exceeded\n");
-    break;
-  case 2:
-    fprintf(pRstFile, "  absolute tolerance reached\n");
-    break;
-  case 3:
-    fprintf(pRstFile, "  relative tolerance reached\n");
-    break;
-  case 4:
-    fprintf(pRstFile, "  negative objective value reached\n");
-    break;
-  default:
-    printf("error occurred in maxdet\n"); 
-    exit(-1);
-  }  
-#endif
+    Q_UNUSED(pRstFile);
+    register int i;
+    int    n, l, max_n, max_l, F_sz, G_sz;
+    int    ptr_size;
 
-  //  truncate hist
-  destCol=0;
-  m3=m+3; m2=m3 -1;
-  for(sourceCol=0;sourceCol<*pNTiters;sourceCol++) 
-    if(hist[sourceCol*m3+m2]!=0.0){
-      dcopy(m3,hist+sourceCol*m3,1,hist+destCol*m3,1);
-      destCol++;
+    int *iwork, lwork;
+    double db0 = 0.0, ul[2], *hist, *truncatedHist, *work;
+    int m3, m2, sourceCol, destCol, destSize;
+    int info, info2;
+
+
+    //  struct tms before,after;
+
+    for (i = 0; i < L; i++) {
+        if (F_blkszs[i] <= 0) {
+            pr_error("Elements of F_blkszs must be positive.\n");
+            errorOccurred = true;
+            return NULL;
+        }
     }
-  //        printf("init Col: %d  final Col: %d \n", sourceCol, destCol);
-  destSize=destCol*m3;
-  truncatedHist=(double *)malloc(destSize*sizeof(double));
-  dcopy(destSize, hist, 1, truncatedHist, 1);
-  *pNTiters=destCol;
-  
-  
-  /* free matrices allocated */
-  free(work); free(iwork); free(hist);
-  
-  return(truncatedHist);
+    for (i = 0; i < K; i++) {
+        if (G_blkszs[i] <= 0) {
+            pr_error("Elements of G_blkszs must be positive.\n");
+            errorOccurred = true;
+            return NULL;
+        }
+    }
+
+    /*  various dimensions
+        n, l: dimensions
+        F_sz, G_sz: length in packed storage
+        F_upsz, G_upsz: length in unpacked storage
+        max_n, max_l: max block size */
+    for (i = 0, n = 0, F_sz = 0, max_n = 0; i < L; i++) {
+        n += F_blkszs[i];
+        F_sz += (F_blkszs[i] * (F_blkszs[i] + 1)) / 2;
+        max_n = MAX(max_n, F_blkszs[i]);
+    }
+    for (i = 0, l = 0, G_sz = 0, max_l = 0; i < K; i++) {
+        l += G_blkszs[i];
+        G_sz += (G_blkszs[i] * (G_blkszs[i] + 1)) / 2;
+        max_l = MAX(max_l, G_blkszs[i]);
+    }
+
+    /* hist (5th output argument) */
+    ptr_size = (3 + m) * (*pNTiters);
+    //    ptr_size =(3+m)*(NTiters);
+    hist = (double *) malloc(ptr_size * sizeof(double));
+    dcopy(ptr_size, &db0, 0, hist, 1);
+
+    /* allocate work space */
+    lwork = (2 * m + 5) * (F_sz + G_sz) + 2 * (n + l) +
+            MAX(m + (F_sz + G_sz) * NB, MAX(3 * (m + SQR(m) + MAX(G_sz, F_sz)),
+                                            MAX(3 * (MAX(max_l, max_n) + MAX(G_sz, F_sz)),
+                                                MAX(G_sz + 3 * max_l, F_sz + 3 * max_n))));
+    work = (double *) malloc(lwork * sizeof(double));
+    dcopy(lwork, &db0, 0, work, 1);
+    iwork = (int *) malloc(10 * m * sizeof(int));
+    for (i = 0; i < 10 * m; i++)   iwork[i] = 0;
+
+    //  times(&before);
+    info2 = maxdet(m, L, (double *)F, (int *) F_blkszs, K, (double *) G,
+                   (int *) G_blkszs, (double *)c, (double *)z0, (double *)Z,
+                   (double *)W, (double *)ul, (double *)hist, gamma, abstol, reltol,
+                   pNTiters, work, lwork, iwork, &info, negativeFlag);
+
+    if (info2) {
+        free(work);
+        free(iwork);
+        free(hist);
+        errorOccurred = true;
+        pr_error("Error in maxdet.\n");
+        return NULL;
+    }
+
+    // times(&after);
+
+    //#ifndef REAL_RUN
+    //  fprintf(pRstFile,"times:  User time: %f seconds\n",(float) (after.tms_utime-before.tms_utime)/sysconf(CLK_TCK));
+    //#endif
+
+    // infostr
+    #ifdef GRASPDEBUG
+    switch (info) {
+        case 1:
+            fprintf(pRstFile, "  maximum Newton iteration exceeded\n");
+            break;
+        case 2:
+            fprintf(pRstFile, "  absolute tolerance reached\n");
+            break;
+        case 3:
+            fprintf(pRstFile, "  relative tolerance reached\n");
+            break;
+        case 4:
+            fprintf(pRstFile, "  negative objective value reached\n");
+            break;
+        default:
+            printf("error occurred in maxdet\n");
+            exit(-1);
+    }
+    #endif
+
+    //  truncate hist
+    destCol = 0;
+    m3 = m + 3;
+    m2 = m3 - 1;
+    for (sourceCol = 0; sourceCol < *pNTiters; sourceCol++)
+        if (hist[sourceCol * m3 + m2] != 0.0) {
+            dcopy(m3, hist + sourceCol * m3, 1, hist + destCol * m3, 1);
+            destCol++;
+        }
+    //        printf("init Col: %d  final Col: %d \n", sourceCol, destCol);
+    destSize = destCol * m3;
+    truncatedHist = (double *)malloc(destSize * sizeof(double));
+    dcopy(destSize, hist, 1, truncatedHist, 1);
+    *pNTiters = destCol;
+
+
+    /* free matrices allocated */
+    free(work);
+    free(iwork);
+    free(hist);
+
+    return (truncatedHist);
 }
 
 /*!
-  Solves the question of whether there is a feasible set of contact forces
-  that will result in equilibrium for the object.
-*/
-void
-LMIOptimizer::feasibilityAnalysis()
-{
-  double *eigF, minEigF;
-  double *eigG, minEigG;
-  double *work, *hist;
-  
-  double *identityF, *identityG;
-  double *expandF, *expandG;
-  double *newF, *newG;
-  int    *newF_blkszs,  newG_blkszs;
-  double db0=0.0,t0, *x0,*Z0, W0, *c;
-  int    newM, newL, newK, newPkSz,initSize;
-  
-  int F_pksz=0, G_pksz=0;
-  int F_dim=0, G_dim=0;
-  int blkSize, maxBlockSize=0;
-  int i,m,workSize;
-  //int  negativeFlag=TRUE;
-    
-  eigF = new double[numDOF*2]; // max dimension of torque limit LMI
-  eigG = new double[mGrasp->numContacts*7];    // max dimension of friction LMI
-  
-  m = nullDim;
-  newM=m+1;
-  newG=(double*)malloc((newM+1)*sizeof(double));
-  newG[0]=1.0;
-  dcopy(newM,&db0,0,newG+1,1);
-  newK=1;
-  newG_blkszs=1;
-  W0=0.0;
-    
-  c=(double*)malloc(newM*sizeof(double));
-  dcopy(m,&db0,0,c,1);
-  c[m]=1.0;
-  
-  for(i=0;i<L;i++){
-    blkSize=F_blkszs[i];
-    F_dim+=blkSize;
-    F_pksz+=(blkSize+1)*blkSize/2;
-    maxBlockSize=MAX(maxBlockSize,blkSize);
-  }
-  workSize=F_pksz+3*maxBlockSize;
-  work=(double*)malloc(workSize*sizeof(double));
-  minEigF=eig_val(eigF,F,L,F_blkszs,F_pksz,work);
-  free(work);
-  
-  maxBlockSize=0;
-  for(i=0;i<K;i++){
-    blkSize=G_blkszs[i];
-    G_dim+=blkSize;
-    G_pksz+=(blkSize+1)*blkSize/2;
-    maxBlockSize=MAX(maxBlockSize,blkSize);
-  }
-  workSize=G_pksz+3*maxBlockSize;
-  work=(double*)malloc(workSize*sizeof(double));
-  minEigG=eig_val(eigG,G,K,G_blkszs,G_pksz,work);
-  free(work);
-  
-#ifdef GRASPDEBUG
-  fprintf(stderr,"minEigF: %f  minEigG:%f \n",minEigF, minEigG);
-  fprintf(stderr," ------- EigF(%d) ------ \n",F_dim);
-  disp_mat(stderr,eigF,1,F_dim,0);
-  fprintf(stderr," ------- EigG(%d) ------ \n",G_dim);
-  disp_mat(stderr,eigG,1,G_dim,0);
-#endif
-  
-  t0=MAX(-1.1*MIN(minEigF,minEigG),1.0);
-  x0=(double*)malloc(newM*sizeof(double));
-  dcopy(m,&db0,0,x0,1);
-  x0[m]=t0;
-  
-  identityF=(double*)block_Identity(L,F_blkszs,F_pksz);
-  identityG=(double*)block_Identity(K,G_blkszs,G_pksz);
-
-#ifdef GRASPDEBUG
-  fprintf(stderr,"------------- Identity_F ---------------- \n");
-  disp_mat(stderr,identityF,1,F_pksz,0);
-  fprintf(stderr,"------------- Identity_G ---------------- \n");
-  disp_mat(stderr,identityG,1,G_pksz,0);
-#endif
-  
-  expandF=(double*)malloc((newM+1)*F_pksz*sizeof(double));
-  initSize=(m+1)*F_pksz;
-  dcopy(initSize,F,1,expandF,1);
-  dcopy(F_pksz,identityF,1,expandF+initSize,1);
-  free(identityF);
-  
-  expandG=(double*)malloc((newM+1)*G_pksz*sizeof(double));
-  initSize=(m+1)*G_pksz;
-  dcopy(initSize,G,1,expandG,1);
-  dcopy(G_pksz,identityG,1,expandG+initSize,1);
-  free(identityG);
-  
-  newF=(double*) combineLMIs(newM,expandF,F_pksz,expandG,G_pksz);
-  free(expandF); free(expandG);
-  
-  newL=L+K;
-  newF_blkszs=(int*)malloc(newL*sizeof(int));
-  for(i=0;i<L;i++)  newF_blkszs[i]=F_blkszs[i];
-  for(i=0;i<K;i++)  newF_blkszs[L+i]=G_blkszs[i];
-  
-  newPkSz=F_pksz+G_pksz;
-  Z0=(double*)malloc(newPkSz*sizeof(double));
-  dcopy(newPkSz,&db0,0,Z0,1);
-  
-#ifdef GRASPDEBUG
-  fprintf(stderr,"------------- Combined LMI (%d x %d) ---------------- \n", F_pksz+G_pksz, newM+1);
-  disp_mat(stderr,newF,F_pksz+G_pksz, newM+1,0);
-  fprintf(stderr,"------------- Combined LMI Block Sizes(%d) ---------------- \n", newL);
-  disp_imat(stderr,newF_blkszs,1, newL,0);
-#endif
-  
-  fprintf(stderr,"Checking grasping force feasibility...\n");
-  hist = maxdet_wrap(newM, newL, newF, newF_blkszs, newK, newG, &newG_blkszs,
-		     c, x0,Z0, &W0, gamma, abstol,  reltol, &feasNTiters,
-		     negativeFlag,pRstFile);
-
-  if (errorOccurred) {
-    free(newF); free(newF_blkszs); free(Z0);
-    free(newG); free(c); free(x0);
-    delete [] eigF; delete [] eigG;
-    return;
-  }
-
-  if (initz0) free(initz0);
-  initz0=(double *)malloc(nullDim*sizeof(double));
-  dcopy(m,x0,1,initz0,1);
-
-  if (feasZHistory) free(feasZHistory);
-  feasZHistory=(double*)malloc((m+3)*(feasNTiters)*sizeof(double));
-  for(i=0;i<feasNTiters;i++){
-    dcopy(newM,hist+i*(newM+3),1,feasZHistory+i*(m+3),1);
-    dcopy(2,hist+i*(newM+3)+newM+1, 1, feasZHistory+i*(m+3)+m+1,1);
-  }
-  if(x0[m]<0) {
-    feasible=TRUE;
-#ifdef GRASPDEBUG
-    printf("\n Feasible! min eig value: %f \n",-x0[m]);
-#endif
-  }
-  else feasible=FALSE;
-  
-  free(newF); free(newF_blkszs); free(Z0);
-  free(newG); free(c); free(x0); free(hist);
-  delete [] eigF; delete [] eigG;
-}
-
-/*!
-  Formulate and solve the optimization 4 problem (See the LMI paper)
+    Solves the question of whether there is a feasible set of contact forces
+    that will result in equilibrium for the object.
 */
 void
-LMIOptimizer::optm_EffortBarrier()
-{
-  int    newL, newK;
-  double *newF, *newG;
-  int    newF_blkszs,  *newG_blkszs;
-  double db0=0.0,Z, *W;
-  int F_pksz=0, G_pksz=0, newPkSz, i, blkSize;
-  int m;
-  
-  
-  m=nullDim;
-  if (optmz0) free(optmz0);
-  optmz0=(double*)malloc(m*sizeof(double));
-  dcopy(m, initz0, 1, optmz0, 1);
+LMIOptimizer::feasibilityAnalysis() {
+    double *eigF, minEigF;
+    double *eigG, minEigG;
+    double *work, *hist;
 
-  newL=1;
-  newF_blkszs=1;
-  newF=(double*)malloc((m+1)*sizeof(double));
-  newF[0]=1.0;
-  dcopy(m,&db0,0,newF+1,1);
-  Z=db0;
-  
-  newK=L+K;
-  newG_blkszs=(int*)malloc(newK*sizeof(int));
-  for(i=0;i<L;i++){
-    blkSize=F_blkszs[i];
-    newG_blkszs[i]= blkSize;
-    F_pksz+=(blkSize+1)*blkSize/2;
-  }
-  for(i=0;i<K;i++){
-    blkSize=G_blkszs[i];
-    newG_blkszs[L+i]= blkSize;
-    G_pksz+=(blkSize+1)*blkSize/2;
-  }
-  newG = (double*) combineLMIs(m,F,F_pksz,G,G_pksz);
-  newPkSz=F_pksz+G_pksz;
-  W=(double*)malloc(newPkSz*sizeof(double));
-  dcopy(newPkSz,&db0,0,W,1);
+    double *identityF, *identityG;
+    double *expandF, *expandG;
+    double *newF, *newG;
+    int    *newF_blkszs,  newG_blkszs;
+    double db0 = 0.0, t0, *x0, *Z0, W0, *c;
+    int    newM, newL, newK, newPkSz, initSize;
 
-  if (optmZHistory) free(optmZHistory);
-  fprintf(stderr,"Optimizing...\n");
-  optmZHistory =  maxdet_wrap(m,newL, newF, &newF_blkszs, newK, newG,
-			      newG_blkszs, c, optmz0, &Z, W, gamma, abstol,
-			      reltol, &optmNTiters, FALSE, pRstFile);
+    int F_pksz = 0, G_pksz = 0;
+    int F_dim = 0, G_dim = 0;
+    int blkSize, maxBlockSize = 0;
+    int i, m, workSize;
+    //int  negativeFlag=TRUE;
 
-  if (errorOccurred) {
-    free(newF); free(newG_blkszs); free(W);
+    eigF = new double[numDOF * 2]; // max dimension of torque limit LMI
+    eigG = new double[mGrasp->numContacts * 7];  // max dimension of friction LMI
+
+    m = nullDim;
+    newM = m + 1;
+    newG = (double *)malloc((newM + 1) * sizeof(double));
+    newG[0] = 1.0;
+    dcopy(newM, &db0, 0, newG + 1, 1);
+    newK = 1;
+    newG_blkszs = 1;
+    W0 = 0.0;
+
+    c = (double *)malloc(newM * sizeof(double));
+    dcopy(m, &db0, 0, c, 1);
+    c[m] = 1.0;
+
+    for (i = 0; i < L; i++) {
+        blkSize = F_blkszs[i];
+        F_dim += blkSize;
+        F_pksz += (blkSize + 1) * blkSize / 2;
+        maxBlockSize = MAX(maxBlockSize, blkSize);
+    }
+    workSize = F_pksz + 3 * maxBlockSize;
+    work = (double *)malloc(workSize * sizeof(double));
+    minEigF = eig_val(eigF, F, L, F_blkszs, F_pksz, work);
+    free(work);
+
+    maxBlockSize = 0;
+    for (i = 0; i < K; i++) {
+        blkSize = G_blkszs[i];
+        G_dim += blkSize;
+        G_pksz += (blkSize + 1) * blkSize / 2;
+        maxBlockSize = MAX(maxBlockSize, blkSize);
+    }
+    workSize = G_pksz + 3 * maxBlockSize;
+    work = (double *)malloc(workSize * sizeof(double));
+    minEigG = eig_val(eigG, G, K, G_blkszs, G_pksz, work);
+    free(work);
+
+    #ifdef GRASPDEBUG
+    fprintf(stderr, "minEigF: %f  minEigG:%f \n", minEigF, minEigG);
+    fprintf(stderr, " ------- EigF(%d) ------ \n", F_dim);
+    disp_mat(stderr, eigF, 1, F_dim, 0);
+    fprintf(stderr, " ------- EigG(%d) ------ \n", G_dim);
+    disp_mat(stderr, eigG, 1, G_dim, 0);
+    #endif
+
+    t0 = MAX(-1.1 * MIN(minEigF, minEigG), 1.0);
+    x0 = (double *)malloc(newM * sizeof(double));
+    dcopy(m, &db0, 0, x0, 1);
+    x0[m] = t0;
+
+    identityF = (double *)block_Identity(L, F_blkszs, F_pksz);
+    identityG = (double *)block_Identity(K, G_blkszs, G_pksz);
+
+    #ifdef GRASPDEBUG
+    fprintf(stderr, "------------- Identity_F ---------------- \n");
+    disp_mat(stderr, identityF, 1, F_pksz, 0);
+    fprintf(stderr, "------------- Identity_G ---------------- \n");
+    disp_mat(stderr, identityG, 1, G_pksz, 0);
+    #endif
+
+    expandF = (double *)malloc((newM + 1) * F_pksz * sizeof(double));
+    initSize = (m + 1) * F_pksz;
+    dcopy(initSize, F, 1, expandF, 1);
+    dcopy(F_pksz, identityF, 1, expandF + initSize, 1);
+    free(identityF);
+
+    expandG = (double *)malloc((newM + 1) * G_pksz * sizeof(double));
+    initSize = (m + 1) * G_pksz;
+    dcopy(initSize, G, 1, expandG, 1);
+    dcopy(G_pksz, identityG, 1, expandG + initSize, 1);
+    free(identityG);
+
+    newF = (double *) combineLMIs(newM, expandF, F_pksz, expandG, G_pksz);
+    free(expandF);
+    free(expandG);
+
+    newL = L + K;
+    newF_blkszs = (int *)malloc(newL * sizeof(int));
+    for (i = 0; i < L; i++)  newF_blkszs[i] = F_blkszs[i];
+    for (i = 0; i < K; i++)  newF_blkszs[L + i] = G_blkszs[i];
+
+    newPkSz = F_pksz + G_pksz;
+    Z0 = (double *)malloc(newPkSz * sizeof(double));
+    dcopy(newPkSz, &db0, 0, Z0, 1);
+
+    #ifdef GRASPDEBUG
+    fprintf(stderr, "------------- Combined LMI (%d x %d) ---------------- \n", F_pksz + G_pksz, newM + 1);
+    disp_mat(stderr, newF, F_pksz + G_pksz, newM + 1, 0);
+    fprintf(stderr, "------------- Combined LMI Block Sizes(%d) ---------------- \n", newL);
+    disp_imat(stderr, newF_blkszs, 1, newL, 0);
+    #endif
+
+    fprintf(stderr, "Checking grasping force feasibility...\n");
+    hist = maxdet_wrap(newM, newL, newF, newF_blkszs, newK, newG, &newG_blkszs,
+                       c, x0, Z0, &W0, gamma, abstol,  reltol, &feasNTiters,
+                       negativeFlag, pRstFile);
+
+    if (errorOccurred) {
+        free(newF);
+        free(newF_blkszs);
+        free(Z0);
+        free(newG);
+        free(c);
+        free(x0);
+        delete [] eigF;
+        delete [] eigG;
+        return;
+    }
+
+    if (initz0) free(initz0);
+    initz0 = (double *)malloc(nullDim * sizeof(double));
+    dcopy(m, x0, 1, initz0, 1);
+
+    if (feasZHistory) free(feasZHistory);
+    feasZHistory = (double *)malloc((m + 3) * (feasNTiters) * sizeof(double));
+    for (i = 0; i < feasNTiters; i++) {
+        dcopy(newM, hist + i * (newM + 3), 1, feasZHistory + i * (m + 3), 1);
+        dcopy(2, hist + i * (newM + 3) + newM + 1, 1, feasZHistory + i * (m + 3) + m + 1, 1);
+    }
+    if (x0[m] < 0) {
+        feasible = TRUE;
+        #ifdef GRASPDEBUG
+        printf("\n Feasible! min eig value: %f \n", -x0[m]);
+        #endif
+    }
+    else feasible = FALSE;
+
+    free(newF);
+    free(newF_blkszs);
+    free(Z0);
     free(newG);
-    return;
-  }
-  
-  // transform the optimal z value to the optimal x value 
-  if (optmx0) free(optmx0);
-  optmx0=(double*)malloc(numWrenches*sizeof(double));
-  dgemv("N", numWrenches, nullDim, 1.0, nullSpace, numWrenches, 
-	optmz0,1, 0.0, optmx0,1);
-  daxpy(numWrenches, 1.0, minNormSln, 1, optmx0, 1);
-
-  free(newF); 
-  free(newG); free(newG_blkszs); free(W);
+    free(c);
+    free(x0);
+    free(hist);
+    delete [] eigF;
+    delete [] eigG;
 }
 
 /*!
-  Compute the value of the objective function for each set of z values
-  stores the optimal z value and the corresponding objective value
-  in \c extendOptmz0.
+    Formulate and solve the optimization 4 problem (See the LMI paper)
 */
 void
-LMIOptimizer::computeObjectives()
-{
-  double *tempG, *zHistory,objective;
-  int    zHistRowDim;
-  
-  double db0=0.0,minEigG, *eigG, *work;
-  int workSize, maxBlockSize=0, lmiDim=0;
-  int i,j;
-
-  /* put the initial z value in the first row of the history, then
-     copy z history after that */
-  zHistRowDim=nullDim+3;
-  if (extendOptmZHistory) free(extendOptmZHistory);
-  extendOptmZHistory=(double*) malloc(zHistRowDim*(optmNTiters+1)*
-					   sizeof(double));
-  dcopy(zHistRowDim,initz0,1,extendOptmZHistory,1);
-  dcopy(zHistRowDim*optmNTiters,optmZHistory,1,extendOptmZHistory+
-	zHistRowDim,1);
-  
-
-  zHistory = extendOptmZHistory;
-
-  tempG=(double *)malloc(GPkRow*sizeof(double));
-  
-  for(i=0;i<K;i++){
-    maxBlockSize=MAX(maxBlockSize, G_blkszs[i]);
-    lmiDim+=G_blkszs[i];
-  }
-  workSize=GPkRow+3*maxBlockSize;
-  work=(double *)malloc(workSize*sizeof(double));
-  eigG=(double *)malloc(lmiDim*sizeof(double));
+LMIOptimizer::optm_EffortBarrier() {
+    int    newL, newK;
+    double *newF, *newG;
+    int    newF_blkszs,  *newG_blkszs;
+    double db0 = 0.0, Z, *W;
+    int F_pksz = 0, G_pksz = 0, newPkSz, i, blkSize;
+    int m;
 
 
-  for(i=0;i<optmNTiters+1;i++) {
-    objective=ddot(nullDim,c,1,zHistory+i*zHistRowDim,1);
-    objective+=constOffset;
-    
-    dcopy(GPkRow,G,1, tempG,1);
-    dgemv("N", GPkRow, nullDim, 1.0, G+GPkRow, GPkRow,
-	   zHistory+i*zHistRowDim,1,1.0, tempG, 1);
-    
-    dcopy(workSize,&db0,0,work,1);
-    dcopy(lmiDim,&db0,0,eigG,1);
-    minEigG=eig_val(eigG,tempG,K,G_blkszs,GPkRow,work);
-    if(minEigG<0)	errMsg("G(x) not positive definite");
-    for(j=0;j<lmiDim; j++)
-      objective -=log(eigG[j]);
-    
-    zHistory[i*zHistRowDim+nullDim]=objective;
-  }
-  free(tempG);  free(work); free(eigG);
+    m = nullDim;
+    if (optmz0) free(optmz0);
+    optmz0 = (double *)malloc(m * sizeof(double));
+    dcopy(m, initz0, 1, optmz0, 1);
+
+    newL = 1;
+    newF_blkszs = 1;
+    newF = (double *)malloc((m + 1) * sizeof(double));
+    newF[0] = 1.0;
+    dcopy(m, &db0, 0, newF + 1, 1);
+    Z = db0;
+
+    newK = L + K;
+    newG_blkszs = (int *)malloc(newK * sizeof(int));
+    for (i = 0; i < L; i++) {
+        blkSize = F_blkszs[i];
+        newG_blkszs[i] = blkSize;
+        F_pksz += (blkSize + 1) * blkSize / 2;
+    }
+    for (i = 0; i < K; i++) {
+        blkSize = G_blkszs[i];
+        newG_blkszs[L + i] = blkSize;
+        G_pksz += (blkSize + 1) * blkSize / 2;
+    }
+    newG = (double *) combineLMIs(m, F, F_pksz, G, G_pksz);
+    newPkSz = F_pksz + G_pksz;
+    W = (double *)malloc(newPkSz * sizeof(double));
+    dcopy(newPkSz, &db0, 0, W, 1);
+
+    if (optmZHistory) free(optmZHistory);
+    fprintf(stderr, "Optimizing...\n");
+    optmZHistory =  maxdet_wrap(m, newL, newF, &newF_blkszs, newK, newG,
+                                newG_blkszs, c, optmz0, &Z, W, gamma, abstol,
+                                reltol, &optmNTiters, FALSE, pRstFile);
+
+    if (errorOccurred) {
+        free(newF);
+        free(newG_blkszs);
+        free(W);
+        free(newG);
+        return;
+    }
+
+    // transform the optimal z value to the optimal x value
+    if (optmx0) free(optmx0);
+    optmx0 = (double *)malloc(numWrenches * sizeof(double));
+    dgemv("N", numWrenches, nullDim, 1.0, nullSpace, numWrenches,
+          optmz0, 1, 0.0, optmx0, 1);
+    daxpy(numWrenches, 1.0, minNormSln, 1, optmx0, 1);
+
+    free(newF);
+    free(newG);
+    free(newG_blkszs);
+    free(W);
+}
+
+/*!
+    Compute the value of the objective function for each set of z values
+    stores the optimal z value and the corresponding objective value
+    in \c extendOptmz0.
+*/
+void
+LMIOptimizer::computeObjectives() {
+    double *tempG, *zHistory, objective;
+    int    zHistRowDim;
+
+    double db0 = 0.0, minEigG, *eigG, *work;
+    int workSize, maxBlockSize = 0, lmiDim = 0;
+    int i, j;
+
+    /*  put the initial z value in the first row of the history, then
+        copy z history after that */
+    zHistRowDim = nullDim + 3;
+    if (extendOptmZHistory) free(extendOptmZHistory);
+    extendOptmZHistory = (double *) malloc(zHistRowDim * (optmNTiters + 1) *
+                                           sizeof(double));
+    dcopy(zHistRowDim, initz0, 1, extendOptmZHistory, 1);
+    dcopy(zHistRowDim * optmNTiters, optmZHistory, 1, extendOptmZHistory +
+          zHistRowDim, 1);
+
+
+    zHistory = extendOptmZHistory;
+
+    tempG = (double *)malloc(GPkRow * sizeof(double));
+
+    for (i = 0; i < K; i++) {
+        maxBlockSize = MAX(maxBlockSize, G_blkszs[i]);
+        lmiDim += G_blkszs[i];
+    }
+    workSize = GPkRow + 3 * maxBlockSize;
+    work = (double *)malloc(workSize * sizeof(double));
+    eigG = (double *)malloc(lmiDim * sizeof(double));
+
+
+    for (i = 0; i < optmNTiters + 1; i++) {
+        objective = ddot(nullDim, c, 1, zHistory + i * zHistRowDim, 1);
+        objective += constOffset;
+
+        dcopy(GPkRow, G, 1, tempG, 1);
+        dgemv("N", GPkRow, nullDim, 1.0, G + GPkRow, GPkRow,
+              zHistory + i * zHistRowDim, 1, 1.0, tempG, 1);
+
+        dcopy(workSize, &db0, 0, work, 1);
+        dcopy(lmiDim, &db0, 0, eigG, 1);
+        minEigG = eig_val(eigG, tempG, K, G_blkszs, GPkRow, work);
+        if (minEigG < 0)   errMsg("G(x) not positive definite");
+        for (j = 0; j < lmiDim; j++)
+            objective -= log(eigG[j]);
+
+        zHistory[i * zHistRowDim + nullDim] = objective;
+    }
+    free(tempG);
+    free(work);
+    free(eigG);
 }
 
 
 /*!
-  Transform z values to values of grasp force x.
+    Transform z values to values of grasp force x.
 */
 double *
-LMIOptimizer::xzHistoryTransfrom(double *zHistory,int numIters)
-{
-  double db0=0.0,*xHistory;
-  int xHistSize, xHistRowSize, zHistRowSize, i;
+LMIOptimizer::xzHistoryTransfrom(double *zHistory, int numIters) {
+    double db0 = 0.0, *xHistory;
+    int xHistSize, xHistRowSize, zHistRowSize, i;
 
 
-  xHistRowSize=numWrenches+1; 		// X+objective
-  xHistSize=xHistRowSize*numIters;
-  xHistory=(double*)malloc(xHistSize*sizeof(double));
-  dcopy(xHistSize,&db0,0,xHistory, 1);
-  
-  zHistRowSize=nullDim+3;
+    xHistRowSize = numWrenches + 1;   // X+objective
+    xHistSize = xHistRowSize * numIters;
+    xHistory = (double *)malloc(xHistSize * sizeof(double));
+    dcopy(xHistSize, &db0, 0, xHistory, 1);
 
-  for(i=0;i<numIters;i++){
-    dgemv("N", numWrenches, nullDim, 1.0, nullSpace, numWrenches, 
-	   zHistory+i*zHistRowSize,1, 0.0, xHistory+i*xHistRowSize,1);
-    daxpy(numWrenches, 1.0, minNormSln, 1, xHistory+i*xHistRowSize, 1);
-  }
-  dcopy(numIters,zHistory+nullDim, zHistRowSize, xHistory+numWrenches,
-	xHistRowSize);
+    zHistRowSize = nullDim + 3;
 
-  return(xHistory);
+    for (i = 0; i < numIters; i++) {
+        dgemv("N", numWrenches, nullDim, 1.0, nullSpace, numWrenches,
+              zHistory + i * zHistRowSize, 1, 0.0, xHistory + i * xHistRowSize, 1);
+        daxpy(numWrenches, 1.0, minNormSln, 1, xHistory + i * xHistRowSize, 1);
+    }
+    dcopy(numIters, zHistory + nullDim, zHistRowSize, xHistory + numWrenches,
+          xHistRowSize);
+
+    return (xHistory);
 }
 
 /*!
-  Main GFO routine.
-  Adapted from Li Han's code.
+    Main GFO routine.
+    Adapted from Li Han's code.
 */
 int
-LMIOptimizer::findOptimalGraspForce()
-{
-  int i;
+LMIOptimizer::findOptimalGraspForce() {
+    int i;
 
-  feasible = FALSE;
+    feasible = FALSE;
 
-  if (numWrenches < 6) {
-    printf("More contacts are necessary before solving for the optimal grasp force\n");
-    return FAILURE;
-  }
-
-#ifdef GRASPDEBUG  
-  char rstFile[40];
-  sprintf(rstFile,"Grasp%02d.rst",graspCounter);
-  if ((pRstFile=fopen(rstFile,"w"))==NULL)
-    FatalErrMsg("failed to open result file");
-
-  //  graspMap = ReadGraspMap("mytest.G",18);
-  printf("---------------- Solve Grasping Force Equation ---------------- \n");
-#endif
-
-  minimalNorm();
-  // if (optmx0) {free(optmx0); optmx0=NULL;}
-  if (errorOccurred) {errorOccurred = false; if (pRstFile) fclose(pRstFile);return FAILURE;}
-
-  computeNullSpace();
-  if (errorOccurred) {errorOccurred = false; if (pRstFile) fclose(pRstFile);return FAILURE;}
-
-  if (nullDim == 0) {
-    printf("The dimension of the null space is 0. Cannot solve for the optimal grasp force.\n");
-
-    return FAILURE;
-  }
- 
-#ifdef GRASPDEBUG  
-  printf("----------- Prepare LMIs for Torque/Contact Limits --------------- \n");
-#endif
-
-  if (F) free(F);
-  F = lmiTorqueLimits();
- 
-#ifdef GRASPDEBUG
-  printf("----------- Prepare LMIs for Friction Cones --------------- \n");
-#endif
-  
-  if (G) free(G);
-  G = lmiFrictionCones();
-
-#ifdef GRASPDEBUG
-  printf("--------- Prepare Weight Vectors in the Objective Function ------- \n");
-#endif
-
-  if (c) free(c);
-  c = weightVec();
-  
-#ifdef GRAPSDEBUG
-  printf("\n -------- The  Feasibility Phase ----------------------- \n");
-  fprintf(pRstFile, "\n -------- The  Feasibility Phase ----------------------- \n");
-#endif
-
-  feasNTiters=MAX_FEAS_LOOPS;  
-  feasibilityAnalysis();
-  if (errorOccurred) {errorOccurred = false; if (pRstFile) fclose(pRstFile); return FAILURE;}
-
-  if (feasXHistory) free(feasXHistory);
-  feasXHistory=xzHistoryTransfrom(feasZHistory, feasNTiters);
-
-  if(feasible) {
-#ifdef GRASPDEBUG
-    printf("\n -------- The  Optimization  Phase ----------------------- \n");
-    fprintf(pRstFile, "\n -------- The  Optimization  Phase ----------------------- \n");
-#endif
-
-    optmNTiters=MAX_OPTM_LOOPS;
-    optm_EffortBarrier();
-    if (errorOccurred) {feasible = FALSE; errorOccurred = false; if (pRstFile) fclose(pRstFile); return FAILURE;}
-    
-    computeObjectives();
-    if (errorOccurred) {feasible = FALSE; errorOccurred = false; if (pRstFile) fclose(pRstFile); return FAILURE;}
-
-    if (optmXHistory) free(optmXHistory);
-    optmXHistory = xzHistoryTransfrom(extendOptmZHistory, optmNTiters+1);
-    
-    printf("OPTIMAL CONTACT FORCES:\n");
-    disp_mat(stdout,optmx0,1,numWrenches);
-
-    //    double *testOut = new double[6];
-    //    dgemv("N",6,numWrenches,1.0,graspMap,6,optmx0,1,0.0,testOut,1);
-    //    printf("CHECK:\n");
-    //    for (i=0;i<6;i++)
-    //      printf("%15.12le ",testOut[i]);
-    //    printf("\n");
-    //    delete [] testOut;
-
-    if (optTorques) delete [] optTorques;
-    optTorques = new double[numDOF];
-
-    dcopy(numDOF,externalTorques,1,optTorques,1);
-    dgemv("T", numWrenches, numDOF, 1.0, Jacobian, numWrenches,
-	  optmx0, 1,1.0, optTorques, 1);
-
-    printf("OPTIMAL TORQUES:\n");
-    disp_mat(stdout,optTorques,1,numDOF);
-
-    int offset = 0;
-    for (i=0;i<mGrasp->numContacts;i++) {
-      mGrasp->contactVec[i]->getMate()->setContactForce(optmx0+offset);
-      offset += mGrasp->contactVec[i]->getContactDim();
+    if (numWrenches < 6) {
+        printf("More contacts are necessary before solving for the optimal grasp force\n");
+        return FAILURE;
     }
-  }
-  else {
-    // prompt that the current grasp force is infeasible.
-    printf("not feasible.\n");
-#ifdef GRASPDEBUG
-    fprintf(pRstFile,"\n --------  Problem Infeasible ----------------------- \n");
-#endif
-    return FAILURE;
-  }
+
+    #ifdef GRASPDEBUG
+    char rstFile[40];
+    sprintf(rstFile, "Grasp%02d.rst", graspCounter);
+    if ((pRstFile = fopen(rstFile, "w")) == NULL)
+        FatalErrMsg("failed to open result file");
+
+    //  graspMap = ReadGraspMap("mytest.G",18);
+    printf("---------------- Solve Grasping Force Equation ---------------- \n");
+    #endif
+
+    minimalNorm();
+    // if (optmx0) {free(optmx0); optmx0=NULL;}
+    if (errorOccurred) {
+        errorOccurred = false;
+        if (pRstFile) fclose(pRstFile);
+        return FAILURE;
+    }
+
+    computeNullSpace();
+    if (errorOccurred) {
+        errorOccurred = false;
+        if (pRstFile) fclose(pRstFile);
+        return FAILURE;
+    }
+
+    if (nullDim == 0) {
+        printf("The dimension of the null space is 0. Cannot solve for the optimal grasp force.\n");
+
+        return FAILURE;
+    }
+
+    #ifdef GRASPDEBUG
+    printf("----------- Prepare LMIs for Torque/Contact Limits --------------- \n");
+    #endif
+
+    if (F) free(F);
+    F = lmiTorqueLimits();
+
+    #ifdef GRASPDEBUG
+    printf("----------- Prepare LMIs for Friction Cones --------------- \n");
+    #endif
+
+    if (G) free(G);
+    G = lmiFrictionCones();
+
+    #ifdef GRASPDEBUG
+    printf("--------- Prepare Weight Vectors in the Objective Function ------- \n");
+    #endif
+
+    if (c) free(c);
+    c = weightVec();
+
+    #ifdef GRAPSDEBUG
+    printf("\n -------- The  Feasibility Phase ----------------------- \n");
+    fprintf(pRstFile, "\n -------- The  Feasibility Phase ----------------------- \n");
+    #endif
+
+    feasNTiters = MAX_FEAS_LOOPS;
+    feasibilityAnalysis();
+    if (errorOccurred) {
+        errorOccurred = false;
+        if (pRstFile) fclose(pRstFile);
+        return FAILURE;
+    }
+
+    if (feasXHistory) free(feasXHistory);
+    feasXHistory = xzHistoryTransfrom(feasZHistory, feasNTiters);
+
+    if (feasible) {
+        #ifdef GRASPDEBUG
+        printf("\n -------- The  Optimization  Phase ----------------------- \n");
+        fprintf(pRstFile, "\n -------- The  Optimization  Phase ----------------------- \n");
+        #endif
+
+        optmNTiters = MAX_OPTM_LOOPS;
+        optm_EffortBarrier();
+        if (errorOccurred) {
+            feasible = FALSE;
+            errorOccurred = false;
+            if (pRstFile) fclose(pRstFile);
+            return FAILURE;
+        }
+
+        computeObjectives();
+        if (errorOccurred) {
+            feasible = FALSE;
+            errorOccurred = false;
+            if (pRstFile) fclose(pRstFile);
+            return FAILURE;
+        }
+
+        if (optmXHistory) free(optmXHistory);
+        optmXHistory = xzHistoryTransfrom(extendOptmZHistory, optmNTiters + 1);
+
+        printf("OPTIMAL CONTACT FORCES:\n");
+        disp_mat(stdout, optmx0, 1, numWrenches);
+
+        //    double *testOut = new double[6];
+        //    dgemv("N",6,numWrenches,1.0,graspMap,6,optmx0,1,0.0,testOut,1);
+        //    printf("CHECK:\n");
+        //    for (i=0;i<6;i++)
+        //      printf("%15.12le ",testOut[i]);
+        //    printf("\n");
+        //    delete [] testOut;
+
+        if (optTorques) delete [] optTorques;
+        optTorques = new double[numDOF];
+
+        dcopy(numDOF, externalTorques, 1, optTorques, 1);
+        dgemv("T", numWrenches, numDOF, 1.0, Jacobian, numWrenches,
+              optmx0, 1, 1.0, optTorques, 1);
+
+        printf("OPTIMAL TORQUES:\n");
+        disp_mat(stdout, optTorques, 1, numDOF);
+
+        int offset = 0;
+        for (i = 0; i < mGrasp->numContacts; i++) {
+            mGrasp->contactVec[i]->getMate()->setContactForce(optmx0 + offset);
+            offset += mGrasp->contactVec[i]->getContactDim();
+        }
+    }
+    else {
+        // prompt that the current grasp force is infeasible.
+        printf("not feasible.\n");
+        #ifdef GRASPDEBUG
+        fprintf(pRstFile, "\n --------  Problem Infeasible ----------------------- \n");
+        #endif
+        return FAILURE;
+    }
 
 
-// save the problem parameters, the timing results and the feaibility as well as 
-// optimization results at the last simulation step to file argv[1].rst
-#ifdef GRASPDEBUG
-  fprintf(pRstFile, "-------------- Jacobian (%-dx%-d) -------------- \n",numWrenches,numDOF);
-  disp_mat(pRstFile, Jacobian, numWrenches, numDOF, 0);
+    // save the problem parameters, the timing results and the feaibility as well as
+    // optimization results at the last simulation step to file argv[1].rst
+    #ifdef GRASPDEBUG
+    fprintf(pRstFile, "-------------- Jacobian (%-dx%-d) -------------- \n", numWrenches, numDOF);
+    disp_mat(pRstFile, Jacobian, numWrenches, numDOF, 0);
 
-  fprintf(pRstFile, "-------------- External Torques (%-d)------------------ \n",numDOF);
-  disp_mat(pRstFile, externalTorques,1,numDOF,0);
-  
-  fprintf(pRstFile, "-------------- Grasp Map (6x%-d) -------------- \n", numWrenches);
-  disp_mat(pRstFile, graspMap,6, numWrenches,0);
-  
-  fprintf(pRstFile, "-------------- Object Wrench (6) -------------- \n");
-  disp_mat(pRstFile, mGrasp->object->getExtWrenchAcc(), 1, 6, 0);
-  
-  fprintf(pRstFile, "-------------- Minimal Norm Solution (%-d)------------------ \n",numWrenches);
-  disp_mat(pRstFile, minNormSln,1,numWrenches,0);
-  
-  fprintf(pRstFile, "-------------- Admissible Null Space (%-dx%-d)------------------ \n",numWrenches, nullDim);
-  disp_mat(pRstFile, nullSpace, numWrenches, nullDim,0);
-  
-  fprintf(pRstFile, "-------------- F blkszs (%d)------------- \n",L);
-  disp_imat(pRstFile, F_blkszs, 1, L, 0);
-  
-  fprintf(pRstFile, "-------------- F (%-dx%-d) ------------- \n",L,nullDim+1);
-  disp_mat(pRstFile, F, L, nullDim+1,0);
-  
-  fprintf(pRstFile, "-------------- G blkszs (%d)------------- \n",K);
-  disp_imat(pRstFile, G_blkszs, 1, K,0);
-  
-  fprintf(pRstFile,"-------------- G (%-dx%-d) -------------- \n",GPkRow,
-	  nullDim+1);
-  disp_mat(pRstFile, G, GPkRow, nullDim+1,0);
-  
-  fprintf(pRstFile,"-------- Final Weight Vector(%d) and Offset: %f -------\n",
-	  nullDim,constOffset);
-  disp_mat(pRstFile, c,1,nullDim,0);
-  
-  fprintf(pRstFile,"------------- Initial Feasible z and History(%dx%d) -------------- \n",
-	  3+nullDim,feasNTiters);
-  disp_mat(pRstFile, initz0,1,nullDim,0);
-  disp_mat(pRstFile, feasZHistory, 3+nullDim, feasNTiters, 0);
-  
-  fprintf(pRstFile,"-------------  Feasible X History(%dx%d) ---------------- \n",
-	  numWrenches+1,feasNTiters);
-  disp_mat(pRstFile, feasXHistory, numWrenches+1, feasNTiters, 0);
-  
-  if(feasible) {
-    fprintf(pRstFile,"------------- Optimal z and History(%dx%d)------------------ \n",
-	    3+nullDim,optmNTiters+1);
-    disp_mat(pRstFile, optmz0,1,nullDim,0);
-    disp_mat(pRstFile, extendOptmZHistory, 3+nullDim, optmNTiters+1, 0);
-    
-    fprintf(pRstFile,"------------- Optimal X and History(%dx%d)------------------ \n",
-	    numWrenches+1,optmNTiters+1);
-    disp_mat(pRstFile, optmXHistory, numWrenches+1, optmNTiters+1, 0);
-  }
+    fprintf(pRstFile, "-------------- External Torques (%-d)------------------ \n", numDOF);
+    disp_mat(pRstFile, externalTorques, 1, numDOF, 0);
 
-  fclose(pRstFile);  
-#endif
+    fprintf(pRstFile, "-------------- Grasp Map (6x%-d) -------------- \n", numWrenches);
+    disp_mat(pRstFile, graspMap, 6, numWrenches, 0);
 
-  return SUCCESS;
+    fprintf(pRstFile, "-------------- Object Wrench (6) -------------- \n");
+    disp_mat(pRstFile, mGrasp->object->getExtWrenchAcc(), 1, 6, 0);
+
+    fprintf(pRstFile, "-------------- Minimal Norm Solution (%-d)------------------ \n", numWrenches);
+    disp_mat(pRstFile, minNormSln, 1, numWrenches, 0);
+
+    fprintf(pRstFile, "-------------- Admissible Null Space (%-dx%-d)------------------ \n", numWrenches, nullDim);
+    disp_mat(pRstFile, nullSpace, numWrenches, nullDim, 0);
+
+    fprintf(pRstFile, "-------------- F blkszs (%d)------------- \n", L);
+    disp_imat(pRstFile, F_blkszs, 1, L, 0);
+
+    fprintf(pRstFile, "-------------- F (%-dx%-d) ------------- \n", L, nullDim + 1);
+    disp_mat(pRstFile, F, L, nullDim + 1, 0);
+
+    fprintf(pRstFile, "-------------- G blkszs (%d)------------- \n", K);
+    disp_imat(pRstFile, G_blkszs, 1, K, 0);
+
+    fprintf(pRstFile, "-------------- G (%-dx%-d) -------------- \n", GPkRow,
+            nullDim + 1);
+    disp_mat(pRstFile, G, GPkRow, nullDim + 1, 0);
+
+    fprintf(pRstFile, "-------- Final Weight Vector(%d) and Offset: %f -------\n",
+            nullDim, constOffset);
+    disp_mat(pRstFile, c, 1, nullDim, 0);
+
+    fprintf(pRstFile, "------------- Initial Feasible z and History(%dx%d) -------------- \n",
+            3 + nullDim, feasNTiters);
+    disp_mat(pRstFile, initz0, 1, nullDim, 0);
+    disp_mat(pRstFile, feasZHistory, 3 + nullDim, feasNTiters, 0);
+
+    fprintf(pRstFile, "-------------  Feasible X History(%dx%d) ---------------- \n",
+            numWrenches + 1, feasNTiters);
+    disp_mat(pRstFile, feasXHistory, numWrenches + 1, feasNTiters, 0);
+
+    if (feasible) {
+        fprintf(pRstFile, "------------- Optimal z and History(%dx%d)------------------ \n",
+                3 + nullDim, optmNTiters + 1);
+        disp_mat(pRstFile, optmz0, 1, nullDim, 0);
+        disp_mat(pRstFile, extendOptmZHistory, 3 + nullDim, optmNTiters + 1, 0);
+
+        fprintf(pRstFile, "------------- Optimal X and History(%dx%d)------------------ \n",
+                numWrenches + 1, optmNTiters + 1);
+        disp_mat(pRstFile, optmXHistory, numWrenches + 1, optmNTiters + 1, 0);
+    }
+
+    fclose(pRstFile);
+    #endif
+
+    return SUCCESS;
 
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,34 +17,34 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: main.cpp,v 1.16 2010/01/13 23:09:30 cmatei Exp $
 //
 //######################################################################
 
 /*! \mainpage GraspIt! Developer Documentation
-  \image html logo.jpg
+    \image html logo.jpg
 
-  These pages document the GraspIt! source code. Please remember this is
-  research code. There are still plenty of pieces of code that are unfinished
-  and several bugs that need to be fixed.
+    These pages document the GraspIt! source code. Please remember this is
+    research code. There are still plenty of pieces of code that are unfinished
+    and several bugs that need to be fixed.
 
-  More information and original source code for the packages included with
-  GraspIt! can be found in the following places:
+    More information and original source code for the packages included with
+    GraspIt! can be found in the following places:
 
-  - <b>qhull:</b> http://www.qhull.org
-  - <b>maxdet:</b> http://www.stanford.edu/~boyd/old_software/MAXDET.html
-  - <b>tinyxml:</b> http://www.grinninglizard.com/tinyxml/
+    - <b>qhull:</b> http://www.qhull.org
+    - <b>maxdet:</b> http://www.stanford.edu/~boyd/old_software/MAXDET.html
+    - <b>tinyxml:</b> http://www.grinninglizard.com/tinyxml/
 */
 
 /*! \file
-  \brief Program execution starts here.  Server is started, main window is built, 
-  and the interactive loop is started.
+    \brief Program execution starts here.  Server is started, main window is built,
+    and the interactive loop is started.
 
-  The main call returns an exit code as indicated by the graspit GUI (0 by default)
-  to provide feedback to calling program, if desired.
- */
+    The main call returns an exit code as indicated by the graspit GUI (0 by default)
+    to provide feedback to calling program, if desired.
+*/
 
 #define GRASPITDBG
 
@@ -59,43 +59,42 @@
 #include <wincon.h>
 #endif
 
-int main(int argc, char **argv)
-{
-#ifdef GRASPITDBG
-#ifdef Q_WS_WIN
-  AllocConsole(); 
-  freopen("conin$", "r", stdin); 
-  freopen("conout$", "w", stdout); 
-  freopen("conout$", "w", stderr); 
-  //ios::sync_with_stdio();
-#endif
-#endif
+int main(int argc, char **argv) {
+    #ifdef GRASPITDBG
+    #ifdef Q_WS_WIN
+    AllocConsole();
+    freopen("conin$", "r", stdin);
+    freopen("conout$", "w", stdout);
+    freopen("conout$", "w", stderr);
+    //ios::sync_with_stdio();
+    #endif
+    #endif
 
-  GraspItApp app(argc, argv);
- 
-  if (app.splashEnabled()) {
-    app.showSplash();
-    QApplication::setOverrideCursor( Qt::waitCursor );
-  }
+    GraspItApp app(argc, argv);
 
-  GraspItGUI gui(argc,argv);
-  
-  //This is the GraspIt TCP server. It can be used to connect to GraspIt from
-  //external programs, such as Matlab.
-  //On some machines, the Q3Socket segfaults at exit, so this is commented out by
-  //default
-  //GraspItServer server(4765);
- 
-  app.setMainWidget(gui.getMainWindow()->mWindow);
-  QObject::connect(qApp, SIGNAL(lastWindowClosed()), qApp, SLOT(quit()));
+    if (app.splashEnabled()) {
+        app.showSplash();
+        QApplication::setOverrideCursor(Qt::waitCursor);
+    }
 
-  if (app.splashEnabled()) {
-    app.closeSplash();
-    QApplication::restoreOverrideCursor();
-  }
+    GraspItGUI gui(argc, argv);
 
-  if (!gui.terminalFailure()) {
-	  gui.startMainLoop();
-  }
-  return gui.getExitCode();
+    //This is the GraspIt TCP server. It can be used to connect to GraspIt from
+    //external programs, such as Matlab.
+    //On some machines, the Q3Socket segfaults at exit, so this is commented out by
+    //default
+    //GraspItServer server(4765);
+
+    app.setMainWidget(gui.getMainWindow()->mWindow);
+    QObject::connect(qApp, SIGNAL(lastWindowClosed()), qApp, SLOT(quit()));
+
+    if (app.splashEnabled()) {
+        app.closeSplash();
+        QApplication::restoreOverrideCursor();
+    }
+
+    if (!gui.terminalFailure()) {
+        gui.startMainLoop();
+    }
+    return gui.getExitCode();
 }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: material.cpp,v 1.3 2009/03/25 22:10:04 cmatei Exp $
 //
@@ -30,162 +30,162 @@
 
 double Cof[NUM_MATERIAL][NUM_MATERIAL];
 double KineticCof[NUM_MATERIAL][NUM_MATERIAL];
-char matNameList[NUM_MATERIAL][30] = {"frictionless","glass","metal","wood",
-				   "plastic","rubber","stone","invalid"};
+char matNameList[NUM_MATERIAL][30] = {"frictionless", "glass", "metal", "wood",
+                                      "plastic", "rubber", "stone", "invalid"
+                                     };
 
-materialT readMaterial(const char *matStr)
-{
-  if (!strcmp(matStr,"frictionless")) return(frictionless);
-  if (!strcmp(matStr,"glass")) return(glass);
-  if (!strcmp(matStr,"metal")) return(metal);
-  if (!strcmp(matStr,"wood")) return(wood);
-  if (!strcmp(matStr,"plastic")) return(plastic);
-  if (!strcmp(matStr,"rubber")) return(rubber);
-  if (!strcmp(matStr,"stone")) return(stone);
-  return(invalid);
+materialT readMaterial(const char *matStr) {
+    if (!strcmp(matStr, "frictionless")) return (frictionless);
+    if (!strcmp(matStr, "glass")) return (glass);
+    if (!strcmp(matStr, "metal")) return (metal);
+    if (!strcmp(matStr, "wood")) return (wood);
+    if (!strcmp(matStr, "plastic")) return (plastic);
+    if (!strcmp(matStr, "rubber")) return (rubber);
+    if (!strcmp(matStr, "stone")) return (stone);
+    return (invalid);
 }
 
-void getMaterialStr(materialT mat,char *str){
-  switch (mat) {
-  case frictionless:
-    strcpy(str,"frictionless");
-    break;
-  case glass:
-    strcpy(str,"glass");
-    break;
-  case metal:
-    strcpy(str,"metal");
-    break;
-  case wood:
-    strcpy(str,"wood");
-    break;
-  case plastic:
-    strcpy(str,"plastic");
-    break;
-  case rubber:
-    strcpy(str,"rubber");
-    break;
-  case stone:
-    strcpy(str,"stone");
-    break;
-  case invalid:
-    strcpy(str,"invalid");
-    break;
-  }
+void getMaterialStr(materialT mat, char *str) {
+    switch (mat) {
+        case frictionless:
+            strcpy(str, "frictionless");
+            break;
+        case glass:
+            strcpy(str, "glass");
+            break;
+        case metal:
+            strcpy(str, "metal");
+            break;
+        case wood:
+            strcpy(str, "wood");
+            break;
+        case plastic:
+            strcpy(str, "plastic");
+            break;
+        case rubber:
+            strcpy(str, "rubber");
+            break;
+        case stone:
+            strcpy(str, "stone");
+            break;
+        case invalid:
+            strcpy(str, "invalid");
+            break;
+    }
 }
 
 const char *
-getMaterialStr(materialT mat){
-  switch (mat) {
-  case frictionless:
-    return "frictionless";
-  case glass:
-    return "glass";
-  case metal:
-    return "metal";
-  case wood:
-    return "wood";
-  case plastic:
-    return "plastic";
-  case rubber:
-    return "rubber";
-  case stone:
-	  return "stone";
-  case invalid:
-    break;
-  }
-  return "invalid";
+getMaterialStr(materialT mat) {
+    switch (mat) {
+        case frictionless:
+            return "frictionless";
+        case glass:
+            return "glass";
+        case metal:
+            return "metal";
+        case wood:
+            return "wood";
+        case plastic:
+            return "plastic";
+        case rubber:
+            return "rubber";
+        case stone:
+            return "stone";
+        case invalid:
+            break;
+    }
+    return "invalid";
 }
 
-void initCof(){
-  int i,j;
-  for (i = 0; i < NUM_MATERIAL; i++)
-    for (j = 0; j < NUM_MATERIAL; j++) {
-      Cof[i][j] = 0.0;
-      KineticCof[i][j] = 0.0;
-    }
+void initCof() {
+    int i, j;
+    for (i = 0; i < NUM_MATERIAL; i++)
+        for (j = 0; j < NUM_MATERIAL; j++) {
+            Cof[i][j] = 0.0;
+            KineticCof[i][j] = 0.0;
+        }
 
-  /* from CRC handbook of chemistry and physics */
-  /* assuming room temperature contact */
+    /* from CRC handbook of chemistry and physics */
+    /* assuming room temperature contact */
 
-  /* Metal on Metal ?guess?: 0.2 */
-  KineticCof[metal][metal] = 0.1;
+    /* Metal on Metal ?guess?: 0.2 */
+    KineticCof[metal][metal] = 0.1;
 
-  /* Wood on Wood -Dry-: 0.25-0.5 */
-  KineticCof[wood][wood] = 0.3;
+    /* Wood on Wood -Dry-: 0.25-0.5 */
+    KineticCof[wood][wood] = 0.3;
 
-  /* Wood on Metal -Dry-: 0.2-0.6 */
-  KineticCof[wood][metal] = KineticCof[metal][wood] = 0.2;
+    /* Wood on Metal -Dry-: 0.2-0.6 */
+    KineticCof[wood][metal] = KineticCof[metal][wood] = 0.2;
 
-  /* Plastic on Plastic ?guess?: 0.3 */
-  KineticCof[plastic][plastic] = 0.2;
+    /* Plastic on Plastic ?guess?: 0.3 */
+    KineticCof[plastic][plastic] = 0.2;
 
-  /* Plastic on Metal ?guess?: 0.2 */
-  KineticCof[plastic][metal] = KineticCof[metal][plastic] = 0.1;
+    /* Plastic on Metal ?guess?: 0.2 */
+    KineticCof[plastic][metal] = KineticCof[metal][plastic] = 0.1;
 
-  /* Plastic on Wood ?guess?: 0.4 */
-  KineticCof[plastic][wood] = KineticCof[wood][plastic] = 0.3;
+    /* Plastic on Wood ?guess?: 0.4 */
+    KineticCof[plastic][wood] = KineticCof[wood][plastic] = 0.3;
 
-  /* Rubber on Solids:  1-4 */
-  KineticCof[rubber][rubber] = 1.9;  
-  KineticCof[rubber][metal] = KineticCof[metal][rubber] = 0.9;
-  KineticCof[rubber][wood] = KineticCof[wood][rubber] = 0.9;
-  KineticCof[rubber][plastic] = KineticCof[plastic][rubber] = 0.9;
+    /* Rubber on Solids:  1-4 */
+    KineticCof[rubber][rubber] = 1.9;
+    KineticCof[rubber][metal] = KineticCof[metal][rubber] = 0.9;
+    KineticCof[rubber][wood] = KineticCof[wood][rubber] = 0.9;
+    KineticCof[rubber][plastic] = KineticCof[plastic][rubber] = 0.9;
 
-  /* for now we simply copy metal values for glass */
-  KineticCof[glass][glass] = 0.1;
-  KineticCof[glass][metal] = KineticCof[metal][glass] = 0.1;
-  KineticCof[glass][wood] = KineticCof[wood][glass] = 0.2;
-  KineticCof[glass][plastic] = KineticCof[plastic][glass] = 0.1;
-  KineticCof[glass][rubber] = KineticCof[rubber][glass] = 0.9;
+    /* for now we simply copy metal values for glass */
+    KineticCof[glass][glass] = 0.1;
+    KineticCof[glass][metal] = KineticCof[metal][glass] = 0.1;
+    KineticCof[glass][wood] = KineticCof[wood][glass] = 0.2;
+    KineticCof[glass][plastic] = KineticCof[plastic][glass] = 0.1;
+    KineticCof[glass][rubber] = KineticCof[rubber][glass] = 0.9;
 
-  /* guessed values for stone */
-  KineticCof[stone][stone] = 0.6;
-  KineticCof[stone][glass] = KineticCof[glass][stone] = 0.3;
-  KineticCof[stone][metal] = KineticCof[metal][stone] = 0.3;
-  KineticCof[stone][wood] = KineticCof[wood][stone] = 0.5;
-  KineticCof[stone][plastic] = KineticCof[plastic][glass] = 0.5;
-  KineticCof[glass][rubber] = KineticCof[rubber][glass] = 1.4;
+    /* guessed values for stone */
+    KineticCof[stone][stone] = 0.6;
+    KineticCof[stone][glass] = KineticCof[glass][stone] = 0.3;
+    KineticCof[stone][metal] = KineticCof[metal][stone] = 0.3;
+    KineticCof[stone][wood] = KineticCof[wood][stone] = 0.5;
+    KineticCof[stone][plastic] = KineticCof[plastic][glass] = 0.5;
+    KineticCof[glass][rubber] = KineticCof[rubber][glass] = 1.4;
 
-  /* Metal on Metal ?guess?: 0.2 */
-  Cof[metal][metal] = 0.2;
+    /* Metal on Metal ?guess?: 0.2 */
+    Cof[metal][metal] = 0.2;
 
-  /* Wood on Wood -Dry-: 0.25-0.5 */
-  Cof[wood][wood] = 0.4;
+    /* Wood on Wood -Dry-: 0.25-0.5 */
+    Cof[wood][wood] = 0.4;
 
-  /* Wood on Metal -Dry-: 0.2-0.6 */
-  Cof[wood][metal] = Cof[metal][wood] = 0.3;
+    /* Wood on Metal -Dry-: 0.2-0.6 */
+    Cof[wood][metal] = Cof[metal][wood] = 0.3;
 
-  /* Plastic on Plastic ?guess?: 0.3 */
-  Cof[plastic][plastic] = 0.3;
+    /* Plastic on Plastic ?guess?: 0.3 */
+    Cof[plastic][plastic] = 0.3;
 
-  /* Plastic on Metal ?guess?: 0.2 */
-  Cof[plastic][metal] = Cof[metal][plastic] = 0.2;
+    /* Plastic on Metal ?guess?: 0.2 */
+    Cof[plastic][metal] = Cof[metal][plastic] = 0.2;
 
-  /* Plastic on Wood ?guess?: 0.4 */
-  Cof[plastic][wood] = Cof[wood][plastic] = 0.4;
+    /* Plastic on Wood ?guess?: 0.4 */
+    Cof[plastic][wood] = Cof[wood][plastic] = 0.4;
 
-  /* Rubber on Solids:  1-4 */
-  Cof[rubber][rubber] = 2.0;  
-  Cof[rubber][metal] = Cof[metal][rubber] = 1.0;
-  Cof[rubber][wood] = Cof[wood][rubber] = 1.0;
-  Cof[rubber][plastic] = Cof[plastic][rubber] = 1.0;
+    /* Rubber on Solids:  1-4 */
+    Cof[rubber][rubber] = 2.0;
+    Cof[rubber][metal] = Cof[metal][rubber] = 1.0;
+    Cof[rubber][wood] = Cof[wood][rubber] = 1.0;
+    Cof[rubber][plastic] = Cof[plastic][rubber] = 1.0;
 
-  /* for now we simply copy metal values for glass */
-  Cof[glass][glass] = 0.2;
-  Cof[glass][metal] = Cof[metal][glass] = 0.2;
-  Cof[glass][wood] = Cof[wood][glass] = 0.3;
-  Cof[glass][plastic] = Cof[plastic][glass] = 0.2;
-  Cof[glass][rubber] = Cof[rubber][glass] = 1.0;
+    /* for now we simply copy metal values for glass */
+    Cof[glass][glass] = 0.2;
+    Cof[glass][metal] = Cof[metal][glass] = 0.2;
+    Cof[glass][wood] = Cof[wood][glass] = 0.3;
+    Cof[glass][plastic] = Cof[plastic][glass] = 0.2;
+    Cof[glass][rubber] = Cof[rubber][glass] = 1.0;
 
-  /* guessed values for stone */
-  Cof[stone][stone] = 0.7;
-  Cof[stone][glass] = Cof[glass][stone] = 0.4;
-  Cof[stone][metal] = Cof[metal][stone] = 0.4;
-  Cof[stone][wood] = Cof[wood][stone] = 0.6;
-  Cof[stone][plastic] = Cof[plastic][stone] = 0.6;
-  Cof[stone][rubber] = Cof[rubber][stone] = 1.5;
+    /* guessed values for stone */
+    Cof[stone][stone] = 0.7;
+    Cof[stone][glass] = Cof[glass][stone] = 0.4;
+    Cof[stone][metal] = Cof[metal][stone] = 0.4;
+    Cof[stone][wood] = Cof[wood][stone] = 0.6;
+    Cof[stone][plastic] = Cof[plastic][stone] = 0.6;
+    Cof[stone][rubber] = Cof[rubber][stone] = 1.5;
 
-}  
-  
+}
+
 

--- a/src/matvec.cpp
+++ b/src/matvec.cpp
@@ -23,9 +23,9 @@
 //
 //######################################################################
 
-/*! \file 
-  \brief Implements the classes: vec3, position , mat3 , Quaternion , and transf
- */
+/*! \file
+    \brief Implements the classes: vec3, position , mat3 , Quaternion , and transf
+*/
 #include "matvec3D.h"
 
 //#define GRASPITDBG
@@ -38,358 +38,351 @@
 //#define GCC22
 
 #define BADCONFIG                                     \
-{                                                     \
-  pr_error("not a valid configuration file!");        \
-  fclose(fp);                                         \
-  return FAILURE;                                     \
-}
+    {                                                     \
+        pr_error("not a valid configuration file!");        \
+        fclose(fp);                                         \
+        return FAILURE;                                     \
+    }
 
 const vec3 vec3::ZERO(0, 0, 0);
 const vec3 vec3::X(1, 0, 0);
 const vec3 vec3::Y(0, 1, 0);
 const vec3 vec3::Z(0, 0, 1);
 const position position::ORIGIN(0, 0, 0);
-const mat3 mat3::ZERO(vec3::ZERO,vec3::ZERO,vec3::ZERO);
+const mat3 mat3::ZERO(vec3::ZERO, vec3::ZERO, vec3::ZERO);
 const mat3 mat3::IDENTITY(vec3(1, 0, 0), vec3(0, 1, 0), vec3(0, 0, 1));
-const Quaternion Quaternion::IDENTITY(1,0,0,0);
-const transf transf::IDENTITY(Quaternion::IDENTITY,vec3::ZERO);
+const Quaternion Quaternion::IDENTITY(1, 0, 0, 0);
+const transf transf::IDENTITY(Quaternion::IDENTITY, vec3::ZERO);
 
 /*!
-  Returns two vectors that are perpendicular to this vector and each other.
+    Returns two vectors that are perpendicular to this vector and each other.
 */
 void
-vec3::perpVectors(vec3 &v1,vec3 &v2)
-{
-  double k;
-  if (fabs(vec[2]) > M_SQRT1_2) {
-    // choose v1 in y-z plane
-    k = 1.0/sqrt(vec[1]*vec[1] + vec[2]*vec[2]);
-    v1[0] = 0;
-    v1[1] = -vec[2]*k;
-    v1[2] = vec[1]*k;
-  }
-  else {
-    // choose v1 in x-y plane
-    k = 1.0/sqrt(vec[0]*vec[0] + vec[1]*vec[1]);
-    v1[0] = -vec[1]*k;
-    v1[1] = vec[0]*k;
-    v1[2] = 0;
-  }
+vec3::perpVectors(vec3 &v1, vec3 &v2) {
+    double k;
+    if (fabs(vec[2]) > M_SQRT1_2) {
+        // choose v1 in y-z plane
+        k = 1.0 / sqrt(vec[1] * vec[1] + vec[2] * vec[2]);
+        v1[0] = 0;
+        v1[1] = -vec[2] * k;
+        v1[2] = vec[1] * k;
+    }
+    else {
+        // choose v1 in x-y plane
+        k = 1.0 / sqrt(vec[0] * vec[0] + vec[1] * vec[1]);
+        v1[0] = -vec[1] * k;
+        v1[1] = vec[0] * k;
+        v1[2] = 0;
+    }
 
-  v2 = *this * v1;
+    v2 = *this * v1;
 }
 
 /*!
-  Converts a rotation matrix to the Euler angles roll, pitch, and yaw.
+    Converts a rotation matrix to the Euler angles roll, pitch, and yaw.
 */
 void
-mat3::ToEulerAngles(double &roll,double &pitch, double &yaw) const
-{
-  double cosPitch;
-  pitch = atan2(-mat[6],sqrt(mat[0]*mat[0]+mat[3]*mat[3]));
-  if (pitch == M_PI/2.0) {
-    yaw = 0.0;
-    roll = atan2(mat[1],mat[4]);
-  }
-  else if (pitch == -M_PI/2.0) {
-    yaw = 0.0;
-    roll = -atan2(mat[1],mat[4]);
-  }
-  else {
-    cosPitch = cos(pitch);
-    yaw = atan2(mat[3]/cosPitch,mat[0]/cosPitch);
-    roll = atan2(mat[7]/cosPitch,mat[8]/cosPitch);
-  }
+mat3::ToEulerAngles(double &roll, double &pitch, double &yaw) const {
+    double cosPitch;
+    pitch = atan2(-mat[6], sqrt(mat[0] * mat[0] + mat[3] * mat[3]));
+    if (pitch == M_PI / 2.0) {
+        yaw = 0.0;
+        roll = atan2(mat[1], mat[4]);
+    }
+    else if (pitch == -M_PI / 2.0) {
+        yaw = 0.0;
+        roll = -atan2(mat[1], mat[4]);
+    }
+    else {
+        cosPitch = cos(pitch);
+        yaw = atan2(mat[3] / cosPitch, mat[0] / cosPitch);
+        roll = atan2(mat[7] / cosPitch, mat[8] / cosPitch);
+    }
 }
 
 /*! Inverts a 3x3 matrix (does not assume matrix is orthonormal) */
 mat3
-mat3::inverse() const
-{
-  double det, detInv;
-  double M[9];
+mat3::inverse() const {
+    double det, detInv;
+    double M[9];
 
-  if (fabs(det = determinant()) < 1.0e-12) return mat3::ZERO;
-  detInv = 1 / det;
+    if (fabs(det = determinant()) < 1.0e-12) return mat3::ZERO;
+    detInv = 1 / det;
 
-  M[0] = (mat[4] * mat[8] - mat[7] * mat[5]) * detInv;
-  M[1] = (mat[7] * mat[2] - mat[1] * mat[8]) * detInv;
-  M[2] = (mat[1] * mat[5] - mat[4] * mat[2]) * detInv;
-  M[3] = (mat[6] * mat[5] - mat[3] * mat[8]) * detInv;
-  M[4] = (mat[0] * mat[8] - mat[6] * mat[2]) * detInv;
-  M[5] = (mat[3] * mat[2] - mat[0] * mat[5]) * detInv;
-  M[6] = (mat[3] * mat[7] - mat[6] * mat[4]) * detInv;
-  M[7] = (mat[6] * mat[1] - mat[0] * mat[7]) * detInv;
-  M[8] = (mat[0] * mat[4] - mat[3] * mat[1]) * detInv;
+    M[0] = (mat[4] * mat[8] - mat[7] * mat[5]) * detInv;
+    M[1] = (mat[7] * mat[2] - mat[1] * mat[8]) * detInv;
+    M[2] = (mat[1] * mat[5] - mat[4] * mat[2]) * detInv;
+    M[3] = (mat[6] * mat[5] - mat[3] * mat[8]) * detInv;
+    M[4] = (mat[0] * mat[8] - mat[6] * mat[2]) * detInv;
+    M[5] = (mat[3] * mat[2] - mat[0] * mat[5]) * detInv;
+    M[6] = (mat[3] * mat[7] - mat[6] * mat[4]) * detInv;
+    M[7] = (mat[6] * mat[1] - mat[0] * mat[7]) * detInv;
+    M[8] = (mat[0] * mat[4] - mat[3] * mat[1]) * detInv;
 
-  return mat3(M);
+    return mat3(M);
 }
 
 /*! Returns this matrix post-multiplied with the matrix \a m. */
-mat3 const&
-mat3::operator*=(const mat3 &m)
-{
-  double M[9];
-  memcpy(M,mat,9*sizeof(double));
+mat3 const &
+mat3::operator*=(const mat3 &m) {
+    double M[9];
+    memcpy(M, mat, 9 * sizeof(double));
 
-  mat[0] = M[0]*m.mat[0] + M[3]*m.mat[1] + M[6]*m.mat[2]; 
-  mat[1] = M[1]*m.mat[0] + M[4]*m.mat[1] + M[7]*m.mat[2]; 
-  mat[2] = M[2]*m.mat[0] + M[5]*m.mat[1] + M[8]*m.mat[2]; 
+    mat[0] = M[0] * m.mat[0] + M[3] * m.mat[1] + M[6] * m.mat[2];
+    mat[1] = M[1] * m.mat[0] + M[4] * m.mat[1] + M[7] * m.mat[2];
+    mat[2] = M[2] * m.mat[0] + M[5] * m.mat[1] + M[8] * m.mat[2];
 
-  mat[3] = M[0]*m.mat[3] + M[3]*m.mat[4] + M[6]*m.mat[5]; 
-  mat[4] = M[1]*m.mat[3] + M[4]*m.mat[4] + M[7]*m.mat[5]; 
-  mat[5] = M[2]*m.mat[3] + M[5]*m.mat[4] + M[8]*m.mat[5]; 
-  
-  mat[6] = M[0]*m.mat[6] + M[3]*m.mat[7] + M[6]*m.mat[8]; 
-  mat[7] = M[1]*m.mat[6] + M[4]*m.mat[7] + M[7]*m.mat[8]; 
-  mat[8] = M[2]*m.mat[6] + M[5]*m.mat[7] + M[8]*m.mat[8]; 
-  return *this;
+    mat[3] = M[0] * m.mat[3] + M[3] * m.mat[4] + M[6] * m.mat[5];
+    mat[4] = M[1] * m.mat[3] + M[4] * m.mat[4] + M[7] * m.mat[5];
+    mat[5] = M[2] * m.mat[3] + M[5] * m.mat[4] + M[8] * m.mat[5];
+
+    mat[6] = M[0] * m.mat[6] + M[3] * m.mat[7] + M[6] * m.mat[8];
+    mat[7] = M[1] * m.mat[6] + M[4] * m.mat[7] + M[7] * m.mat[8];
+    mat[8] = M[2] * m.mat[6] + M[5] * m.mat[7] + M[8] * m.mat[8];
+    return *this;
 }
 
 /*! Returns the product of \a m1 * \a m2. */
 mat3
-operator*(const mat3 &m1, const mat3 &m2)
-{
-  double M[9];
+operator*(const mat3 &m1, const mat3 &m2) {
+    double M[9];
 
-  M[0] = m1.mat[0]*m2.mat[0] + m1.mat[3]*m2.mat[1] + m1.mat[6]*m2.mat[2]; 
-  M[1] = m1.mat[1]*m2.mat[0] + m1.mat[4]*m2.mat[1] + m1.mat[7]*m2.mat[2]; 
-  M[2] = m1.mat[2]*m2.mat[0] + m1.mat[5]*m2.mat[1] + m1.mat[8]*m2.mat[2]; 
+    M[0] = m1.mat[0] * m2.mat[0] + m1.mat[3] * m2.mat[1] + m1.mat[6] * m2.mat[2];
+    M[1] = m1.mat[1] * m2.mat[0] + m1.mat[4] * m2.mat[1] + m1.mat[7] * m2.mat[2];
+    M[2] = m1.mat[2] * m2.mat[0] + m1.mat[5] * m2.mat[1] + m1.mat[8] * m2.mat[2];
 
-  M[3] = m1.mat[0]*m2.mat[3] + m1.mat[3]*m2.mat[4] + m1.mat[6]*m2.mat[5]; 
-  M[4] = m1.mat[1]*m2.mat[3] + m1.mat[4]*m2.mat[4] + m1.mat[7]*m2.mat[5]; 
-  M[5] = m1.mat[2]*m2.mat[3] + m1.mat[5]*m2.mat[4] + m1.mat[8]*m2.mat[5]; 
+    M[3] = m1.mat[0] * m2.mat[3] + m1.mat[3] * m2.mat[4] + m1.mat[6] * m2.mat[5];
+    M[4] = m1.mat[1] * m2.mat[3] + m1.mat[4] * m2.mat[4] + m1.mat[7] * m2.mat[5];
+    M[5] = m1.mat[2] * m2.mat[3] + m1.mat[5] * m2.mat[4] + m1.mat[8] * m2.mat[5];
 
-  M[6] = m1.mat[0]*m2.mat[6] + m1.mat[3]*m2.mat[7] + m1.mat[6]*m2.mat[8]; 
-  M[7] = m1.mat[1]*m2.mat[6] + m1.mat[4]*m2.mat[7] + m1.mat[7]*m2.mat[8]; 
-  M[8] = m1.mat[2]*m2.mat[6] + m1.mat[5]*m2.mat[7] + m1.mat[8]*m2.mat[8]; 
+    M[6] = m1.mat[0] * m2.mat[6] + m1.mat[3] * m2.mat[7] + m1.mat[6] * m2.mat[8];
+    M[7] = m1.mat[1] * m2.mat[6] + m1.mat[4] * m2.mat[7] + m1.mat[7] * m2.mat[8];
+    M[8] = m1.mat[2] * m2.mat[6] + m1.mat[5] * m2.mat[7] + m1.mat[8] * m2.mat[8];
 
-  return mat3(M);
+    return mat3(M);
 }
 
 /*!
-  Creates a 6x6 jacobian from a transform.  Code adapted from Peter Corke's
-  Robot Toolbox for MATLAB.
+    Creates a 6x6 jacobian from a transform.  Code adapted from Peter Corke's
+    Robot Toolbox for MATLAB.
 
- MATLAB representation:
-\verbatim
-	J = [	t(1:3,1)'	cross(t(1:3,4),t(1:3,1))'
-			t(1:3,2)'	cross(t(1:3,4),t(1:3,2))'
-			t(1:3,3)'	cross(t(1:3,4),t(1:3,3))'
-			zeros(3,3)		t(1:3,1:3)'		];
-\endverbatim
+    MATLAB representation:
+    \verbatim
+    J = [   t(1:3,1)'   cross(t(1:3,4),t(1:3,1))'
+            t(1:3,2)'   cross(t(1:3,4),t(1:3,2))'
+            t(1:3,3)'   cross(t(1:3,4),t(1:3,3))'
+            zeros(3,3)      t(1:3,1:3)'     ];
+    \endverbatim
 
-The jacobian is returned is in column-major format.
+    The jacobian is returned is in column-major format.
 */
 void
-transf::jacobian(double jac[])
-{
-  mat3 m = affine();
-  vec3 p = translation();
+transf::jacobian(double jac[]) {
+    mat3 m = affine();
+    vec3 p = translation();
 
-  // first 3 columns of jac
-  jac[0]  = m.element(0,0); jac[6]  = m.element(0,1); jac[12] = m.element(0,2);
-  jac[1]  = m.element(1,0); jac[7]  = m.element(1,1); jac[13] = m.element(1,2);
-  jac[2]  = m.element(2,0); jac[8]  = m.element(2,1); jac[14] = m.element(2,2);
-  jac[3]  = 0.0;            jac[9]  = 0.0;            jac[15] = 0.0;
-  jac[4]  = 0.0;            jac[10] = 0.0;            jac[16] = 0.0;
-  jac[5]  = 0.0;            jac[11] = 0.0;            jac[17] = 0.0;
+    // first 3 columns of jac
+    jac[0]  = m.element(0, 0);
+    jac[6]  = m.element(0, 1);
+    jac[12] = m.element(0, 2);
+    jac[1]  = m.element(1, 0);
+    jac[7]  = m.element(1, 1);
+    jac[13] = m.element(1, 2);
+    jac[2]  = m.element(2, 0);
+    jac[8]  = m.element(2, 1);
+    jac[14] = m.element(2, 2);
+    jac[3]  = 0.0;
+    jac[9]  = 0.0;
+    jac[15] = 0.0;
+    jac[4]  = 0.0;
+    jac[10] = 0.0;
+    jac[16] = 0.0;
+    jac[5]  = 0.0;
+    jac[11] = 0.0;
+    jac[17] = 0.0;
 
-  // 4th column of jac
-  jac[18] = p.y()*m.element(0,2) - p.z()*m.element(0,1);
-  jac[19] = p.y()*m.element(1,2) - p.z()*m.element(1,1);
-  jac[20] = p.y()*m.element(2,2) - p.z()*m.element(2,1);
-  jac[21] = m.element(0,0);
-  jac[22] = m.element(1,0);
-  jac[23] = m.element(2,0);
+    // 4th column of jac
+    jac[18] = p.y() * m.element(0, 2) - p.z() * m.element(0, 1);
+    jac[19] = p.y() * m.element(1, 2) - p.z() * m.element(1, 1);
+    jac[20] = p.y() * m.element(2, 2) - p.z() * m.element(2, 1);
+    jac[21] = m.element(0, 0);
+    jac[22] = m.element(1, 0);
+    jac[23] = m.element(2, 0);
 
-  // 5th column of jac
-  jac[24] = p.z()*m.element(0,0) - p.x()*m.element(0,2);
-  jac[25] = p.z()*m.element(1,0) - p.x()*m.element(1,2);
-  jac[26] = p.z()*m.element(2,0) - p.x()*m.element(2,2);
-  jac[27] = m.element(0,1);
-  jac[28] = m.element(1,1);
-  jac[29] = m.element(2,1);
+    // 5th column of jac
+    jac[24] = p.z() * m.element(0, 0) - p.x() * m.element(0, 2);
+    jac[25] = p.z() * m.element(1, 0) - p.x() * m.element(1, 2);
+    jac[26] = p.z() * m.element(2, 0) - p.x() * m.element(2, 2);
+    jac[27] = m.element(0, 1);
+    jac[28] = m.element(1, 1);
+    jac[29] = m.element(2, 1);
 
-  // 6th column of jac
-  jac[30] = p.x()*m.element(0,1) - p.y()*m.element(0,0);
-  jac[31] = p.x()*m.element(1,1) - p.y()*m.element(1,0);
-  jac[32] = p.x()*m.element(2,1) - p.y()*m.element(2,0);
-  jac[33] = m.element(0,2);
-  jac[34] = m.element(1,2);
-  jac[35] = m.element(2,2);
+    // 6th column of jac
+    jac[30] = p.x() * m.element(0, 1) - p.y() * m.element(0, 0);
+    jac[31] = p.x() * m.element(1, 1) - p.y() * m.element(1, 0);
+    jac[32] = p.x() * m.element(2, 1) - p.y() * m.element(2, 0);
+    jac[33] = m.element(0, 2);
+    jac[34] = m.element(1, 2);
+    jac[35] = m.element(2, 2);
 }
 
 //---------------------------------------------------------------------------
 /*!
-  Sets this quaternion by converting from rotation matrix \a R.
+    Sets this quaternion by converting from rotation matrix \a R.
 */
 void
-Quaternion::set(const mat3 &R)
-{
+Quaternion::set(const mat3 &R) {
     // Algorithm in Ken Shoemake's article in 1987 SIGGRAPH course notes
     // article "Quaternion Calculus and Fast Animation".
 
-    double trace = R.element(0,0)+R.element(1,1)+R.element(2,2);
+    double trace = R.element(0, 0) + R.element(1, 1) + R.element(2, 2);
     double root;
 
-    if ( trace > 0.0 )
-    {
+    if (trace > 0.0) {
         // |w| > 1/2, may as well choose w > 1/2
-        root = sqrt(trace+1.0);  // 2w
-        w = 0.5*root;
-        root = 0.5/root;  // 1/(4w)
-        x = (R.element(1,2)-R.element(2,1))*root;
-        y = (R.element(2,0)-R.element(0,2))*root;
-        z = (R.element(0,1)-R.element(1,0))*root;
+        root = sqrt(trace + 1.0); // 2w
+        w = 0.5 * root;
+        root = 0.5 / root; // 1/(4w)
+        x = (R.element(1, 2) - R.element(2, 1)) * root;
+        y = (R.element(2, 0) - R.element(0, 2)) * root;
+        z = (R.element(0, 1) - R.element(1, 0)) * root;
     }
-    else
-    {
+    else {
         // |w| <= 1/2
         static int next[3] = { 1, 2, 0 };
         int i = 0;
-        if ( R.element(1,1) > R.element(0,0) )
+        if (R.element(1, 1) > R.element(0, 0))
             i = 1;
-        if ( R.element(2,2) > R.element(i,i) )
+        if (R.element(2, 2) > R.element(i, i))
             i = 2;
         int j = next[i];
         int k = next[j];
 
-        root = sqrt(R.element(i,i)-R.element(j,j)-R.element(k,k)+1.0);
-        double* quat[3] = { &x, &y, &z };
-        *quat[i] = 0.5*root;
-        root = 0.5/root;
-        w = (R.element(j,k)-R.element(k,j))*root;
-        *quat[j] = (R.element(i,j)+R.element(j,i))*root;
-        *quat[k] = (R.element(i,k)+R.element(k,i))*root;
+        root = sqrt(R.element(i, i) - R.element(j, j) - R.element(k, k) + 1.0);
+        double *quat[3] = { &x, &y, &z };
+        *quat[i] = 0.5 * root;
+        root = 0.5 / root;
+        w = (R.element(j, k) - R.element(k, j)) * root;
+        *quat[j] = (R.element(i, j) + R.element(j, i)) * root;
+        *quat[k] = (R.element(i, k) + R.element(k, i)) * root;
     }
     normalise();
 }
 
 /*!
-  Sets this quaternion by converting the rotation from angle-axis formate.
-  The angle is specified in radians.
+    Sets this quaternion by converting the rotation from angle-axis formate.
+    The angle is specified in radians.
 */
 void
-Quaternion::set(const double& angle, const vec3& axis)
-{
+Quaternion::set(const double &angle, const vec3 &axis) {
     // assert:  axis[] is unit length
     //
-	// The quaternion representing the rotation is
-	//   q = cos(A/2)+sin(A/2)*(x*i+y*j+z*k)
+    // The quaternion representing the rotation is
+    //   q = cos(A/2)+sin(A/2)*(x*i+y*j+z*k)
 
-    double halfAngle = 0.5*angle;
+    double halfAngle = 0.5 * angle;
     double sn = sin(halfAngle);
     w = cos(halfAngle);
-    x = sn*axis.x();
-    y = sn*axis.y();
-    z = sn*axis.z();
+    x = sn * axis.x();
+    y = sn * axis.y();
+    z = sn * axis.z();
     normalise();
 }
 
 /*!
-  Sets this quaternion by converting from Inventor format.
+    Sets this quaternion by converting from Inventor format.
 */
 void
-Quaternion::set(const SbRotation &SbRot)
-{
-  w = (double)SbRot.getValue()[3];
-  x = (double)SbRot.getValue()[0];
-  y = (double)SbRot.getValue()[1];
-  z = (double)SbRot.getValue()[2];
-  normalise();
-}
-
-/*!
-  Sets this quaternion as the rotation that transforms start into dest.
-  Inspired by Ogre3D getRotationTo(...) function at:
-  http://www.ogre3d.org/docs/api/html/OgreVector3_8h_source.html#l00651
-*/
-void Quaternion::set(const vec3 &start, const vec3 &dest)
-{
-  vec3 v0(start);
-  vec3 v1(dest);
-  v0 = v0 / v0.len();
-  v1 = v1 / v1.len();
-
-  double d = v0 % v1;
-  // If dot == 1, vectors are the same
-  if (d >= 1.0f)
-  {
-    set(Quaternion::IDENTITY);
-  }
-  if (d < (1e-6f - 1.0f))
-  {
-    // Generate an axis
-    vec3 axis = vec3(1,0,0) * v0;
-    // pick another if colinear
-    if (axis.len() < 1.0e-5) axis = vec3(0,1,0) * v0;
-    axis = axis / axis.len();
-    set(M_PI, axis);
-  }
-  else
-  {
-    double s = sqrt( (1+d)*2 );
-    double invs = 1 / s;    
-    vec3 c = v0 * v1;
-    x = c.x() * invs;
-    y = c.y() * invs;
-    z = c.z() * invs;
-    w = s * 0.5f;
+Quaternion::set(const SbRotation &SbRot) {
+    w = (double)SbRot.getValue()[3];
+    x = (double)SbRot.getValue()[0];
+    y = (double)SbRot.getValue()[1];
+    z = (double)SbRot.getValue()[2];
     normalise();
-  }
 }
 
 /*!
-  Converts this quaternion to a 3x3 rotation matrix.
+    Sets this quaternion as the rotation that transforms start into dest.
+    Inspired by Ogre3D getRotationTo(...) function at:
+    http://www.ogre3d.org/docs/api/html/OgreVector3_8h_source.html#l00651
 */
-void
-Quaternion::ToRotationMatrix(mat3 &R) const
-{
-    double tx  = 2.0*x;
-    double ty  = 2.0*y;
-    double tz  = 2.0*z;
-    double twx = tx*w;
-    double twy = ty*w;
-    double twz = tz*w;
-    double txx = tx*x;
-    double txy = ty*x;
-    double txz = tz*x;
-    double tyy = ty*y;
-    double tyz = tz*y;
-    double tzz = tz*z;
+void Quaternion::set(const vec3 &start, const vec3 &dest) {
+    vec3 v0(start);
+    vec3 v1(dest);
+    v0 = v0 / v0.len();
+    v1 = v1 / v1.len();
 
-    R.element(0,0) = 1.0-(tyy+tzz);
-    R.element(1,0) = txy-twz;
-    R.element(2,0) = txz+twy;
-    R.element(0,1) = txy+twz;
-    R.element(1,1) = 1.0-(txx+tzz);
-    R.element(2,1) = tyz-twx;
-    R.element(0,2) = txz-twy;
-    R.element(1,2) = tyz+twx;
-    R.element(2,2) = 1.0-(txx+tyy);
-}
-
-/*!
-  Converts this quaternion to angle-axis format.
-*/
-void
-Quaternion::ToAngleAxis(double& angle, vec3& axis) const
-{
-	// The quaternion representing the rotation is
-	//   q = cos(A/2)+sin(A/2)*(x*i+y*j+z*k)
-
-    double length2 = x*x+y*y+z*z;
-    if ( length2 > 1.0e-15 )
-    {
-        angle = 2.0*acos(w);
-        double invlen = 1.0/sqrt(length2);
-        axis[0] = x*invlen;
-        axis[1] = y*invlen;
-        axis[2] = z*invlen;
+    double d = v0 % v1;
+    // If dot == 1, vectors are the same
+    if (d >= 1.0f) {
+        set(Quaternion::IDENTITY);
     }
-    else
-    {
+    if (d < (1e-6f - 1.0f)) {
+        // Generate an axis
+        vec3 axis = vec3(1, 0, 0) * v0;
+        // pick another if colinear
+        if (axis.len() < 1.0e-5) axis = vec3(0, 1, 0) * v0;
+        axis = axis / axis.len();
+        set(M_PI, axis);
+    }
+    else {
+        double s = sqrt((1 + d) * 2);
+        double invs = 1 / s;
+        vec3 c = v0 * v1;
+        x = c.x() * invs;
+        y = c.y() * invs;
+        z = c.z() * invs;
+        w = s * 0.5f;
+        normalise();
+    }
+}
+
+/*!
+    Converts this quaternion to a 3x3 rotation matrix.
+*/
+void
+Quaternion::ToRotationMatrix(mat3 &R) const {
+    double tx  = 2.0 * x;
+    double ty  = 2.0 * y;
+    double tz  = 2.0 * z;
+    double twx = tx * w;
+    double twy = ty * w;
+    double twz = tz * w;
+    double txx = tx * x;
+    double txy = ty * x;
+    double txz = tz * x;
+    double tyy = ty * y;
+    double tyz = tz * y;
+    double tzz = tz * z;
+
+    R.element(0, 0) = 1.0 - (tyy + tzz);
+    R.element(1, 0) = txy - twz;
+    R.element(2, 0) = txz + twy;
+    R.element(0, 1) = txy + twz;
+    R.element(1, 1) = 1.0 - (txx + tzz);
+    R.element(2, 1) = tyz - twx;
+    R.element(0, 2) = txz - twy;
+    R.element(1, 2) = tyz + twx;
+    R.element(2, 2) = 1.0 - (txx + tyy);
+}
+
+/*!
+    Converts this quaternion to angle-axis format.
+*/
+void
+Quaternion::ToAngleAxis(double &angle, vec3 &axis) const {
+    // The quaternion representing the rotation is
+    //   q = cos(A/2)+sin(A/2)*(x*i+y*j+z*k)
+
+    double length2 = x * x + y * y + z * z;
+    if (length2 > 1.0e-15) {
+        angle = 2.0 * acos(w);
+        double invlen = 1.0 / sqrt(length2);
+        axis[0] = x * invlen;
+        axis[1] = y * invlen;
+        axis[2] = z * invlen;
+    }
+    else {
         // angle is 0 (mod 2*pi), so any axis will do
         angle = 0.0;
         axis[0] = 1.0;
@@ -399,250 +392,243 @@ Quaternion::ToAngleAxis(double& angle, vec3& axis) const
 }
 
 /*!
-  Computes a rotation between \a p and \a q using spherical linear
-  interpolation and the scalar \a t [0..1].  If \a t is 0, \a p will be
-  returned.  If \a t is 1, \a q will be returned.
-*/  
+    Computes a rotation between \a p and \a q using spherical linear
+    interpolation and the scalar \a t [0..1].  If \a t is 0, \a p will be
+    returned.  If \a t is 1, \a q will be returned.
+*/
 Quaternion
-Quaternion::Slerp (double t, const Quaternion& p,
-		   const Quaternion& q)
-{
-  Quaternion q1;
-  double sn,c0,c1,angle;
-  double cs;
-  
-  if (t == 0.0) return p;
-  if (t == 1.0) return q;
+Quaternion::Slerp(double t, const Quaternion &p,
+                  const Quaternion &q) {
+    Quaternion q1;
+    double sn, c0, c1, angle;
+    double cs;
 
-  cs = p % q;
+    if (t == 0.0) return p;
+    if (t == 1.0) return q;
 
-  if (cs < 0.0) {
-    cs = -cs;
-    q1 = -q;
-  }
-  else q1 = q;
+    cs = p % q;
 
-  // calculate interpolating coeffs
-  if ((1.0 - cs) > 0.00001) {
-    // standard case
-    angle = acos(cs);
-    sn = sin(angle);
-    c0 = sin((1.0 - t) * angle) / sn;
-    c1 = sin(t * angle) / sn;
-  } else {        
-    // q0 and q1 very close - just do linear interp.
-    c0 = 1.0 - t;
-    c1 = t;
-  }
+    if (cs < 0.0) {
+        cs = -cs;
+        q1 = -q;
+    }
+    else q1 = q;
 
-  return Quaternion(c0*p.w + c1*q1.w,c0*p.x + c1*q1.x,c0*p.y + c1*q1.y,
-		    c0*p.z + c1*q1.z);
+    // calculate interpolating coeffs
+    if ((1.0 - cs) > 0.00001) {
+        // standard case
+        angle = acos(cs);
+        sn = sin(angle);
+        c0 = sin((1.0 - t) * angle) / sn;
+        c1 = sin(t * angle) / sn;
+    }
+    else {
+        // q0 and q1 very close - just do linear interp.
+        c0 = 1.0 - t;
+        c1 = t;
+    }
+
+    return Quaternion(c0 * p.w + c1 * q1.w, c0 * p.x + c1 * q1.x, c0 * p.y + c1 * q1.y,
+                      c0 * p.z + c1 * q1.z);
 }
 
 
 /*! Reads the values of a vector \a v from stream \a is formatted as
-  "[#, #, #]"
- */
-std::istream&
-operator>>(std::istream &is, vec3 &v)
-{
-  char ch;
-  double x,y,z;
-  if (is >> ch && ch == '[' && is >> x && is >> y && is >> z &&
-      is >> ch && ch == ']') {
-    v.vec[0] = x; v.vec[1] = y; v.vec[2] = z;
-  }
-//  else
-//    is.setstate(ios::failbit);
-  
-  return is;
+    "[#, #, #]"
+*/
+std::istream &
+operator>>(std::istream &is, vec3 &v) {
+    char ch;
+    double x, y, z;
+    if (is >> ch && ch == '[' && is >> x && is >> y && is >> z &&
+            is >> ch && ch == ']') {
+        v.vec[0] = x;
+        v.vec[1] = y;
+        v.vec[2] = z;
+    }
+    //  else
+    //    is.setstate(ios::failbit);
+
+    return is;
 }
 
 /*! Writes the values of vector \a v to a stream \a os in the format
-  "[#, #, #]".
- */
+    "[#, #, #]".
+*/
 std::ostream &
-operator<<(std::ostream &os, const vec3 &v)
-{
-#ifdef WIN32
-  int oldFlags = os.setf(std::ios_base::showpos);
-#else
-#ifdef GCC22
- int oldFlags = os.setf(ios::showpos);
-#else
-  std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
-#endif 
-#endif
-  os << '[' << v.vec[0] << ' ' << v.vec[1] << ' ' << v.vec[2] << ']';
-  os.flags(oldFlags);
-  return os;
+operator<<(std::ostream &os, const vec3 &v) {
+    #ifdef WIN32
+    int oldFlags = os.setf(std::ios_base::showpos);
+    #else
+    #ifdef GCC22
+    int oldFlags = os.setf(ios::showpos);
+    #else
+    std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
+    #endif
+    #endif
+    os << '[' << v.vec[0] << ' ' << v.vec[1] << ' ' << v.vec[2] << ']';
+    os.flags(oldFlags);
+    return os;
 }
 
 /*! Reads the values of a position \a p from stream \a is formatted as
-  "[#, #, #]".
+    "[#, #, #]".
 */
-std::istream&
-operator>>(std::istream &is, position &p)
-{
-  char ch;
-  double x,y,z;
-  if (is >> ch && ch == '[' && is >> x && is >> y && is >> z &&
-      is >> ch && ch == ']') {
-    p.pos[0] = x; p.pos[1] = y; p.pos[2] = z;
-  } 
-//  else
-//    is.setstate(ios::failbit);
+std::istream &
+operator>>(std::istream &is, position &p) {
+    char ch;
+    double x, y, z;
+    if (is >> ch && ch == '[' && is >> x && is >> y && is >> z &&
+            is >> ch && ch == ']') {
+        p.pos[0] = x;
+        p.pos[1] = y;
+        p.pos[2] = z;
+    }
+    //  else
+    //    is.setstate(ios::failbit);
 
-  return is;
+    return is;
 }
 
 /*! Writes the values of position \a p to a stream \a os in the format
-  "[#, #, #]". */
+    "[#, #, #]". */
 std::ostream &
-operator<<(std::ostream &os, const position &p)
-{
-#ifdef WIN32
-  int oldFlags = os.setf(std::ios_base::showpos);
-#else
-#ifdef GCC22
- int oldFlags = os.setf(ios::showpos);
-#else
-  std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
-#endif 
-#endif
-  os << '[' << p.pos[0] << ' ' << p.pos[1] << ' ' << p.pos[2] << ']';
-  os.flags(oldFlags);
-  return os;
+operator<<(std::ostream &os, const position &p) {
+    #ifdef WIN32
+    int oldFlags = os.setf(std::ios_base::showpos);
+    #else
+    #ifdef GCC22
+    int oldFlags = os.setf(ios::showpos);
+    #else
+    std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
+    #endif
+    #endif
+    os << '[' << p.pos[0] << ' ' << p.pos[1] << ' ' << p.pos[2] << ']';
+    os.flags(oldFlags);
+    return os;
 }
 
 /*! Reads the 9 consecutive values of a 3x3 matrix in column major format. */
 std::istream &
-operator>>(std::istream &is, mat3 &m)
-{
-  is >> m.mat[0] >> m.mat[3] >> m.mat[6];
-  is >> m.mat[1] >> m.mat[4] >> m.mat[7];
-  is >> m.mat[2] >> m.mat[5] >> m.mat[8];
-  return is;
+operator>>(std::istream &is, mat3 &m) {
+    is >> m.mat[0] >> m.mat[3] >> m.mat[6];
+    is >> m.mat[1] >> m.mat[4] >> m.mat[7];
+    is >> m.mat[2] >> m.mat[5] >> m.mat[8];
+    return is;
 }
 
 /*!
-  Writes the matrix out on 3 lines in the following format:
-\verbatim
-[ # # #]
-[ # # #]
-[ # # #]
-\endverbatim
+    Writes the matrix out on 3 lines in the following format:
+    \verbatim
+    [ # # #]
+    [ # # #]
+    [ # # #]
+    \endverbatim
 */
 std::ostream &
-operator<<(std::ostream &os, const mat3 &m)
-{
-#ifdef WIN32
-  int oldFlags = os.setf(std::ios_base::showpos);
-#else
-#ifdef GCC22
- int oldFlags = os.setf(ios::showpos);
-#else
-  std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
-#endif
-#endif
-  os << '[' << m.mat[0] << ' ' << m.mat[3] << ' ' << m.mat[6]<< ']'<<std::endl;
-  os << '[' << m.mat[1] << ' ' << m.mat[4] << ' ' << m.mat[7]<< ']'<<std::endl;
-  os << '[' << m.mat[2] << ' ' << m.mat[5] << ' ' << m.mat[8]<< ']'<<std::endl;
-  os.flags(oldFlags);
-  return os;
+operator<<(std::ostream &os, const mat3 &m) {
+    #ifdef WIN32
+    int oldFlags = os.setf(std::ios_base::showpos);
+    #else
+    #ifdef GCC22
+    int oldFlags = os.setf(ios::showpos);
+    #else
+    std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
+    #endif
+    #endif
+    os << '[' << m.mat[0] << ' ' << m.mat[3] << ' ' << m.mat[6] << ']' << std::endl;
+    os << '[' << m.mat[1] << ' ' << m.mat[4] << ' ' << m.mat[7] << ']' << std::endl;
+    os << '[' << m.mat[2] << ' ' << m.mat[5] << ' ' << m.mat[8] << ']' << std::endl;
+    os.flags(oldFlags);
+    return os;
 }
 
 /*!
-  Reads the 4 values of a quaternion \a q formatted as "(w, x, y, z)" from a 
-  stream \a is.
+    Reads the 4 values of a quaternion \a q formatted as "(w, x, y, z)" from a
+    stream \a is.
 */
 std::istream &
-operator>>(std::istream &is, Quaternion &q)
-{
-  char ch;
-  double w,x,y,z;
-  if (is >> ch && ch == '(' && is >> w && is >> x && is >> y && is >> z &&
-      is >> ch && ch == ')') {
-    q.w = w; q.x = x; q.y = y; q.z = z;
-  } 
-//  else
-//    is.setstate(ios::failbit);
-  
-  return is;
+operator>>(std::istream &is, Quaternion &q) {
+    char ch;
+    double w, x, y, z;
+    if (is >> ch && ch == '(' && is >> w && is >> x && is >> y && is >> z &&
+            is >> ch && ch == ')') {
+        q.w = w;
+        q.x = x;
+        q.y = y;
+        q.z = z;
+    }
+    //  else
+    //    is.setstate(ios::failbit);
+
+    return is;
 }
 
 /*!
-  Writes the 4 values of a quaternion \a q in the format "(w, x, y, z)" to as
-  stream \a os.
-*/
-std::ostream&
-operator<<(std::ostream &os, const Quaternion &q)
-{
-#ifdef WIN32
-  int oldFlags = os.setf(std::ios_base::showpos);
-#else
-#ifdef GCC22
- int oldFlags = os.setf(ios::showpos);
-#else
-  std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
-#endif
-#endif 
-  os <<'('<< q.w <<' '<< q.x <<' '<< q.y <<' '<< q.z <<')';
-  os.flags(oldFlags);
-  return os;
-}
-
-/*!
-  Reads the 7 values of a transform \a tr formated as "(w, x, y, z) [v1,v2,v3]"
-  from stream \a is.
-*/
-std::istream&
-operator>>(std::istream &is, transf &tr)
-{
-  Quaternion q;
-  vec3 v;
-
-  if (is >> q && is >> v)
-    tr.set(q,v);
-//  else
-//    is.setstate(ios::failbit);
-
-  return is;
-}
-
-/*!
-  Writes the 7 values of a transform \a tr formated as
-  "(w, x, y, z) [v1,v2,v3]" to stream \a os.
+    Writes the 4 values of a quaternion \a q in the format "(w, x, y, z)" to as
+    stream \a os.
 */
 std::ostream &
-operator<<(std::ostream &os, const transf &tr)
-{
-  return os << tr.rot << tr.t;
+operator<<(std::ostream &os, const Quaternion &q) {
+    #ifdef WIN32
+    int oldFlags = os.setf(std::ios_base::showpos);
+    #else
+    #ifdef GCC22
+    int oldFlags = os.setf(ios::showpos);
+    #else
+    std::_Ios_Fmtflags oldFlags = os.setf(std::ios_base::showpos);
+    #endif
+    #endif
+    os << '(' << q.w << ' ' << q.x << ' ' << q.y << ' ' << q.z << ')';
+    os.flags(oldFlags);
+    return os;
 }
 
-void FlockTransf::identity()
-{
-	mount = transf::IDENTITY;
-	mountInv = transf::IDENTITY;
-	flockBaseInv = transf::IDENTITY;
-	objBase = transf::IDENTITY;
-}
-
-transf FlockTransf::get(transf t) const
-{
-	return mountInv * t * flockBaseInv * mount * objBase;
-}
-
-transf FlockTransf::getAbsolute(transf t) const
-{
-	return mountInv * t;
-}
-
-/*!	Does not multiply with the mount transform. It is meant to use with 
-	camera, and we assume we already have the camera mount built into the
-	objectBase.
+/*!
+    Reads the 7 values of a transform \a tr formated as "(w, x, y, z) [v1,v2,v3]"
+    from stream \a is.
 */
-transf FlockTransf::get2(transf t) const
-{
-	return mountInv * t * flockBaseInv * objBase;
+std::istream &
+operator>>(std::istream &is, transf &tr) {
+    Quaternion q;
+    vec3 v;
+
+    if (is >> q && is >> v)
+        tr.set(q, v);
+    //  else
+    //    is.setstate(ios::failbit);
+
+    return is;
+}
+
+/*!
+    Writes the 7 values of a transform \a tr formated as
+    "(w, x, y, z) [v1,v2,v3]" to stream \a os.
+*/
+std::ostream &
+operator<<(std::ostream &os, const transf &tr) {
+    return os << tr.rot << tr.t;
+}
+
+void FlockTransf::identity() {
+    mount = transf::IDENTITY;
+    mountInv = transf::IDENTITY;
+    flockBaseInv = transf::IDENTITY;
+    objBase = transf::IDENTITY;
+}
+
+transf FlockTransf::get(transf t) const {
+    return mountInv * t * flockBaseInv * mount * objBase;
+}
+
+transf FlockTransf::getAbsolute(transf t) const {
+    return mountInv * t;
+}
+
+/*! Does not multiply with the mount transform. It is meant to use with
+    camera, and we assume we already have the camera mount built into the
+    objectBase.
+*/
+transf FlockTransf::get2(transf t) const {
+    return mountInv * t * flockBaseInv * objBase;
 }

--- a/src/matvecIO.cpp
+++ b/src/matvecIO.cpp
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: matvecIO.cpp,v 1.5 2009/03/25 22:10:04 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Implements the QTextStream input and output operators for various matrices and vectors.
+    \brief Implements the QTextStream input and output operators for various matrices and vectors.
 */
 
 #include "matvecIO.h"
@@ -34,224 +34,225 @@
 #include "mytools.h"
 
 /*!
-  Reads a vec3 from a QTextStream.  The format should be "[x y z]".
-*/
-QTextStream&
-operator>>(QTextStream &is, vec3 &v)
-{
-  QChar ch;
-  double x,y,z;
-  is >> ch >> x >> y >> z >> ch;
-  v[0] = x; v[1] = y; v[2] = z;
-  
-  return is;
-}
-
-/*!
-  Writes a vec3 to a QTextStream in the format "[x y z]".
+    Reads a vec3 from a QTextStream.  The format should be "[x y z]".
 */
 QTextStream &
-operator<<(QTextStream &os, const vec3 &v)
-{
-  int oldFlags = os.setf(QTextStream::showpos);
-  os << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
-  os.flags(oldFlags);
-  return os;
+operator>>(QTextStream &is, vec3 &v) {
+    QChar ch;
+    double x, y, z;
+    is >> ch >> x >> y >> z >> ch;
+    v[0] = x;
+    v[1] = y;
+    v[2] = z;
+
+    return is;
 }
 
 /*!
-  Reads a position from a QTextStream.  The format should be "[x y z]".
-*/
-QTextStream&
-operator>>(QTextStream &is, position &p)
-{
-  QChar ch;
-  double x,y,z;
-  is >> ch >> x >> y >> z >> ch;
-  p[0] = x; p[1] = y; p[2] = z;
-
-  return is;
-}
-
-/*!
-  Writes a position to a QTextStream in the format "[x y z]".
+    Writes a vec3 to a QTextStream in the format "[x y z]".
 */
 QTextStream &
-operator<<(QTextStream &os, const position &p)
-{
-  int oldFlags = os.setf(QTextStream::showpos);
-  os << '[' << p[0] << ' ' << p[1] << ' ' << p[2] << ']';
-  os.flags(oldFlags);
-  return os;
+operator<<(QTextStream &os, const vec3 &v) {
+    int oldFlags = os.setf(QTextStream::showpos);
+    os << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
+    os.flags(oldFlags);
+    return os;
 }
 
 /*!
-  Reads a mat3 from a QTextStream.  The format should be:
-  \verbatim
-  [m1,1 m1,2 m1,3]
-  [m2,1 m2,2 m2,3]
-  [m3,1 m3,2 m3,3]
-  \endverbatim
+    Reads a position from a QTextStream.  The format should be "[x y z]".
 */
 QTextStream &
-operator>>(QTextStream &is, mat3 &m)
-{
-  is >> m[0] >> m[3] >> m[6];
-  is >> m[1] >> m[4] >> m[7];
-  is >> m[2] >> m[5] >> m[8];
-  return is;
+operator>>(QTextStream &is, position &p) {
+    QChar ch;
+    double x, y, z;
+    is >> ch >> x >> y >> z >> ch;
+    p[0] = x;
+    p[1] = y;
+    p[2] = z;
+
+    return is;
 }
 
 /*!
-  Writes a mat3 to a QTextStream in the format:
-  \verbatim
-  [m1,1 m1,2 m1,3]
-  [m2,1 m2,2 m2,3]
-  [m3,1 m3,2 m3,3]
-  \endverbatim
+    Writes a position to a QTextStream in the format "[x y z]".
 */
 QTextStream &
-operator<<(QTextStream &os, const mat3 &m)
-{
-  int oldFlags = os.setf(QTextStream::showpos);
-  os << '[' << m[0] << ' ' << m[3] << ' ' << m[6] << ']' << endl;
-  os << '[' << m[1] << ' ' << m[4] << ' ' << m[7] << ']' << endl;
-  os << '[' << m[2] << ' ' << m[5] << ' ' << m[8] << ']' << endl;
-  os.flags(oldFlags);
-  return os;
+operator<<(QTextStream &os, const position &p) {
+    int oldFlags = os.setf(QTextStream::showpos);
+    os << '[' << p[0] << ' ' << p[1] << ' ' << p[2] << ']';
+    os.flags(oldFlags);
+    return os;
 }
 
 /*!
-  Reads a Quaternion from a QTextStream.  The format should be 
-  "(qw qx qy qz)".
+    Reads a mat3 from a QTextStream.  The format should be:
+    \verbatim
+    [m1,1 m1,2 m1,3]
+    [m2,1 m2,2 m2,3]
+    [m3,1 m3,2 m3,3]
+    \endverbatim
 */
 QTextStream &
-operator>>(QTextStream &is, Quaternion &q)
-{
-  QChar ch;
-  double w,x,y,z;
-  is >> ch >> w >> x >> y >> z >> ch;
-  q.w = w; q.x = x; q.y = y; q.z = z;
-  return is;
+operator>>(QTextStream &is, mat3 &m) {
+    is >> m[0] >> m[3] >> m[6];
+    is >> m[1] >> m[4] >> m[7];
+    is >> m[2] >> m[5] >> m[8];
+    return is;
 }
 
 /*!
-  Writes a quaternion to a QTextStream in the format "(qw qx qy qz)".
-*/
-QTextStream&
-operator<<(QTextStream &os, const Quaternion &q)
-{
-  int oldFlags = os.setf(QTextStream::showpos);
-  os <<'('<< q.w <<' '<< q.x <<' '<< q.y <<' '<< q.z <<')';
-  os.flags(oldFlags);
-  return os;
-}
-
-/*!
-  Reads a transf from a QTextStream.  The format should be 
-  "(qw qx qy qz)[x y z]", where the 4 vector is a quaternion describing the
-  rotation and the 3 vector is a position.
-*/
-QTextStream&
-operator>>(QTextStream &is, transf &tr)
-{
-  Quaternion q;
-  vec3 v;
-
-  is >> q >> v;
-  tr.set(q,v);
-
-  return is;
-}
-
-/*!
-  Writes a transf to a QTextStream in the format "(qw qx qy qz)[x y z]".
+    Writes a mat3 to a QTextStream in the format:
+    \verbatim
+    [m1,1 m1,2 m1,3]
+    [m2,1 m2,2 m2,3]
+    [m3,1 m3,2 m3,3]
+    \endverbatim
 */
 QTextStream &
-operator<<(QTextStream &os, const transf &tr)
-{
-  return os << tr.rotation() << tr.translation();
+operator<<(QTextStream &os, const mat3 &m) {
+    int oldFlags = os.setf(QTextStream::showpos);
+    os << '[' << m[0] << ' ' << m[3] << ' ' << m[6] << ']' << endl;
+    os << '[' << m[1] << ' ' << m[4] << ' ' << m[7] << ']' << endl;
+    os << '[' << m[2] << ' ' << m[5] << ' ' << m[8] << ']' << endl;
+    os.flags(oldFlags);
+    return os;
 }
 
 /*!
-  Reads a transform from a QTextStream that could be in a number of possible
-  formats.  The first character of the line determines the format:
+    Reads a Quaternion from a QTextStream.  The format should be
+    "(qw qx qy qz)".
+*/
+QTextStream &
+operator>>(QTextStream &is, Quaternion &q) {
+    QChar ch;
+    double w, x, y, z;
+    is >> ch >> w >> x >> y >> z >> ch;
+    q.w = w;
+    q.x = x;
+    q.y = y;
+    q.z = z;
+    return is;
+}
+
+/*!
+    Writes a quaternion to a QTextStream in the format "(qw qx qy qz)".
+*/
+QTextStream &
+operator<<(QTextStream &os, const Quaternion &q) {
+    int oldFlags = os.setf(QTextStream::showpos);
+    os << '(' << q.w << ' ' << q.x << ' ' << q.y << ' ' << q.z << ')';
+    os.flags(oldFlags);
+    return os;
+}
+
+/*!
+    Reads a transf from a QTextStream.  The format should be
+    "(qw qx qy qz)[x y z]", where the 4 vector is a quaternion describing the
+    rotation and the 3 vector is a position.
+*/
+QTextStream &
+operator>>(QTextStream &is, transf &tr) {
+    Quaternion q;
+    vec3 v;
+
+    is >> q >> v;
+    tr.set(q, v);
+
+    return is;
+}
+
+/*!
+    Writes a transf to a QTextStream in the format "(qw qx qy qz)[x y z]".
+*/
+QTextStream &
+operator<<(QTextStream &os, const transf &tr) {
+    return os << tr.rotation() << tr.translation();
+}
+
+/*!
+    Reads a transform from a QTextStream that could be in a number of possible
+    formats.  The first character of the line determines the format:
     - "T" means a full transform read as (qw qx qy qz)[x y z]
     - "R" means a rotation matrix read in as a mat3
     - "t" means a translation read in as x y z
-    - "r" means a rotation about a coordinate axis.  The angle and then a 
+    - "r" means a rotation about a coordinate axis.  The angle and then a
       character denoting the axis ("x", "y", or "z") is read in.  If the
       second character in the line is also an "r" then the angle is assumed
       to be in radians, otherwise it is in degrees.
 
-  The total transform starts as the identitiy, and after a transform from a
-  line is read, it is multipled to the total.  This continues until the first
-  charater of a line is not one of the above 4 characters.  The total transform
-  is returned in \a tr.  FAILURE is returned if a formatting error is
-  encountered, otherwise SUCCESS is returned.
+    The total transform starts as the identitiy, and after a transform from a
+    line is read, it is multipled to the total.  This continues until the first
+    charater of a line is not one of the above 4 characters.  The total transform
+    is returned in \a tr.  FAILURE is returned if a formatting error is
+    encountered, otherwise SUCCESS is returned.
 */
 int
-readTransRotFromQTextStream(QTextStream &stream,transf &tr)
-{
-  QString line;
-  QChar axis;
-  double theta,x,y,z;
-  transf tmpTr;
-  vec3 tmpVec;
-  bool ok;
-  QStringList strings;
-  
-  tr = transf::IDENTITY;
+readTransRotFromQTextStream(QTextStream &stream, transf &tr) {
+    QString line;
+    QChar axis;
+    double theta, x, y, z;
+    transf tmpTr;
+    vec3 tmpVec;
+    bool ok;
+    QStringList strings;
 
-	while (1) {
-		line = stream.readLine();
-		if ( line.isNull() ) break;
-		if ( !line.isEmpty() && line[0]!='#' ) break;
-	}
+    tr = transf::IDENTITY;
 
-  do{
-	if ( !line.isNull() &&(line[0]=='r' || line[0]=='t' || line[0]=='T' || line[0]=='R')){
-      if (line[0]=='r') {  /* rotation */
-		strings = QStringList::split(QChar(' '),line);
-		if (strings.count() < 3) return FAILURE;
-		theta = strings[1].toDouble(&ok); if (!ok) return FAILURE;
-		axis = strings[2][0];
-
-		if (strings[0]!="rr") /* radians */
-		  theta *= M_PI/180.0;
-	
-		if (axis == 'x') tmpVec = vec3::X;
-		else if (axis == 'y') tmpVec = vec3::Y;
-		else if (axis == 'z') tmpVec = vec3::Z;
-		else return FAILURE;
-
-		tmpTr = rotate_transf(theta,tmpVec);
-      }
-      else if (line[0]=='t') { /* translation */
-		strings = QStringList::split(QChar(' '),line);
-		if (strings.count() < 4) return FAILURE;
-		x = strings[1].toDouble(&ok); if (!ok) return FAILURE;
-		y = strings[2].toDouble(&ok); if (!ok) return FAILURE;
-		z = strings[3].toDouble(&ok); if (!ok) return FAILURE;
-		tmpVec = vec3(x,y,z);
-		//	printf("   Reading translation transform...\n");
-		tmpTr = translate_transf(tmpVec);
-      }
-      else if (line[0]=='T') { /* full transform: (Quaternion)[Translation] */
-		QString trStr = line.section(' ',1,-1);
-		QTextStream lineStream(&trStr,QIODevice::ReadOnly);
-		lineStream >> tmpTr;  
-      }
-      else if (line[0]=='R') { /* Rotation matrix */
-		mat3 tmpMat;
-		stream >> tmpMat;		
-		tmpTr = transf(tmpMat,vec3::ZERO);
-		line=stream.readLine();
-      }
-      tr = tmpTr * tr;
+    while (1) {
+        line = stream.readLine();
+        if (line.isNull()) break;
+        if (!line.isEmpty() && line[0] != '#') break;
     }
-    line=stream.readLine();
-  }while ( !line.isNull() && (line[0]=='r' || line[0]=='t' || line[0]=='T' || line[0]=='R'));
 
-  return SUCCESS;
+    do {
+        if (!line.isNull() && (line[0] == 'r' || line[0] == 't' || line[0] == 'T' || line[0] == 'R')) {
+            if (line[0] == 'r') { /* rotation */
+                strings = QStringList::split(QChar(' '), line);
+                if (strings.count() < 3) return FAILURE;
+                theta = strings[1].toDouble(&ok);
+                if (!ok) return FAILURE;
+                axis = strings[2][0];
+
+                if (strings[0] != "rr") /* radians */
+                    theta *= M_PI / 180.0;
+
+                if (axis == 'x') tmpVec = vec3::X;
+                else if (axis == 'y') tmpVec = vec3::Y;
+                else if (axis == 'z') tmpVec = vec3::Z;
+                else return FAILURE;
+
+                tmpTr = rotate_transf(theta, tmpVec);
+            }
+            else if (line[0] == 't') { /* translation */
+                strings = QStringList::split(QChar(' '), line);
+                if (strings.count() < 4) return FAILURE;
+                x = strings[1].toDouble(&ok);
+                if (!ok) return FAILURE;
+                y = strings[2].toDouble(&ok);
+                if (!ok) return FAILURE;
+                z = strings[3].toDouble(&ok);
+                if (!ok) return FAILURE;
+                tmpVec = vec3(x, y, z);
+                //  printf("   Reading translation transform...\n");
+                tmpTr = translate_transf(tmpVec);
+            }
+            else if (line[0] == 'T') { /* full transform: (Quaternion)[Translation] */
+                QString trStr = line.section(' ', 1, -1);
+                QTextStream lineStream(&trStr, QIODevice::ReadOnly);
+                lineStream >> tmpTr;
+            }
+            else if (line[0] == 'R') { /* Rotation matrix */
+                mat3 tmpMat;
+                stream >> tmpMat;
+                tmpTr = transf(tmpMat, vec3::ZERO);
+                line = stream.readLine();
+            }
+            tr = tmpTr * tr;
+        }
+        line = stream.readLine();
+    }
+    while (!line.isNull() && (line[0] == 'r' || line[0] == 't' || line[0] == 'T' || line[0] == 'R'));
+
+    return SUCCESS;
 }

--- a/src/maxdet_src.cpp
+++ b/src/maxdet_src.cpp
@@ -1,24 +1,24 @@
 /*
- * maxdet, version alpha
- * C source for MAXDET-programs
- *
- * Shao-Po Wu, Lieven Vandenberghe and Stephen Boyd 
- * Apr. 27, 1996, last major update
- *
- * COPYRIGHT 1996 SHAO-PO WU, LIEVEN VANDENBERGHE AND STEPHEN BOYD
- * Permission to use, copy, modify, and distribute this software for
- * any purpose without fee is hereby granted, provided that this entire
- * notice is included in all copies of any software which is or includes
- * a copy or modification of this software and in all copies of the
- * supporting documentation for such software.
- * This software is being provided "as is", without any express or
- * implied warranty.  In particular, the authors do not make any
- * representation or warranty of any kind concerning the merchantability
- * of this software or its fitness for any particular purpose.
- */
+    maxdet, version alpha
+    C source for MAXDET-programs
+
+    Shao-Po Wu, Lieven Vandenberghe and Stephen Boyd
+    Apr. 27, 1996, last major update
+
+    COPYRIGHT 1996 SHAO-PO WU, LIEVEN VANDENBERGHE AND STEPHEN BOYD
+    Permission to use, copy, modify, and distribute this software for
+    any purpose without fee is hereby granted, provided that this entire
+    notice is included in all copies of any software which is or includes
+    a copy or modification of this software and in all copies of the
+    supporting documentation for such software.
+    This software is being provided "as is", without any express or
+    implied warranty.  In particular, the authors do not make any
+    representation or warranty of any kind concerning the merchantability
+    of this software or its fitness for any particular purpose.
+*/
 
 /*! \file
-  \brief C source code for solving determinant maximization problems
+    \brief C source code for solving determinant maximization problems
 */
 
 #include <stdio.h>
@@ -34,69 +34,67 @@
 
 #include "maxdet.h"
 
-void mydlascl(double from,double to,int m,int n,double *A)
-{
-  int i;
-  double scale=to/from;
-  for(i=0;i<m*n;i++)
-      A[i] *= scale;
+void mydlascl(double from, double to, int m, int n, double *A) {
+    int i;
+    double scale = to / from;
+    for (i = 0; i < m * n; i++)
+        A[i] *= scale;
 }
 
 
 
 /* from sdpsol, for debugging */
 /* print an integer matrix to a stream */
-void disp_imat(FILE *fp,int *ip,int  r, int c)
-{
-    register int i,j;
+void disp_imat(FILE *fp, int *ip, int  r, int c) {
+    register int i, j;
     register int *rip;
 
-    for (i=0; i<r; i++) {
-        fprintf(fp,"| ");
-        for (rip=ip+i, j=0; j<c; rip+=r, j++)
-            fprintf(fp,"%8d  ",*rip);
-        fprintf(fp,"|\n");
+    for (i = 0; i < r; i++) {
+        fprintf(fp, "| ");
+        for (rip = ip + i, j = 0; j < c; rip += r, j++)
+            fprintf(fp, "%8d  ", *rip);
+        fprintf(fp, "|\n");
     }
-    fprintf(fp,"\n");
+    fprintf(fp, "\n");
 }
 
 /* print a double matrix to a stream */
-void disp_mat(FILE *fp, double *dp,int r,int c)
-{
-    register int    i,j;
-    register double *rdp,dtmp,maxmag=0;
+void disp_mat(FILE *fp, double *dp, int r, int c) {
+    register int    i, j;
+    register double *rdp, dtmp, maxmag = 0;
 
     /* test r and c */
     if (!r || !c) {    /* empty mat */
-        fprintf(fp,"[]\n\n");
+        fprintf(fp, "[]\n\n");
         return;
     }
     /* get the largest (in magnitude) entry */
-    for (i=0, rdp=dp; i<r*c; i++, rdp++) {
+    for (i = 0, rdp = dp; i < r * c; i++, rdp++) {
         dtmp = fabs(*rdp);
-        if (dtmp>maxmag)
+        if (dtmp > maxmag)
             maxmag = dtmp;
     }
     /* print */
-    if (maxmag>=1e4 || (maxmag<=1e-4 && maxmag>0)) {
-        maxmag = pow((double) 10.0,(double) floor(log10(maxmag)));
-        fprintf(fp,"%e *\n",maxmag);
-        for (i=0; i<r; i++) {
-            fprintf(fp,"%s",(i ? "\n " : " "));
-            for (rdp=dp+i, j=0; j<c; rdp+=r, j++)
-		  fprintf(fp,"% 7.3f ",*rdp/maxmag);
-	    fprintf(fp,"\n");  
+    if (maxmag >= 1e4 || (maxmag <= 1e-4 && maxmag > 0)) {
+        maxmag = pow((double) 10.0, (double) floor(log10(maxmag)));
+        fprintf(fp, "%e *\n", maxmag);
+        for (i = 0; i < r; i++) {
+            fprintf(fp, "%s", (i ? "\n " : " "));
+            for (rdp = dp + i, j = 0; j < c; rdp += r, j++)
+                fprintf(fp, "% 7.3f ", *rdp / maxmag);
+            fprintf(fp, "\n");
 
         }
-	fprintf(fp," \n\n");
-    } else {
-        for (i=0; i<r; i++) {
-            fprintf(fp,"%s",(i ? "\n " : " "));
-            for (rdp=dp+i, j=0; j<c; rdp+=r, j++)
-                fprintf(fp,"% 10.4f ",*rdp);
-            fprintf(fp," ");
+        fprintf(fp, " \n\n");
+    }
+    else {
+        for (i = 0; i < r; i++) {
+            fprintf(fp, "%s", (i ? "\n " : " "));
+            for (rdp = dp + i, j = 0; j < c; rdp += r, j++)
+                fprintf(fp, "% 10.4f ", *rdp);
+            fprintf(fp, " ");
         }
-        fprintf(fp,"  \n\n");
+        fprintf(fp, "  \n\n");
     }
 }
 
@@ -106,40 +104,40 @@ void disp_mat(FILE *fp, double *dp,int r,int c)
 double inprd(double *X, double *Z, int L, int *blck_szs)
 
 /*
- * Computes Tr X*Z
- *
- * Arguments:
- * X,Z:       block diagonal matrices with L blocks X^0, ..., X^{L-1},
- *            and Z^0, ..., Z^{L-1}.  X^j and Z^j have size 
- *            blck_szs[j] times blck_szs[j].  Every block is stored 
- *            using packed storage of the lower triangle.
- * L:         number of blocks
- * blck_szs:  integer vector of length L 
- *            blck_szs[i], i=0,...,L-1 is the size of block i
- */
+    Computes Tr X*Z
+
+    Arguments:
+    X,Z:       block diagonal matrices with L blocks X^0, ..., X^{L-1},
+              and Z^0, ..., Z^{L-1}.  X^j and Z^j have size
+              blck_szs[j] times blck_szs[j].  Every block is stored
+              using packed storage of the lower triangle.
+    L:         number of blocks
+    blck_szs:  integer vector of length L
+              blck_szs[i], i=0,...,L-1 is the size of block i
+*/
 {
     register int i, j, k;
     double result;
     int    lngth, pos, sz;
- 
-    /* sz = length of Z and X */  
-    for (i=0, sz=0;  i<L;  i++)  sz += (blck_szs[i]*(blck_szs[i]+1))/2;
+
+    /* sz = length of Z and X */
+    for (i = 0, sz = 0;  i < L;  i++)  sz += (blck_szs[i] * (blck_szs[i] + 1)) / 2;
 
     /* result = Tr X Z + contributions of diagonal elements */
-    result = 2.0*ddot(sz, X, 1, Z, 1);
+    result = 2.0 * ddot(sz, X, 1, Z, 1);
 
-    /* correct for diagonal elements 
-     * loop over blocks, j=0,...,L-1  */
-    for (j=0, pos=0;  j<L;  j++)
+    /*  correct for diagonal elements
+        loop over blocks, j=0,...,L-1  */
+    for (j = 0, pos = 0;  j < L;  j++)
 
-        /* loop over columns, k=0,...,blck_szs[j]-1 
-         * pos is position of (k,k) element of block j 
-         * lngth is length of column k */
-        for (k=0, lngth=blck_szs[j];  k<blck_szs[j];  pos+=lngth, 
-             lngth-=1, k++)
+        /*  loop over columns, k=0,...,blck_szs[j]-1
+            pos is position of (k,k) element of block j
+            lngth is length of column k */
+        for (k = 0, lngth = blck_szs[j];  k < blck_szs[j];  pos += lngth,
+                lngth -= 1, k++)
 
             /* subtract Z^j_{kk}*X^j_{kk} from result */
-            result -= Z[pos]*X[pos];
+            result -= Z[pos] * X[pos];
 
     return result;
 }
@@ -148,58 +146,58 @@ double inprd(double *X, double *Z, int L, int *blck_szs)
 
 /* maxdet routines */
 
-double eig_val(double *sig, double *ap,int L, int *blck_szs, int Npd,
-	       double *work)
-/* 
- * find eigenvalues and the minimum one of a symmetric block-diagonal
- * matrix in packed storage.
- * routine returns the minimum eigenvalue on exit.
- *
- * sig      -- (on exit) vector of eigenvalues
- * ap       -- symmetric block-diagonal matrix in packed storage
- * L        -- number of diagonal blocks
- * blck_szs -- sizes of the diagonal blocks
- * Npd      -- length of the maxtrix in packed storage
- * work     -- double precision workspace, dimension Npd+3*(max block size)
- *             work[0 -- Npd-1] : copy of ap
- *             work[Npd -- ]    : workspace for DSPEV
- *
- * NOTICE: This routine finds the eigenvalues block-by-block,
- *         LAPACK routine DSPEV is NOT used UNLESS the block size exceeds 2.
- */
+double eig_val(double *sig, double *ap, int L, int *blck_szs, int Npd,
+               double *work)
+/*
+    find eigenvalues and the minimum one of a symmetric block-diagonal
+    matrix in packed storage.
+    routine returns the minimum eigenvalue on exit.
+
+    sig      -- (on exit) vector of eigenvalues
+    ap       -- symmetric block-diagonal matrix in packed storage
+    L        -- number of diagonal blocks
+    blck_szs -- sizes of the diagonal blocks
+    Npd      -- length of the maxtrix in packed storage
+    work     -- double precision workspace, dimension Npd+3*(max block size)
+               work[0 -- Npd-1] : copy of ap
+               work[Npd -- ]    : workspace for DSPEV
+
+    NOTICE: This routine finds the eigenvalues block-by-block,
+           LAPACK routine DSPEV is NOT used UNLESS the block size exceeds 2.
+*/
 {
     register int i;
     int    nainfo; /* int1=1; */
-    double min_ev=0.0, *dps, *sigptr;
+    double min_ev = 0.0, *dps, *sigptr;
 
-    memcpy(work,ap,Npd*sizeof(double));
-    for (i=0, sigptr=sig, dps=work; i<L; i++) {
+    memcpy(work, ap, Npd * sizeof(double));
+    for (i = 0, sigptr = sig, dps = work; i < L; i++) {
         switch (blck_szs[i]) {
-          case 1:    /* 1-by-1 block */
-            *sigptr = *dps;
-            min_ev = (i ? MIN(min_ev,*dps) : *dps);
-            sigptr++;
-            dps++;
-            break;
-          case 2:    /* 2-by-2 block */
-            *sigptr = (dps[0]+dps[2]
-                       -sqrt(SQR(dps[0]-dps[2])+4.0*SQR(dps[1])))/2.0;
-            *(sigptr+1) = (dps[0]+dps[2]
-                           +sqrt(SQR(dps[0]-dps[2])+4.0*SQR(dps[1])))/2.0;
-            min_ev = (i ? MIN(min_ev,*sigptr) : *sigptr);
-            sigptr += 2;
-            dps += 3;
-            break;
-          default:   /* 3-by-3 or larger block */
-            dspev("N","L",blck_szs[i],dps,sigptr,NULL,1,work+Npd,&nainfo);
-            if (nainfo) {
-                fprintf(stderr,"Error in dspev(0), info = %d.\n", nainfo);
-                exit(-1);
-            }
-            min_ev = (i ? MIN(min_ev,*sigptr) : *sigptr);
-            sigptr += blck_szs[i];
-            dps += blck_szs[i]*(blck_szs[i]+1)/2;
-            break;
+            case 1:    /* 1-by-1 block */
+                *sigptr = *dps;
+                min_ev = (i ? MIN(min_ev, *dps) : *dps);
+                sigptr++;
+                dps++;
+                break;
+            case 2:    /* 2-by-2 block */
+                *sigptr = (dps[0] + dps[2]
+                           - sqrt(SQR(dps[0] - dps[2]) + 4.0 * SQR(dps[1]))) / 2.0;
+                *(sigptr + 1) = (dps[0] + dps[2]
+                                 + sqrt(SQR(dps[0] - dps[2]) + 4.0 * SQR(dps[1]))) / 2.0;
+                min_ev = (i ? MIN(min_ev, *sigptr) : *sigptr);
+                sigptr += 2;
+                dps += 3;
+                break;
+            default:   /* 3-by-3 or larger block */
+                dspev("N", "L", blck_szs[i], dps, sigptr, NULL, 1, work + Npd, &nainfo);
+                if (nainfo) {
+                    fprintf(stderr, "Error in dspev(0), info = %d.\n", nainfo);
+                    exit(-1);
+                }
+                min_ev = (i ? MIN(min_ev, *sigptr) : *sigptr);
+                sigptr += blck_szs[i];
+                dps += blck_szs[i] * (blck_szs[i] + 1) / 2;
+                break;
         }
     }
     return min_ev;
@@ -209,137 +207,137 @@ double eig_val(double *sig, double *ap,int L, int *blck_szs, int Npd,
 
 
 int maxdet(
- int m,                /* no of variables */
- int L,                /* no of blocks in F */
- double *F,            /* F_i's in packed storage */
- int *F_blkszs,        /* L-vector, dimensions of diagonal blocks of F */
- int K,                /* no of blocks in G */
- double *G,            /* G_i's in packed storage */
- int *G_blkszs,        /* K-vector, dimensions of diagonal blocks of G */
- double *c,            /* m-vector */
- double *x,            /* m-vector */
- double *Z,            /* block diagonal matrix in packed storage */
- double *W,            /* block diagonal matrix in packed storage */
- double *ul,           /* ul[0] = pr. obj, ul[1] = du. obj */
- double *hist,         /* history, 3-by-NTiter matrix */
- double gamma,         /* > 0 */
- double abstol,        /* absolute accuracy */
- double reltol,        /* relative accuracy */
- int *NTiters,         /* on entry: maximum number of (total) Newton iters,
-                        * on exit: number of Newton iterations taken */
- double *work,         /* (double) work array */
- int lwork,            /* size of work */
- int *iwork,           /* (int) work array */
- int *info,            /* status on termination */
- int negativeFlag 	/* if negativeFlag is set, terminator maxdet when ul[0]<0 */
+    int m,                /* no of variables */
+    int L,                /* no of blocks in F */
+    double *F,            /* F_i's in packed storage */
+    int *F_blkszs,        /* L-vector, dimensions of diagonal blocks of F */
+    int K,                /* no of blocks in G */
+    double *G,            /* G_i's in packed storage */
+    int *G_blkszs,        /* K-vector, dimensions of diagonal blocks of G */
+    double *c,            /* m-vector */
+    double *x,            /* m-vector */
+    double *Z,            /* block diagonal matrix in packed storage */
+    double *W,            /* block diagonal matrix in packed storage */
+    double *ul,           /* ul[0] = pr. obj, ul[1] = du. obj */
+    double *hist,         /* history, 3-by-NTiter matrix */
+    double gamma,         /* > 0 */
+    double abstol,        /* absolute accuracy */
+    double reltol,        /* relative accuracy */
+    int *NTiters,         /* on entry: maximum number of (total) Newton iters,
+                          on exit: number of Newton iterations taken */
+    double *work,         /* (double) work array */
+    int lwork,            /* size of work */
+    int *iwork,           /* (int) work array */
+    int *info,            /* status on termination */
+    int negativeFlag   /* if negativeFlag is set, terminator maxdet when ul[0]<0 */
 )
 
 
 /*
- * Solves determinant-maximization (MAXDET) program 
- *
- * (P) minimize    c^Tx - \log\det G(x)
- *     subject to  G(x)\geq 0
- *                 F(x)\geq 0
- *
- * and its dual
- *
- * (D) maximize    \log\det W -\Tr ZF_0 -\Tr WG_0 + l
- *     subject to  W\geq 0, Z\geq 0
- *                 \Tr ZF_i + \Tr WG_i = c_i, i=1,...,m
- *
- * Convergence criteria: 
- * (1) maxiters is exceeded
- * (2) duality gap is less than abstol
- * (3) primal and dual objective are both positive and 
- *     duality gap is less than reltol * dual objective;         
- *     or, primal and dual objective are both negative and
- *     duality gap is less than reltol * minus the primal objective
- * 
- * Arguments:
- * - m:        number of variables x_i. m >= 1.
- * - L:        number of diagonal blocks in F_i. L >= 1.
- * - F:        block diagonal matrices F_i, i=0,...,m. 
- *             it is assumed that the matrices diag(F_i,G_i) are linearly 
- *             independent. 
- *             let F_i^j, i=0,..,m, j=0,...,L-1 denote the jth 
- *             diagonal block of F_i, 
- *             the array F contains F_0^0, ..., F_0^{L-1}, F_1^0, ..., 
- *             F_1^{L-1}, ..., F_m^0, ..., F_m^{L-1}, in this order, 
- *             using packed storage for the lower triangular part of 
- *             F_i^j.
- * - F_blkszs: an integer L-vector. F_blkszs[j], j=0,...,L-1 gives the 
- *             size of block j, ie, F_i^j has size F_blkszs[j] 
- *             times F_blkszs[j].
- * - K:        number of diagonal blocks in G_i. K >= 1.
- * - G:        the block diagonal matrices G_i, i=0,...,m. 
- *             it is assumed that the matrices diag(F_i,G_i) are linearly 
- *             independent. 
- * - G_blkszs: an integer K-vector. G_blkszs[j], j=0,...,K-1 gives the
- *             size of block j, ie, G_i^j has size G_blkszs[j]
- * - c:        m-vector, primal objective.
- * - x:        m-vector.  On entry, a strictly primal feasible point. 
- *             On exit, the last iterate for x.
- * - Z:        block diagonal matrix with L blocks Z^0, ..., Z^{L-1}.
- *             Z^j has size F_blkszs[j] times F_blkszs[j].
- *             Every block is stored using packed storage of the lower 
- *             triangular part.
- *             On entry, a strictly dual feasible point is OPTIONAL.
- *             On exit, the last dual iterate.
- * - W:        block diagonal matrix with K blocks W^0, ..., W^{K-1}.
- *             W^j has size G_blkszs[j] times G_blkszs[j].
- *             Every block is stored using packed storage of the lower 
- *             triangular part.
- *             On entry, a strictly dual feasible point is OPTIONAL.
- *             On exit, the last dual iterate.
- * - ul:       two-vector.  On exit, ul[0] is the primal objective value
- *             c^Tx-\logdet G(x);  ul[1] is the dual objective value
- *             \log\det W -\Tr ZF_0 -\Tr WG_0 + l.
- * - hist:     history, (3+m) -by-NTiter matrix.  !!!!!!!!!!!!!!!!!!!!!!
- *             hist = [x; objective; duality gap; # of NT iterations]
- * - gamma:    > 0. Controls how aggressively the algorithm works.
- * - abstol:   absolute tolerance, >= MINABSTOL (MINABSTOL in maxdet.h).
- * - reltol:   relative tolerance, >= 0.
- * - NTiters:  On entry: maximum number of Newton (and predictor) iterations,
- *             NTiters >= 0.
- *             On exit: the number of Newton iterations taken.
- * - work:     (double) work array of size lwork.
- * - lwork:    size of work, must be at least:
- *             2*(m+2)*sz + 2*(n+l) + ltemp, with 
- *             ltemp = max( m+sz*NB, 3*(m+m^2+max(G_sz,F_sz)),
- *                          3*(max(max_l,max_n)+max(G_sz,F_sz)) ),
- *             where 
- *             sz: space needed to store one matrix F_i AND one matrix
- *                 G_i in packed storage;
- *             F_sz: space needed to store one matrix F_i packed;
- *             G_sz: space needed to store one matrix G_i packed;
- *             max_n: max block size in F;
- *             max_l: max block size in G;
- *             NB >= 1, for best performance, NB should be at least
- *             equal to the optimal block size for dgels.
- * - iwork     (int) work array of size m
- * - info:     returns 1 if maximum Newton iterations exceeded,
- *             2 if absolute accuracy is reached,  3 if relative accuracy
- *             is reached;
- *             negative values indicate errors: -i means argument i 
- *             has an illegal value; -23 means \diag(G_i,F_i) dependent;
- *             -24 stands for all other errors.
- *
- *-negativeFlag (int) if true, terminate maxdet when ul[0]<0; 
- *		otherwise, use the standard terminate condition.
- *
- * Returns 0 for normal exit, 1 if an error occurred.
- *
- */
- 
+    Solves determinant-maximization (MAXDET) program
+
+    (P) minimize    c^Tx - \log\det G(x)
+       subject to  G(x)\geq 0
+                   F(x)\geq 0
+
+    and its dual
+
+    (D) maximize    \log\det W -\Tr ZF_0 -\Tr WG_0 + l
+       subject to  W\geq 0, Z\geq 0
+                   \Tr ZF_i + \Tr WG_i = c_i, i=1,...,m
+
+    Convergence criteria:
+    (1) maxiters is exceeded
+    (2) duality gap is less than abstol
+    (3) primal and dual objective are both positive and
+       duality gap is less than reltol * dual objective;
+       or, primal and dual objective are both negative and
+       duality gap is less than reltol * minus the primal objective
+
+    Arguments:
+    - m:        number of variables x_i. m >= 1.
+    - L:        number of diagonal blocks in F_i. L >= 1.
+    - F:        block diagonal matrices F_i, i=0,...,m.
+               it is assumed that the matrices diag(F_i,G_i) are linearly
+               independent.
+               let F_i^j, i=0,..,m, j=0,...,L-1 denote the jth
+               diagonal block of F_i,
+               the array F contains F_0^0, ..., F_0^{L-1}, F_1^0, ...,
+               F_1^{L-1}, ..., F_m^0, ..., F_m^{L-1}, in this order,
+               using packed storage for the lower triangular part of
+               F_i^j.
+    - F_blkszs: an integer L-vector. F_blkszs[j], j=0,...,L-1 gives the
+               size of block j, ie, F_i^j has size F_blkszs[j]
+               times F_blkszs[j].
+    - K:        number of diagonal blocks in G_i. K >= 1.
+    - G:        the block diagonal matrices G_i, i=0,...,m.
+               it is assumed that the matrices diag(F_i,G_i) are linearly
+               independent.
+    - G_blkszs: an integer K-vector. G_blkszs[j], j=0,...,K-1 gives the
+               size of block j, ie, G_i^j has size G_blkszs[j]
+    - c:        m-vector, primal objective.
+    - x:        m-vector.  On entry, a strictly primal feasible point.
+               On exit, the last iterate for x.
+    - Z:        block diagonal matrix with L blocks Z^0, ..., Z^{L-1}.
+               Z^j has size F_blkszs[j] times F_blkszs[j].
+               Every block is stored using packed storage of the lower
+               triangular part.
+               On entry, a strictly dual feasible point is OPTIONAL.
+               On exit, the last dual iterate.
+    - W:        block diagonal matrix with K blocks W^0, ..., W^{K-1}.
+               W^j has size G_blkszs[j] times G_blkszs[j].
+               Every block is stored using packed storage of the lower
+               triangular part.
+               On entry, a strictly dual feasible point is OPTIONAL.
+               On exit, the last dual iterate.
+    - ul:       two-vector.  On exit, ul[0] is the primal objective value
+               c^Tx-\logdet G(x);  ul[1] is the dual objective value
+               \log\det W -\Tr ZF_0 -\Tr WG_0 + l.
+    - hist:     history, (3+m) -by-NTiter matrix.  !!!!!!!!!!!!!!!!!!!!!!
+               hist = [x; objective; duality gap; # of NT iterations]
+    - gamma:    > 0. Controls how aggressively the algorithm works.
+    - abstol:   absolute tolerance, >= MINABSTOL (MINABSTOL in maxdet.h).
+    - reltol:   relative tolerance, >= 0.
+    - NTiters:  On entry: maximum number of Newton (and predictor) iterations,
+               NTiters >= 0.
+               On exit: the number of Newton iterations taken.
+    - work:     (double) work array of size lwork.
+    - lwork:    size of work, must be at least:
+               2*(m+2)*sz + 2*(n+l) + ltemp, with
+               ltemp = max( m+sz*NB, 3*(m+m^2+max(G_sz,F_sz)),
+                            3*(max(max_l,max_n)+max(G_sz,F_sz)) ),
+               where
+               sz: space needed to store one matrix F_i AND one matrix
+                   G_i in packed storage;
+               F_sz: space needed to store one matrix F_i packed;
+               G_sz: space needed to store one matrix G_i packed;
+               max_n: max block size in F;
+               max_l: max block size in G;
+               NB >= 1, for best performance, NB should be at least
+               equal to the optimal block size for dgels.
+    - iwork     (int) work array of size m
+    - info:     returns 1 if maximum Newton iterations exceeded,
+               2 if absolute accuracy is reached,  3 if relative accuracy
+               is reached;
+               negative values indicate errors: -i means argument i
+               has an illegal value; -23 means \diag(G_i,F_i) dependent;
+               -24 stands for all other errors.
+
+    -negativeFlag (int) if true, terminate maxdet when ul[0]<0;
+        otherwise, use the standard terminate condition.
+
+    Returns 0 for normal exit, 1 if an error occurred.
+
+*/
+
 
 {
     register int i, j, k, iii;
     double *dps, *dpt, dtmp, dtmp2;
     int    iters, minlwork, lwkspc, maxNTiters; /* itmp */
-    int    dual_equ_feas=YES, dual_PD_feas=NO;
+    int    dual_equ_feas = YES, dual_PD_feas = NO;
     int    n, F_sz, F_upsz, max_n, l, G_sz, G_upsz, max_l, sz, M_sz, M_upsz;
-    double t, sqrtt, t_old, y=0, gap, mu, lambda, alpha[2], beta=0, psi_ub;
+    double t, sqrtt, t_old, y = 0, gap, mu, lambda, alpha[2], beta = 0, psi_ub;
     double grad1, grad2, hess1, hess2;
     double *rhs, *GaF, *ZWtmp, *Fsc, *Gsc, *XF, *XG, *dXF, *dXG, *dW, *dZ;
     double *LF, *LG, *LFinv, *LGinv;
@@ -351,69 +349,69 @@ int maxdet(
     /*    double dbl0=0.0, dbl1=1.0, dblm1=-1.0; */
 
     if (m < 1) {
-        fprintf(stderr,"maxdet: m must be at least one.\n");
+        fprintf(stderr, "maxdet: m must be at least one.\n");
         *info = -1;
         return 1;
     }
     if (L < 1) {
-        fprintf(stderr,"maxdet: L must be at least one.\n");
+        fprintf(stderr, "maxdet: L must be at least one.\n");
         *info = -2;
         return 1;
     }
     if (K < 1) {
-        fprintf(stderr,"maxdet: K must be at least one.\n");
+        fprintf(stderr, "maxdet: K must be at least one.\n");
         *info = -5;
         return 1;
     }
-    for (i=0; i<L; i++)
+    for (i = 0; i < L; i++)
         if (F_blkszs[i] < 1) {
-            fprintf(stderr,"maxdet: F_blkszs[%d] must be at least one.\n",i);
+            fprintf(stderr, "maxdet: F_blkszs[%d] must be at least one.\n", i);
             *info = -4;
             return 1;
         }
-    for (i=0; i<K; i++)
+    for (i = 0; i < K; i++)
         if (G_blkszs[i] < 1) {
-            fprintf(stderr,"maxdet: G_blkszs[%d] must be at least one.\n",i);
+            fprintf(stderr, "maxdet: G_blkszs[%d] must be at least one.\n", i);
             *info = -7;
             return 1;
         }
     if (gamma <= 0) {
-        fprintf(stderr,"maxdet: gamma must be greater than zero.\n");
+        fprintf(stderr, "maxdet: gamma must be greater than zero.\n");
         *info = -14;
         return 1;
     }
     if (reltol < 0) {
-        fprintf(stderr,"maxdet: reltol must be non-negative.\n");
+        fprintf(stderr, "maxdet: reltol must be non-negative.\n");
         *info = -16;
         return 1;
     }
     if (abstol < MINABSTOL)
-        fprintf(stderr,"maxdet: (warning) abstol less than MINABSTOL=%10.2e\n\
-        MINABSTOL is used instead.\n",MINABSTOL);
+        fprintf(stderr, "maxdet: (warning) abstol less than MINABSTOL=%10.2e\n\
+        MINABSTOL is used instead.\n", MINABSTOL);
 
     /*check parameters passing*/
-#ifdef DEBUG
-	printf("m:%d L:%d K:%d NTiters:%d  abstol:%f  \n",m,L,K, *NTiters, abstol);
-	printf("-------------- F ------------------\n");
-	disp_mat(stdout,F,1,168,0);
-	printf("-------------- F_blkszs ------------------\n");
-        disp_imat(stdout,F_blkszs,1,24,0);
+    #ifdef DEBUG
+    printf("m:%d L:%d K:%d NTiters:%d  abstol:%f  \n", m, L, K, *NTiters, abstol);
+    printf("-------------- F ------------------\n");
+    disp_mat(stdout, F, 1, 168, 0);
+    printf("-------------- F_blkszs ------------------\n");
+    disp_imat(stdout, F_blkszs, 1, 24, 0);
 
-        printf("-------------- G ------------------\n");
-        disp_mat(stdout,G,1,168,0);
-        printf("-------------- G_blkszs ------------------\n");
-        disp_imat(stdout,G_blkszs,1,4,0);
+    printf("-------------- G ------------------\n");
+    disp_mat(stdout, G, 1, 168, 0);
+    printf("-------------- G_blkszs ------------------\n");
+    disp_imat(stdout, G_blkszs, 1, 4, 0);
 
-        printf("-------------- c ------------------\n");
-        disp_mat(stdout,c,1,m,0);
-        printf("-------------- z0 ------------------\n");
-        disp_mat(stdout,x,1,m,0);
+    printf("-------------- c ------------------\n");
+    disp_mat(stdout, c, 1, m, 0);
+    printf("-------------- z0 ------------------\n");
+    disp_mat(stdout, x, 1, m, 0);
 
-        printf("-------------- Z ------------------\n");
-        disp_mat(stdout,Z,1,24,0);
-        printf("-------------- W ------------------\n");
-        disp_mat(stdout,W,1,24,0);
-#endif
+    printf("-------------- Z ------------------\n");
+    disp_mat(stdout, Z, 1, 24, 0);
+    printf("-------------- W ------------------\n");
+    disp_mat(stdout, W, 1, 24, 0);
+    #endif
 
 
 
@@ -421,30 +419,30 @@ int maxdet(
 
 
     /*
-     * calculate dimensions:
-     * n:      (total) size of F(x)
-     * F_sz:   length of one block-diagonal matrix in packed storage
-     * F_upsz: length of one block-diagonal matrix in unpacked storage
-     * max_n:  size of biggest block in F
-     * l:      (total) size of G(x)
-     * G_sz:   length of one block-diagonal matrix in packed storage
-     * G_upsz: length of one block-diagonal matrix in unpacked storage
-     * max_l:  size of biggest block in G
-     */
-    for (i=0, n=0, F_sz=0, F_upsz=0, max_n=0;  i<L;  i++) {
+        calculate dimensions:
+        n:      (total) size of F(x)
+        F_sz:   length of one block-diagonal matrix in packed storage
+        F_upsz: length of one block-diagonal matrix in unpacked storage
+        max_n:  size of biggest block in F
+        l:      (total) size of G(x)
+        G_sz:   length of one block-diagonal matrix in packed storage
+        G_upsz: length of one block-diagonal matrix in unpacked storage
+        max_l:  size of biggest block in G
+    */
+    for (i = 0, n = 0, F_sz = 0, F_upsz = 0, max_n = 0;  i < L;  i++) {
         n += F_blkszs[i];
-        F_sz += F_blkszs[i]*(F_blkszs[i]+1)/2;
-        F_upsz += F_blkszs[i]*F_blkszs[i];
+        F_sz += F_blkszs[i] * (F_blkszs[i] + 1) / 2;
+        F_upsz += F_blkszs[i] * F_blkszs[i];
         max_n  = MAX(max_n, F_blkszs[i]);
-    } 
-    for (i=0, l=0, G_sz=0, G_upsz=0, max_l=0;  i<K;  i++) {
+    }
+    for (i = 0, l = 0, G_sz = 0, G_upsz = 0, max_l = 0;  i < K;  i++) {
         l += G_blkszs[i];
-        G_sz += G_blkszs[i]*(G_blkszs[i]+1)/2;
-        G_upsz += G_blkszs[i]*G_blkszs[i];
+        G_sz += G_blkszs[i] * (G_blkszs[i] + 1) / 2;
+        G_upsz += G_blkszs[i] * G_blkszs[i];
         max_l  = MAX(max_l, G_blkszs[i]);
     }
-    sz = F_sz+G_sz;
-    M_sz = m*(m+1)/2;
+    sz = F_sz + G_sz;
+    M_sz = m * (m + 1) / 2;
     M_upsz = SQR(m);
     if (m > sz) {
         fprintf(stderr, "maxdet: matrices diag(Fi,Gi), i=1,...,m are linearly\
@@ -455,75 +453,75 @@ int maxdet(
 
 
     /*
-     * organize workspace
-     *
-     * work:  2*(m+2)*sz + 2*(n+l) + ltemp
-     * minimum ltemp: the maximum of the following
-     *   m+sz*NB, 3*(MAX(max_l,max_n)+MAX(G_sz,F_sz)),
-     *   MAX(G_sz+3*max_l,F_sz+3*max_n), 3*(m+m^2+MAX(G_sz,F_sz))
-     * 
-     * for dgels:        m + sz*NB,
-     * for dspev:        3*MAX(max_n,max_l)
-     * for dspgv:        3*MAX(max_n,max_l)
-     * for dtrcon:       (double) 3*m;  (int) m
-     * for eig_val:      MAX(G_sz+3*max_l,F_sz+3*max_n)
-     * 
-     * rhs  (sz):        work
-     * GaF  (m*sz):      work+sz
-     * ZWtmp(sz):        work+(m+1)*sz
-     * Fsc  (m*F_sz):    work+(m+2)*sz
-     * Gsc  (m*G_sz):    work+(m+2)*sz+m*F_sz
-     * LF   (F_sz):      work+(2*m+2)*sz
-     * LG   (G_sz):      work+(2*m+2)*sz+F_sz
-     * XF   (F_sz):      work+(2*m+3)*sz
-     * XG   (G_sz):      work+(2*m+3)*sz+F_sz
-     * dXF  (F_sz):      work+(2*m+4)*sz
-     * dXG  (G_sz):      work+(2*m+4)*sz+F_sz
-     * sigF (n):         work+(2*m+5)*sz
-     * sigG (l):         work+(2*m+5)*sz+n
-     * sigZ (n):         work+(2*m+5)*sz+(n+l)
-     * sigW (l):         work+(2*m+5)*sz+(2*n+l)
-     * wkspc(ltemp):     work+(2*m+5)*sz+2*(n+l)
-     *
-     * M1   (M_upsz):    wkspc+3*m
-     * LM   (M_upsz):    wkspc+3*m+m^2
-     * VM   (M_upsz):    wkspc+3*m+2*m^2
-     * sigM (m):         work+(2*m+3)*sz
-     * v1   (m):         work+(2*m+4)*sz
-     * v2   (m):         work+(2*m+4)*sz+(n+l)
-     * LFinv(F_sz):      temp
-     * LGinv(G_sz):      temp
-     * dZ   (F_sz):      work+sz+G_sz
-     * dW   (G_sz):      work+sz
-     *
-     * temp  (MAX(F_sz,G_sz)):  wkspc+(lwkspc-3*MAX(G_sz,F_sz))
-     * temp2 (MAX(F_sz,G_sz)):  temp+MAX(G_sz,F_sz)
-     * temp3 (MAX(F_sz,G_sz)):  temp+2*MAX(G_sz,F_sz)
-     * temp4 (sz):              work+(2*m+1)*sz
-     */
+        organize workspace
+
+        work:  2*(m+2)*sz + 2*(n+l) + ltemp
+        minimum ltemp: the maximum of the following
+         m+sz*NB, 3*(MAX(max_l,max_n)+MAX(G_sz,F_sz)),
+         MAX(G_sz+3*max_l,F_sz+3*max_n), 3*(m+m^2+MAX(G_sz,F_sz))
+
+        for dgels:        m + sz*NB,
+        for dspev:        3*MAX(max_n,max_l)
+        for dspgv:        3*MAX(max_n,max_l)
+        for dtrcon:       (double) 3*m;  (int) m
+        for eig_val:      MAX(G_sz+3*max_l,F_sz+3*max_n)
+
+        rhs  (sz):        work
+        GaF  (m*sz):      work+sz
+        ZWtmp(sz):        work+(m+1)*sz
+        Fsc  (m*F_sz):    work+(m+2)*sz
+        Gsc  (m*G_sz):    work+(m+2)*sz+m*F_sz
+        LF   (F_sz):      work+(2*m+2)*sz
+        LG   (G_sz):      work+(2*m+2)*sz+F_sz
+        XF   (F_sz):      work+(2*m+3)*sz
+        XG   (G_sz):      work+(2*m+3)*sz+F_sz
+        dXF  (F_sz):      work+(2*m+4)*sz
+        dXG  (G_sz):      work+(2*m+4)*sz+F_sz
+        sigF (n):         work+(2*m+5)*sz
+        sigG (l):         work+(2*m+5)*sz+n
+        sigZ (n):         work+(2*m+5)*sz+(n+l)
+        sigW (l):         work+(2*m+5)*sz+(2*n+l)
+        wkspc(ltemp):     work+(2*m+5)*sz+2*(n+l)
+
+        M1   (M_upsz):    wkspc+3*m
+        LM   (M_upsz):    wkspc+3*m+m^2
+        VM   (M_upsz):    wkspc+3*m+2*m^2
+        sigM (m):         work+(2*m+3)*sz
+        v1   (m):         work+(2*m+4)*sz
+        v2   (m):         work+(2*m+4)*sz+(n+l)
+        LFinv(F_sz):      temp
+        LGinv(G_sz):      temp
+        dZ   (F_sz):      work+sz+G_sz
+        dW   (G_sz):      work+sz
+
+        temp  (MAX(F_sz,G_sz)):  wkspc+(lwkspc-3*MAX(G_sz,F_sz))
+        temp2 (MAX(F_sz,G_sz)):  temp+MAX(G_sz,F_sz)
+        temp3 (MAX(F_sz,G_sz)):  temp+2*MAX(G_sz,F_sz)
+        temp4 (sz):              work+(2*m+1)*sz
+    */
 
     /* check lwork */
-    minlwork = (2*m+5)*sz + 2*(n+l) + 
-        MAX(m+sz*NB,MAX(3*(m+M_upsz+MAX(G_sz,F_sz)),
-                        MAX(3*(MAX(max_l,max_n)+MAX(G_sz,F_sz)),
-                            MAX(G_sz+3*max_l,F_sz+3*max_n))));
-    if (lwork < minlwork){
+    minlwork = (2 * m + 5) * sz + 2 * (n + l) +
+               MAX(m + sz * NB, MAX(3 * (m + M_upsz + MAX(G_sz, F_sz)),
+                                    MAX(3 * (MAX(max_l, max_n) + MAX(G_sz, F_sz)),
+                                        MAX(G_sz + 3 * max_l, F_sz + 3 * max_n))));
+    if (lwork < minlwork) {
         fprintf(stderr, "maxdet: not enough workspace, need at least\
  %d*sizeof(double).\n", minlwork);
         *info = -20;
         return 1;
-    } 
-    lwkspc = lwork - (2*m+5)*sz - 2*(n+l);
-#ifdef MAXDET_DEBUG
-    fprintf(stdout,"workspace %d bytes.\n",8*lwork+4*m);
-#endif
+    }
+    lwkspc = lwork - (2 * m + 5) * sz - 2 * (n + l);
+    #ifdef MAXDET_DEBUG
+    fprintf(stdout, "workspace %d bytes.\n", 8 * lwork + 4 * m);
+    #endif
 
     rhs   = work;          /* rhs for LS problem, also for dx */
     GaF   = rhs + sz;      /* lhs for LS problem */
     ZWtmp = GaF + sz;      /* temporary storage of Z and W */
-    Fsc   = ZWtmp + m*sz;  /* scaled F_i's */
-    Gsc   = Fsc + m*F_sz;  /* scaled G_i's */
-    LF    = Gsc + m*G_sz;  /* cholesky of F */
+    Fsc   = ZWtmp + m * sz; /* scaled F_i's */
+    Gsc   = Fsc + m * F_sz; /* scaled G_i's */
+    LF    = Gsc + m * G_sz; /* cholesky of F */
     LG    = LF + F_sz;     /* cholesky of G */
     XF    = LG + G_sz;     /* F */
     XG    = XF + F_sz;     /* G */
@@ -534,16 +532,16 @@ int maxdet(
     sigZ  = sigG + l;      /* eig(dZ,Z) */
     sigW  = sigZ + n;      /* eig(dW,W) */
 
-    wkspc = work + (2*m+5)*sz + 2*(n+l);        /* workspace for LAPACK */
-    temp  = wkspc + (lwkspc-3*MAX(G_sz,F_sz));  /* size MAX(G_sz,F_sz) */
-    temp2 = temp + MAX(G_sz,F_sz);              /* size MAX(G_sz,F_sz) */
-    temp3 = temp2 + MAX(G_sz,F_sz);             /* size MAX(G_sz,F_sz) */
+    wkspc = work + (2 * m + 5) * sz + 2 * (n + l); /* workspace for LAPACK */
+    temp  = wkspc + (lwkspc - 3 * MAX(G_sz, F_sz)); /* size MAX(G_sz,F_sz) */
+    temp2 = temp + MAX(G_sz, F_sz);             /* size MAX(G_sz,F_sz) */
+    temp3 = temp2 + MAX(G_sz, F_sz);            /* size MAX(G_sz,F_sz) */
     temp4 = LF;                                 /* size sz */
 
     LFinv = temp;          /* LF^{-1} */
     LGinv = temp;          /* LG^{-1} */
 
-    M1 = wkspc + 3*m;      /* used in preliminary phase */
+    M1 = wkspc + 3 * m;    /* used in preliminary phase */
     LM = M1 + M_upsz;      /* chol(M1+M2) */
     VM = LM + M_upsz;      /* eigen vectors of eig(M1,M1+M2) */
     sigM = dXF;            /* eig(M1,M1+M2), used in preliminary phase */
@@ -558,363 +556,368 @@ int maxdet(
     *NTiters = 0;          /* reset *NTiters */
     *info = -24;           /* default: all other errors */
     t = 1;
-#ifdef MAXDET_DEBUG
-    fprintf(stdout," iters        obj            gap\n"); 
-#endif
+    #ifdef MAXDET_DEBUG
+    fprintf(stdout, " iters        obj            gap\n");
+    #endif
     /*
-     * (outer) iterations begin here
-     */
-    for (iters=1; ; iters++) {
+        (outer) iterations begin here
+    */
+    for (iters = 1; ; iters++) {
 
 
         int    pos, pos2, NTcount;
         double mat_norm, rcond;
 
-        /* compute F(x) = F_0 + x_1*F_1 + ... + x_m*F_m, store in XF
-         * also    G(x) = G_0 + x_1*G_1 + ... + x_m*G_m, store in XG */
-        dcopy(F_sz,F,1,XF,1);
-        dgemv("N",F_sz,m,1.0,F+F_sz,F_sz,x,1,1.0,XF,1);
-        dcopy(G_sz,G,1,XG,1);
-        dgemv("N",G_sz,m,1.0,G+G_sz,G_sz,x,1,1.0,XG,1);
-/*
-	printf("-------------- Initial GX------------------\n");
-	disp_mat(stdout,XG,6,4,0);
-*/
+        /*  compute F(x) = F_0 + x_1*F_1 + ... + x_m*F_m, store in XF
+            also    G(x) = G_0 + x_1*G_1 + ... + x_m*G_m, store in XG */
+        dcopy(F_sz, F, 1, XF, 1);
+        dgemv("N", F_sz, m, 1.0, F + F_sz, F_sz, x, 1, 1.0, XF, 1);
+        dcopy(G_sz, G, 1, XG, 1);
+        dgemv("N", G_sz, m, 1.0, G + G_sz, G_sz, x, 1, 1.0, XG, 1);
+        /*
+            printf("-------------- Initial GX------------------\n");
+            disp_mat(stdout,XG,6,4,0);
+        */
 
-        if (iters==1) {
+        if (iters == 1) {
 
-            /* preliminary phase (cf. maxdet paper):
-             *   1. check dual equalities
-             *   2. if (1) is satisfied, check dual positive-definiteness
-             *   3. if (2) is satisfied, compute initial t using the dual
-             *   4. otherwise use the heuristic preliminary centering
-             *      (minimizing newton decrement) to obtain initial t */
+            /*  preliminary phase (cf. maxdet paper):
+                 1. check dual equalities
+                 2. if (1) is satisfied, check dual positive-definiteness
+                 3. if (2) is satisfied, compute initial t using the dual
+                 4. otherwise use the heuristic preliminary centering
+                    (minimizing newton decrement) to obtain initial t */
 
             /* check if \Tr ZF_i + \Tr WG_i = c_i, i=1,...,m */
-            mat_norm = sqrt(inprd(Z,Z,L,F_blkszs)+inprd(W,W,K,G_blkszs));
+            mat_norm = sqrt(inprd(Z, Z, L, F_blkszs) + inprd(W, W, K, G_blkszs));
             i = 0;
-            while (dual_equ_feas==YES && i<m) {
-                if (fabs(inprd(F+(i+1)*F_sz,Z,L,F_blkszs)+
-                         inprd(G+(i+1)*G_sz,W,K,G_blkszs)-c[i])
-                    > mat_norm*TOLC)
+            while (dual_equ_feas == YES && i < m) {
+                if (fabs(inprd(F + (i + 1)*F_sz, Z, L, F_blkszs) +
+                         inprd(G + (i + 1)*G_sz, W, K, G_blkszs) - c[i])
+                        > mat_norm * TOLC)
                     dual_equ_feas = NO;
                 i++;
             }
             /* check dual positive-definiteness */
-            if (dual_equ_feas && eig_val(sigZ,Z,L,F_blkszs,F_sz,wkspc)>0 &&
-                eig_val(sigW,W,K,G_blkszs,G_sz,wkspc)>0)
+            if (dual_equ_feas && eig_val(sigZ, Z, L, F_blkszs, F_sz, wkspc) > 0 &&
+                    eig_val(sigW, W, K, G_blkszs, G_sz, wkspc) > 0)
                 dual_PD_feas = YES;
         }
 
         /* Newton's method begins here */
         sqrtt = sqrt(t);
-        for (NTcount=0; *NTiters<maxNTiters; ) {
+        for (NTcount = 0; *NTiters < maxNTiters;) {
             (*NTiters)++;
             NTcount++;
-            /* cholesky decompositions of F and G are used for scaling
-             *   XF = LF*LF^T;  XG = LG*LG^T
-             * and the scaled F_i's and G_i's
-             *   Gsc = LG^{-1}*G_i*LG^{-T}
-             *   Fsc = LF^{-1}*F_i*LF^{-T} */
-            memcpy(Gsc,G+G_sz,m*G_sz*sizeof(double));  /* copy G to Gsc */
-            memcpy(Fsc,F+F_sz,m*F_sz*sizeof(double));  /* copy F to Fsc */
-            memcpy(LG,XG,G_sz*sizeof(double));         /* copy XG to LG */
+            /*  cholesky decompositions of F and G are used for scaling
+                 XF = LF*LF^T;  XG = LG*LG^T
+                and the scaled F_i's and G_i's
+                 Gsc = LG^{-1}*G_i*LG^{-T}
+                 Fsc = LF^{-1}*F_i*LF^{-T} */
+            memcpy(Gsc, G + G_sz, m * G_sz * sizeof(double)); /* copy G to Gsc */
+            memcpy(Fsc, F + F_sz, m * F_sz * sizeof(double)); /* copy F to Fsc */
+            memcpy(LG, XG, G_sz * sizeof(double));     /* copy XG to LG */
 
-/*
-        printf("-------------- Initial LG------------------\n");
-        disp_mat(stdout,XG,6,4,0);
-*/
+            /*
+                    printf("-------------- Initial LG------------------\n");
+                    disp_mat(stdout,XG,6,4,0);
+            */
 
 
-            memcpy(LF,XF,F_sz*sizeof(double));         /* copy XF to LF */
-            for (i=0, pos=0, dpt=LG; i<K;
-                 pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, dpt=LG+pos, i++) {
-                /* loop over blocks, do the cholesky decomp and form Gsc.
-                 * DPPTRF is called only if the block size exceeds 2 */
+            memcpy(LF, XF, F_sz * sizeof(double));     /* copy XF to LF */
+            for (i = 0, pos = 0, dpt = LG; i < K;
+                    pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, dpt = LG + pos, i++) {
+                /*  loop over blocks, do the cholesky decomp and form Gsc.
+                    DPPTRF is called only if the block size exceeds 2 */
                 switch (G_blkszs[i]) {
-                  case 1:    /* 1-by-1 block */
-                    if (*dpt<=0) {
-                        fprintf(stderr,"maxdet: x(1x1) infeasible because G(x)<=0.\n");
-                        *info = -9;
-                        return 1;
-                    }
-                    *dpt = sqrt(*dpt);
-                    break;
-                  case 2:    /* 2-by-2 block */
-                    if (*dpt + *(dpt+2)<=0 ||
-                        *dpt * *(dpt+2) - SQR(*(dpt+1))<=0) {
-                        fprintf(stderr,"maxdet: x(2x2) infeasible because G(x)<=0.\n");
-                        *info = -9;
-                        return 1;
-                    }
-                    *dpt = sqrt(*dpt);
-                    *(dpt+1) = *(dpt+1) / *dpt;
-                    *(dpt+2) = sqrt(*(dpt+2)-SQR(*(dpt+1)));
-                    break;
-                  default:   /* 3-by-3 or larger block */
-                    dpptrf("L",G_blkszs[i],dpt,&NAinfo);
-                    if (NAinfo>0) {
-                        fprintf(stderr,"maxdet: x infeasible because G(x)<=0. %d block(3x3) %d iterations\n",i,NTcount);
-                        *info = -9;
-                        return 1;
-                    } else if (NAinfo) {
-                        fprintf(stderr,"Error in dpptrf(0), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    break;
+                    case 1:    /* 1-by-1 block */
+                        if (*dpt <= 0) {
+                            fprintf(stderr, "maxdet: x(1x1) infeasible because G(x)<=0.\n");
+                            *info = -9;
+                            return 1;
+                        }
+                        *dpt = sqrt(*dpt);
+                        break;
+                    case 2:    /* 2-by-2 block */
+                        if (*dpt + * (dpt + 2) <= 0 ||
+                                *dpt * *(dpt + 2) - SQR(*(dpt + 1)) <= 0) {
+                            fprintf(stderr, "maxdet: x(2x2) infeasible because G(x)<=0.\n");
+                            *info = -9;
+                            return 1;
+                        }
+                        *dpt = sqrt(*dpt);
+                        *(dpt + 1) = *(dpt + 1) / *dpt;
+                        *(dpt + 2) = sqrt(*(dpt + 2) - SQR(*(dpt + 1)));
+                        break;
+                    default:   /* 3-by-3 or larger block */
+                        dpptrf("L", G_blkszs[i], dpt, &NAinfo);
+                        if (NAinfo > 0) {
+                            fprintf(stderr, "maxdet: x infeasible because G(x)<=0. %d block(3x3) %d iterations\n", i, NTcount);
+                            *info = -9;
+                            return 1;
+                        }
+                        else if (NAinfo) {
+                            fprintf(stderr, "Error in dpptrf(0), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        break;
                 }
                 /* ith blocks of scaled matrices Gsc_j, j=1,...,m */
-                for (j=0; j<m; j++) {
-                    dspgst(1,"L",G_blkszs[i],Gsc+j*G_sz+pos,dpt,&NAinfo);
-                    if (NAinfo){ 
-                        fprintf(stderr,"Error in dspgst(0), info = %d.\n",NAinfo);
+                for (j = 0; j < m; j++) {
+                    dspgst(1, "L", G_blkszs[i], Gsc + j * G_sz + pos, dpt, &NAinfo);
+                    if (NAinfo) {
+                        fprintf(stderr, "Error in dspgst(0), info = %d.\n", NAinfo);
                         return 1;
                     }
                 }
             }
-            for (i=0, pos=0, dpt=LF; i<L;
-                 pos+=F_blkszs[i]*(F_blkszs[i]+1)/2, dpt=LF+pos, i++) {
-                /* loop over blocks, do the cholesky decomp and form Fsc.
-                 * DPPTRF is called only if the block size exceeds 2 */
+            for (i = 0, pos = 0, dpt = LF; i < L;
+                    pos += F_blkszs[i] * (F_blkszs[i] + 1) / 2, dpt = LF + pos, i++) {
+                /*  loop over blocks, do the cholesky decomp and form Fsc.
+                    DPPTRF is called only if the block size exceeds 2 */
                 switch (F_blkszs[i]) {
-                  case 1:    /* 1-by-1 block */
-                    if (*dpt<=0) {
-                        fprintf(stderr,"maxdet: x infeasible because F(x)<=0.\n");
-                        *info = -9;
-                        return 1;
-                    }
-                    *dpt = sqrt(*dpt);
-                    break;
-                  case 2:    /* 2-by-2 block */
-                    if (*dpt + *(dpt+2)<=0 ||
-                        *dpt * *(dpt+2) - SQR(*(dpt+1))<=0) {
-                        fprintf(stderr,"maxdet: x infeasible because F(x)<=0.\n");
-                        *info = -9;
-                        return 1;
-                    }
-                    *dpt = sqrt(*dpt);
-                    *(dpt+1) = *(dpt+1) / *dpt;
-                    *(dpt+2) = sqrt(*(dpt+2)-SQR(*(dpt+1)));
-                    break;
-                  default:   /* 3-by-3 or larger block */
-                    dpptrf("L",F_blkszs[i],dpt,&NAinfo);
-                    if (NAinfo>0) {
-                        fprintf(stderr,"maxdet: x infeasible because F(x)<=0.\n");
-                        *info = -9;
-                        return 1;
-                    } else if (NAinfo) {
-                        fprintf(stderr,"Error in dpptrf(1), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    break;
+                    case 1:    /* 1-by-1 block */
+                        if (*dpt <= 0) {
+                            fprintf(stderr, "maxdet: x infeasible because F(x)<=0.\n");
+                            *info = -9;
+                            return 1;
+                        }
+                        *dpt = sqrt(*dpt);
+                        break;
+                    case 2:    /* 2-by-2 block */
+                        if (*dpt + * (dpt + 2) <= 0 ||
+                                *dpt * *(dpt + 2) - SQR(*(dpt + 1)) <= 0) {
+                            fprintf(stderr, "maxdet: x infeasible because F(x)<=0.\n");
+                            *info = -9;
+                            return 1;
+                        }
+                        *dpt = sqrt(*dpt);
+                        *(dpt + 1) = *(dpt + 1) / *dpt;
+                        *(dpt + 2) = sqrt(*(dpt + 2) - SQR(*(dpt + 1)));
+                        break;
+                    default:   /* 3-by-3 or larger block */
+                        dpptrf("L", F_blkszs[i], dpt, &NAinfo);
+                        if (NAinfo > 0) {
+                            fprintf(stderr, "maxdet: x infeasible because F(x)<=0.\n");
+                            *info = -9;
+                            return 1;
+                        }
+                        else if (NAinfo) {
+                            fprintf(stderr, "Error in dpptrf(1), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        break;
                 }
                 /* ith blocks of scaled matrices Fsc_j, j=1,...,m */
-                for (j=0; j<m; j++) {
-                    dspgst(1,"L",F_blkszs[i],Fsc+j*F_sz+pos,dpt,&NAinfo);
-                    if (NAinfo){ 
-                        fprintf(stderr,"Error in dspgst(1), info = %d.\n",NAinfo);
+                for (j = 0; j < m; j++) {
+                    dspgst(1, "L", F_blkszs[i], Fsc + j * F_sz + pos, dpt, &NAinfo);
+                    if (NAinfo) {
+                        fprintf(stderr, "Error in dspgst(1), info = %d.\n", NAinfo);
                         return 1;
                     }
                 }
             }
 
-            if (iters==1 && !dual_PD_feas) {
-                /* preliminary Newton iteration:
-                 * each iteration updates t such that Newton decrement
-                 * is minimized. Denote the hessian by
-                 *   H = tM_1 + M_2  (t > 0)
-                 * we will simultaneously diagonalize M_1 and M_2 using
-                 * the following generalized eigen-decomp (M_1+M_2>0 is known):
-                 * M_1*V = (M_1+M_2)*V*Lambda such that
-                 *   V^T*(M_1+M_2)*V = I
-                 *   V^T*M_1*V       = Lambda
-                 * thus, V^T*H*V = I + (t-1)*Lambda and
-                 * g^T*H^{-1}*g = g^T*V*(V^T*H*V)^{-1}*V^T*g
-                 *              = \tilde{g}^T\tilde{H}^{-1}\tilde{g}
-                 * where
-                 *   \tilde{g} = tv_1 + v_2;
-                 *   \tilde{H} = tSigM + (I-SigM)
-                 * now we could easily compute the
-                 * gradient and hessian of Newton decrement over t.
-                 * Newton direction is then computed directly from -H^{-1}g */
+            if (iters == 1 && !dual_PD_feas) {
+                /*  preliminary Newton iteration:
+                    each iteration updates t such that Newton decrement
+                    is minimized. Denote the hessian by
+                     H = tM_1 + M_2  (t > 0)
+                    we will simultaneously diagonalize M_1 and M_2 using
+                    the following generalized eigen-decomp (M_1+M_2>0 is known):
+                    M_1*V = (M_1+M_2)*V*Lambda such that
+                     V^T*(M_1+M_2)*V = I
+                     V^T*M_1*V       = Lambda
+                    thus, V^T*H*V = I + (t-1)*Lambda and
+                    g^T*H^{-1}*g = g^T*V*(V^T*H*V)^{-1}*V^T*g
+                                = \tilde{g}^T\tilde{H}^{-1}\tilde{g}
+                    where
+                     \tilde{g} = tv_1 + v_2;
+                     \tilde{H} = tSigM + (I-SigM)
+                    now we could easily compute the
+                    gradient and hessian of Newton decrement over t.
+                    Newton direction is then computed directly from -H^{-1}g */
 
-                /* (M1)_{ij} = \Tr(Gsc_i,Gsc_j);
-                   (M2)_{ij} = \Tr(Fsc_i,Fsc_j);  (M2 stored in LM) */
-                for (i=0, dps=M1, dpt=LM; i<m; i++)
-                    for(j=i; j<m; j++, dps++, dpt++) {
-                        *dps = inprd(Gsc+i*G_sz,Gsc+j*G_sz,K,G_blkszs);
-                        *dpt = inprd(Fsc+i*F_sz,Fsc+j*F_sz,L,F_blkszs);
+                /*  (M1)_{ij} = \Tr(Gsc_i,Gsc_j);
+                    (M2)_{ij} = \Tr(Fsc_i,Fsc_j);  (M2 stored in LM) */
+                for (i = 0, dps = M1, dpt = LM; i < m; i++)
+                    for (j = i; j < m; j++, dps++, dpt++) {
+                        *dps = inprd(Gsc + i * G_sz, Gsc + j * G_sz, K, G_blkszs);
+                        *dpt = inprd(Fsc + i * F_sz, Fsc + j * F_sz, L, F_blkszs);
                     }
-                for (i=0, dpt=LM, dps=M1; i<M_sz; i++, dpt++, dps++)
+                for (i = 0, dpt = LM, dps = M1; i < M_sz; i++, dpt++, dps++)
                     *dpt += *dps;    /* LM = M2+M1, in packed storage */
                 /* generalize eigen-decomp: eig(M1,M1+M2) */
-                dspgv(1,"V","L",m,M1,LM,sigM,VM,m,wkspc,&NAinfo);
-                if (NAinfo>m) {
+                dspgv(1, "V", "L", m, M1, LM, sigM, VM, m, wkspc, &NAinfo);
+                if (NAinfo > m) {
                     fprintf(stderr, "maxdet: matrices diag(Fi,Gi), i=1,...,m\
  are linearly dependent\n        (or F(x) and/or G(x) are very badly\
  conditioned).\n");
                     *info = -23;
                     return 1;
-                } else if (NAinfo) {
-                    fprintf(stderr,"Error in dspgv(0), info = %d.\n",NAinfo);
+                }
+                else if (NAinfo) {
+                    fprintf(stderr, "Error in dspgv(0), info = %d.\n", NAinfo);
                     return 1;
                 }
                 /* v1 = VM^T*(c-\Tr(Gsc,I));  v2 = VM^T*(-\TR(Fsc,I)) */
-                memcpy(temp,c,m*sizeof(double));    /* copy c to temp */
-                for (i=0; i<m; i++)
-                    for (j=0, dps=Gsc+i*G_sz; j<K; j++)
-                        for (k=G_blkszs[j]; k>0; dps+=k, k--)
-                            *(temp+i) -= *dps;      /* temp = c-\Tr(Gsc,I) */
-                dgemv("T",m,m,1.0,VM,m,temp,1,0.0,v1,1);
-                memset(temp,0,m*sizeof(double));
-                for (i=0; i<m; i++)
-                    for (j=0, dps=Fsc+i*F_sz; j<L; j++)
-                        for (k=F_blkszs[j]; k>0; dps+=k, k--)
-                            *(temp+i) -= *dps;      /* temp = -\Tr(Fsc,I) */
-                dgemv("T",m,m,1.0,VM,m,temp,1,0.0,v2,1);
+                memcpy(temp, c, m * sizeof(double)); /* copy c to temp */
+                for (i = 0; i < m; i++)
+                    for (j = 0, dps = Gsc + i * G_sz; j < K; j++)
+                        for (k = G_blkszs[j]; k > 0; dps += k, k--)
+                            * (temp + i) -= *dps;   /* temp = c-\Tr(Gsc,I) */
+                dgemv("T", m, m, 1.0, VM, m, temp, 1, 0.0, v1, 1);
+                memset(temp, 0, m * sizeof(double));
+                for (i = 0; i < m; i++)
+                    for (j = 0, dps = Fsc + i * F_sz; j < L; j++)
+                        for (k = F_blkszs[j]; k > 0; dps += k, k--)
+                            * (temp + i) -= *dps;   /* temp = -\Tr(Fsc,I) */
+                dgemv("T", m, m, 1.0, VM, m, temp, 1, 0.0, v2, 1);
                 /* Newton's method for minimizing t */
                 /* t_old = t; */
-                for (i=0; i<LSITERUB; i++) {
+                for (i = 0; i < LSITERUB; i++) {
                     grad1 = 0.0;
                     hess1 = 0.0;
-                    for (j=0, dps=v1, dpt=sigM; j<m; j++, dps++, dpt++) {
-                        dtmp = t * *dps + *(v2+j);     /* \tilde{g} */
-                        dtmp2 = (t-1) * *dpt + 1.0;    /* \tilde{H} */
+                    for (j = 0, dps = v1, dpt = sigM; j < m; j++, dps++, dpt++) {
+                        dtmp = t * *dps + *(v2 + j);   /* \tilde{g} */
+                        dtmp2 = (t - 1) * *dpt + 1.0;  /* \tilde{H} */
                         grad1 += 2 * *dps * dtmp / dtmp2 -
-                            SQR(dtmp) * *dpt / SQR(dtmp2);
+                                 SQR(dtmp) * *dpt / SQR(dtmp2);
                         hess1 += 2 * SQR(*dps) / dtmp2 -
-                            4 * dtmp * *dps * *dpt / SQR(dtmp2) +
-                            2 * SQR(dtmp) * SQR(*dpt) / (SQR(dtmp2)*dtmp2);
+                                 4 * dtmp * *dps * *dpt / SQR(dtmp2) +
+                                 2 * SQR(dtmp) * SQR(*dpt) / (SQR(dtmp2) * dtmp2);
                     }
-                    if (hess1<=0) {
+                    if (hess1 <= 0) {
                         lambda = 0;
-                    } else {
-                        lambda = sqrt(SQR(grad1)/hess1);
-                        t = MAX(1,t-1/(1+lambda)*(grad1/hess1)); 
-                                  /* guarded by 1 */
+                    }
+                    else {
+                        lambda = sqrt(SQR(grad1) / hess1);
+                        t = MAX(1, t - 1 / (1 + lambda) * (grad1 / hess1));
+                        /* guarded by 1 */
                     }
                     if (lambda < LSTOL)
                         break;    /* break line search loop */
                 }
-                t = MAX(1,t);     /* t is guarded by 1 */
-#ifdef debug
-printf("t=%10.4e from preliminary phase\n",t);
-#endif
+                t = MAX(1, t);    /* t is guarded by 1 */
+                #ifdef debug
+                printf("t=%10.4e from preliminary phase\n", t);
+                #endif
                 /* dx = -VM*((t*v1+v2)./((t-1)*sigM+I)), stored in rhs */
-                for (i=0, dpt=rhs; i<m; i++, dpt++)
-                    *dpt = -( (t * *(v1+i) + *(v2+i)) /
-                              ((t-1) * *(sigM+i)+ 1.0) );
-                memcpy(temp,rhs,m*sizeof(double));
-                dgemv("N",m,m,1.0,VM,m,temp,1,0.0,rhs,1);
+                for (i = 0, dpt = rhs; i < m; i++, dpt++)
+                    *dpt = -((t * *(v1 + i) + * (v2 + i)) /
+                             ((t - 1) * *(sigM + i) + 1.0));
+                memcpy(temp, rhs, m * sizeof(double));
+                dgemv("N", m, m, 1.0, VM, m, temp, 1, 0.0, rhs, 1);
                 sqrtt = sqrt(t);
 
-            } else {
+            }
+            else {
 
-                if (NTcount==1 && iters==1) {
-                    /* compute initial t from duality gap:
-                     *   t = MAX(1, n/gap)
-                     *   gap = c^Tx + \TrZF_0 + \TrWG_0 - l - \logdet G*W
-                     *       = \TrZF + TrWG - l -logdet GW
-                     *         (where GW = LG^T*W*LG)
-                     *       = \TrZF + sum_i eig(GW)_i -1 - \log eig(GW)_i */
-                    gap = inprd(Z,XF,L,F_blkszs);      /* \TrZF */
+                if (NTcount == 1 && iters == 1) {
+                    /*  compute initial t from duality gap:
+                         t = MAX(1, n/gap)
+                         gap = c^Tx + \TrZF_0 + \TrWG_0 - l - \logdet G*W
+                             = \TrZF + TrWG - l -logdet GW
+                               (where GW = LG^T*W*LG)
+                             = \TrZF + sum_i eig(GW)_i -1 - \log eig(GW)_i */
+                    gap = inprd(Z, XF, L, F_blkszs);   /* \TrZF */
                     /* compute GW = LG^T*W*LG */
-                    memcpy(rhs,W,G_sz*sizeof(double)); /* copy W to rhs(=GW) */
-                    for (i=0, pos=0, dpt=LG; i<K;
-                         pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, dpt=LG+pos, i++) {
-                        dspgst(2,"L",G_blkszs[i],rhs+pos,dpt,&NAinfo);
-                        if (NAinfo){ 
-                            fprintf(stderr,"Error in dspgst(2), info = %d.\n",
+                    memcpy(rhs, W, G_sz * sizeof(double)); /* copy W to rhs(=GW) */
+                    for (i = 0, pos = 0, dpt = LG; i < K;
+                            pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, dpt = LG + pos, i++) {
+                        dspgst(2, "L", G_blkszs[i], rhs + pos, dpt, &NAinfo);
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgst(2), info = %d.\n",
                                     NAinfo);
                             return 1;
                         }
                     }
-                    eig_val(sigG,rhs,K,G_blkszs,G_sz,wkspc);
-                    for (i=0; i<l; i++)    /* sigG = eig(GW) here */
-                        gap += sigG[i]-1.0-log(sigG[i]);
-                    t = MAX(1.0 , n/gap);
+                    eig_val(sigG, rhs, K, G_blkszs, G_sz, wkspc);
+                    for (i = 0; i < l; i++) /* sigG = eig(GW) here */
+                        gap += sigG[i] - 1.0 - log(sigG[i]);
+                    t = MAX(1.0 , n / gap);
                     sqrtt = sqrt(t);
-#ifdef debug
-printf("t=%10.2e from feasible dual\n",t);
-#endif
+                    #ifdef debug
+                    printf("t=%10.2e from feasible dual\n", t);
+                    #endif
                 }
 
-                /* Newton iteration:
-                 * solve primal LS problem to find Newton direction */
-                memcpy(rhs,W,G_sz*sizeof(double));       /* copy -W to rhs */
-                dscal(G_sz,-1.0,rhs,1);
-                memcpy(rhs+G_sz,Z,F_sz*sizeof(double));  /* copy -t*Z to rhs */
+                /*  Newton iteration:
+                    solve primal LS problem to find Newton direction */
+                memcpy(rhs, W, G_sz * sizeof(double));   /* copy -W to rhs */
+                dscal(G_sz, -1.0, rhs, 1);
+                memcpy(rhs + G_sz, Z, F_sz * sizeof(double)); /* copy -t*Z to rhs */
                 dtmp = -t;
-                dscal(F_sz,dtmp,rhs+G_sz,1);
+                dscal(F_sz, dtmp, rhs + G_sz, 1);
                 /* form rhs of primal LS (G, W related) */
-                for (i=0, pos=0, dpt=LG; i<K;
-                     pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, dpt=LG+pos, i++) {
-                    /* ith block of rhs is sqrt(t)*(I-GW)
-                     *   GW = LG^T*W*LG */
-                    dspgst(2,"L",G_blkszs[i],rhs+pos,dpt,&NAinfo);
-                    if (NAinfo){ 
-                        fprintf(stderr,"Error in dspgst(3), info = %d.\n",NAinfo);
+                for (i = 0, pos = 0, dpt = LG; i < K;
+                        pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, dpt = LG + pos, i++) {
+                    /*  ith block of rhs is sqrt(t)*(I-GW)
+                         GW = LG^T*W*LG */
+                    dspgst(2, "L", G_blkszs[i], rhs + pos, dpt, &NAinfo);
+                    if (NAinfo) {
+                        fprintf(stderr, "Error in dspgst(3), info = %d.\n", NAinfo);
                         return 1;
                     }
-                    /* add 1 to diagonal elements of rhs and scale them
-                     * by 1/sqrt(2) */
-                    for (k=0, pos2=pos; k<G_blkszs[i]; pos2+=G_blkszs[i]-k,
-                         k++)
-                        *(rhs+pos2) = (*(rhs+pos2)+1.0)/sqrt(2.0);
+                    /*  add 1 to diagonal elements of rhs and scale them
+                        by 1/sqrt(2) */
+                    for (k = 0, pos2 = pos; k < G_blkszs[i]; pos2 += G_blkszs[i] - k,
+                            k++)
+                        * (rhs + pos2) = (*(rhs + pos2) + 1.0) / sqrt(2.0);
                     /* scale rhs by sqrt(t) (2 lines below) */
                 }
-                dscal(G_sz,sqrtt,rhs,1);
+                dscal(G_sz, sqrtt, rhs, 1);
                 /* form rhs of primal LS (F, Z related) */
-                for (i=0, pos=0, dpt=LF; i<L;
-                     pos+=F_blkszs[i]*(F_blkszs[i]+1)/2, dpt=LF+pos, i++) {
-                    /* ith block of rhs is I-t*FZ
-                     *   FZ = LF^T*Z*LF */
-                    dspgst(2,"L",F_blkszs[i],rhs+G_sz+pos,dpt,&NAinfo);
-                    if (NAinfo){ 
-                        fprintf(stderr,"Error in dspgst(4), info = %d.\n",NAinfo);
+                for (i = 0, pos = 0, dpt = LF; i < L;
+                        pos += F_blkszs[i] * (F_blkszs[i] + 1) / 2, dpt = LF + pos, i++) {
+                    /*  ith block of rhs is I-t*FZ
+                         FZ = LF^T*Z*LF */
+                    dspgst(2, "L", F_blkszs[i], rhs + G_sz + pos, dpt, &NAinfo);
+                    if (NAinfo) {
+                        fprintf(stderr, "Error in dspgst(4), info = %d.\n", NAinfo);
                         return 1;
                     }
-                    /* add 1 to diagonal elements of rhs and scale them
-                     * by 1/sqrt(2) */
-                    for (k=0, pos2=pos; k<F_blkszs[i]; pos2+=F_blkszs[i]-k,
-                         k++)
-                        *(rhs+G_sz+pos2) = (*(rhs+G_sz+pos2)+1.0)/sqrt(2.0);
+                    /*  add 1 to diagonal elements of rhs and scale them
+                        by 1/sqrt(2) */
+                    for (k = 0, pos2 = pos; k < F_blkszs[i]; pos2 += F_blkszs[i] - k,
+                            k++)
+                        * (rhs + G_sz + pos2) = (*(rhs + G_sz + pos2) + 1.0) / sqrt(2.0);
                 }
                 /* prepare the left-hand-side of the primal LS problem */
-                for (i=0, dpt=GaF; i<m; i++, dpt+=sz) {
-                    memcpy(dpt,Gsc+i*G_sz,G_sz*sizeof(double));
-                    for (j=0, dps=dpt; j<K; j++)
-                        for (k=G_blkszs[j]; k>0; dps+=k, k--)
-                            *dps /= sqrt(2.0);   /* scale diagonal elements */
-                    memcpy(dpt+G_sz,Fsc+i*F_sz,F_sz*sizeof(double));
-                    for (j=0, dps=dpt+G_sz; j<L; j++)
-                        for (k=F_blkszs[j]; k>0; dps+=k, k--)
-                            *dps /= sqrt(2.0);   /* scale diagonal elements */
+                for (i = 0, dpt = GaF; i < m; i++, dpt += sz) {
+                    memcpy(dpt, Gsc + i * G_sz, G_sz * sizeof(double));
+                    for (j = 0, dps = dpt; j < K; j++)
+                        for (k = G_blkszs[j]; k > 0; dps += k, k--)
+                            * dps /= sqrt(2.0);  /* scale diagonal elements */
+                    memcpy(dpt + G_sz, Fsc + i * F_sz, F_sz * sizeof(double));
+                    for (j = 0, dps = dpt + G_sz; j < L; j++)
+                        for (k = F_blkszs[j]; k > 0; dps += k, k--)
+                            * dps /= sqrt(2.0);  /* scale diagonal elements */
                 }
-		dlascl("G",0,0,1.0,sqrtt,G_sz,m,GaF,sz,&NAinfo);
-                if (NAinfo){ 
-                    fprintf(stderr,"Error in dlascl(0), info = %d.\n",NAinfo);
+                dlascl("G", 0, 0, 1.0, sqrtt, G_sz, m, GaF, sz, &NAinfo);
+                if (NAinfo) {
+                    fprintf(stderr, "Error in dlascl(0), info = %d.\n", NAinfo);
                     return 1;
                 }
                 /* solve the primal LS problem */
-                dgels("N",sz,m,1,GaF,sz,rhs,sz,wkspc,lwkspc,&NAinfo);
-                if (NAinfo){ 
-                    fprintf(stderr,"Error in dgels(0), info = %d.\n",NAinfo);
+                dgels("N", sz, m, 1, GaF, sz, rhs, sz, wkspc, lwkspc, &NAinfo);
+                if (NAinfo) {
+                    fprintf(stderr, "Error in dgels(0), info = %d.\n", NAinfo);
                     return 1;
                 }
 
-                /* check the rank of GaF (for the first iteration only):
-                 * estimate the condition number in 1-norm of R of the QR-decomp
-                 * of GaF (stored in upper-triangular part of GaF after calling
-                 *  dgels). if rcond < MINRCOND, GaF is low-rank */
+                /*  check the rank of GaF (for the first iteration only):
+                    estimate the condition number in 1-norm of R of the QR-decomp
+                    of GaF (stored in upper-triangular part of GaF after calling
+                    dgels). if rcond < MINRCOND, GaF is low-rank */
                 if (iters == 1) {
-                    dtrcon("1","U","N",m,GaF,sz,&rcond,wkspc,iwork,&NAinfo);
-                    if (NAinfo < 0){
-                        fprintf(stderr,"Error in dtrcon(0), info = %d.\n", NAinfo);
+                    dtrcon("1", "U", "N", m, GaF, sz, &rcond, wkspc, iwork, &NAinfo);
+                    if (NAinfo < 0) {
+                        fprintf(stderr, "Error in dtrcon(0), info = %d.\n", NAinfo);
                         return 1;
                     }
                     if (rcond < MINRCOND) {
-                        fprintf(stderr,"maxdet: matrices diag(G_i,F_i), i=1,...,m\
+                        fprintf(stderr, "maxdet: matrices diag(G_i,F_i), i=1,...,m\
  are linearly dependent\n        (or F(x) and/or G(x) are very badly\
  conditioned).\n");
                         *info = -23;
@@ -924,573 +927,577 @@ printf("t=%10.2e from feasible dual\n",t);
             }
 
             /* compute dXG and dXF */
-            dgemv("N",G_sz,m,1.0,G+G_sz,G_sz,rhs,1,0.0,dXG,1);
-            dgemv("N",F_sz,m,1.0,F+F_sz,F_sz,rhs,1,0.0,dXF,1);
+            dgemv("N", G_sz, m, 1.0, G + G_sz, G_sz, rhs, 1, 0.0, dXG, 1);
+            dgemv("N", F_sz, m, 1.0, F + F_sz, F_sz, rhs, 1, 0.0, dXF, 1);
 
             /* find sigG=eig(dXG,XG) and sigF=eig(dXF,XF) */
-            memcpy(temp,XG,G_sz*sizeof(double));      /* copy XG to temp */
-            memcpy(temp2,dXG,G_sz*sizeof(double));    /* copy dXG to temp2 */
-            for (i=0, pos=0, dpt=sigG; i<K; dpt+=G_blkszs[i],
-                 pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, i++) {
+            memcpy(temp, XG, G_sz * sizeof(double));  /* copy XG to temp */
+            memcpy(temp2, dXG, G_sz * sizeof(double)); /* copy dXG to temp2 */
+            for (i = 0, pos = 0, dpt = sigG; i < K; dpt += G_blkszs[i],
+                    pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, i++) {
                 switch (G_blkszs[i]) {
-                  case 1:
-                    *dpt = *(temp2+pos) / *(temp+pos);
-                    break;
-                  default:
-                    dspgv(1,"N","L",G_blkszs[i],temp2+pos,temp+pos,dpt,
-                           NULL,1,wkspc,&NAinfo);  /* workspace 3*max_l */
-                    if (NAinfo) {
-                        fprintf(stderr,"Error in dspgv(1), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    break;
+                    case 1:
+                        *dpt = *(temp2 + pos) / *(temp + pos);
+                        break;
+                    default:
+                        dspgv(1, "N", "L", G_blkszs[i], temp2 + pos, temp + pos, dpt,
+                              NULL, 1, wkspc, &NAinfo); /* workspace 3*max_l */
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgv(1), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        break;
                 }
             }
-            memcpy(temp,XF,F_sz*sizeof(double));      /* copy XF to temp */
-            memcpy(temp2,dXF,F_sz*sizeof(double));    /* copy dXF to temp2 */
-            for (i=0, pos=0, dpt=sigF; i<L; dpt+=F_blkszs[i],
-                 pos+=F_blkszs[i]*(F_blkszs[i]+1)/2, i++) {
+            memcpy(temp, XF, F_sz * sizeof(double));  /* copy XF to temp */
+            memcpy(temp2, dXF, F_sz * sizeof(double)); /* copy dXF to temp2 */
+            for (i = 0, pos = 0, dpt = sigF; i < L; dpt += F_blkszs[i],
+                    pos += F_blkszs[i] * (F_blkszs[i] + 1) / 2, i++) {
                 switch (F_blkszs[i]) {
-                  case 1:
-                    *dpt = *(temp2+pos) / *(temp+pos);
-                    break;
-                  default:
-                    dspgv(1,"N","L",F_blkszs[i],temp2+pos,temp+pos,dpt,
-                           NULL,1,wkspc,&NAinfo);  /* workspace 3*max_n */
-                    if (NAinfo) {
-                        fprintf(stderr,"Error in dspgv(2), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    break;
+                    case 1:
+                        *dpt = *(temp2 + pos) / *(temp + pos);
+                        break;
+                    default:
+                        dspgv(1, "N", "L", F_blkszs[i], temp2 + pos, temp + pos, dpt,
+                              NULL, 1, wkspc, &NAinfo); /* workspace 3*max_n */
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgv(2), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        break;
                 }
             }
 
-            /* check dual infeasibility (for the preliminary phase ONLY):
-             *   if sigG and sigF are all non-negative, and c^Tdx <=0,
-             *   we conclude dual infeasibility */
-            if (iters==1 && !dual_PD_feas) {
+            /*  check dual infeasibility (for the preliminary phase ONLY):
+                 if sigG and sigF are all non-negative, and c^Tdx <=0,
+                 we conclude dual infeasibility */
+            if (iters == 1 && !dual_PD_feas) {
 
-                int neg_sig=NO;
+                int neg_sig = NO;
 
-                for (i=0, dps=sigG; (i<l && !neg_sig); i++, dps++)
-                    if (*dps<0)  neg_sig=YES;
-                for (i=0, dps=sigF; (i<n && !neg_sig); i++, dps++)
-                    if (*dps<0)  neg_sig=YES;
-                if (ddot(m,c,1,rhs,1)<=0 && !neg_sig) {
-                    fprintf(stderr,"maxdet: The dual problem is infeasible.\n");
+                for (i = 0, dps = sigG; (i < l && !neg_sig); i++, dps++)
+                    if (*dps < 0)  neg_sig = YES;
+                for (i = 0, dps = sigF; (i < n && !neg_sig); i++, dps++)
+                    if (*dps < 0)  neg_sig = YES;
+                if (ddot(m, c, 1, rhs, 1) <= 0 && !neg_sig) {
+                    fprintf(stderr, "maxdet: The dual problem is infeasible.\n");
                     return 1;
                 }
             }
 
             /* compute Newton decrement (denoted by mu) */
             mu = 0.0;
-            for (i=0, dps=sigG; i<l; i++, dps++)
+            for (i = 0, dps = sigG; i < l; i++, dps++)
                 mu += SQR(*dps);
             mu *= t;
-            for (i=0, dps=sigF; i<n; i++, dps++)
+            for (i = 0, dps = sigF; i < n; i++, dps++)
                 mu += SQR(*dps);
             mu = sqrt(mu);
             if (mu < CENTOL)
                 break;    /* break the loop of NTcount */
 
-            /* determine step length:
-             *   mu > .5 -- use line search
-             *   mu <=.5 -- use Newton step obtained */
+            /*  determine step length:
+                 mu > .5 -- use line search
+                 mu <=.5 -- use Newton step obtained */
             if (mu > .5) {
-                for (i=0, *alpha=0.0; i<LSITERUB; i++) {
+                for (i = 0, *alpha = 0.0; i < LSITERUB; i++) {
                     grad1 = 0.0;
                     hess1 = 0.0;
-                    for (j=0, dps=sigG; j<l; j++, dps++) {
+                    for (j = 0, dps = sigG; j < l; j++, dps++) {
                         dtmp = 1 + *alpha * *dps;
                         grad1 -= *dps / dtmp;
                         hess1 += SQR(*dps) / SQR(dtmp);
                     }
                     grad1 *= t;
                     hess1 *= t;
-                    for (j=0, dps=sigF; j<n; j++, dps++) {
+                    for (j = 0, dps = sigF; j < n; j++, dps++) {
                         dtmp = 1 + *alpha * *dps;
                         grad1 -= *dps / dtmp;
                         hess1 += SQR(*dps) / SQR(dtmp);
                     }
-                    grad1 += t * ddot(m,c,1,rhs,1);
-                    lambda = sqrt(SQR(grad1)/hess1);
-                    *alpha -= 1/(1+lambda)*(grad1/hess1);
+                    grad1 += t * ddot(m, c, 1, rhs, 1);
+                    lambda = sqrt(SQR(grad1) / hess1);
+                    *alpha -= 1 / (1 + lambda) * (grad1 / hess1);
                     if (lambda < LSTOL)
                         break;    /* break line search loop */
                 }
-            } else {
+            }
+            else {
                 *alpha = 1.0;
             }
 
             /* corrector step updates */
-            daxpy(m,*alpha,rhs,1,x,1);      /* x  += alpha * dx  */
-            daxpy(G_sz,*alpha,dXG,1,XG,1);  /* XG += alpha * dXG */
-            daxpy(F_sz,*alpha,dXF,1,XF,1);  /* XF += alpha * dXF */
+            daxpy(m, *alpha, rhs, 1, x, 1); /* x  += alpha * dx  */
+            daxpy(G_sz, *alpha, dXG, 1, XG, 1); /* XG += alpha * dXG */
+            daxpy(F_sz, *alpha, dXF, 1, XF, 1); /* XF += alpha * dXF */
 
 
-        dpt = hist+((*NTiters)-1)*(m+3);
-        for (iii=0;iii<m;iii++)
-          *(dpt+iii)=x[iii];
-        *(dpt+m) = 0;
-        *(dpt+m+1) =0;
-        *(dpt+m+2) =-1;
+            dpt = hist + ((*NTiters) - 1) * (m + 3);
+            for (iii = 0; iii < m; iii++)
+                *(dpt + iii) = x[iii];
+            *(dpt + m) = 0;
+            *(dpt + m + 1) = 0;
+            *(dpt + m + 2) = -1;
 
 
         }   /* end of Newton iterations loop */
 
 
-        /* update dual:
-         *   W = LG^{-T}*(I-Gsc*dx)*LG^{-1}
-         *   Z = (1/t)*(LF^{-T}*(I-Fsc*dx)*LF^{-1}) */
-        memcpy(ZWtmp,Z,F_sz*sizeof(double));      /* copy of Z for later use */
-        memcpy(ZWtmp+F_sz,W,G_sz*sizeof(double)); /* copy of W for later use */
-        memset(W,0,G_sz*sizeof(double));
-        memset(Z,0,F_sz*sizeof(double));
-        for (i=0, dpt=W; i<K; i++)    /* store I in W */
-            for (j=G_blkszs[i]; j>0; dpt+=j, j--)
-                *dpt = 1.0;
-        dgemv("N",G_sz,m,-1.0,Gsc,G_sz,rhs,1,1.0,W,1);
-        memcpy(LGinv,LG,G_sz*sizeof(double));
+        /*  update dual:
+             W = LG^{-T}*(I-Gsc*dx)*LG^{-1}
+             Z = (1/t)*(LF^{-T}*(I-Fsc*dx)*LF^{-1}) */
+        memcpy(ZWtmp, Z, F_sz * sizeof(double));  /* copy of Z for later use */
+        memcpy(ZWtmp + F_sz, W, G_sz * sizeof(double)); /* copy of W for later use */
+        memset(W, 0, G_sz * sizeof(double));
+        memset(Z, 0, F_sz * sizeof(double));
+        for (i = 0, dpt = W; i < K; i++) /* store I in W */
+            for (j = G_blkszs[i]; j > 0; dpt += j, j--)
+                * dpt = 1.0;
+        dgemv("N", G_sz, m, -1.0, Gsc, G_sz, rhs, 1, 1.0, W, 1);
+        memcpy(LGinv, LG, G_sz * sizeof(double));
         /* loop over the blocks for scaling of W */
-        for (i=0, pos=0; i<K; pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, i++) {
-            dtptri("L","N",G_blkszs[i],LGinv+pos,&NAinfo);  /* find LG^{-1} */
+        for (i = 0, pos = 0; i < K; pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, i++) {
+            dtptri("L", "N", G_blkszs[i], LGinv + pos, &NAinfo); /* find LG^{-1} */
             if (NAinfo) {
-                fprintf(stderr,"Error in dtptri(0), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dtptri(0), info = %d.\n", NAinfo);
                 return 1;
             }
-            dspgst(2,"L",G_blkszs[i],W+pos,LGinv+pos,&NAinfo);
+            dspgst(2, "L", G_blkszs[i], W + pos, LGinv + pos, &NAinfo);
             if (NAinfo) {
-                fprintf(stderr,"Error in dspgst(5), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dspgst(5), info = %d.\n", NAinfo);
                 return 1;
             }
         }
-        for (i=0, dpt=Z; i<L; i++)    /* store I in Z */
-            for (j=F_blkszs[i]; j>0; dpt+=j, j--)
-                *dpt = 1.0;
-        dgemv("N",F_sz,m,-1.0,Fsc,F_sz,rhs,1,1.0,Z,1);
-        memcpy(LFinv,LF,F_sz*sizeof(double));
+        for (i = 0, dpt = Z; i < L; i++) /* store I in Z */
+            for (j = F_blkszs[i]; j > 0; dpt += j, j--)
+                * dpt = 1.0;
+        dgemv("N", F_sz, m, -1.0, Fsc, F_sz, rhs, 1, 1.0, Z, 1);
+        memcpy(LFinv, LF, F_sz * sizeof(double));
         /* loop over the blocks for scaling of Z*/
-        for (i=0, pos=0; i<L; pos+=F_blkszs[i]*(F_blkszs[i]+1)/2, i++) {
-            dtptri("L","N",F_blkszs[i],LFinv+pos,&NAinfo);  /* find LF^{-1} */
+        for (i = 0, pos = 0; i < L; pos += F_blkszs[i] * (F_blkszs[i] + 1) / 2, i++) {
+            dtptri("L", "N", F_blkszs[i], LFinv + pos, &NAinfo); /* find LF^{-1} */
             if (NAinfo) {
-                fprintf(stderr,"Error in dtptri(1), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dtptri(1), info = %d.\n", NAinfo);
                 return 1;
             }
-            dspgst(2,"L",F_blkszs[i],Z+pos,LFinv+pos,&NAinfo);
+            dspgst(2, "L", F_blkszs[i], Z + pos, LFinv + pos, &NAinfo);
             if (NAinfo) {
-                fprintf(stderr,"Error in dspgst(6), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dspgst(6), info = %d.\n", NAinfo);
                 return 1;
             }
         }
-        dtmp=1/t;
-        dscal(F_sz,dtmp,Z,1);
+        dtmp = 1 / t;
+        dscal(F_sz, dtmp, Z, 1);
 
-        /* check the positive-definiteness of Z and W: (test only if
-         * within preliminary phase or maxNTiters exceeded)
-         *   if not,
-         *     within the preliminary phase it indicates the dual
-         *     is probably infeasible.
-         *     if maxNTiters is exceeded (non-PD of W and Z is caused by
-         *     prematural termination of Newton's method), then retrieve
-         *     the previous W and Z saved */
-        if ((iters==1 && !dual_PD_feas) || *NTiters>=maxNTiters) {
-            if (eig_val(sigZ,Z,L,F_blkszs,F_sz,wkspc)<=0 ||
-                eig_val(sigW,W,K,G_blkszs,G_sz,wkspc)<=0) {
-                if (iters==1 && !dual_PD_feas) {
-                    fprintf(stderr,"maxdet: Infeasible dual updates, the dual\
+        /*  check the positive-definiteness of Z and W: (test only if
+            within preliminary phase or maxNTiters exceeded)
+             if not,
+               within the preliminary phase it indicates the dual
+               is probably infeasible.
+               if maxNTiters is exceeded (non-PD of W and Z is caused by
+               prematural termination of Newton's method), then retrieve
+               the previous W and Z saved */
+        if ((iters == 1 && !dual_PD_feas) || *NTiters >= maxNTiters) {
+            if (eig_val(sigZ, Z, L, F_blkszs, F_sz, wkspc) <= 0 ||
+                    eig_val(sigW, W, K, G_blkszs, G_sz, wkspc) <= 0) {
+                if (iters == 1 && !dual_PD_feas) {
+                    fprintf(stderr, "maxdet: Infeasible dual updates, the dual\
  problem is likely to be infeasible.\n");
                     return 1;
-                } else {
-                    memcpy(Z,ZWtmp,F_sz*sizeof(double));       /* recover Z */
-                    memcpy(W,ZWtmp+F_sz,G_sz*sizeof(double));  /* recover W */
                 }
-	    }
-	}
+                else {
+                    memcpy(Z, ZWtmp, F_sz * sizeof(double));   /* recover Z */
+                    memcpy(W, ZWtmp + F_sz, G_sz * sizeof(double)); /* recover W */
+                }
+            }
+        }
 
-        /* update duality gap:
-         *   gap = c^Tx + \TrZF_0 + \TrWG_0 - l - \logdet G - \logdet W
-         *       = c^Tx + \TrZF_0 + \TrWG_0 - l - \logdet (I - dXG*G^{-1})
-         *       = \TrZF + sum_i eig(GW)_i -1 - \log eig(GW)_i
-         *   where GW = LG^T*W*LG
-         *
-         * NOTE: the 3rd formula is used to evaluate the gap, even it requires
-         *       eigen-decompositions of GW. the second one has serious
-         *       numerical problems, especially at center where XG~=W^{-1} */
-        gap = inprd(Z,XF,L,F_blkszs);         /* \TrZF */
+        /*  update duality gap:
+             gap = c^Tx + \TrZF_0 + \TrWG_0 - l - \logdet G - \logdet W
+                 = c^Tx + \TrZF_0 + \TrWG_0 - l - \logdet (I - dXG*G^{-1})
+                 = \TrZF + sum_i eig(GW)_i -1 - \log eig(GW)_i
+             where GW = LG^T*W*LG
+
+            NOTE: the 3rd formula is used to evaluate the gap, even it requires
+                 eigen-decompositions of GW. the second one has serious
+                 numerical problems, especially at center where XG~=W^{-1} */
+        gap = inprd(Z, XF, L, F_blkszs);      /* \TrZF */
         /* compute GW = LG^T*W*LG */
-        memcpy(rhs,W,G_sz*sizeof(double));    /* copy W to rhs(=GW) */
-        for (i=0, pos=0, dpt=LG; i<K;
-             pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, dpt=LG+pos, i++) {
-            dspgst(2,"L",G_blkszs[i],rhs+pos,dpt,&NAinfo);
-            if (NAinfo){ 
-                fprintf(stderr,"Error in dspgst(7), info = %d.\n",NAinfo);
+        memcpy(rhs, W, G_sz * sizeof(double)); /* copy W to rhs(=GW) */
+        for (i = 0, pos = 0, dpt = LG; i < K;
+                pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, dpt = LG + pos, i++) {
+            dspgst(2, "L", G_blkszs[i], rhs + pos, dpt, &NAinfo);
+            if (NAinfo) {
+                fprintf(stderr, "Error in dspgst(7), info = %d.\n", NAinfo);
                 return 1;
             }
         }
-        eig_val(sigG,rhs,K,G_blkszs,G_sz,wkspc);
-        for (i=0; i<l; i++)    /* sigG = eig(GW) here */
-            gap += sigG[i]-1.0-log(sigG[i]);
- 
+        eig_val(sigG, rhs, K, G_blkszs, G_sz, wkspc);
+        for (i = 0; i < l; i++) /* sigG = eig(GW) here */
+            gap += sigG[i] - 1.0 - log(sigG[i]);
+
         /* recompute ul[0] */
-        eig_val(sigG,XG,K,G_blkszs,G_sz,wkspc);  /* sigG = eig(G) here */
-        ul[0] = ddot(m,c,1,x,1);
-        for (i=0; i<l; i++)
+        eig_val(sigG, XG, K, G_blkszs, G_sz, wkspc); /* sigG = eig(G) here */
+        ul[0] = ddot(m, c, 1, x, 1);
+        for (i = 0; i < l; i++)
             ul[0] -= log(sigG[i]);
 
         /* update ul[1] from gap and ul[0] */
         ul[1] = ul[0] - gap;
 
         /* update hist */
-        dpt = hist+(*NTiters-1)*(m+3);
-	for (iii=0;iii<m;iii++)
-	  *(dpt+iii)=x[iii];    
-	*(dpt+m) = ul[0];
-        *(dpt+m+1) = gap;
-        *(dpt+m+2) = NTcount; 
-	
+        dpt = hist + (*NTiters - 1) * (m + 3);
+        for (iii = 0; iii < m; iii++)
+            *(dpt + iii) = x[iii];
+        *(dpt + m) = ul[0];
+        *(dpt + m + 1) = gap;
+        *(dpt + m + 2) = NTcount;
+
         /* check convergence */
-#ifdef MAXDET_DEBUG
-        fprintf(stdout,"  %3d     %10.2e     %10.2e\n",*NTiters,ul[0],gap);
-#endif
-	if(negativeFlag && ul[0] < 0){
-	    *info=4;
-	    dpt = hist+(*NTiters)*(m+3);
-   	    *(dpt+m+2) = -2;
-	    return(0);
-	}
-        if (gap <= MAX(abstol,MINABSTOL)) {
-            *info = 2;    /* absolute accuracy achieved */
-	    dpt = hist+(*NTiters)*(m+3);
-	    *(dpt+m+2) = -2;
-            return(0);
+        #ifdef MAXDET_DEBUG
+        fprintf(stdout, "  %3d     %10.2e     %10.2e\n", *NTiters, ul[0], gap);
+        #endif
+        if (negativeFlag && ul[0] < 0) {
+            *info = 4;
+            dpt = hist + (*NTiters) * (m + 3);
+            *(dpt + m + 2) = -2;
+            return (0);
         }
-        if ( (ul[1] > 0 && gap <= reltol*ul[1]) ||
-             (ul[0] < 0 && gap <= reltol*(-ul[0])) ) {
+        if (gap <= MAX(abstol, MINABSTOL)) {
+            *info = 2;    /* absolute accuracy achieved */
+            dpt = hist + (*NTiters) * (m + 3);
+            *(dpt + m + 2) = -2;
+            return (0);
+        }
+        if ((ul[1] > 0 && gap <= reltol * ul[1]) ||
+                (ul[0] < 0 && gap <= reltol * (-ul[0]))) {
             *info = 3;    /* relative accuracy achieved */
-            dpt = hist+(*NTiters)*(m+3);
-            *(dpt+m+2) = -2;
-            return(0);
+            dpt = hist + (*NTiters) * (m + 3);
+            *(dpt + m + 2) = -2;
+            return (0);
         }
         if (*NTiters >= maxNTiters) {
             *info = 1;    /* max number of total Newton iterations exceeded */
-            dpt = hist+(*NTiters)*(m+3);
-            *(dpt+m+2) = -2;
-            return(0);
+            dpt = hist + (*NTiters) * (m + 3);
+            *(dpt + m + 2) = -2;
+            return (0);
         }
 
 
 
-        /* PREDICTOR step:
-         *   1. update t by at least l(t^+/t - 1 - \log t^+/t) = \gamma
-         *   2. compute tangential direction
-         *   3. minimize \psi_ub along the tangential direction (plane search)
-         *   4. update t such that \psi_ub = \gamma (Newton's method)
-         *   5. repeat 3 and 4 until either min \psi_ub in 3 is close to
-         *      \gamma, or t is greater than 10 times n/abstol */
+        /*  PREDICTOR step:
+             1. update t by at least l(t^+/t - 1 - \log t^+/t) = \gamma
+             2. compute tangential direction
+             3. minimize \psi_ub along the tangential direction (plane search)
+             4. update t such that \psi_ub = \gamma (Newton's method)
+             5. repeat 3 and 4 until either min \psi_ub in 3 is close to
+                \gamma, or t is greater than 10 times n/abstol */
 
         /* decompositions of XG and XF for the PREDICTOR step */
-        memcpy(Gsc,G+G_sz,m*G_sz*sizeof(double));  /* copy G to Gsc */
-        memcpy(Fsc,F+F_sz,m*F_sz*sizeof(double));  /* copy F to Fsc */
-        memcpy(LG,XG,G_sz*sizeof(double));         /* copy XG to LG */
-        memcpy(LF,XF,F_sz*sizeof(double));         /* copy XF to LF */
-        memcpy(rhs,W,G_sz*sizeof(double));         /* copy -W to rhs(1:) */
-        dscal(G_sz,-1.0,rhs,1);
-        memcpy(rhs+G_sz,Z,F_sz*sizeof(double));    /* copy -t*Z to rhs(:sz) */
+        memcpy(Gsc, G + G_sz, m * G_sz * sizeof(double)); /* copy G to Gsc */
+        memcpy(Fsc, F + F_sz, m * F_sz * sizeof(double)); /* copy F to Fsc */
+        memcpy(LG, XG, G_sz * sizeof(double));     /* copy XG to LG */
+        memcpy(LF, XF, F_sz * sizeof(double));     /* copy XF to LF */
+        memcpy(rhs, W, G_sz * sizeof(double));     /* copy -W to rhs(1:) */
+        dscal(G_sz, -1.0, rhs, 1);
+        memcpy(rhs + G_sz, Z, F_sz * sizeof(double)); /* copy -t*Z to rhs(:sz) */
         dtmp = -t;
-        dscal(F_sz,dtmp,rhs+G_sz,1);
+        dscal(F_sz, dtmp, rhs + G_sz, 1);
         /* decomposition of XG */
-        for (i=0, pos=0, dpt=LG; i<K;
-             pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, dpt=LG+pos, i++) {
-            /* loop over blocks, to compute rhs and Gsc.
-             * DPPTRF is called only if the block size exceeds 2 */
+        for (i = 0, pos = 0, dpt = LG; i < K;
+                pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, dpt = LG + pos, i++) {
+            /*  loop over blocks, to compute rhs and Gsc.
+                DPPTRF is called only if the block size exceeds 2 */
             switch (G_blkszs[i]) {
-              case 1:    /* 1-by-1 block */
-                if (*dpt<=0) {
-                  fprintf(stderr,"maxdet: x infeasible because G(x)<=0.\n");
-                  *info = -9;
-                  return 1;
-                }
-                *dpt = sqrt(*dpt);
-                break;
-              case 2:    /* 2-by-2 block */
-                if (*dpt + *(dpt+2)<=0 ||
-                    *dpt * *(dpt+2) - SQR(*(dpt+1))<=0) {
-                  fprintf(stderr,"maxdet: x infeasible because G(x)<=0.\n");
-                  *info = -9;
-                  return 1;
-                }
-                *dpt = sqrt(*dpt);
-                *(dpt+1) = *(dpt+1) / *dpt;
-                *(dpt+2) = sqrt(*(dpt+2)-SQR(*(dpt+1)));
-                break;
-              default:   /* 3-by-3 or larger block */
-                dpptrf("L",G_blkszs[i],dpt,&NAinfo);
-                if (NAinfo>0) {
-                  fprintf(stderr,"maxdet: x infeasible because G(x)<=0.\n");
-                  *info = -9;
-                  return 1;
-                } else if (NAinfo) {
-                    fprintf(stderr,"Error in dpptrf(2), info = %d.\n",NAinfo);
+                case 1:    /* 1-by-1 block */
+                    if (*dpt <= 0) {
+                        fprintf(stderr, "maxdet: x infeasible because G(x)<=0.\n");
+                        *info = -9;
+                        return 1;
+                    }
+                    *dpt = sqrt(*dpt);
+                    break;
+                case 2:    /* 2-by-2 block */
+                    if (*dpt + * (dpt + 2) <= 0 ||
+                            *dpt * *(dpt + 2) - SQR(*(dpt + 1)) <= 0) {
+                        fprintf(stderr, "maxdet: x infeasible because G(x)<=0.\n");
+                        *info = -9;
+                        return 1;
+                    }
+                    *dpt = sqrt(*dpt);
+                    *(dpt + 1) = *(dpt + 1) / *dpt;
+                    *(dpt + 2) = sqrt(*(dpt + 2) - SQR(*(dpt + 1)));
+                    break;
+                default:   /* 3-by-3 or larger block */
+                    dpptrf("L", G_blkszs[i], dpt, &NAinfo);
+                    if (NAinfo > 0) {
+                        fprintf(stderr, "maxdet: x infeasible because G(x)<=0.\n");
+                        *info = -9;
+                        return 1;
+                    }
+                    else if (NAinfo) {
+                        fprintf(stderr, "Error in dpptrf(2), info = %d.\n", NAinfo);
+                        return 1;
+                    }
+                    break;
+            }
+            /*  ith blocks of scaled matrices Gsc_j, j=1,...,m
+                 Gsc = LG^{-1}*G_i*LG^{-T} */
+            for (j = 0; j < m; j++) {
+                dspgst(1, "L", G_blkszs[i], Gsc + j * G_sz + pos, dpt, &NAinfo);
+                if (NAinfo) {
+                    fprintf(stderr, "Error in dspgst(8), info = %d.\n", NAinfo);
                     return 1;
                 }
-                break;
             }
-            /* ith blocks of scaled matrices Gsc_j, j=1,...,m
-             *   Gsc = LG^{-1}*G_i*LG^{-T} */
-            for (j=0; j<m; j++) {
-                dspgst(1,"L",G_blkszs[i],Gsc+j*G_sz+pos,dpt,&NAinfo);
-                if (NAinfo){ 
-                    fprintf(stderr,"Error in dspgst(8), info = %d.\n",NAinfo);
-                    return 1;
-                }
-            }
-            /* ith block of rhs is sqrt(t)*(I-GW)
-             *   GW = LG^T*W*LG */
-            dspgst(2,"L",G_blkszs[i],rhs+pos,dpt,&NAinfo);
-            if (NAinfo){ 
-                fprintf(stderr,"Error in dspgst(9), info = %d.\n",NAinfo);
+            /*  ith block of rhs is sqrt(t)*(I-GW)
+                 GW = LG^T*W*LG */
+            dspgst(2, "L", G_blkszs[i], rhs + pos, dpt, &NAinfo);
+            if (NAinfo) {
+                fprintf(stderr, "Error in dspgst(9), info = %d.\n", NAinfo);
                 return 1;
             }
-            /* add 1 to diagonal elements of rhs and scale them
-             * by 1/sqrt(2) */
-            for (k=0, pos2=pos; k<G_blkszs[i]; pos2+=G_blkszs[i]-k,k++)
-                *(rhs+pos2) = (*(rhs+pos2)+1.0)/sqrt(2.0);
+            /*  add 1 to diagonal elements of rhs and scale them
+                by 1/sqrt(2) */
+            for (k = 0, pos2 = pos; k < G_blkszs[i]; pos2 += G_blkszs[i] - k, k++)
+                * (rhs + pos2) = (*(rhs + pos2) + 1.0) / sqrt(2.0);
             /* scale rhs by sqrt(t) (2 lines below) */
         }
-        dscal(G_sz,sqrtt,rhs,1);
+        dscal(G_sz, sqrtt, rhs, 1);
         /* decomposition of XF */
-        for (i=0, pos=0, dpt=LF; i<L;
-             pos+=F_blkszs[i]*(F_blkszs[i]+1)/2, dpt=LF+pos, i++) {
-            /* loop over blocks, to compute rhs and Fsc.
-             * DPPTRF is called only if the block size exceeds 2 */
+        for (i = 0, pos = 0, dpt = LF; i < L;
+                pos += F_blkszs[i] * (F_blkszs[i] + 1) / 2, dpt = LF + pos, i++) {
+            /*  loop over blocks, to compute rhs and Fsc.
+                DPPTRF is called only if the block size exceeds 2 */
             switch (F_blkszs[i]) {
-              case 1:    /* 1-by-1 block */
-                if (*dpt<=0) {
-                  fprintf(stderr,"maxdet: x infeasible because F(x)<=0.\n");
-                  *info = -9;
-                  return 1;
-                }
-                *dpt = sqrt(*dpt);
-                break;
-              case 2:    /* 2-by-2 block */
-                if (*dpt + *(dpt+2)<=0 ||
-                    *dpt * *(dpt+2) - SQR(*(dpt+1))<=0) {
-                  fprintf(stderr,"maxdet: x infeasible because F(x)<=0.\n");
-                  *info = -9;
-                  return 1;
-                }
-                *dpt = sqrt(*dpt);
-                *(dpt+1) = *(dpt+1) / *dpt;
-                *(dpt+2) = sqrt(*(dpt+2)-SQR(*(dpt+1)));
-                break;
-              default:   /* 3-by-3 or larger block */
-                dpptrf("L",F_blkszs[i],dpt,&NAinfo);
-                if (NAinfo>0) {
-                  fprintf(stderr,"maxdet: x infeasible because F(x)<=0.\n");
-                  *info = -9;
-                  return 1;
-                } else if (NAinfo) {
-                    fprintf(stderr,"Error in dpptrf(3), info = %d.\n",NAinfo);
+                case 1:    /* 1-by-1 block */
+                    if (*dpt <= 0) {
+                        fprintf(stderr, "maxdet: x infeasible because F(x)<=0.\n");
+                        *info = -9;
+                        return 1;
+                    }
+                    *dpt = sqrt(*dpt);
+                    break;
+                case 2:    /* 2-by-2 block */
+                    if (*dpt + * (dpt + 2) <= 0 ||
+                            *dpt * *(dpt + 2) - SQR(*(dpt + 1)) <= 0) {
+                        fprintf(stderr, "maxdet: x infeasible because F(x)<=0.\n");
+                        *info = -9;
+                        return 1;
+                    }
+                    *dpt = sqrt(*dpt);
+                    *(dpt + 1) = *(dpt + 1) / *dpt;
+                    *(dpt + 2) = sqrt(*(dpt + 2) - SQR(*(dpt + 1)));
+                    break;
+                default:   /* 3-by-3 or larger block */
+                    dpptrf("L", F_blkszs[i], dpt, &NAinfo);
+                    if (NAinfo > 0) {
+                        fprintf(stderr, "maxdet: x infeasible because F(x)<=0.\n");
+                        *info = -9;
+                        return 1;
+                    }
+                    else if (NAinfo) {
+                        fprintf(stderr, "Error in dpptrf(3), info = %d.\n", NAinfo);
+                        return 1;
+                    }
+                    break;
+            }
+            /*  ith blocks of scaled matrices Fsc_j, j=1,...,m
+                 Fsc = LF^{-1}*F_i*LF^{-T} */
+            for (j = 0; j < m; j++) {
+                dspgst(1, "L", F_blkszs[i], Fsc + j * F_sz + pos, dpt, &NAinfo);
+                if (NAinfo) {
+                    fprintf(stderr, "Error in dspgst(10), info = %d.\n", NAinfo);
                     return 1;
                 }
-                break;
             }
-            /* ith blocks of scaled matrices Fsc_j, j=1,...,m
-             *   Fsc = LF^{-1}*F_i*LF^{-T} */
-            for (j=0; j<m; j++) {
-                dspgst(1,"L",F_blkszs[i],Fsc+j*F_sz+pos,dpt,&NAinfo);
-                if (NAinfo){ 
-                    fprintf(stderr,"Error in dspgst(10), info = %d.\n",NAinfo);
-                    return 1;
-                }
-            }
-            /* ith block of rhs is -t*FZ
-             *   FZ = LF^T*Z*LF */
-            dspgst(2,"L",F_blkszs[i],rhs+G_sz+pos,dpt,&NAinfo);
-            if (NAinfo){ 
-                fprintf(stderr,"Error in dspgst(11), info = %d.\n",NAinfo);
+            /*  ith block of rhs is -t*FZ
+                 FZ = LF^T*Z*LF */
+            dspgst(2, "L", F_blkszs[i], rhs + G_sz + pos, dpt, &NAinfo);
+            if (NAinfo) {
+                fprintf(stderr, "Error in dspgst(11), info = %d.\n", NAinfo);
                 return 1;
             }
             /* scale diagonal elements of rhs by 1/sqrt(2) */
-            for (k=0, pos2=pos; k<F_blkszs[i]; pos2+=F_blkszs[i]-k,k++)
-                *(rhs+G_sz+pos2) = *(rhs+G_sz+pos2) / sqrt(2.0);
+            for (k = 0, pos2 = pos; k < F_blkszs[i]; pos2 += F_blkszs[i] - k, k++)
+                * (rhs + G_sz + pos2) = *(rhs + G_sz + pos2) / sqrt(2.0);
         }
         /* prepare the left-hand-side of the LS problem */
-        for (i=0, dpt=GaF; i<m; i++, dpt+=sz) {
-            memcpy(dpt,Gsc+i*G_sz,G_sz*sizeof(double));
-            for (j=0, dps=dpt; j<K; j++)       /* scale diagonal elements */
-                for (k=G_blkszs[j]; k>0; dps+=k, k--)
-                    *dps /= sqrt(2.0);
-            memcpy(dpt+G_sz,Fsc+i*F_sz,F_sz*sizeof(double));
-            for (j=0, dps=dpt+G_sz; j<L; j++)  /* scale diagonal elements */
-                for (k=F_blkszs[j]; k>0; dps+=k, k--)
-                    *dps /= sqrt(2.0);
+        for (i = 0, dpt = GaF; i < m; i++, dpt += sz) {
+            memcpy(dpt, Gsc + i * G_sz, G_sz * sizeof(double));
+            for (j = 0, dps = dpt; j < K; j++) /* scale diagonal elements */
+                for (k = G_blkszs[j]; k > 0; dps += k, k--)
+                    * dps /= sqrt(2.0);
+            memcpy(dpt + G_sz, Fsc + i * F_sz, F_sz * sizeof(double));
+            for (j = 0, dps = dpt + G_sz; j < L; j++) /* scale diagonal elements */
+                for (k = F_blkszs[j]; k > 0; dps += k, k--)
+                    * dps /= sqrt(2.0);
         }
-	dlascl("G",0,0,1.0,sqrtt,G_sz,m,GaF,sz,&NAinfo);
-        if (NAinfo){ 
-            fprintf(stderr,"Error in dlascl(1), info = %d.\n",NAinfo);
+        dlascl("G", 0, 0, 1.0, sqrtt, G_sz, m, GaF, sz, &NAinfo);
+        if (NAinfo) {
+            fprintf(stderr, "Error in dlascl(1), info = %d.\n", NAinfo);
             return 1;
         }
         /* solve the PREDICTOR LS problem */
-        dgels("N",sz,m,1,GaF,sz,rhs,sz,wkspc,lwkspc,&NAinfo);
-        if (NAinfo){ 
-            fprintf(stderr,"Error in dgels(1), info = %d.\n",NAinfo);
+        dgels("N", sz, m, 1, GaF, sz, rhs, sz, wkspc, lwkspc, &NAinfo);
+        if (NAinfo) {
+            fprintf(stderr, "Error in dgels(1), info = %d.\n", NAinfo);
             return 1;
         }
         /* increase *NTiters by 1 */
         (*NTiters)++;
 
         /* compute dXG and dXF */
-        dgemv("N",G_sz,m,1.0,G+G_sz,G_sz,rhs,1,0.0,dXG,1);
-        dgemv("N",F_sz,m,1.0,F+F_sz,F_sz,rhs,1,0.0,dXF,1);
+        dgemv("N", G_sz, m, 1.0, G + G_sz, G_sz, rhs, 1, 0.0, dXG, 1);
+        dgemv("N", F_sz, m, 1.0, F + F_sz, F_sz, rhs, 1, 0.0, dXF, 1);
 
-        /* compute dW = t*(-W + G^{-1} - G^{-1}*dXG*G^{-1})
-         *            = t*(-W + LG^{-T}*(I-Gsc*dx)*LG^{-1})
-         *         dZ = -t*Z - F^{-1}*dXF*F^{-1}
-         *            = -t*Z + LF^{-T}*(-Fsc*dx)*LF^{-1} */
-        memset(dW,0,G_sz*sizeof(double));
-        memset(dZ,0,F_sz*sizeof(double));
-        for (i=0, dpt=dW; i<K; i++)    /* store I in dW */
-            for (j=G_blkszs[i]; j>0; dpt+=j, j--)
-                *dpt = 1.0;
-        dgemv("N",G_sz,m,-1.0,Gsc,G_sz,rhs,1,1.0,dW,1);
-        memcpy(LGinv,LG,G_sz*sizeof(double));
+        /*  compute dW = t*(-W + G^{-1} - G^{-1}*dXG*G^{-1})
+                      = t*(-W + LG^{-T}*(I-Gsc*dx)*LG^{-1})
+                   dZ = -t*Z - F^{-1}*dXF*F^{-1}
+                      = -t*Z + LF^{-T}*(-Fsc*dx)*LF^{-1} */
+        memset(dW, 0, G_sz * sizeof(double));
+        memset(dZ, 0, F_sz * sizeof(double));
+        for (i = 0, dpt = dW; i < K; i++) /* store I in dW */
+            for (j = G_blkszs[i]; j > 0; dpt += j, j--)
+                * dpt = 1.0;
+        dgemv("N", G_sz, m, -1.0, Gsc, G_sz, rhs, 1, 1.0, dW, 1);
+        memcpy(LGinv, LG, G_sz * sizeof(double));
         /* loop over the blocks for scaling of dW */
-        for (i=0, pos=0; i<K; pos+=G_blkszs[i]*(G_blkszs[i]+1)/2, i++) {
-            dtptri("L","N",G_blkszs[i],LGinv+pos,&NAinfo);  /* find LG^{-1} */
+        for (i = 0, pos = 0; i < K; pos += G_blkszs[i] * (G_blkszs[i] + 1) / 2, i++) {
+            dtptri("L", "N", G_blkszs[i], LGinv + pos, &NAinfo); /* find LG^{-1} */
             if (NAinfo) {
-                fprintf(stderr,"Error in dtptri(2), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dtptri(2), info = %d.\n", NAinfo);
                 return 1;
             }
-            dspgst(2,"L",G_blkszs[i],dW+pos,LGinv+pos,&NAinfo);
+            dspgst(2, "L", G_blkszs[i], dW + pos, LGinv + pos, &NAinfo);
             if (NAinfo) {
-                fprintf(stderr,"Error in dspgst(12), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dspgst(12), info = %d.\n", NAinfo);
                 return 1;
             }
         }                            /* dW = LG^{-T}*(I-Gsc*dx)*LG^{-1} */
-        for (i=0, dpt=dW, dps=W; i<G_sz; i++, dpt++, dps++)
-            *dpt = t*(*dpt - *dps);  /* dW=t*(-W+LG^{-T}*(I-Gsc*dx)*LG^{-1}) */
+        for (i = 0, dpt = dW, dps = W; i < G_sz; i++, dpt++, dps++)
+            *dpt = t * (*dpt - *dps); /* dW=t*(-W+LG^{-T}*(I-Gsc*dx)*LG^{-1}) */
 
-        dgemv("N",F_sz,m,-1.0,Fsc,F_sz,rhs,1,0.0,dZ,1);
-        memcpy(LFinv,LF,F_sz*sizeof(double));
+        dgemv("N", F_sz, m, -1.0, Fsc, F_sz, rhs, 1, 0.0, dZ, 1);
+        memcpy(LFinv, LF, F_sz * sizeof(double));
         /* loop over the blocks for scaling of dZ*/
-        for (i=0, pos=0; i<L; pos+=F_blkszs[i]*(F_blkszs[i]+1)/2, i++) {
-            dtptri("L","N",F_blkszs[i],LFinv+pos,&NAinfo);  /* find LF^{-1} */
+        for (i = 0, pos = 0; i < L; pos += F_blkszs[i] * (F_blkszs[i] + 1) / 2, i++) {
+            dtptri("L", "N", F_blkszs[i], LFinv + pos, &NAinfo); /* find LF^{-1} */
             if (NAinfo) {
-                fprintf(stderr,"Error in dtptri(3), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dtptri(3), info = %d.\n", NAinfo);
                 return 1;
             }
-            dspgst(2,"L",F_blkszs[i],dZ+pos,LFinv+pos,&NAinfo);
+            dspgst(2, "L", F_blkszs[i], dZ + pos, LFinv + pos, &NAinfo);
             if (NAinfo) {
-                fprintf(stderr,"Error in dspgst(13), info = %d.\n",NAinfo);
+                fprintf(stderr, "Error in dspgst(13), info = %d.\n", NAinfo);
                 return 1;
             }
         }                            /* dZ = LF^{-T}*(-Fsc*dx)*LF^{-1} */
         dtmp = -t;                   /* dZ = -t*Z + LF^{-T}*(-Fsc*dx)*LF^{-1} */
-        daxpy(F_sz,dtmp,Z,1,dZ,1);
+        daxpy(F_sz, dtmp, Z, 1, dZ, 1);
 
-        /* find least t update: y = t^+/t via solving 
-         *   n(y-1-\log y) = \gamma  (for the first iteration only) */
+        /*  find least t update: y = t^+/t via solving
+             n(y-1-\log y) = \gamma  (for the first iteration only) */
         if (iters == 1) {
-            dtmp = gamma/n;
-            y = 1+sqrt(2.0*dtmp);    /* lower bound of the solution */
+            dtmp = gamma / n;
+            y = 1 + sqrt(2.0 * dtmp); /* lower bound of the solution */
             dtmp2 = y;
-            lambda = y-1-log(y)-dtmp;
-            for (i=0; i<LSITERUB; i++) {
-                y = y-lambda/(1-1/y);
-                lambda = y-1-log(y)-dtmp;
-                if (fabs(lambda)<LSTOL)
+            lambda = y - 1 - log(y) - dtmp;
+            for (i = 0; i < LSITERUB; i++) {
+                y = y - lambda / (1 - 1 / y);
+                lambda = y - 1 - log(y) - dtmp;
+                if (fabs(lambda) < LSTOL)
                     break;
             }
-            y = MAX(y,dtmp2);
+            y = MAX(y, dtmp2);
         }
 
         /* least t update */
         t *= y;
 
         /* predictor-step plane search iterations */
-        for (i=0; i<LSITERUB; i++) {
+        for (i = 0; i < LSITERUB; i++) {
 
             double norm_p, norm_d, norm_max;
-            double gap_upd1=0.0, gap_upd2=0.0;
+            double gap_upd1 = 0.0, gap_upd2 = 0.0;
 
-            /* general eigen-decomp for plane-search:
-             * find sigG=eig(dXG,XG) and sigW=eig(dW,W) */
-            memcpy(temp,XG,G_sz*sizeof(double));
-            memcpy(temp2,dXG,G_sz*sizeof(double));
-            memcpy(temp3,W,G_sz*sizeof(double));
-            memcpy(temp4,dW,G_sz*sizeof(double));
-            for (j=0, pos=0, dpt=sigG, dps=sigW; j<K; dpt+=G_blkszs[j],
-                 dps+=G_blkszs[j], pos+=G_blkszs[j]*(G_blkszs[j]+1)/2, j++) {
+            /*  general eigen-decomp for plane-search:
+                find sigG=eig(dXG,XG) and sigW=eig(dW,W) */
+            memcpy(temp, XG, G_sz * sizeof(double));
+            memcpy(temp2, dXG, G_sz * sizeof(double));
+            memcpy(temp3, W, G_sz * sizeof(double));
+            memcpy(temp4, dW, G_sz * sizeof(double));
+            for (j = 0, pos = 0, dpt = sigG, dps = sigW; j < K; dpt += G_blkszs[j],
+                    dps += G_blkszs[j], pos += G_blkszs[j] * (G_blkszs[j] + 1) / 2, j++) {
                 switch (G_blkszs[j]) {
-                  case 1:
-                    *dpt = *(dXG+pos) / *(XG+pos);
-                    *dps = *(dW+pos) / *(W+pos);
-                    break;
-                  default:
-                    dspgv(1,"N","L",G_blkszs[j],temp2+pos,temp+pos,dpt,
-                           NULL,1,wkspc,&NAinfo);
-                    if (NAinfo) {
-                        fprintf(stderr,"Error in dspgv(3), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    dspgv(1,"N","L",G_blkszs[j],temp4+pos,temp3+pos,dps,
-                           NULL,1,wkspc,&NAinfo);
-                    if (NAinfo) {
-                        fprintf(stderr,"Error in dspgv(4), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    break;
+                    case 1:
+                        *dpt = *(dXG + pos) / *(XG + pos);
+                        *dps = *(dW + pos) / *(W + pos);
+                        break;
+                    default:
+                        dspgv(1, "N", "L", G_blkszs[j], temp2 + pos, temp + pos, dpt,
+                              NULL, 1, wkspc, &NAinfo);
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgv(3), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        dspgv(1, "N", "L", G_blkszs[j], temp4 + pos, temp3 + pos, dps,
+                              NULL, 1, wkspc, &NAinfo);
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgv(4), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        break;
                 }
             }
             /* find sigF=eig(dXF,XF) and sigZ=eig(dZ,Z) */
-            memcpy(temp,XF,F_sz*sizeof(double));
-            memcpy(temp2,dXF,F_sz*sizeof(double));
-            memcpy(temp3,Z,F_sz*sizeof(double));
-            memcpy(temp4,dZ,F_sz*sizeof(double));
-            for (j=0, pos=0, dpt=sigF, dps=sigZ; j<L; dpt+=F_blkszs[j],
-                 dps+=F_blkszs[j], pos+=F_blkszs[j]*(F_blkszs[j]+1)/2, j++) {
+            memcpy(temp, XF, F_sz * sizeof(double));
+            memcpy(temp2, dXF, F_sz * sizeof(double));
+            memcpy(temp3, Z, F_sz * sizeof(double));
+            memcpy(temp4, dZ, F_sz * sizeof(double));
+            for (j = 0, pos = 0, dpt = sigF, dps = sigZ; j < L; dpt += F_blkszs[j],
+                    dps += F_blkszs[j], pos += F_blkszs[j] * (F_blkszs[j] + 1) / 2, j++) {
                 switch (F_blkszs[j]) {
-                  case 1:
-                    *dpt = *(dXF+pos) / *(XF+pos);
-                    *dps = *(dZ+pos) / *(Z+pos);
-                    break;
-                  default:
-                    dspgv(1,"N","L",F_blkszs[j],temp2+pos,temp+pos,dpt,
-                           NULL,1,wkspc,&NAinfo);
-                    if (NAinfo) {
-                        fprintf(stderr,"Error in dspgv(5), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    dspgv(1,"N","L",F_blkszs[j],temp4+pos,temp3+pos,dps,
-                           NULL,1,wkspc,&NAinfo);
-                    if (NAinfo) {
-                        fprintf(stderr,"Error in dspgv(6), info = %d.\n",NAinfo);
-                        return 1;
-                    }
-                    break;
+                    case 1:
+                        *dpt = *(dXF + pos) / *(XF + pos);
+                        *dps = *(dZ + pos) / *(Z + pos);
+                        break;
+                    default:
+                        dspgv(1, "N", "L", F_blkszs[j], temp2 + pos, temp + pos, dpt,
+                              NULL, 1, wkspc, &NAinfo);
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgv(5), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        dspgv(1, "N", "L", F_blkszs[j], temp4 + pos, temp3 + pos, dps,
+                              NULL, 1, wkspc, &NAinfo);
+                        if (NAinfo) {
+                            fprintf(stderr, "Error in dspgv(6), info = %d.\n", NAinfo);
+                            return 1;
+                        }
+                        break;
                 }
             }
 
-            /* check degenerate cases:
-             * plane search degenerates to line search if norm_p or norm_d
-             * is zero. */
-            norm_p = dnrm2(n,sigF,1);
-            norm_p += dnrm2(l,sigG,1);
-            norm_d = dnrm2(n,sigZ,1);
-            norm_d += dnrm2(l,sigW,1);
-            norm_max = MAX(norm_p,norm_d);
+            /*  check degenerate cases:
+                plane search degenerates to line search if norm_p or norm_d
+                is zero. */
+            norm_p = dnrm2(n, sigF, 1);
+            norm_p += dnrm2(l, sigG, 1);
+            norm_d = dnrm2(n, sigZ, 1);
+            norm_d += dnrm2(l, sigW, 1);
+            norm_max = MAX(norm_p, norm_d);
 
-            /* predictor-step plane-search:
-             *   minimize \psi_{ub} over the feasible rectangle */
-            alpha[0]=0.0;
-            alpha[1]=0.0;
-            for (j=0; j<LSITERUB; j++) {
+            /*  predictor-step plane-search:
+                 minimize \psi_{ub} over the feasible rectangle */
+            alpha[0] = 0.0;
+            alpha[1] = 0.0;
+            for (j = 0; j < LSITERUB; j++) {
                 grad1 = 0.0;
                 grad2 = 0.0;
                 hess1 = 0.0;
                 hess2 = 0.0;
-                for (k=0, dps=sigG, dpt=sigW; k<l; k++, dps++, dpt++) {
+                for (k = 0, dps = sigG, dpt = sigW; k < l; k++, dps++, dpt++) {
                     dtmp = 1 + alpha[0] * *dps;
                     dtmp2 = 1 + alpha[1] * *dpt;
                     grad1 -= t * *dps / dtmp;
@@ -1498,7 +1505,7 @@ printf("t=%10.2e from feasible dual\n",t);
                     hess1 += t * SQR(*dps) / SQR(dtmp);
                     hess2 += t * SQR(*dpt) / SQR(dtmp2);
                 }
-                for (k=0, dps=sigF, dpt=sigZ; k<n; k++, dps++, dpt++) {
+                for (k = 0, dps = sigF, dpt = sigZ; k < n; k++, dps++, dpt++) {
                     dtmp = 1 + alpha[0] * *dps;
                     dtmp2 = 1 + alpha[1] * *dpt;
                     grad1 -= *dps / dtmp;
@@ -1506,90 +1513,94 @@ printf("t=%10.2e from feasible dual\n",t);
                     hess1 += SQR(*dps) / SQR(dtmp);
                     hess2 += SQR(*dpt) / SQR(dtmp2);
                 }
-                grad1 += t*ddot(m,c,1,rhs,1);
-                grad2 += t*(inprd(dW,G,K,G_blkszs)+inprd(dZ,F,L,F_blkszs));
+                grad1 += t * ddot(m, c, 1, rhs, 1);
+                grad2 += t * (inprd(dW, G, K, G_blkszs) + inprd(dZ, F, L, F_blkszs));
                 /* check degenrate cases */
-                if (norm_p>SIGTOL*norm_max && norm_d>SIGTOL*norm_max) {
-                    lambda = sqrt(SQR(grad1)/hess1+SQR(grad2)/hess2);
-                    dtmp = 1/(1+lambda);
-                    alpha[0] -= dtmp*grad1/hess1;
-                    alpha[1] -= dtmp*grad2/hess2;
-                } else if (norm_p>SIGTOL*norm_max) {
-                    lambda = sqrt(SQR(grad1)/hess1);
-                    alpha[0] -= 1/(1+lambda)*grad1/hess1;
-                } else if (norm_d>SIGTOL*norm_max) {
-                    lambda = sqrt(SQR(grad2)/hess2);
-                    alpha[1] -= 1/(1+lambda)*grad2/hess2;
-                } else
+                if (norm_p > SIGTOL * norm_max && norm_d > SIGTOL * norm_max) {
+                    lambda = sqrt(SQR(grad1) / hess1 + SQR(grad2) / hess2);
+                    dtmp = 1 / (1 + lambda);
+                    alpha[0] -= dtmp * grad1 / hess1;
+                    alpha[1] -= dtmp * grad2 / hess2;
+                }
+                else if (norm_p > SIGTOL * norm_max) {
+                    lambda = sqrt(SQR(grad1) / hess1);
+                    alpha[0] -= 1 / (1 + lambda) * grad1 / hess1;
+                }
+                else if (norm_d > SIGTOL * norm_max) {
+                    lambda = sqrt(SQR(grad2) / hess2);
+                    alpha[1] -= 1 / (1 + lambda) * grad2 / hess2;
+                }
+                else
                     lambda = 0;
                 if (lambda < LSTOL)
                     break;
             }
 
-            /* update gap, ul[0], beta and \psi_{ub}:
-             * stop plane search if \psi_{ub} here is close to \gamma
-             *   gap = c^T(x+alpha_0*dx)
-             *         +\Tr(Z+alpha_1*dZ)F_0+\Tr(W+alpha_1*dW)G_0-l
-             *         -\logdet(G+alpha_0*dG)-\logdet(W+alpha_1*dW)
-             *       = gap_old+alpha0*c^Tdx+alpha_1(\TrdWG_0+\TrdZF_0)
-             *         -\logdet(I+alpha_0*G^{-1}dG)
-             *         -\logdet(I+alpha_1*W^{-1}dW)
-             *   beta = -\logdet(F+alpha_0*dF)-\logdet(Z+alpha_1*dZ)-n
-             *        = beta_old-\logdet(I+alpha_0*F^{-1}dF)
-             *          -\logdet(I+alpha_1*Z^{-1}dZ) 
-             *   \psi_{ub} = t*gap+beta-n*log(t) */
+            /*  update gap, ul[0], beta and \psi_{ub}:
+                stop plane search if \psi_{ub} here is close to \gamma
+                 gap = c^T(x+alpha_0*dx)
+                       +\Tr(Z+alpha_1*dZ)F_0+\Tr(W+alpha_1*dW)G_0-l
+                       -\logdet(G+alpha_0*dG)-\logdet(W+alpha_1*dW)
+                     = gap_old+alpha0*c^Tdx+alpha_1(\TrdWG_0+\TrdZF_0)
+                       -\logdet(I+alpha_0*G^{-1}dG)
+                       -\logdet(I+alpha_1*W^{-1}dW)
+                 beta = -\logdet(F+alpha_0*dF)-\logdet(Z+alpha_1*dZ)-n
+                      = beta_old-\logdet(I+alpha_0*F^{-1}dF)
+                        -\logdet(I+alpha_1*Z^{-1}dZ)
+                 \psi_{ub} = t*gap+beta-n*log(t) */
             if (!i) {
-                gap_upd1 = ddot(m,c,1,rhs,1);
-                gap_upd2 = inprd(dZ,F,L,F_blkszs)+inprd(dW,G,K,G_blkszs);
+                gap_upd1 = ddot(m, c, 1, rhs, 1);
+                gap_upd2 = inprd(dZ, F, L, F_blkszs) + inprd(dW, G, K, G_blkszs);
             }
-            dtmp = alpha[0]*gap_upd1;
-            gap += dtmp+alpha[1]*gap_upd2;
+            dtmp = alpha[0] * gap_upd1;
+            gap += dtmp + alpha[1] * gap_upd2;
             ul[0] += dtmp;
-            for (j=0; j<l; j++) {
-                gap -= (log(1.0 + alpha[0] * *(sigG+j))
-                    +log(1.0 + alpha[1] * *(sigW+j)));
-                ul[0] -= log(1.0 + alpha[0] * *(sigG+j));
+            for (j = 0; j < l; j++) {
+                gap -= (log(1.0 + alpha[0] * *(sigG + j))
+                        + log(1.0 + alpha[1] * *(sigW + j)));
+                ul[0] -= log(1.0 + alpha[0] * *(sigG + j));
             }
 
             /* predictor step updates */
-            daxpy(m,*alpha,rhs,1,x,1);      /* x  += alpha[0] * dx  */
-            daxpy(G_sz,*alpha,dXG,1,XG,1);  /* XG += alpha[0] * dXG */
-            daxpy(F_sz,*alpha,dXF,1,XF,1);  /* XF += alpha[0] * dXF */
-            daxpy(G_sz,*(alpha+1),dW,1,W,1);  /* W += alpha[1] * dW */
-            daxpy(F_sz,*(alpha+1),dZ,1,Z,1);  /* Z += alpha[1] * dZ */
+            daxpy(m, *alpha, rhs, 1, x, 1); /* x  += alpha[0] * dx  */
+            daxpy(G_sz, *alpha, dXG, 1, XG, 1); /* XG += alpha[0] * dXG */
+            daxpy(F_sz, *alpha, dXF, 1, XF, 1); /* XF += alpha[0] * dXF */
+            daxpy(G_sz, *(alpha + 1), dW, 1, W, 1); /* W += alpha[1] * dW */
+            daxpy(F_sz, *(alpha + 1), dZ, 1, Z, 1); /* Z += alpha[1] * dZ */
 
             if (!i) {
                 beta = -n;
-                eig_val(sigF,XF,L,F_blkszs,F_sz,wkspc); /* sigF=eig(XF) here */
-                eig_val(sigZ,Z,L,F_blkszs,F_sz,wkspc);  /* sigZ=eig(Z) here */
-                for (j=0; j<n; j++)
-                    beta += log(1 / *(sigF+j)) + log(1 / *(sigZ+j));
-            } else {
-                for (j=0; j<n; j++)
-                    beta -= log(1.0 + alpha[0] * *(sigF+j))
-                        +log(1.0 + alpha[1] * *(sigZ+j));
+                eig_val(sigF, XF, L, F_blkszs, F_sz, wkspc); /* sigF=eig(XF) here */
+                eig_val(sigZ, Z, L, F_blkszs, F_sz, wkspc); /* sigZ=eig(Z) here */
+                for (j = 0; j < n; j++)
+                    beta += log(1 / * (sigF + j)) + log(1 / * (sigZ + j));
+            }
+            else {
+                for (j = 0; j < n; j++)
+                    beta -= log(1.0 + alpha[0] * *(sigF + j))
+                            + log(1.0 + alpha[1] * *(sigZ + j));
             }
 
             /* find \psi_{ub} and check \gamma-\psi_{ub} */
-            psi_ub = t*gap+beta-n*log(t);
-            dtmp = MAX(abstol,MAX(MINABSTOL,reltol*MAX(-ul[0],ul[1])));
-            if (gamma-psi_ub < LSTOL || t > 10*n/MAX(abstol,MINABSTOL)
-                || gap<dtmp)
+            psi_ub = t * gap + beta - n * log(t);
+            dtmp = MAX(abstol, MAX(MINABSTOL, reltol * MAX(-ul[0], ul[1])));
+            if (gamma - psi_ub < LSTOL || t > 10 * n / MAX(abstol, MINABSTOL)
+                    || gap < dtmp)
                 break;    /* break plane search iteration */
 
-            /* update t: compute t^+ from \psi_{ub}=\gamma using
-             * Newton's method */
+            /*  update t: compute t^+ from \psi_{ub}=\gamma using
+                Newton's method */
             t_old = t;
-            t = t_old+(gamma-psi_ub)/gap;    /* lower bound of solution */
+            t = t_old + (gamma - psi_ub) / gap; /* lower bound of solution */
             dtmp = t;
-            lambda = t*gap+beta-n*log(t)-gamma;  /* psi_ub - gamma */
-            for (j=0; j<LSITERUB; j++) {
-                t -= lambda/(gap-n/t);
-                lambda = t*gap+beta-n*log(t)-gamma;
+            lambda = t * gap + beta - n * log(t) - gamma; /* psi_ub - gamma */
+            for (j = 0; j < LSITERUB; j++) {
+                t -= lambda / (gap - n / t);
+                lambda = t * gap + beta - n * log(t) - gamma;
                 if (fabs(lambda) < LSTOL)
                     break;
             }
-            t = MAX(t,dtmp);
+            t = MAX(t, dtmp);
 
         }   /* end of predictor plane search iteration loop */
 

--- a/src/mytools.cpp
+++ b/src/mytools.cpp
@@ -24,7 +24,7 @@
 //######################################################################
 
 /*! \file
-  \brief Implements the load_pixmap() function.  Other misc. functions could go here too.
+    \brief Implements the load_pixmap() function.  Other misc. functions could go here too.
 */
 
 #include <Q3MimeSourceFactory>
@@ -39,320 +39,314 @@
 #include "matvecIO.h"
 
 /*!
-  Read, decode, and return the pixmap of the given name from the
-  QMimeSourceFactory.
+    Read, decode, and return the pixmap of the given name from the
+    QMimeSourceFactory.
 */
-QPixmap load_pixmap(const QString &name)
-{
-    const QMimeSource *m = Q3MimeSourceFactory::defaultFactory()->data( name );
-    if ( !m )
-	return QPixmap();
+QPixmap load_pixmap(const QString &name) {
+    const QMimeSource *m = Q3MimeSourceFactory::defaultFactory()->data(name);
+    if (!m)
+        return QPixmap();
     QPixmap pix;
-    Q3ImageDrag::decode( m, pix );
+    Q3ImageDrag::decode(m, pix);
     return pix;
 }
 
-int nextValidLine(QTextStream *stream, QString *line)
-{
-	while (1) {
-		*line = stream->readLine();
-		if ( line->isNull() ) break;
-		if ( !line->isEmpty() && (*line)[0]!='#' ) break;
-	}
-	if ( line->isNull() ) return 0;
-	else return 1;
+int nextValidLine(QTextStream *stream, QString *line) {
+    while (1) {
+        *line = stream->readLine();
+        if (line->isNull()) break;
+        if (!line->isEmpty() && (*line)[0] != '#') break;
+    }
+    if (line->isNull()) return 0;
+    else return 1;
 }
 
-int nextCommentLine(QTextStream *stream, QString *line)
-{
-	while (1) {
-		*line = stream->readLine();
-		if ( line->isNull() ) break;
-		if ( !line->isEmpty() && (*line)[0]=='#' ) break;
-	}
-	if ( line->isNull() ) return 0;
-	else return 1;
+int nextCommentLine(QTextStream *stream, QString *line) {
+    while (1) {
+        *line = stream->readLine();
+        if (line->isNull()) break;
+        if (!line->isEmpty() && (*line)[0] == '#') break;
+    }
+    if (line->isNull()) return 0;
+    else return 1;
 }
 
-int findString(QTextStream *stream, QString target)
-{
-	QString line;
-	while ( nextValidLine(stream,&line) )
-	{
-		if ( !(QString::compare(line,target)) )
-			return 1;
-	}
-	return 0;
+int findString(QTextStream *stream, QString target) {
+    QString line;
+    while (nextValidLine(stream, &line)) {
+        if (!(QString::compare(line, target)))
+            return 1;
+    }
+    return 0;
 }
 
 /*! If the two paths have no common root, the returned path is
-	identical to \a absolutePath. 
-	Code adapted from;
-	http://mrpmorris.blogspot.com/2007/05/convert-absolute-path-to-relative-path.html
+    identical to \a absolutePath.
+    Code adapted from;
+    http://mrpmorris.blogspot.com/2007/05/convert-absolute-path-to-relative-path.html
 */
-QString 
-relativePath(QString absolutePath, QString relativeToDir )
-{
-	absolutePath.replace("\\","/");
-	relativeToDir.replace("\\","/");
-	QStringList absoluteDirectories = absolutePath.split( '/', QString::SkipEmptyParts );
-	QStringList relativeDirectories = relativeToDir.split( '/', QString::SkipEmptyParts );
+QString
+relativePath(QString absolutePath, QString relativeToDir) {
+    absolutePath.replace("\\", "/");
+    relativeToDir.replace("\\", "/");
+    QStringList absoluteDirectories = absolutePath.split('/', QString::SkipEmptyParts);
+    QStringList relativeDirectories = relativeToDir.split('/', QString::SkipEmptyParts);
 
-	//Get the shortest of the two paths
-	int length = std::min(absoluteDirectories.count(), relativeDirectories.count());
-		
-	//Use to determine where in the loop we exited
-	int lastCommonRoot = -1;
-	int index;
+    //Get the shortest of the two paths
+    int length = std::min(absoluteDirectories.count(), relativeDirectories.count());
 
-	DBGP("Absolute path: " << absolutePath.latin1());
-	DBGP("Relative to  : " << relativeToDir.latin1());
+    //Use to determine where in the loop we exited
+    int lastCommonRoot = -1;
+    int index;
 
-	//Find common root
-	for (index = 0; index < length; index++) {
-		if (absoluteDirectories[index] == relativeDirectories[index]) {
-			lastCommonRoot = index;
-		} else {
-			break;
-		}
-	}
-	DBGP("Last common root: " << lastCommonRoot);
+    DBGP("Absolute path: " << absolutePath.latin1());
+    DBGP("Relative to  : " << relativeToDir.latin1());
 
-	//If we didn't find a common prefix then return full absolute path
-	if (lastCommonRoot == -1) {
-		return absolutePath;
-	}
-	
-	//Build up the relative path
-	QString relativePath;
+    //Find common root
+    for (index = 0; index < length; index++) {
+        if (absoluteDirectories[index] == relativeDirectories[index]) {
+            lastCommonRoot = index;
+        }
+        else {
+            break;
+        }
+    }
+    DBGP("Last common root: " << lastCommonRoot);
 
-	//Add on the ..
-	for (index = lastCommonRoot + 1; index < relativeDirectories.count(); index++) {
-		if (relativeDirectories[index].length() > 0) {
-			relativePath.append("../");
-		}
-	}
+    //If we didn't find a common prefix then return full absolute path
+    if (lastCommonRoot == -1) {
+        return absolutePath;
+    }
 
-	//Add on the folders
-	for (index = lastCommonRoot + 1; index < absoluteDirectories.count() - 1; index++) {
-		relativePath.append(absoluteDirectories[index] ).append( "/" );
-	}
-	relativePath.append(absoluteDirectories[absoluteDirectories.count() - 1]);
+    //Build up the relative path
+    QString relativePath;
 
-	DBGP("Relative path: " << relativePath.latin1());
-	return relativePath;
+    //Add on the ..
+    for (index = lastCommonRoot + 1; index < relativeDirectories.count(); index++) {
+        if (relativeDirectories[index].length() > 0) {
+            relativePath.append("../");
+        }
+    }
+
+    //Add on the folders
+    for (index = lastCommonRoot + 1; index < absoluteDirectories.count() - 1; index++) {
+        relativePath.append(absoluteDirectories[index]).append("/");
+    }
+    relativePath.append(absoluteDirectories[absoluteDirectories.count() - 1]);
+
+    DBGP("Relative path: " << relativePath.latin1());
+    return relativePath;
 }
 
 /*! Given a pointer to an XML node \a root, this will
-	cycle through all the children and return the first
-	whose definition string matches \a defStr. If no
-	such child is found, returns NULL.
+    cycle through all the children and return the first
+    whose definition string matches \a defStr. If no
+    such child is found, returns NULL.
 */
-const TiXmlElement*
-findXmlElement(const TiXmlElement *root, QString defStr)
-{
-	defStr = defStr.stripWhiteSpace();
-	const TiXmlElement* child = root->FirstChildElement();
-	while(child!=NULL){
-		if(child->Value()==defStr) break;
-		child = child->NextSiblingElement();
-	}
-	return child;
+const TiXmlElement *
+findXmlElement(const TiXmlElement *root, QString defStr) {
+    defStr = defStr.stripWhiteSpace();
+    const TiXmlElement *child = root->FirstChildElement();
+    while (child != NULL) {
+        if (child->Value() == defStr) break;
+        child = child->NextSiblingElement();
+    }
+    return child;
 }
 
 /*! Given a pointer to an XML node \a root, this will
-	cycle through all the children and return all children
-	whose definition string matches \a defStr. If no
-	such child is found, returns NULL.
+    cycle through all the children and return all children
+    whose definition string matches \a defStr. If no
+    such child is found, returns NULL.
 */
-std::list<const TiXmlElement*>
-findAllXmlElements(const TiXmlElement *root, QString defStr)
-{
-	defStr = defStr.stripWhiteSpace();
-	std::list<const TiXmlElement*> children;
-	const TiXmlElement* child = root->FirstChildElement();
-	while(child!=NULL){
-		if(child->Value()==defStr) {
-			children.push_back(child);
-		}
-		child = child->NextSiblingElement();
-	}
-	return children;
+std::list<const TiXmlElement *>
+findAllXmlElements(const TiXmlElement *root, QString defStr) {
+    defStr = defStr.stripWhiteSpace();
+    std::list<const TiXmlElement *> children;
+    const TiXmlElement *child = root->FirstChildElement();
+    while (child != NULL) {
+        if (child->Value() == defStr) {
+            children.push_back(child);
+        }
+        child = child->NextSiblingElement();
+    }
+    return children;
 }
 
 /*! Given a pointer to an XML node \a root, this will
-	cycle through all the children and count how many children
-	whose definition string matches \a defStr. If no
-	such child is found, returns 0.
+    cycle through all the children and count how many children
+    whose definition string matches \a defStr. If no
+    such child is found, returns 0.
 */
-int countXmlElements(const TiXmlElement *root, QString defStr)
-{
-	int count = 0;
-	const TiXmlElement* child = root->FirstChildElement();
-	while(child!=NULL){
-		if(child->Value()==defStr) count++;
-		child = child->NextSiblingElement();
-	}
-	return count;
+int countXmlElements(const TiXmlElement *root, QString defStr) {
+    int count = 0;
+    const TiXmlElement *child = root->FirstChildElement();
+    while (child != NULL) {
+        if (child->Value() == defStr) count++;
+        child = child->NextSiblingElement();
+    }
+    return count;
 }
 
 /*! Given a pointer to an XML node \a root, this will
-	cycle through all the children and return true if such child 
-	whose definition string matches \a defStr exists. If such child exists,
-	this will set \a val to the double value in the first child it found.
-	If no such child is found, returns false. 
+    cycle through all the children and return true if such child
+    whose definition string matches \a defStr exists. If such child exists,
+    this will set \a val to the double value in the first child it found.
+    If no such child is found, returns false.
 
 */
-bool getDouble(const TiXmlElement *root, QString defStr, double& val){
-	const TiXmlElement* child = root->FirstChildElement();
-	while(child!=NULL){
-		if(child->Value()==defStr){
-			QString valueStr = child->GetText();
-			val = valueStr.toDouble();
-			return true;
-		}
-		child = child->NextSiblingElement();
-	}
-	return false;
+bool getDouble(const TiXmlElement *root, QString defStr, double &val) {
+    const TiXmlElement *child = root->FirstChildElement();
+    while (child != NULL) {
+        if (child->Value() == defStr) {
+            QString valueStr = child->GetText();
+            val = valueStr.toDouble();
+            return true;
+        }
+        child = child->NextSiblingElement();
+    }
+    return false;
 }
 
 
 /*! Given a pointer to an XML node \a root, this will
-	cycle through all the children and return true if such child 
-	whose definition string matches \a defStr exists. If such child exists,
-	this will set \a val to the int value in the first child it found.
-	If no such child is found, returns false. 
+    cycle through all the children and return true if such child
+    whose definition string matches \a defStr exists. If such child exists,
+    this will set \a val to the int value in the first child it found.
+    If no such child is found, returns false.
 
 */
-bool getInt(const TiXmlElement *root, QString defStr,int &val){
-	const TiXmlElement* child = root->FirstChildElement();
-	while(child!=NULL){
-		if(child->Value()==defStr){
-			QString valueStr = child->GetText();
-			val = valueStr.toInt();
-			return true;
-		}
-		child = child->NextSiblingElement();
-	}
-	return false;
+bool getInt(const TiXmlElement *root, QString defStr, int &val) {
+    const TiXmlElement *child = root->FirstChildElement();
+    while (child != NULL) {
+        if (child->Value() == defStr) {
+            QString valueStr = child->GetText();
+            val = valueStr.toInt();
+            return true;
+        }
+        child = child->NextSiblingElement();
+    }
+    return false;
 }
-bool getPosition(const TiXmlElement *root, vec3 &pos){
-	bool ok1, ok2, ok3;
-	if(root == NULL){
-		QTWARNING("The given root is not a Position Element");
-		return false;
-	}
-	QString rootValue = root->Value();
-	rootValue = rootValue.stripWhiteSpace();
-	if(!(rootValue=="position"||rootValue=="orientation")){
-		QTWARNING("The given root is not a Position Element");
-		return false;
-	}
-	QString valueStr = root->GetText();
-	valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
-	QStringList l;
-	l = QStringList::split(' ', valueStr);
-	if(l.count()!=3){
-			QTWARNING("Invalid position input");
-			return false;
-	}		
-	double x,y,z;		
-	x = l[0].toDouble(&ok1);
-	y = l[1].toDouble(&ok2);
-	z = l[2].toDouble(&ok3);
-	if(!ok1 || !ok2 || !ok3){
-		QTWARNING("Invalid position input");
-		return false;
-	}
-	pos.set(x,y,z);
-	return true;
+bool getPosition(const TiXmlElement *root, vec3 &pos) {
+    bool ok1, ok2, ok3;
+    if (root == NULL) {
+        QTWARNING("The given root is not a Position Element");
+        return false;
+    }
+    QString rootValue = root->Value();
+    rootValue = rootValue.stripWhiteSpace();
+    if (!(rootValue == "position" || rootValue == "orientation")) {
+        QTWARNING("The given root is not a Position Element");
+        return false;
+    }
+    QString valueStr = root->GetText();
+    valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
+    QStringList l;
+    l = QStringList::split(' ', valueStr);
+    if (l.count() != 3) {
+        QTWARNING("Invalid position input");
+        return false;
+    }
+    double x, y, z;
+    x = l[0].toDouble(&ok1);
+    y = l[1].toDouble(&ok2);
+    z = l[2].toDouble(&ok3);
+    if (!ok1 || !ok2 || !ok3) {
+        QTWARNING("Invalid position input");
+        return false;
+    }
+    pos.set(x, y, z);
+    return true;
 }
 
-bool getTransform(const TiXmlElement *root, transf &totalTran)
-{
-	bool ok1, ok2, ok3;
-	bool ok[9];
-	if(root == NULL){
-		QTWARNING("The given root is not a Transform Element");
-		return false;
-	}
-	QString rootValue = root->Value();
-	rootValue = rootValue.stripWhiteSpace();
-	if(rootValue!="transform"){
-		QTWARNING("The given root is not a Transform Element");
-		return false;
-	}
+bool getTransform(const TiXmlElement *root, transf &totalTran) {
+    bool ok1, ok2, ok3;
+    bool ok[9];
+    if (root == NULL) {
+        QTWARNING("The given root is not a Transform Element");
+        return false;
+    }
+    QString rootValue = root->Value();
+    rootValue = rootValue.stripWhiteSpace();
+    if (rootValue != "transform") {
+        QTWARNING("The given root is not a Transform Element");
+        return false;
+    }
 
-	totalTran = transf::IDENTITY;
+    totalTran = transf::IDENTITY;
 
-	const TiXmlElement* child = root->FirstChildElement();
-	while(child!=NULL){
-		transf newTran;
-		QString valueStr = child->GetText();
-		valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
-		QStringList l;
-		l = QStringList::split(' ', valueStr);
-		QString defString = child->Value();
-		defString = defString.stripWhiteSpace();
-		if(defString=="translation"){
-			if(l.count()!=3){
-				QTWARNING("Invalid translation transformation input");
-				return false;
-			}		
-			double x,y,z;		
-			x = l[0].toDouble(&ok1);
-			y = l[1].toDouble(&ok2);
-			z = l[2].toDouble(&ok3);
-			if(!ok1 || !ok2 || !ok3){
-				QTWARNING("Invalid translation transformation input");
-				return false;
-			}
-			newTran.set(Quaternion::IDENTITY, vec3(x,y,z));
-		}
-		else if(defString=="rotation"){
-			if(l.count()!=2){
-				QTWARNING("Invalid rotation transformation input");
-				return false;
-			}
-			double rotationAngle = l[0].toDouble(&ok1);
-			if(!ok1){
-				QTWARNING("Invalid rotation transformation input");
-				return false;
-			}
-			rotationAngle *= M_PI / 180.0;
-			QString rotationAxis = l[1];
-			if (rotationAxis=="x") {
-				newTran.set(Quaternion(rotationAngle, vec3::X), vec3(0,0,0));
-			} else if (rotationAxis=="y") {
-				newTran.set(Quaternion(rotationAngle, vec3::Y), vec3(0,0,0));
-			} else if (rotationAxis=="z") {
-				newTran.set(Quaternion(rotationAngle, vec3::Z), vec3(0,0,0));
-			} else {
-				QTWARNING("Invalid rotation transformation input");
-				return false;
-			}
-		}
-		else if(defString=="rotationMatrix"){
-			if(l.count()!=9){
-				QTWARNING("Invalid rotation transformation input");
-				return false;
-			}
-			double R[9];
-			for(int i=0;i<9;i++){
-				R[i]=l[i].toDouble(&ok[i]);
-				if(!ok[i]){
-					QTWARNING("Invalid rotation transformation input");
-					return false;	
-				}
-			}
-			newTran.set(Quaternion(mat3(R).transpose()), vec3(0,0,0));
-		}
-		else if(defString=="fullTransform"){
-			QTextStream lineStream(&valueStr,QIODevice::ReadOnly);
-			lineStream>>newTran;
-		}
-		totalTran = newTran*totalTran;
-		child = child->NextSiblingElement();
-	}
-	return true;
+    const TiXmlElement *child = root->FirstChildElement();
+    while (child != NULL) {
+        transf newTran;
+        QString valueStr = child->GetText();
+        valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
+        QStringList l;
+        l = QStringList::split(' ', valueStr);
+        QString defString = child->Value();
+        defString = defString.stripWhiteSpace();
+        if (defString == "translation") {
+            if (l.count() != 3) {
+                QTWARNING("Invalid translation transformation input");
+                return false;
+            }
+            double x, y, z;
+            x = l[0].toDouble(&ok1);
+            y = l[1].toDouble(&ok2);
+            z = l[2].toDouble(&ok3);
+            if (!ok1 || !ok2 || !ok3) {
+                QTWARNING("Invalid translation transformation input");
+                return false;
+            }
+            newTran.set(Quaternion::IDENTITY, vec3(x, y, z));
+        }
+        else if (defString == "rotation") {
+            if (l.count() != 2) {
+                QTWARNING("Invalid rotation transformation input");
+                return false;
+            }
+            double rotationAngle = l[0].toDouble(&ok1);
+            if (!ok1) {
+                QTWARNING("Invalid rotation transformation input");
+                return false;
+            }
+            rotationAngle *= M_PI / 180.0;
+            QString rotationAxis = l[1];
+            if (rotationAxis == "x") {
+                newTran.set(Quaternion(rotationAngle, vec3::X), vec3(0, 0, 0));
+            }
+            else if (rotationAxis == "y") {
+                newTran.set(Quaternion(rotationAngle, vec3::Y), vec3(0, 0, 0));
+            }
+            else if (rotationAxis == "z") {
+                newTran.set(Quaternion(rotationAngle, vec3::Z), vec3(0, 0, 0));
+            }
+            else {
+                QTWARNING("Invalid rotation transformation input");
+                return false;
+            }
+        }
+        else if (defString == "rotationMatrix") {
+            if (l.count() != 9) {
+                QTWARNING("Invalid rotation transformation input");
+                return false;
+            }
+            double R[9];
+            for (int i = 0; i < 9; i++) {
+                R[i] = l[i].toDouble(&ok[i]);
+                if (!ok[i]) {
+                    QTWARNING("Invalid rotation transformation input");
+                    return false;
+                }
+            }
+            newTran.set(Quaternion(mat3(R).transpose()), vec3(0, 0, 0));
+        }
+        else if (defString == "fullTransform") {
+            QTextStream lineStream(&valueStr, QIODevice::ReadOnly);
+            lineStream >> newTran;
+        }
+        totalTran = newTran * totalTran;
+        child = child->NextSiblingElement();
+    }
+    return true;
 }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -27,7 +27,7 @@
 #include "dlfcn-win32.h"
 #define LIBRARY_SUFFIX ".dll"
 #else
-extern "C"{
+extern "C" {
 #include <dlfcn.h>
 }
 #define LIBRARY_SUFFIX ".so"
@@ -42,115 +42,110 @@ extern "C"{
 
 
 
-PluginCreator::~PluginCreator()
-{
-  dlclose(mLibraryHandle);
+PluginCreator::~PluginCreator() {
+    dlclose(mLibraryHandle);
 }
 
 
-Plugin* PluginCreator::createPlugin(int argc, char** argv)
-{
-  Plugin* plugin = (*mCreatePluginFctn)();
-  if (!plugin)
-  {
-      return NULL;
-  }
+Plugin *PluginCreator::createPlugin(int argc, char **argv) {
+    Plugin *plugin = (*mCreatePluginFctn)();
+    if (!plugin) {
+        return NULL;
+    }
 
-  //make copy of argv, so plugins cannot interfere with each other.
-  char ** argv_copy = new char*[argc+1];
-  for(int i=0; i < argc; i++)
-  {
-      argv_copy[i] = strdup(argv[i]);
-  }
-  argv_copy[argc] = NULL;
+    //make copy of argv, so plugins cannot interfere with each other.
+    char **argv_copy = new char *[argc + 1];
+    for (int i = 0; i < argc; i++) {
+        argv_copy[i] = strdup(argv[i]);
+    }
+    argv_copy[argc] = NULL;
 
-  if (plugin->init(argc, argv_copy) != SUCCESS)
-  {
-    DBGA("Failed to initialize new plugin of type " << mType);
-    delete plugin;
-    return NULL;
-  }
-  return plugin;
+    if (plugin->init(argc, argv_copy) != SUCCESS) {
+        DBGA("Failed to initialize new plugin of type " << mType);
+        delete plugin;
+        return NULL;
+    }
+    return plugin;
 }
 
-PluginCreator* PluginCreator::loadFromLibrary(std::string libName)
-{
-  QString filename = QString::fromStdString(libName);
-  //append library suffix if it does not already have it
-  if (!filename.endsWith(LIBRARY_SUFFIX)) {
-    filename.append(LIBRARY_SUFFIX);
-  }
-
-  if (filename.startsWith("/")) {
-    //filename is an absolute path
-    QFile file(filename);
-    if (!file.exists()) {
-      DBGA("Could not find absolute plugin file " << filename.latin1());
-      return NULL;
+PluginCreator *PluginCreator::loadFromLibrary(std::string libName) {
+    QString filename = QString::fromStdString(libName);
+    //append library suffix if it does not already have it
+    if (!filename.endsWith(LIBRARY_SUFFIX)) {
+        filename.append(LIBRARY_SUFFIX);
     }
-  } else{
-    //filename is relative to GRASPIT_PLUGIN_DIR
-    QString pluginDirs = QString(getenv("GRASPIT_PLUGIN_DIR"));
-    if (pluginDirs.isNull()) {
-      DBGA("Relative plugin file specified, but GRASPIT_PLUGIN_DIR is not set");
-      return NULL;
+
+    if (filename.startsWith("/")) {
+        //filename is an absolute path
+        QFile file(filename);
+        if (!file.exists()) {
+            DBGA("Could not find absolute plugin file " << filename.latin1());
+            return NULL;
+        }
     }
-    bool found = false;
-    for (int i=0; i<=pluginDirs.count(","); i++) {
-      QString dir = pluginDirs.section(',',i,i);
-      if (!dir.endsWith("/")) dir.append("/");
-      dir.append(filename);
-      QFile file(dir);
-      if (file.exists()) {
-        found = true;
-        filename = dir;
-        break;
-      }
+    else {
+        //filename is relative to GRASPIT_PLUGIN_DIR
+        QString pluginDirs = QString(getenv("GRASPIT_PLUGIN_DIR"));
+        if (pluginDirs.isNull()) {
+            DBGA("Relative plugin file specified, but GRASPIT_PLUGIN_DIR is not set");
+            return NULL;
+        }
+        bool found = false;
+        for (int i = 0; i <= pluginDirs.count(","); i++) {
+            QString dir = pluginDirs.section(',', i, i);
+            if (!dir.endsWith("/")) dir.append("/");
+            dir.append(filename);
+            QFile file(dir);
+            if (file.exists()) {
+                found = true;
+                filename = dir;
+                break;
+            }
+        }
+        if (!found) {
+            DBGA("Could not find relative plugin file " << filename.latin1() <<
+                 " in any directory specified in GRASPIT_PLUGIN_DIR");
+            return NULL;
+        }
     }
-    if (!found) {
-      DBGA("Could not find relative plugin file " << filename.latin1() <<
-           " in any directory specified in GRASPIT_PLUGIN_DIR");
-      return NULL;
+
+    //look for the library file and load it
+    void *handle = dlopen(filename.toAscii().constData(), RTLD_NOW | RTLD_GLOBAL);
+    char *errstr = dlerror();
+    if (!handle) {
+        DBGA("Failed to open dynamic library " << filename.toAscii().constData());
+        if (errstr) DBGA("Error: " << errstr);
+        return NULL;
     }
-  }
 
-  //look for the library file and load it
-   void* handle = dlopen(filename.toAscii().constData(), RTLD_NOW | RTLD_GLOBAL);
-  char *errstr = dlerror();
-  if (!handle) {
-    DBGA("Failed to open dynamic library " << filename.toAscii().constData() );
-    if (errstr) DBGA("Error: " << errstr);
-    return NULL;
-  }
+    //instantiate the plugin inside of the library
+    //this is pretty bad, but is based on example here:
+    // http://pubs.opengroup.org/onlinepubs/009695399/functions/dlsym.html
+    //see also discussion here:
+    // http://www.trilithium.com/johan/2004/12/problem-with-dlsym/
+    //maybe in the future a better solution can be found...
+    PluginCreator::CreatePluginFctn createPluginFctn;
+    *(void **)(&createPluginFctn) = dlsym(handle, "createPlugin");
+    if (dlerror()) {
+        DBGA("Could not load symbol createPlugin from library " << filename.toAscii().constData());
+        return NULL;
+    }
 
-  //instantiate the plugin inside of the library
-  //this is pretty bad, but is based on example here:
-  // http://pubs.opengroup.org/onlinepubs/009695399/functions/dlsym.html
-  //see also discussion here:
-  // http://www.trilithium.com/johan/2004/12/problem-with-dlsym/
-  //maybe in the future a better solution can be found...
-  PluginCreator::CreatePluginFctn createPluginFctn;
-  *(void **)(&createPluginFctn) = dlsym(handle,"createPlugin");
-  if (dlerror()) {
-    DBGA("Could not load symbol createPlugin from library " << filename.toAscii().constData());
-    return NULL;
-  }
+    //read the type of plugin
+    PluginCreator::GetTypeFctn getTypeFctn;
+    *(void **)(&getTypeFctn) = dlsym(handle, "getType");
+    if (dlerror()) {
+        DBGA("Could not load symbol getType from library " << filename.toAscii().constData());
+        return NULL;
+    }
+    std::cout << "Function name " << (*getTypeFctn)() << std::endl;
+    std::string type = (*getTypeFctn)();
+    if (type.empty()) {
+        DBGA("Could not get plugin type from library " << filename.toAscii().constData());
+    }
 
-  //read the type of plugin
-  PluginCreator::GetTypeFctn getTypeFctn;
-  *(void **)(&getTypeFctn) = dlsym(handle,"getType");
-  if (dlerror()) {
-    DBGA("Could not load symbol getType from library " << filename.toAscii().constData());
-    return NULL;
-  }
-  std::cout << "Function name " << (*getTypeFctn)() <<std::endl;
-  std::string type = (*getTypeFctn)();
-  if (type.empty()) {
-    DBGA("Could not get plugin type from library " << filename.toAscii().constData());
-  }
-
-  //create the PluginCreator and push it back
-  bool autoStart = true;
-  PluginCreator *creator = new PluginCreator(handle, createPluginFctn, autoStart, type);
-  return creator;
+    //create the PluginCreator and push it back
+    bool autoStart = true;
+    PluginCreator *creator = new PluginCreator(handle, createPluginFctn, autoStart, type);
+    return creator;
 }

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -27,94 +27,79 @@
 
 namespace Profiling {
 
-ProfileInstance::ProfileInstance()
-{
-  mCount = -1;
-  mRunning = false;
-  mName = "UNNAMED";
-}
+    ProfileInstance::ProfileInstance() {
+        mCount = -1;
+        mRunning = false;
+        mName = "UNNAMED";
+    }
 
-double 
-ProfileInstance::getTotalTimeMicroseconds()
-{
-  if (mRunning) 
-  {
-    stopTimer();
-    startTimer();
-  }
-  double result;
-  PROF_CONVERT_TO_MICROS(mElapsedTime, result);
-  return result;
-}
+    double
+    ProfileInstance::getTotalTimeMicroseconds() {
+        if (mRunning) {
+            stopTimer();
+            startTimer();
+        }
+        double result;
+        PROF_CONVERT_TO_MICROS(mElapsedTime, result);
+        return result;
+    }
 
-void ProfileInstance::print()
-{
-  double totalTime = getTotalTimeMicroseconds();
-  if (mCount == 0 && totalTime <= 0) return;
-  std::cerr << mName << ": ";
-  if (mCount > 0) std::cerr << "Count is "<< mCount << "; ";
-  if (totalTime > 0) 
-  {
-    std::cerr << "Time is " << ((float)totalTime)/1000 << "ms";
-    if (mRunning) std::cerr << " (still running)";
-    std::cerr << "; ";
-  }
-  std::cerr << std::endl;
-}
+    void ProfileInstance::print() {
+        double totalTime = getTotalTimeMicroseconds();
+        if (mCount == 0 && totalTime <= 0) return;
+        std::cerr << mName << ": ";
+        if (mCount > 0) std::cerr << "Count is " << mCount << "; ";
+        if (totalTime > 0) {
+            std::cerr << "Time is " << ((float)totalTime) / 1000 << "ms";
+            if (mRunning) std::cerr << " (still running)";
+            std::cerr << "; ";
+        }
+        std::cerr << std::endl;
+    }
 
-Profiler::Profiler()
-{
-  mSize = 0;
-  resize(10);
-  mNextIndex = 0;
-#ifdef WIN32
-  LARGE_INTEGER tmp;
-  QueryPerformanceFrequency(&tmp);
-  COUNTS_PER_SEC = tmp.QuadPart;
-  if (COUNTS_PER_SEC==0) 
-  {
-    std::cerr << "High performance timer not availabled! PROFILER NOT OPERATIONAL.\n";
-    COUNTS_PER_SEC = 1;
-  }
-#endif
-}
+    Profiler::Profiler() {
+        mSize = 0;
+        resize(10);
+        mNextIndex = 0;
+        #ifdef WIN32
+        LARGE_INTEGER tmp;
+        QueryPerformanceFrequency(&tmp);
+        COUNTS_PER_SEC = tmp.QuadPart;
+        if (COUNTS_PER_SEC == 0) {
+            std::cerr << "High performance timer not availabled! PROFILER NOT OPERATIONAL.\n";
+            COUNTS_PER_SEC = 1;
+        }
+        #endif
+    }
 
-Profiler::~Profiler()
-{
-}
+    Profiler::~Profiler() {
+    }
 
-void Profiler::resize(int size) 
-{
-  if (size <= mSize) return;
-  mSize = size;
-  mPI.resize(mSize,ProfileInstance());
-}
+    void Profiler::resize(int size) {
+        if (size <= mSize) return;
+        mSize = size;
+        mPI.resize(mSize, ProfileInstance());
+    }
 
-int Profiler::getNewIndex(const char *name)
-{
-  if (mNextIndex >= mSize) 
-  {
-    resize(2*mSize);
-  }
-  mPI[mNextIndex].setName(name);
-  mPI[mNextIndex].reset();
-  return mNextIndex++;
-}
+    int Profiler::getNewIndex(const char *name) {
+        if (mNextIndex >= mSize) {
+            resize(2 * mSize);
+        }
+        mPI[mNextIndex].setName(name);
+        mPI[mNextIndex].reset();
+        return mNextIndex++;
+    }
 
-void Profiler::resetAll()
-{
-  for (int i=0; i<mNextIndex; i++) 
-  {
-    mPI[i].reset();
-  }
-}
+    void Profiler::resetAll() {
+        for (int i = 0; i < mNextIndex; i++) {
+            mPI[i].reset();
+        }
+    }
 
-void Profiler::printAll()
-{
-  for (int i=0; i<mNextIndex; i++) 
-  {
-    mPI[i].print();
-  }
-}
-  
+    void Profiler::printAll() {
+        for (int i = 0; i < mNextIndex; i++) {
+            mPI[i].print();
+        }
+    }
+
 }

--- a/src/quality.cpp
+++ b/src/quality.cpp
@@ -17,14 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with GraspIt!.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Author(s): Andrew T. Miller 
+// Author(s): Andrew T. Miller
 //
 // $Id: quality.cpp,v 1.12 2009/03/31 15:36:58 cmatei Exp $
 //
 //######################################################################
 
 /*! \file
-  \brief Implements base QualityMeasure class and specifc qm classes.
+    \brief Implements base QualityMeasure class and specifc qm classes.
 */
 
 #include "quality.h"
@@ -51,67 +51,62 @@
 //Static class variables
 
 //! A list of the possible qm types expressed as strings
-const char *QualityMeasure::TYPE_LIST[] = {"Epsilon","Volume",NULL};
+const char *QualityMeasure::TYPE_LIST[] = {"Epsilon", "Volume", NULL};
 
 const char *QualEpsilon::type = "Epsilon";
 const char *QualVolume::type = "Volume";
 
 /*!
-  Sets the name of this QM to the text contained within the name widget.
-  Sets the grasp pointer for this qm to the grasp in qmData.
+    Sets the name of this QM to the text contained within the name widget.
+    Sets the grasp pointer for this qm to the grasp in qmData.
 */
-QualityMeasure::QualityMeasure(qmDlgDataT *qmData)
-{
-  name = qmData->qmName->text();
-  grasp = qmData->grasp;
+QualityMeasure::QualityMeasure(qmDlgDataT *qmData) {
+    name = qmData->qmName->text();
+    grasp = qmData->grasp;
 }
 
-QualityMeasure::QualityMeasure(Grasp *g, QString n)
-{
-	grasp = g;
-	name = n;
+QualityMeasure::QualityMeasure(Grasp *g, QString n) {
+    grasp = g;
+    name = n;
 }
 
 /*!
-  Stub Destructor
+    Stub Destructor
 */
-QualityMeasure::~QualityMeasure()
- {  
-#ifdef GRASPITDBG
-   std::cout << "deleting QualityMeasure" << std::endl;
-#endif
- }
+QualityMeasure::~QualityMeasure() {
+    #ifdef GRASPITDBG
+    std::cout << "deleting QualityMeasure" << std::endl;
+    #endif
+}
 
 
 /*!
-  Calls the appropriate buildParameterArea method from the specific subclass
-  of the quality measure contained within qmData.  The type of the qm is
-  determined by examining the string qmData->qmType.
+    Calls the appropriate buildParameterArea method from the specific subclass
+    of the quality measure contained within qmData.  The type of the qm is
+    determined by examining the string qmData->qmType.
 */
 void
-QualityMeasure::buildParamArea(qmDlgDataT *qmData)
-{
-  if (!strcmp(qmData->qmType,QualEpsilon::getClassType()))
-    QualEpsilon::buildParamArea(qmData);
+QualityMeasure::buildParamArea(qmDlgDataT *qmData) {
+    if (!strcmp(qmData->qmType, QualEpsilon::getClassType()))
+        QualEpsilon::buildParamArea(qmData);
 
-  else if (!strcmp(qmData->qmType,QualVolume::getClassType()))
-    QualVolume::buildParamArea(qmData);
+    else if (!strcmp(qmData->qmType, QualVolume::getClassType()))
+        QualVolume::buildParamArea(qmData);
 }
 
 /*!
-  Creates an instance of the specific subclass that is named in the string
-  pointed to by qmData->qmType.
+    Creates an instance of the specific subclass that is named in the string
+    pointed to by qmData->qmType.
 */
 QualityMeasure *
-QualityMeasure::createInstance(qmDlgDataT *qmData)
-{
-  if (!strcmp(qmData->qmType,QualEpsilon::getClassType()))
-    return new QualEpsilon(qmData);
+QualityMeasure::createInstance(qmDlgDataT *qmData) {
+    if (!strcmp(qmData->qmType, QualEpsilon::getClassType()))
+        return new QualEpsilon(qmData);
 
-  else if (!strcmp(qmData->qmType,QualVolume::getClassType()))
-    return new QualVolume(qmData);
+    else if (!strcmp(qmData->qmType, QualVolume::getClassType()))
+        return new QualVolume(qmData);
 
-  return NULL;
+    return NULL;
 }
 
 
@@ -123,133 +118,127 @@ QualityMeasure::createInstance(qmDlgDataT *qmData)
 
 //! Structure holding pointers to UI items specific to this quality measure
 /*!
-  Quality parameter structure that simply holds a pointer to the gws type
-  combo box in the parameter area.
+    Quality parameter structure that simply holds a pointer to the gws type
+    combo box in the parameter area.
 */
 struct QualEpsilonParamT {
-  QComboBox *gwsTypeComboBox,*twsTypeComboBox;
+    QComboBox *gwsTypeComboBox, *twsTypeComboBox;
 };
 
 /*!
-  Adds the GWS specified by the combo box in the parameter area of the
-  dialog box to the grasp associated with this qm.  The grasp will take care
-  of creating it if it doesn't already exist.
+    Adds the GWS specified by the combo box in the parameter area of the
+    dialog box to the grasp associated with this qm.  The grasp will take care
+    of creating it if it doesn't already exist.
 */
-QualEpsilon::QualEpsilon(qmDlgDataT *data) : QualityMeasure(data)
-{
-  QualEpsilonParamT *params = (QualEpsilonParamT *)data->paramPtr;
-  gws = grasp->addGWS(params->gwsTypeComboBox->currentText().latin1());
+QualEpsilon::QualEpsilon(qmDlgDataT *data) : QualityMeasure(data) {
+    QualEpsilonParamT *params = (QualEpsilonParamT *)data->paramPtr;
+    gws = grasp->addGWS(params->gwsTypeComboBox->currentText().latin1());
 }
 
-QualEpsilon::QualEpsilon(Grasp *g, QString n, const char *gwsType) : QualityMeasure(g,n)
-{
-	gws = grasp->addGWS( gwsType );
+QualEpsilon::QualEpsilon(Grasp *g, QString n, const char *gwsType) : QualityMeasure(g, n) {
+    gws = grasp->addGWS(gwsType);
 }
 /*!
-  Removes the GWS used for this qm from the grasp.  The grasp will delete it
-  if necessary.
+    Removes the GWS used for this qm from the grasp.  The grasp will delete it
+    if necessary.
 */
-QualEpsilon::~QualEpsilon()
-{
-#ifdef GRASPITDBG
-   std::cout << "deleting QualEpsilon" << std::endl;
-#endif
-  grasp->removeGWS(gws);
+QualEpsilon::~QualEpsilon() {
+    #ifdef GRASPITDBG
+    std::cout << "deleting QualEpsilon" << std::endl;
+    #endif
+    grasp->removeGWS(gws);
 }
 
 /*!
-  Returns the minimum distance from the origin to any of the hyperplanes
-  defining the boundary of the GWS.
+    Returns the minimum distance from the origin to any of the hyperplanes
+    defining the boundary of the GWS.
 */
 double
-QualEpsilon::evaluate()
-{
-  double minOffset=std::numeric_limits<double>::max();
+QualEpsilon::evaluate() {
+    double minOffset = std::numeric_limits<double>::max();
 
-  if (!gws->hyperPlanes) {
-#ifdef GRASPITDBG
-    std::cout << "hyperplanes is NULL"<<std::endl;
-#endif
-    return -1.0;
-  }
-
-#ifdef GRASPITDBG
-  std::cout << "numHyperPlanes"<<gws->numHyperPlanes<<std::endl;
-#endif
-
-  for (int i=0;i<gws->numHyperPlanes;i++) {
-    if (i==0 || -(gws->hyperPlanes[i][6])<minOffset) {
-      minOffset = -(gws->hyperPlanes[i][6]);
-      if (minOffset < 0) return -1.0;     // not a force-closure grasp
+    if (!gws->hyperPlanes) {
+        #ifdef GRASPITDBG
+        std::cout << "hyperplanes is NULL" << std::endl;
+        #endif
+        return -1.0;
     }
-  }
 
-  val = minOffset;
-  return val;
+    #ifdef GRASPITDBG
+    std::cout << "numHyperPlanes" << gws->numHyperPlanes << std::endl;
+    #endif
+
+    for (int i = 0; i < gws->numHyperPlanes; i++) {
+        if (i == 0 || -(gws->hyperPlanes[i][6]) < minOffset) {
+            minOffset = -(gws->hyperPlanes[i][6]);
+            if (minOffset < 0) return -1.0;     // not a force-closure grasp
+        }
+    }
+
+    val = minOffset;
+    return val;
 }
 
 double
-QualEpsilon::evaluate3D()
-{
-  if (!gws->hyperPlanes) {
-#ifdef GRASPITDBG
-    std::cout << "hyperplanes is NULL"<<std::endl;
-#endif
-    return -1.0e3;
-  }
-
-#ifdef GRASPITDBG
-  std::cout << "numHyperPlanes"<<gws->numHyperPlanes<<std::endl;
-#endif
-
-  double minOffset = -1.0e3;
-  for (int i=0;i<gws->numHyperPlanes;i++) {
-    if ( gws->hyperPlanes[i][6] > minOffset) {
-	  minOffset = gws->hyperPlanes[i][6];
+QualEpsilon::evaluate3D() {
+    if (!gws->hyperPlanes) {
+        #ifdef GRASPITDBG
+        std::cout << "hyperplanes is NULL" << std::endl;
+        #endif
+        return -1.0e3;
     }
-  }
-  val = - minOffset;
-  return val;
+
+    #ifdef GRASPITDBG
+    std::cout << "numHyperPlanes" << gws->numHyperPlanes << std::endl;
+    #endif
+
+    double minOffset = -1.0e3;
+    for (int i = 0; i < gws->numHyperPlanes; i++) {
+        if (gws->hyperPlanes[i][6] > minOffset) {
+            minOffset = gws->hyperPlanes[i][6];
+        }
+    }
+    val = - minOffset;
+    return val;
 }
 
 /*!
-  Builds an epsilon qm parameter area within the quality measure dialog
-  box.  This includes building a QT combo box for the GWS selection and
-  one for the TWS selection.  However, currently there is only one possible
-  TWS.  In the future, there may be ways to define others.
+    Builds an epsilon qm parameter area within the quality measure dialog
+    box.  This includes building a QT combo box for the GWS selection and
+    one for the TWS selection.  However, currently there is only one possible
+    TWS.  In the future, there may be ways to define others.
 */
 void
-QualEpsilon::buildParamArea(qmDlgDataT *qmData)
-{
-  int i;
-  static QualEpsilonParamT params;
+QualEpsilon::buildParamArea(qmDlgDataT *qmData) {
+    int i;
+    static QualEpsilonParamT params;
 
-  QualEpsilon *currQM = (QualEpsilon *)qmData->currQM;
+    QualEpsilon *currQM = (QualEpsilon *)qmData->currQM;
 
-#ifdef GRASPITDBG
-  std::cout << "building qualepsilon" << std::endl;
-#endif
+    #ifdef GRASPITDBG
+    std::cout << "building qualepsilon" << std::endl;
+    #endif
 
-  QLayout *l = new QGridLayout(qmData->settingsArea,2,2,1);
-  l->setAutoAdd(true);
+    QLayout *l = new QGridLayout(qmData->settingsArea, 2, 2, 1);
+    l->setAutoAdd(true);
 
-  // create the GWS type menu
-  new QLabel(QString("Limit unit GWS using:"),qmData->settingsArea);
-  params.gwsTypeComboBox = new QComboBox(qmData->settingsArea,"gwsComboBox");  
+    // create the GWS type menu
+    new QLabel(QString("Limit unit GWS using:"), qmData->settingsArea);
+    params.gwsTypeComboBox = new QComboBox(qmData->settingsArea, "gwsComboBox");
 
-  new QLabel(QString("Task Wrench Space (TWS):"),qmData->settingsArea);
-  params.twsTypeComboBox = new QComboBox(qmData->settingsArea,"twsComboBox");  
+    new QLabel(QString("Task Wrench Space (TWS):"), qmData->settingsArea);
+    params.twsTypeComboBox = new QComboBox(qmData->settingsArea, "twsComboBox");
 
-  // count the number of possible gws types
-  for (i=0;GWS::TYPE_LIST[i];i++) {
-    params.gwsTypeComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
-    if (currQM && !strcmp(currQM->gws->getType(),GWS::TYPE_LIST[i]))
-      params.gwsTypeComboBox->setCurrentItem(i);
-  }
-  
-  params.twsTypeComboBox->insertItem(QString("Unit Ball"));
+    // count the number of possible gws types
+    for (i = 0; GWS::TYPE_LIST[i]; i++) {
+        params.gwsTypeComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
+        if (currQM && !strcmp(currQM->gws->getType(), GWS::TYPE_LIST[i]))
+            params.gwsTypeComboBox->setCurrentItem(i);
+    }
 
-  qmData->paramPtr = &params;
+    params.twsTypeComboBox->insertItem(QString("Unit Ball"));
+
+    qmData->paramPtr = &params;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -260,89 +249,83 @@ QualEpsilon::buildParamArea(qmDlgDataT *qmData)
 
 //! Structure holding pointers to UI items specific to this quality measure
 /*!
-  Quality parameter structure that simply holds a pointer to the gws type
-  combo box in the parameter area.
+    Quality parameter structure that simply holds a pointer to the gws type
+    combo box in the parameter area.
 */
 struct QualVolumeParamT {
-  QWidget *gwsTypeComboBox;
+    QWidget *gwsTypeComboBox;
 };
 
 /*!
-  Adds the GWS specified by the combo box in the parameter area of the
-  dialog box to the grasp associated with this qm.  The grasp will take care
-  of creating it if it doesn't already exist.
+    Adds the GWS specified by the combo box in the parameter area of the
+    dialog box to the grasp associated with this qm.  The grasp will take care
+    of creating it if it doesn't already exist.
 */
-QualVolume::QualVolume(qmDlgDataT *data) : QualityMeasure(data)
-{
-  QComboBox *gwsType = (QComboBox *)data->paramPtr;
-  gws = grasp->addGWS(gwsType->currentText().latin1());
+QualVolume::QualVolume(qmDlgDataT *data) : QualityMeasure(data) {
+    QComboBox *gwsType = (QComboBox *)data->paramPtr;
+    gws = grasp->addGWS(gwsType->currentText().latin1());
 }
 
-QualVolume::QualVolume(Grasp *g, QString n, const char *gwsType) : QualityMeasure(g,n)
-{
-	gws = grasp->addGWS( gwsType );
+QualVolume::QualVolume(Grasp *g, QString n, const char *gwsType) : QualityMeasure(g, n) {
+    gws = grasp->addGWS(gwsType);
 }
 
 
 /*!
-  Removes the GWS used for this qm from the grasp.  The grasp will delete it
-  if necessary.
+    Removes the GWS used for this qm from the grasp.  The grasp will delete it
+    if necessary.
 */
-QualVolume::~QualVolume()
-{
-#ifdef GRASPITDBG
-  std::cout << "deleting QualVolume" << std::endl;
-#endif
-  grasp->removeGWS(gws);
+QualVolume::~QualVolume() {
+    #ifdef GRASPITDBG
+    std::cout << "deleting QualVolume" << std::endl;
+    #endif
+    grasp->removeGWS(gws);
 }
 
 /*!
-  Returns the volume of the GWS.  The GWS is responsible for computing its
-  volume when it is updated.
+    Returns the volume of the GWS.  The GWS is responsible for computing its
+    volume when it is updated.
 */
 double
-QualVolume::evaluate()
-{
-  val = gws->hullVolume;
-  return val;
+QualVolume::evaluate() {
+    val = gws->hullVolume;
+    return val;
 }
 
 double
-QualVolume::evaluate3D()
-{
-  val = gws->hullVolume;
-  return val;
+QualVolume::evaluate3D() {
+    val = gws->hullVolume;
+    return val;
 }
 
 /*!
-  Builds a volume qm parameter area within the quality measure dialog
-  box.  This is simply building a QT combo box for the GWS selection.
+    Builds a volume qm parameter area within the quality measure dialog
+    box.  This is simply building a QT combo box for the GWS selection.
 */
 void
-QualVolume::buildParamArea(qmDlgDataT *qmData)
-{
-  int i;
-  QualVolume *currQM = (QualVolume *)qmData->currQM;
+QualVolume::buildParamArea(qmDlgDataT *qmData) {
+    int i;
+    QualVolume *currQM = (QualVolume *)qmData->currQM;
 
-#ifdef GRASPITDBG
-  std::cout << "building qualvolume" << std::endl;
-#endif
+    #ifdef GRASPITDBG
+    std::cout << "building qualvolume" << std::endl;
+    #endif
 
-  QBoxLayout *l = new QHBoxLayout(qmData->settingsArea);
-  l->setAutoAdd(true);
+    QBoxLayout *l = new QHBoxLayout(qmData->settingsArea);
+    l->setAutoAdd(true);
 
-  // create the GWS type menu
-  new QLabel(QString("Limit unit GWS using:"),qmData->settingsArea);
-  QComboBox *gwsComboBox = new QComboBox(qmData->settingsArea,"gwsComboBox");  
+    // create the GWS type menu
+    new QLabel(QString("Limit unit GWS using:"), qmData->settingsArea);
+    QComboBox *gwsComboBox = new QComboBox(qmData->settingsArea, "gwsComboBox");
 
-  // count the number of possible gws types
-  for (i=0;GWS::TYPE_LIST[i];i++) {
-    gwsComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
-    if (currQM && !strcmp(currQM->gws->getType(),GWS::TYPE_LIST[i]))
-      gwsComboBox->setCurrentItem(i);
-  }
+    // count the number of possible gws types
+    for (i = 0; GWS::TYPE_LIST[i]; i++) {
+        gwsComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
+        if (currQM && !strcmp(currQM->gws->getType(), GWS::TYPE_LIST[i]))
+            gwsComboBox->setCurrentItem(i);
+    }
 
-  qmData->paramPtr = gwsComboBox;
+    qmData->paramPtr = gwsComboBox;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -23,8 +23,8 @@
 //
 //######################################################################
 
-/*! \file 
-\brief Implements the robot class hierarchy
+/*! \file
+    \brief Implements the robot class hierarchy
 */
 #include <iomanip>
 #include <QFile>
@@ -65,2150 +65,2123 @@ PROF_DECLARE(MOVE_DOF);
 const double Robot::AUTO_GRASP_TIME_STEP = 0.01;
 
 /*! Removes the base and mountpiece from the world, and deletes the
-kinematic chains and DOFs.  If this robot is connected to a parent
-robot, it detaches itself.
+    kinematic chains and DOFs.  If this robot is connected to a parent
+    robot, it detaches itself.
 */
-Robot::~Robot()
-{
-	for (int i=0;i<numChains;i++) {
-		if (chainVec[i]) delete chainVec[i];
-	}
-	for (int i=0;i<numDOF;i++) {
-		if (dofVec[i]) delete dofVec[i];
-	}
-	if (base) myWorld->destroyElement(base);  
-	if (mountPiece) myWorld->destroyElement(mountPiece);
-	if (parent) parent->detachRobot(this);
-	if (mGloveInterface) delete mGloveInterface;
-	if (mEigenGrasps) delete mEigenGrasps;
+Robot::~Robot() {
+    for (int i = 0; i < numChains; i++) {
+        if (chainVec[i]) delete chainVec[i];
+    }
+    for (int i = 0; i < numDOF; i++) {
+        if (dofVec[i]) delete dofVec[i];
+    }
+    if (base) myWorld->destroyElement(base);
+    if (mountPiece) myWorld->destroyElement(mountPiece);
+    if (parent) parent->detachRobot(this);
+    if (mGloveInterface) delete mGloveInterface;
+    if (mEigenGrasps) delete mEigenGrasps;
 
-	std::cout << "Deleted robot: " << name() <<std::endl;
+    std::cout << "Deleted robot: " << name() << std::endl;
 }
 
 /*! Loads the robot information from an XML node, which is asumed
-	to be the root of a hierarchy containing all the relevant
-	information. The \a rootPath is considered the reference path
-	for other files which are referenced in the XML. One exception
-	are the link files which are assumed to be placed in 
-	rootPath/iv
+    to be the root of a hierarchy containing all the relevant
+    information. The \a rootPath is considered the reference path
+    for other files which are referenced in the XML. One exception
+    are the link files which are assumed to be placed in
+    rootPath/iv
 */
 int
-Robot::loadFromXml(const TiXmlElement* root,QString rootPath)
-{
-	QString robotName = root->Attribute("type");
-	if(robotName.isNull()){
-		QTWARNING("Robot Name undefined");
-		return FAILURE;
-	}
-	QString robotDBName = root->Attribute("DBName");
-	if(robotDBName.isNull()) robotDBName = robotName;
-        setDBName(robotDBName);
+Robot::loadFromXml(const TiXmlElement *root, QString rootPath) {
+    QString robotName = root->Attribute("type");
+    if (robotName.isNull()) {
+        QTWARNING("Robot Name undefined");
+        return FAILURE;
+    }
+    QString robotDBName = root->Attribute("DBName");
+    if (robotDBName.isNull()) robotDBName = robotName;
+    setDBName(robotDBName);
 
-	const TiXmlElement* element = findXmlElement(root,"palm");
-	QString valueStr;
-	QString ivdir = rootPath + "iv/";
-	// read and load the base; automatically placed at origin
-	DBGA("Creating base...\n");  
-	if(element){
-		valueStr = element->GetText();	
-		valueStr = valueStr.stripWhiteSpace();
-		base = new Link(this,-1,-1,myWorld,(QString(name())+"Base").latin1());
-		if (!base  || base->load(ivdir+valueStr)==FAILURE) {
-			if (base) delete base; 
-			base = NULL;
-			DBGA("Failed to load base");
-			return FAILURE;
-		}
-		base->addToIvc();
+    const TiXmlElement *element = findXmlElement(root, "palm");
+    QString valueStr;
+    QString ivdir = rootPath + "iv/";
+    // read and load the base; automatically placed at origin
+    DBGA("Creating base...\n");
+    if (element) {
+        valueStr = element->GetText();
+        valueStr = valueStr.stripWhiteSpace();
+        base = new Link(this, -1, -1, myWorld, (QString(name()) + "Base").latin1());
+        if (!base  || base->load(ivdir + valueStr) == FAILURE) {
+            if (base) delete base;
+            base = NULL;
+            DBGA("Failed to load base");
+            return FAILURE;
+        }
+        base->addToIvc();
 
-		//init my IVRoot and add the base
-		IVRoot = new SoSeparator;
-		IVRoot->addChild(base->getIVRoot());
-	}
-	else{
-		QTWARNING("Base not found");
-		return FAILURE;
-	}
-	std::list<const TiXmlElement*> elementList = findAllXmlElements(root, "dof");
-	numDOF = countXmlElements(root, "dof");
-	if (numDOF < 1) {
-		DBGA("Wrong number of DOFs specified: " << numDOF);
-		return FAILURE;
-	}
-	DBGA("Setting up " << numDOF << " degrees of freedom...");
-	dofVec.resize(numDOF, NULL);
+        //init my IVRoot and add the base
+        IVRoot = new SoSeparator;
+        IVRoot->addChild(base->getIVRoot());
+    }
+    else {
+        QTWARNING("Base not found");
+        return FAILURE;
+    }
+    std::list<const TiXmlElement *> elementList = findAllXmlElements(root, "dof");
+    numDOF = countXmlElements(root, "dof");
+    if (numDOF < 1) {
+        DBGA("Wrong number of DOFs specified: " << numDOF);
+        return FAILURE;
+    }
+    DBGA("Setting up " << numDOF << " degrees of freedom...");
+    dofVec.resize(numDOF, NULL);
 
-	//read each dof information
-	std::list<const TiXmlElement*>::iterator p = elementList.begin();
-	int f=0;
-	while(p!=elementList.end()){
-		valueStr = (*p)->Attribute("type");
-		if(valueStr.isNull()){
-			QTWARNING("DOF Type not found");
-			return FAILURE;
-		}
-		QString dofType = valueStr.stripWhiteSpace();
-		if(dofType == "r")
-			dofVec[f] = new RigidDOF();
-		else if(dofType == "b")
-			dofVec[f] = new BreakAwayDOF();
-		else if(dofType == "c")
-			dofVec[f] = new CompliantDOF();
-		else {
-			DBGA("Unknown DOF Type requested: " << dofType.toStdString() << " for DOF " << f);
-			return FAILURE;
-		}
-		dofVec[f]->dofNum = f;
-		if (!dofVec[f]->readParametersFromXml(*p)) {
-			DBGA("Failed to read DOF " << f );
-			return FAILURE;
-		}
-		p++;
-		f++;
-	}
+    //read each dof information
+    std::list<const TiXmlElement *>::iterator p = elementList.begin();
+    int f = 0;
+    while (p != elementList.end()) {
+        valueStr = (*p)->Attribute("type");
+        if (valueStr.isNull()) {
+            QTWARNING("DOF Type not found");
+            return FAILURE;
+        }
+        QString dofType = valueStr.stripWhiteSpace();
+        if (dofType == "r")
+            dofVec[f] = new RigidDOF();
+        else if (dofType == "b")
+            dofVec[f] = new BreakAwayDOF();
+        else if (dofType == "c")
+            dofVec[f] = new CompliantDOF();
+        else {
+            DBGA("Unknown DOF Type requested: " << dofType.toStdString() << " for DOF " << f);
+            return FAILURE;
+        }
+        dofVec[f]->dofNum = f;
+        if (!dofVec[f]->readParametersFromXml(*p)) {
+            DBGA("Failed to read DOF " << f);
+            return FAILURE;
+        }
+        p++;
+        f++;
+    }
 
-	//read number of chains and allocate them
-	numChains = countXmlElements(root,"chain");
-	if (numChains < 1) {
-		DBGA("Wrong number of chains"); 
-		return FAILURE;
-	}
-	DBGA("Creating " << numChains << " kinematic chains (fingers)...");
-	chainVec.resize(numChains, NULL);
+    //read number of chains and allocate them
+    numChains = countXmlElements(root, "chain");
+    if (numChains < 1) {
+        DBGA("Wrong number of chains");
+        return FAILURE;
+    }
+    DBGA("Creating " << numChains << " kinematic chains (fingers)...");
+    chainVec.resize(numChains, NULL);
 
-	//ask each chain to read itself from the file
-	numJoints = 0;
-	f = 0;
-	elementList = findAllXmlElements(root, "chain");
-	p = elementList.begin();
-	while(p!=elementList.end()){
-		fprintf(stderr, "Chain %d: ",f);
-		chainVec[f] = new KinematicChain(this,f, numJoints);
-		if (chainVec[f]->initChainFromXml((*p),ivdir)==FAILURE) {
-			DBGA("Failed to read chain " << f);
-			return FAILURE;
-		}
-		numJoints += chainVec[f]->getNumJoints();
-		p++;	
-		f++;
-	}
+    //ask each chain to read itself from the file
+    numJoints = 0;
+    f = 0;
+    elementList = findAllXmlElements(root, "chain");
+    p = elementList.begin();
+    while (p != elementList.end()) {
+        fprintf(stderr, "Chain %d: ", f);
+        chainVec[f] = new KinematicChain(this, f, numJoints);
+        if (chainVec[f]->initChainFromXml((*p), ivdir) == FAILURE) {
+            DBGA("Failed to read chain " << f);
+            return FAILURE;
+        }
+        numJoints += chainVec[f]->getNumJoints();
+        p++;
+        f++;
+    }
 
-	//set up DOFs before setting up EigenGrasps
+    //set up DOFs before setting up EigenGrasps
     std::vector<Joint *>jointList;
-	for (int d=0; d<numDOF; d++) {
-		jointList.clear();
-		for (int f=0; f<numChains; f++) {
-			for (int j=0; j<chainVec[f]->getNumJoints(); j++) {
-				if (chainVec[f]->getJoint(j)->getDOFNum() == d) {
-					jointList.push_back(chainVec[f]->getJoint(j));
-				}
-			}
-		}
-		dofVec[d]->initDOF(this,jointList);
-	}
-        //with DOF initialized with joints, we can set default values
-        forceDefaultDOFVals();
+    for (int d = 0; d < numDOF; d++) {
+        jointList.clear();
+        for (int f = 0; f < numChains; f++) {
+            for (int j = 0; j < chainVec[f]->getNumJoints(); j++) {
+                if (chainVec[f]->getJoint(j)->getDOFNum() == d) {
+                    jointList.push_back(chainVec[f]->getJoint(j));
+                }
+            }
+        }
+        dofVec[d]->initDOF(this, jointList);
+    }
+    //with DOF initialized with joints, we can set default values
+    forceDefaultDOFVals();
 
-	//reset the dynamics: fix the base and set desired dof's to current values
-	getBase()->fix();
-	for (int i=0; i<getNumDOF(); i++) {
-		getDOF(i)->setDesiredPos( getDOF(i)->getVal() );
-	}
+    //reset the dynamics: fix the base and set desired dof's to current values
+    getBase()->fix();
+    for (int i = 0; i < getNumDOF(); i++) {
+        getDOF(i)->setDesiredPos(getDOF(i)->getVal());
+    }
 
-	//optional information
+    //optional information
 
-	//load approach direction
-	approachTran = transf::IDENTITY;
-	element = findXmlElement(root,"approachDirection");
-	if(element){
-		const TiXmlElement* tmp = findXmlElement(element,"referenceLocation");
-		if(!tmp){
-			DBGA("Failed to read approach direction");	
-			return FAILURE;
-		}
-		valueStr = tmp->GetText();
-		valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
-		QStringList l = QStringList::split(' ', valueStr);
-		if(l.count()!=3){
-			DBGA("Invalid approach direction input");
-			return FAILURE;
-		}
-		bool ok1, ok2, ok3;
-		float locX, locY, locZ;
-		locX = l[0].toFloat(&ok1);
-		locY = l[1].toFloat(&ok2);
-		locZ = l[2].toFloat(&ok3);
-		if(!ok1 || !ok2 || !ok3){
-			DBGA("Invalid approach direction input");
-			return FAILURE;
-		}
-		vec3 aPt = vec3(locX, locY, locZ);
+    //load approach direction
+    approachTran = transf::IDENTITY;
+    element = findXmlElement(root, "approachDirection");
+    if (element) {
+        const TiXmlElement *tmp = findXmlElement(element, "referenceLocation");
+        if (!tmp) {
+            DBGA("Failed to read approach direction");
+            return FAILURE;
+        }
+        valueStr = tmp->GetText();
+        valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
+        QStringList l = QStringList::split(' ', valueStr);
+        if (l.count() != 3) {
+            DBGA("Invalid approach direction input");
+            return FAILURE;
+        }
+        bool ok1, ok2, ok3;
+        float locX, locY, locZ;
+        locX = l[0].toFloat(&ok1);
+        locY = l[1].toFloat(&ok2);
+        locZ = l[2].toFloat(&ok3);
+        if (!ok1 || !ok2 || !ok3) {
+            DBGA("Invalid approach direction input");
+            return FAILURE;
+        }
+        vec3 aPt = vec3(locX, locY, locZ);
 
-		tmp = findXmlElement(element,"direction");
-		if(!tmp){
-			DBGA("Failed to read approach direction");	
-			return FAILURE;
-		}
-		valueStr = tmp->GetText();
-		valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
-		l = QStringList::split(' ', valueStr);
-		if(l.count()!=3){
-			DBGA("Invalid approach direction input");
-			return FAILURE;
-		}
-		locX = l[0].toFloat(&ok1);
-		locY = l[1].toFloat(&ok2);
-		locZ = l[2].toFloat(&ok3);
-		if(!ok1 || !ok2 || !ok3){
-			DBGA("Invalid approach direction input");
-			return FAILURE;
-		}
-		vec3 zdir = vec3(locX, locY, locZ);
-		zdir = normalise(zdir);
+        tmp = findXmlElement(element, "direction");
+        if (!tmp) {
+            DBGA("Failed to read approach direction");
+            return FAILURE;
+        }
+        valueStr = tmp->GetText();
+        valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
+        l = QStringList::split(' ', valueStr);
+        if (l.count() != 3) {
+            DBGA("Invalid approach direction input");
+            return FAILURE;
+        }
+        locX = l[0].toFloat(&ok1);
+        locY = l[1].toFloat(&ok2);
+        locZ = l[2].toFloat(&ok3);
+        if (!ok1 || !ok2 || !ok3) {
+            DBGA("Invalid approach direction input");
+            return FAILURE;
+        }
+        vec3 zdir = vec3(locX, locY, locZ);
+        zdir = normalise(zdir);
 
-		vec3 xdir;
-		if ( fabs(zdir % vec3(1,0,0)) > 0.9 ) xdir = vec3(0,1,0);
-		else xdir = vec3(1,0,0);
-		vec3 ydir = zdir * xdir;
-		xdir = ydir * zdir;
+        vec3 xdir;
+        if (fabs(zdir % vec3(1, 0, 0)) > 0.9) xdir = vec3(0, 1, 0);
+        else xdir = vec3(1, 0, 0);
+        vec3 ydir = zdir * xdir;
+        xdir = ydir * zdir;
 
-		mat3 r(xdir, ydir, zdir);
-		approachTran.set(r, aPt);
-	}
-	addApproachGeometry();
+        mat3 r(xdir, ydir, zdir);
+        approachTran.set(r, aPt);
+    }
+    addApproachGeometry();
 
-	//load EigenGrasps
-	mEigenGrasps = new EigenGraspInterface(this);
-	bool eigenLoaded = false;
-	element = findXmlElement(root,"eigenGrasps");
-	if(element) {
-		valueStr = element->GetText();
-		valueStr = valueStr.stripWhiteSpace();
-		QString eigenFile = rootPath + valueStr;
-		if (loadEigenData(eigenFile)==SUCCESS) {
-			DBGA("Using eigengrasps from file: " << valueStr.latin1());
-			eigenLoaded = true;
-		}
-	}
-	if (!eigenLoaded) {
-		mEigenGrasps->setTrivial();
-		DBGA("Using identity eigengrasps");
-	}
+    //load EigenGrasps
+    mEigenGrasps = new EigenGraspInterface(this);
+    bool eigenLoaded = false;
+    element = findXmlElement(root, "eigenGrasps");
+    if (element) {
+        valueStr = element->GetText();
+        valueStr = valueStr.stripWhiteSpace();
+        QString eigenFile = rootPath + valueStr;
+        if (loadEigenData(eigenFile) == SUCCESS) {
+            DBGA("Using eigengrasps from file: " << valueStr.latin1());
+            eigenLoaded = true;
+        }
+    }
+    if (!eigenLoaded) {
+        mEigenGrasps->setTrivial();
+        DBGA("Using identity eigengrasps");
+    }
 
-	//load pre-defined, "virtual" contact locations
-	element = findXmlElement(root,"virtualContacts");
-	if(element){
-		valueStr = element->GetText();
-		valueStr = valueStr.stripWhiteSpace();
-		QString contactFile = rootPath + valueStr;
-		if (loadContactData(contactFile)==SUCCESS) {
-			DBGA("Loaded virtual contacts from file " << valueStr.latin1());
-			showVirtualContacts(true);
-		} else {
-			DBGA("Failed to load virtual contacts from file " << valueStr.latin1());
-		}
-	}
+    //load pre-defined, "virtual" contact locations
+    element = findXmlElement(root, "virtualContacts");
+    if (element) {
+        valueStr = element->GetText();
+        valueStr = valueStr.stripWhiteSpace();
+        QString contactFile = rootPath + valueStr;
+        if (loadContactData(contactFile) == SUCCESS) {
+            DBGA("Loaded virtual contacts from file " << valueStr.latin1());
+            showVirtualContacts(true);
+        }
+        else {
+            DBGA("Failed to load virtual contacts from file " << valueStr.latin1());
+        }
+    }
 
-	//load CyberGlove information
-	mUseCyberGlove = false;
-	element = findXmlElement(root,"cyberGlove");
-	if(element){
-		valueStr = element->GetText();
-		valueStr = valueStr.stripWhiteSpace();
-		mGloveInterface = new GloveInterface(this);
-		QString calibFile = rootPath + valueStr;
-		if (!mGloveInterface->loadCalibration(calibFile.latin1())) {
-			DBGA("Failed to load glove calibration file " << calibFile.latin1());
-			delete mGloveInterface; mGloveInterface = NULL;
-			mUseCyberGlove = false;
-		} else {
-			DBGA("Cyberglove calibration loaded from " << calibFile.latin1());
-			mUseCyberGlove = true;
-		}
-	}
+    //load CyberGlove information
+    mUseCyberGlove = false;
+    element = findXmlElement(root, "cyberGlove");
+    if (element) {
+        valueStr = element->GetText();
+        valueStr = valueStr.stripWhiteSpace();
+        mGloveInterface = new GloveInterface(this);
+        QString calibFile = rootPath + valueStr;
+        if (!mGloveInterface->loadCalibration(calibFile.latin1())) {
+            DBGA("Failed to load glove calibration file " << calibFile.latin1());
+            delete mGloveInterface;
+            mGloveInterface = NULL;
+            mUseCyberGlove = false;
+        }
+        else {
+            DBGA("Cyberglove calibration loaded from " << calibFile.latin1());
+            mUseCyberGlove = true;
+        }
+    }
 
-	//load flock of birds information
-	element = findXmlElement(root,"flockOfBirds");
-	if(element){
-		QString birdNumber = element->Attribute("number");
-		if(birdNumber.isNull()){
-			DBGA("There was a problem reading the Flock of Birds data in the configuration file");
-			return FAILURE;
-		}
-		birdNumber = birdNumber.stripWhiteSpace();
-		mBirdNumber = birdNumber.toInt();
-		transf sensorTrans;
-		const TiXmlElement* tmp = findXmlElement(element,"transform");
-		if(!getTransform(tmp, sensorTrans)){
-			DBGA("There was a problem reading the Flock of Birds data in the configuration file");
-			return FAILURE;
-		}		
-		mFlockTran.identity();
-		mFlockTran.setMount(sensorTrans);
-		mUsesFlock = true;
-		DBGA("Robot using Flock of Birds sensor " << mBirdNumber);
-	}
-	if (mUsesFlock) {
-		addFlockSensorGeometry();
-	}
-	return SUCCESS;
+    //load flock of birds information
+    element = findXmlElement(root, "flockOfBirds");
+    if (element) {
+        QString birdNumber = element->Attribute("number");
+        if (birdNumber.isNull()) {
+            DBGA("There was a problem reading the Flock of Birds data in the configuration file");
+            return FAILURE;
+        }
+        birdNumber = birdNumber.stripWhiteSpace();
+        mBirdNumber = birdNumber.toInt();
+        transf sensorTrans;
+        const TiXmlElement *tmp = findXmlElement(element, "transform");
+        if (!getTransform(tmp, sensorTrans)) {
+            DBGA("There was a problem reading the Flock of Birds data in the configuration file");
+            return FAILURE;
+        }
+        mFlockTran.identity();
+        mFlockTran.setMount(sensorTrans);
+        mUsesFlock = true;
+        DBGA("Robot using Flock of Birds sensor " << mBirdNumber);
+    }
+    if (mUsesFlock) {
+        addFlockSensorGeometry();
+    }
+    return SUCCESS;
 }
 
 /*! Loads the eigengrasp information from the file \a filename. */
 int
-Robot::loadEigenData(QString filename)
-{
-	if ( !mEigenGrasps->readFromFile(filename.latin1()) ) {
-		DBGA("Unable to load eigenGrasp file " << filename.latin1());
-		return FAILURE;
-	}
-	QString name = filename.section('/',-1,-1);
-	name = name.section('.',0,0);
-	mEigenGrasps->setName(name);
-	return SUCCESS;
+Robot::loadEigenData(QString filename) {
+    if (!mEigenGrasps->readFromFile(filename.latin1())) {
+        DBGA("Unable to load eigenGrasp file " << filename.latin1());
+        return FAILURE;
+    }
+    QString name = filename.section('/', -1, -1);
+    name = name.section('.', 0, 0);
+    mEigenGrasps->setName(name);
+    return SUCCESS;
 }
 
 /*! Loads all the virtual contacts specified in the file \a filename
 */
-int 
-Robot::loadContactData(QString filename)
-{
-  FILE *fp = fopen(filename.latin1(), "r");
-  if (!fp) {
-    DBGA("Could not open contact file " << filename.latin1());
-    return FAILURE;
-  }
-  
-  char robotName[500];
-  ; //yes, I know, can seg fault...
-  if(fscanf(fp,"%s",robotName) <= 0)
-    {
-      DBGA("Robot::loadContactData - failed to read robot name");
-      return 0;
+int
+Robot::loadContactData(QString filename) {
+    FILE *fp = fopen(filename.latin1(), "r");
+    if (!fp) {
+        DBGA("Could not open contact file " << filename.latin1());
+        return FAILURE;
     }
-  
-  int numContacts;
-  if( fscanf(fp,"%d",&numContacts) <= 0){
-    DBGA("Robot::loadContactData - failed to read number of contacts");
-    return -1;
-  }
 
-  for (int i=0; i<numContacts; i++) {
-    VirtualContact* newContact = new VirtualContact();
-    newContact->readFromFile(fp);    
-    int f = newContact->getFingerNum();
-    int l = newContact->getLinkNum();
-    if ( f >= 0) {
-      if ( f>=getNumChains() || l>=getChain(f)->getNumLinks()) {
-        DBGA("Virtual contact error, chain " << f << " link " << l << " does not exist");
-        delete newContact;
-        continue;
-      }
-      newContact->setBody( getChain(f)->getLink(l) );
-      getChain(f)->getLink(l)->addVirtualContact( newContact );
+    char robotName[500];
+    ; //yes, I know, can seg fault...
+    if (fscanf(fp, "%s", robotName) <= 0) {
+        DBGA("Robot::loadContactData - failed to read robot name");
+        return 0;
     }
-    else {
-      newContact->setBody( getBase() );
-      getBase()->addVirtualContact(newContact);
+
+    int numContacts;
+    if (fscanf(fp, "%d", &numContacts) <= 0) {
+        DBGA("Robot::loadContactData - failed to read number of contacts");
+        return -1;
     }
-    newContact->computeWrenches(false,false);
-  }
-  fclose(fp);
-  return SUCCESS;
+
+    for (int i = 0; i < numContacts; i++) {
+        VirtualContact *newContact = new VirtualContact();
+        newContact->readFromFile(fp);
+        int f = newContact->getFingerNum();
+        int l = newContact->getLinkNum();
+        if (f >= 0) {
+            if (f >= getNumChains() || l >= getChain(f)->getNumLinks()) {
+                DBGA("Virtual contact error, chain " << f << " link " << l << " does not exist");
+                delete newContact;
+                continue;
+            }
+            newContact->setBody(getChain(f)->getLink(l));
+            getChain(f)->getLink(l)->addVirtualContact(newContact);
+        }
+        else {
+            newContact->setBody(getBase());
+            getBase()->addVirtualContact(newContact);
+        }
+        newContact->computeWrenches(false, false);
+    }
+    fclose(fp);
+    return SUCCESS;
 }
 
 /*! This robot becomes a "clone" of another robot, specified in \a original.
-This means that the new robot has its own kinematic structure, DOF's, etc
-but its links share the geometry of the original robot. See the clone 
-function in the Body class for details on how that works.
+    This means that the new robot has its own kinematic structure, DOF's, etc
+    but its links share the geometry of the original robot. See the clone
+    function in the Body class for details on how that works.
 
-This is generally used for multi-threading, if you want to do spread the 
-computations done on a robot to multiple cores. You then create multiple
-clones of your robot and pass one to each thread. See the threading 
-documentation in the collision detection classes for details.
+    This is generally used for multi-threading, if you want to do spread the
+    computations done on a robot to multiple cores. You then create multiple
+    clones of your robot and pass one to each thread. See the threading
+    documentation in the collision detection classes for details.
 */
 void
-Robot::cloneFrom(Robot *original)
-{
-	myName = original->getName() + QString(" clone");
+Robot::cloneFrom(Robot *original) {
+    myName = original->getName() + QString(" clone");
 
-	//new robots have contact indicators disabled by default
-	if (base) delete base;
-	base = new Link(this,-1,-1,myWorld,(QString(name())+"Base").latin1());
-	base->cloneFrom( original->getBase() );
-	//base->initDynamics();
-	IVRoot = new SoSeparator;
-	IVRoot->addChild(base->getIVRoot());
+    //new robots have contact indicators disabled by default
+    if (base) delete base;
+    base = new Link(this, -1, -1, myWorld, (QString(name()) + "Base").latin1());
+    base->cloneFrom(original->getBase());
+    //base->initDynamics();
+    IVRoot = new SoSeparator;
+    IVRoot->addChild(base->getIVRoot());
 
-	numDOF = original->getNumDOF();
-	dofVec.resize(numDOF, NULL);
-	for (int f=0; f<numDOF; f++) {
-		switch(original->getDOF(f)->getType()) {
-			case DOF::RIGID:
-				dofVec[f] = new RigidDOF( (RigidDOF*)(original->getDOF(f)) );
-				break;
-			case DOF::BREAKAWAY:
-				dofVec[f] = new BreakAwayDOF( (BreakAwayDOF*)(original->getDOF(f)) );
-				break;
-			case DOF::COMPLIANT:
-				dofVec[f] = new CompliantDOF( (CompliantDOF*)(original->getDOF(f)) );
-				break;
-			default:
-				DBGA("ERROR: Unknown DOF type in original!");
-				assert(0);
-		}
-	}
+    numDOF = original->getNumDOF();
+    dofVec.resize(numDOF, NULL);
+    for (int f = 0; f < numDOF; f++) {
+        switch (original->getDOF(f)->getType()) {
+            case DOF::RIGID:
+                dofVec[f] = new RigidDOF((RigidDOF *)(original->getDOF(f)));
+                break;
+            case DOF::BREAKAWAY:
+                dofVec[f] = new BreakAwayDOF((BreakAwayDOF *)(original->getDOF(f)));
+                break;
+            case DOF::COMPLIANT:
+                dofVec[f] = new CompliantDOF((CompliantDOF *)(original->getDOF(f)));
+                break;
+            default:
+                DBGA("ERROR: Unknown DOF type in original!");
+                assert(0);
+        }
+    }
 
-	numChains = original->getNumChains();
-	chainVec.resize(numChains, NULL);
-	numJoints = 0;
-	for (int f=0; f<numChains; f++) {
-		chainVec[f] = new KinematicChain(this,f,numJoints);
-		chainVec[f]->cloneFrom( original->getChain(f) );
-		numJoints += chainVec[f]->getNumJoints();
-	}
-	assert (numJoints == original->getNumJoints() );
+    numChains = original->getNumChains();
+    chainVec.resize(numChains, NULL);
+    numJoints = 0;
+    for (int f = 0; f < numChains; f++) {
+        chainVec[f] = new KinematicChain(this, f, numJoints);
+        chainVec[f]->cloneFrom(original->getChain(f));
+        numJoints += chainVec[f]->getNumJoints();
+    }
+    assert(numJoints == original->getNumJoints());
 
     std::vector<Joint *>jointList;
-	for (int d=0; d<numDOF; d++) {
-		jointList.clear();
-		for (int f=0; f<numChains; f++) {
-			for (int j=0; j<chainVec[f]->getNumJoints(); j++) {
-				if (chainVec[f]->getJoint(j)->getDOFNum() == d) {
-					jointList.push_back(chainVec[f]->getJoint(j));
-				}
-			}
-		}
-		dofVec[d]->initDOF(this,jointList);
-	}
-        //with DOF initialized with joints, we can set default values
-        forceDefaultDOFVals();
+    for (int d = 0; d < numDOF; d++) {
+        jointList.clear();
+        for (int f = 0; f < numChains; f++) {
+            for (int j = 0; j < chainVec[f]->getNumJoints(); j++) {
+                if (chainVec[f]->getJoint(j)->getDOFNum() == d) {
+                    jointList.push_back(chainVec[f]->getJoint(j));
+                }
+            }
+        }
+        dofVec[d]->initDOF(this, jointList);
+    }
+    //with DOF initialized with joints, we can set default values
+    forceDefaultDOFVals();
 
-	base->setTran(transf::IDENTITY);
-	//careful: clones robots have never been tested with the dynamics engine
-	getBase()->fix();
-	for (int i=0; i<getNumDOF(); i++) {
-		getDOF(i)->setDesiredPos( getDOF(i)->getVal() );
-	}
+    base->setTran(transf::IDENTITY);
+    //careful: clones robots have never been tested with the dynamics engine
+    getBase()->fix();
+    for (int i = 0; i < getNumDOF(); i++) {
+        getDOF(i)->setDesiredPos(getDOF(i)->getVal());
+    }
 
-	setRenderGeometry( original->getRenderGeometry() );
+    setRenderGeometry(original->getRenderGeometry());
 
-	//check if original has an approach tran
-	approachTran = original->getApproachTran();
-	addApproachGeometry();
+    //check if original has an approach tran
+    approachTran = original->getApproachTran();
+    addApproachGeometry();
 
-	//clone eigengrasp interface
-	mEigenGrasps = new EigenGraspInterface(original->getEigenGrasps());
+    //clone eigengrasp interface
+    mEigenGrasps = new EigenGraspInterface(original->getEigenGrasps());
 
-	//no glove interface
-	mGloveInterface = NULL;
-	this->mUseCyberGlove = false;
+    //no glove interface
+    mGloveInterface = NULL;
+    this->mUseCyberGlove = false;
 }
 
 /*! Sets the transparency of all the links that make up this robot,
-as well as the base
+    as well as the base
 */
 void
-Robot::setTransparency(float t)
-{
-	base->setTransparency(t);
-	for (int i=0; i<getNumChains(); i++) {
-		for (int l=0; l<getChain(i)->getNumLinks(); l++) {
-			getChain(i)->getLink(l)->setTransparency(t);
-		}
-	}
+Robot::setTransparency(float t) {
+    base->setTransparency(t);
+    for (int i = 0; i < getNumChains(); i++) {
+        for (int l = 0; l < getChain(i)->getNumLinks(); l++) {
+            getChain(i)->getLink(l)->setTransparency(t);
+        }
+    }
 }
 
 /*! Sets the name \a newName for the robot, as well as derived names of the form
-newName_chain#_link# for the links and newName_base for the base.
+    newName_chain#_link# for the links and newName_base for the base.
 */
 void
-Robot::setName(QString newName)
-{
-	WorldElement::setName(newName);
-	for (int c=0; c<getNumChains(); c++) {
-		for (int l=0; l<getChain(c)->getNumLinks(); l++){
-			getChain(c)->getLink(l)->setName( newName + QString("_chain%1_link%2").arg(c).arg(l) );
-		}
-	}
-	if (base) base->setName(newName + QString("_base"));
+Robot::setName(QString newName) {
+    WorldElement::setName(newName);
+    for (int c = 0; c < getNumChains(); c++) {
+        for (int l = 0; l < getChain(c)->getNumLinks(); l++) {
+            getChain(c)->getLink(l)->setName(newName + QString("_chain%1_link%2").arg(c).arg(l));
+        }
+    }
+    if (base) base->setName(newName + QString("_base"));
 }
 
 /*! Adds an arrow that shows the pre-defined approach direction for this
-robot. The arrow is rooted at the origin of the approach direction and
-points in the z direction of mApproachTran
+    robot. The arrow is rooted at the origin of the approach direction and
+    points in the z direction of mApproachTran
 */
 void
-Robot::addApproachGeometry()
-{	
-	IVApproachRoot = new SoSeparator();
-	
-	SoTransform *t1 = new SoTransform();
-	approachTran.toSoTransform(t1);
-	IVApproachRoot->addChild(t1);
+Robot::addApproachGeometry() {
+    IVApproachRoot = new SoSeparator();
 
-	SoArrow *arrow = new SoArrow;
-	arrow->height = 14;
-	arrow->cylRadius = (float)1.25;
-	arrow->coneRadius = (float)2.6;
-	arrow->coneHeight = (float)5.5;
-	SoTransform *arrowTran = new SoTransform();
-	arrowTran->rotation.setValue(SbVec3f(1,0,0),(float)(M_PI/2.0));
-	IVApproachRoot->addChild(arrowTran);
-	IVApproachRoot->addChild(arrow);
+    SoTransform *t1 = new SoTransform();
+    approachTran.toSoTransform(t1);
+    IVApproachRoot->addChild(t1);
 
-	getBase()->getIVRoot()->addChild(IVApproachRoot);	
+    SoArrow *arrow = new SoArrow;
+    arrow->height = 14;
+    arrow->cylRadius = (float)1.25;
+    arrow->coneRadius = (float)2.6;
+    arrow->coneHeight = (float)5.5;
+    SoTransform *arrowTran = new SoTransform();
+    arrowTran->rotation.setValue(SbVec3f(1, 0, 0), (float)(M_PI / 2.0));
+    IVApproachRoot->addChild(arrowTran);
+    IVApproachRoot->addChild(arrow);
+
+    getBase()->getIVRoot()->addChild(IVApproachRoot);
 }
 
 /*! Adds a visual marker that shows where on the robot the Flock of Birds
-sensor is mounted. Uses the mounting information stored in the
-mFlockTran, which is usually pre-defined in the robot file
+    sensor is mounted. Uses the mounting information stored in the
+    mFlockTran, which is usually pre-defined in the robot file
 */
 void
-Robot::addFlockSensorGeometry()
-{
-	IVFlockRoot = new SoSeparator();
-	SoTransform *t = new SoTransform();
-	mFlockTran.getMount().toSoTransform( t );
-	IVFlockRoot->addChild(t);
-	SoCube *cube = new SoCube();
-	cube->width = 30;
-	cube->height = 20;
-	cube->depth = 4;
-	IVFlockRoot->addChild(cube);
-	SoCube *smallCube = new SoCube();
-	smallCube->width = 10;
-	smallCube->height = 20;
-	smallCube->depth = 6;
-	SoTransform *t2 = new SoTransform();
-	t2->translation.setValue(10,0,-5);
-	IVFlockRoot->addChild(t2);
-	IVFlockRoot->addChild(smallCube);
-	getBase()->getIVRoot()->addChild(IVFlockRoot);
+Robot::addFlockSensorGeometry() {
+    IVFlockRoot = new SoSeparator();
+    SoTransform *t = new SoTransform();
+    mFlockTran.getMount().toSoTransform(t);
+    IVFlockRoot->addChild(t);
+    SoCube *cube = new SoCube();
+    cube->width = 30;
+    cube->height = 20;
+    cube->depth = 4;
+    IVFlockRoot->addChild(cube);
+    SoCube *smallCube = new SoCube();
+    smallCube->width = 10;
+    smallCube->height = 20;
+    smallCube->depth = 6;
+    SoTransform *t2 = new SoTransform();
+    t2->translation.setValue(10, 0, -5);
+    IVFlockRoot->addChild(t2);
+    IVFlockRoot->addChild(smallCube);
+    getBase()->getIVRoot()->addChild(IVFlockRoot);
 }
 
 /*! Sets the robot to use the trivial eigengrasps set, where each eigengrasp
-corresponds to a single DOF with an amplitude of 1.0. In this case, there
-is no difference between seting EG's and using DOF's directly.
+    corresponds to a single DOF with an amplitude of 1.0. In this case, there
+    is no difference between seting EG's and using DOF's directly.
 */
 int
-Robot::useIdentityEigenData()
-{
-	if (!mEigenGrasps->setTrivial()) {
-		QTWARNING("Error setting Identity EigenGrasps");
-		return FAILURE;
-	}
-	return SUCCESS;
+Robot::useIdentityEigenData() {
+    if (!mEigenGrasps->setTrivial()) {
+        QTWARNING("Error setting Identity EigenGrasps");
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 /*! Tells the robot which CyberGlove the raw sensor data is coming from. The robot
-does not process raw data directly, just passes it to the mGloveInterface which
-hodsl calibration and DOF mapping between a raw Glove and this particular robot
+    does not process raw data directly, just passes it to the mGloveInterface which
+    hodsl calibration and DOF mapping between a raw Glove and this particular robot
 */
-void Robot::setGlove(CyberGlove *glove)
-{
-	if (!mGloveInterface) {
-		mUseCyberGlove = false;
-		return;
-	}
-	mGloveInterface->setGlove(glove);
+void Robot::setGlove(CyberGlove *glove) {
+    if (!mGloveInterface) {
+        mUseCyberGlove = false;
+        return;
+    }
+    mGloveInterface->setGlove(glove);
 }
 
 /*! Sets the values of the DOF's based on the information from the mGloveInterface,
-which has presumably processed a new batch of raw information from a
-real CyberGlove
+    which has presumably processed a new batch of raw information from a
+    real CyberGlove
 */
 void
-Robot::processCyberGlove()
-{
-	int i;
-	double *desiredVals = new double[getNumDOF()];
-	for (i=0; i<getNumDOF(); i++) {
-		if ( mGloveInterface->isDOFControlled(i) ) {
-			desiredVals[i] = mGloveInterface->getDOFValue(i);
-			if ( desiredVals[i] < getDOF(i)->getMin() ) desiredVals[i] = getDOF(i)->getMin();
-			if ( desiredVals[i] > getDOF(i)->getMax() ) desiredVals[i] = getDOF(i)->getMax();
-		}
-		else {
-			desiredVals[i] = getDOF(i)->getVal();
-		}
-	}
-	moveDOFToContacts(desiredVals, NULL, false);
-	emitConfigChange();
-	delete [] desiredVals;
+Robot::processCyberGlove() {
+    int i;
+    double *desiredVals = new double[getNumDOF()];
+    for (i = 0; i < getNumDOF(); i++) {
+        if (mGloveInterface->isDOFControlled(i)) {
+            desiredVals[i] = mGloveInterface->getDOFValue(i);
+            if (desiredVals[i] < getDOF(i)->getMin()) desiredVals[i] = getDOF(i)->getMin();
+            if (desiredVals[i] > getDOF(i)->getMax()) desiredVals[i] = getDOF(i)->getMax();
+        }
+        else {
+            desiredVals[i] = getDOF(i)->getVal();
+        }
+    }
+    moveDOFToContacts(desiredVals, NULL, false);
+    emitConfigChange();
+    delete [] desiredVals;
 }
 
 /*!
-Given the body filename of a mountpiece, this will load it into the
-world and connect it to the base of this robot.
+    Given the body filename of a mountpiece, this will load it into the
+    world and connect it to the base of this robot.
 */
 Link *
-Robot::importMountPiece(QString filename)
-{
-	QString mountName = QString(name())+"_mount";
-	mountPiece = new Link(this,-1,-1,myWorld,mountName.latin1());
-	if (mountPiece->load(filename)==FAILURE){
-		delete mountPiece; mountPiece = NULL; return NULL;
-	}
-	mountPiece->addToIvc();
-	IVRoot->addChild(mountPiece->getIVRoot());
-	mountPiece->setTran(base->getTran());
-	base->setDynJoint(new FixedDynJoint(mountPiece,base));
-	return mountPiece;
+Robot::importMountPiece(QString filename) {
+    QString mountName = QString(name()) + "_mount";
+    mountPiece = new Link(this, -1, -1, myWorld, mountName.latin1());
+    if (mountPiece->load(filename) == FAILURE) {
+        delete mountPiece;
+        mountPiece = NULL;
+        return NULL;
+    }
+    mountPiece->addToIvc();
+    IVRoot->addChild(mountPiece->getIVRoot());
+    mountPiece->setTran(base->getTran());
+    base->setDynJoint(new FixedDynJoint(mountPiece, base));
+    return mountPiece;
 }
 
 /*! Adds all the bodies associated with this robot (links, base, mountpiece,
-attached robots) to the given vector of bodies.
+    attached robots) to the given vector of bodies.
 */
-void 
-Robot::getBodyList(std::vector<Body*> *bodies)
-{
-	if (base) bodies->push_back(base);
-	if (mountPiece) bodies->push_back(mountPiece);
-	for (int c=0; c<numChains; c++) {
-		for (int l=0; l<chainVec[c]->getNumLinks(); l++) {
-			bodies->push_back(chainVec[c]->getLink(l));
-		}
-	}
-	for (int c=0; c<numChains; c++) {
-		for (int i=0; i<chainVec[c]->getNumAttachedRobots(); i++) {
-			chainVec[c]->getAttachedRobot(i)->getBodyList(bodies);
-		}
-	}
+void
+Robot::getBodyList(std::vector<Body *> *bodies) {
+    if (base) bodies->push_back(base);
+    if (mountPiece) bodies->push_back(mountPiece);
+    for (int c = 0; c < numChains; c++) {
+        for (int l = 0; l < chainVec[c]->getNumLinks(); l++) {
+            bodies->push_back(chainVec[c]->getLink(l));
+        }
+    }
+    for (int c = 0; c < numChains; c++) {
+        for (int i = 0; i < chainVec[c]->getNumAttachedRobots(); i++) {
+            chainVec[c]->getAttachedRobot(i)->getBodyList(bodies);
+        }
+    }
 }
 
 /*!
-Returns a vector of all links associated with this robot including
-all links in all chains, the base, and the mountpiece.
+    Returns a vector of all links associated with this robot including
+    all links in all chains, the base, and the mountpiece.
 */
 void
-Robot::getAllLinks(std::vector<DynamicBody *> &allLinkVec)
-{
-	int c,l,i;
-	if (base) allLinkVec.push_back(base);
-	if (mountPiece) allLinkVec.push_back(mountPiece);
+Robot::getAllLinks(std::vector<DynamicBody *> &allLinkVec) {
+    int c, l, i;
+    if (base) allLinkVec.push_back(base);
+    if (mountPiece) allLinkVec.push_back(mountPiece);
 
-	for (c=0;c<numChains;c++)
-		for (l=0;l<chainVec[c]->getNumLinks();l++)
-			allLinkVec.push_back(chainVec[c]->getLink(l));
-	for (c=0;c<numChains;c++)
-		for (i=0;i<chainVec[c]->getNumAttachedRobots();i++)
-			chainVec[c]->getAttachedRobot(i)->getAllLinks(allLinkVec);
+    for (c = 0; c < numChains; c++)
+        for (l = 0; l < chainVec[c]->getNumLinks(); l++)
+            allLinkVec.push_back(chainVec[c]->getLink(l));
+    for (c = 0; c < numChains; c++)
+        for (i = 0; i < chainVec[c]->getNumAttachedRobots(); i++)
+            chainVec[c]->getAttachedRobot(i)->getAllLinks(allLinkVec);
 }
 
 /*!
-Returns a pointer to this robot and recursively, all child robots
-connected to this one
+    Returns a pointer to this robot and recursively, all child robots
+    connected to this one
 */
 void
-Robot::getAllAttachedRobots(std::vector<Robot *> &robotVec)
-{
-	robotVec.push_back(this);
-	for (int c=0;c<numChains;c++) {
-		for (int i=0;i<chainVec[c]->getNumAttachedRobots();i++) {
-			chainVec[c]->getAttachedRobot(i)->getAllAttachedRobots(robotVec);
-		}
-	}
+Robot::getAllAttachedRobots(std::vector<Robot *> &robotVec) {
+    robotVec.push_back(this);
+    for (int c = 0; c < numChains; c++) {
+        for (int i = 0; i < chainVec[c]->getNumAttachedRobots(); i++) {
+            chainVec[c]->getAttachedRobot(i)->getAllAttachedRobots(robotVec);
+        }
+    }
 }
 
 
 /*!
-  Given a pointer to a robot, the number of the chain on this robot to
-  connect the new robot to, and the offset transform between the chain end
-  and the base of the new robot, this will attach the new robot to this
-  robot's chain end.
+    Given a pointer to a robot, the number of the chain on this robot to
+    connect the new robot to, and the offset transform between the chain end
+    and the base of the new robot, this will attach the new robot to this
+    robot's chain end.
 
-  Also disables collision between the link of this robot that the other
-  robot is attached to and the base of the other robot as well as the mount
-  piece.
+    Also disables collision between the link of this robot that the other
+    robot is attached to and the base of the other robot as well as the mount
+    piece.
 */
 void
-Robot::attachRobot(Robot *r,int chainNum,const transf &offsetTr)
-{
-  r->parent = this;
-  r->parentChainNum = chainNum;
-  r->tranToParentEnd = offsetTr.inverse();
-  chainVec[chainNum]->attachRobot(r,offsetTr);
+Robot::attachRobot(Robot *r, int chainNum, const transf &offsetTr) {
+    r->parent = this;
+    r->parentChainNum = chainNum;
+    r->tranToParentEnd = offsetTr.inverse();
+    chainVec[chainNum]->attachRobot(r, offsetTr);
 
-  Link *lastLink = chainVec[chainNum]->getLink(chainVec[chainNum]->getNumLinks()-1);
-  myWorld->toggleCollisions(false, lastLink, r->getBase());
-  if (r->getMountPiece()) {
-	  myWorld->toggleCollisions(false, lastLink, r->getMountPiece());
-  }
+    Link *lastLink = chainVec[chainNum]->getLink(chainVec[chainNum]->getNumLinks() - 1);
+    myWorld->toggleCollisions(false, lastLink, r->getBase());
+    if (r->getMountPiece()) {
+        myWorld->toggleCollisions(false, lastLink, r->getMountPiece());
+    }
 }
 
 
 /*!
-The detaches the robot pointed to by \a r from this robot so that they may
-move independently.
+    The detaches the robot pointed to by \a r from this robot so that they may
+    move independently.
 */
 void
-Robot::detachRobot(Robot *r)
-{
-	DBGA("Detaching Robot " << r->getName().latin1() << " from " << getName().latin1());
-	r->parent = NULL;
-	chainVec[r->parentChainNum]->detachRobot(r);
+Robot::detachRobot(Robot *r) {
+    DBGA("Detaching Robot " << r->getName().latin1() << " from " << getName().latin1());
+    r->parent = NULL;
+    chainVec[r->parentChainNum]->detachRobot(r);
 }
 
 
 /*!
-Given an array of DOF values equal in length to the number of DOFs in
-this robot, and the chain number for which the  kinematics should be
-computed, this will return a vector of transforms corresponding to
-the pose of each link in the chain.
+    Given an array of DOF values equal in length to the number of DOFs in
+    this robot, and the chain number for which the  kinematics should be
+    computed, this will return a vector of transforms corresponding to
+    the pose of each link in the chain.
 */
 void
-Robot::fwdKinematics(double* dofVals,std::vector<transf>& trVec,int chainNum)
-{
-	double *jointVals = new double[numJoints];
-	getJointValues(jointVals);
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->accumulateMove(dofVals[d], jointVals, NULL);
-	}
-	chainVec[chainNum]->fwdKinematics(jointVals,trVec);
-	delete [] jointVals;
+Robot::fwdKinematics(double *dofVals, std::vector<transf> &trVec, int chainNum) {
+    double *jointVals = new double[numJoints];
+    getJointValues(jointVals);
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->accumulateMove(dofVals[d], jointVals, NULL);
+    }
+    chainVec[chainNum]->fwdKinematics(jointVals, trVec);
+    delete [] jointVals;
 }
 
 /*! Given a transform for the end pose of a particular kinematic chain,
-	this will compute the DOF values corresponding to that pose.
-	It will use an iterative approximation technique. In this method,
-	the jacobian is based on each dofs rather than the joint angles
+    this will compute the DOF values corresponding to that pose.
+    It will use an iterative approximation technique. In this method,
+    the jacobian is based on each dofs rather than the joint angles
 */
 int
-Robot::invKinematics(const transf& targetPos, double* dofVals, int chainNum)
-{
-	//upperBound constrains the change of the joint values in radian
-	//epsilon is the upper bound for a joint delta value in radian to check the convergence
-	double factor = 0, epsilon = 0.0001, upperBound = 0.2;
-	const int safeGuardUpperBound = 200;
-	Matrix deltaPR(6,1); // the difference of the position and the orientation
-	deltaPR.setAllElements(1.0);
-	Matrix deltaDOF(numDOF, 1); // the delta of dof value in this robot
-	std::vector<double> currentDOFVals(numDOF);
+Robot::invKinematics(const transf &targetPos, double *dofVals, int chainNum) {
+    //upperBound constrains the change of the joint values in radian
+    //epsilon is the upper bound for a joint delta value in radian to check the convergence
+    double factor = 0, epsilon = 0.0001, upperBound = 0.2;
+    const int safeGuardUpperBound = 200;
+    Matrix deltaPR(6, 1); // the difference of the position and the orientation
+    deltaPR.setAllElements(1.0);
+    Matrix deltaDOF(numDOF, 1); // the delta of dof value in this robot
+    std::vector<double> currentDOFVals(numDOF);
 
-	for(int i = 0; i < numDOF; ++i){
-		//get the dof vals for inverse kinematics computation
-		currentDOFVals[i] = dofVec[i]->getVal();
-		//get the dof vals, for later comparison and decision
-		dofVals[i] = dofVec[i]->getVal();
-	}
+    for (int i = 0; i < numDOF; ++i) {
+        //get the dof vals for inverse kinematics computation
+        currentDOFVals[i] = dofVec[i]->getVal();
+        //get the dof vals, for later comparison and decision
+        dofVals[i] = dofVec[i]->getVal();
+    }
 
-	std::vector<transf> fwdK;
-	fwdK.resize(chainVec[chainNum]->getNumLinks(), transf::IDENTITY);
-	transf currentPos;
+    std::vector<transf> fwdK;
+    fwdK.resize(chainVec[chainNum]->getNumLinks(), transf::IDENTITY);
+    transf currentPos;
 
-	// forwardKinematics only calculates the forward kinematics with respect to the base
-	// of the robot, did not consider the transformation from world origin to the base
-	
-	fwdKinematics(&currentDOFVals[0], fwdK, chainNum);
-	currentPos = fwdK[chainVec[chainNum]->getNumLinks() - 1];
+    // forwardKinematics only calculates the forward kinematics with respect to the base
+    // of the robot, did not consider the transformation from world origin to the base
 
-	DBGP("from: " << currentPos.translation().x() << " " <<
-		currentPos.translation().y() << " " <<
-		currentPos.translation().z() << " " <<
-		currentPos.rotation().w << " " <<
-		currentPos.rotation().x << " " <<
-		currentPos.rotation().y << " " <<
-		currentPos.rotation().z);
+    fwdKinematics(&currentDOFVals[0], fwdK, chainNum);
+    currentPos = fwdK[chainVec[chainNum]->getNumLinks() - 1];
 
-	DBGP("to: " << targetPos.translation().x() << " " <<
-		targetPos.translation().y() << " " <<
-		targetPos.translation().z() << " " <<
-		targetPos.rotation().w << " " <<
-		targetPos.rotation().x << " " <<
-		targetPos.rotation().y << " " <<
-		targetPos.rotation().z);
+    DBGP("from: " << currentPos.translation().x() << " " <<
+         currentPos.translation().y() << " " <<
+         currentPos.translation().z() << " " <<
+         currentPos.rotation().w << " " <<
+         currentPos.rotation().x << " " <<
+         currentPos.rotation().y << " " <<
+         currentPos.rotation().z);
 
-	int safeguard = 0;
-	while(++safeguard < safeGuardUpperBound){
-		/* forwardKinematics calculates the forward kinematics with respect to the world
-		*/
-		fwdKinematics(&currentDOFVals[0], fwdK, chainNum);
-		currentPos = fwdK[chainVec[chainNum]->getNumLinks() - 1];
-		//compute the deltaPR, the difference of the position and orientation
-		vec3 dtLocation, dtOrientation;
-		dtLocation = targetPos.translation() - currentPos.translation();
+    DBGP("to: " << targetPos.translation().x() << " " <<
+         targetPos.translation().y() << " " <<
+         targetPos.translation().z() << " " <<
+         targetPos.rotation().w << " " <<
+         targetPos.rotation().x << " " <<
+         targetPos.rotation().y << " " <<
+         targetPos.rotation().z);
 
-		vec3 v1, v2;
-		mat3 m1, m2;
-		currentPos.rotation().ToRotationMatrix(m1);
-		targetPos.rotation().ToRotationMatrix(m2);
+    int safeguard = 0;
+    while (++safeguard < safeGuardUpperBound) {
+        /*  forwardKinematics calculates the forward kinematics with respect to the world
+        */
+        fwdKinematics(&currentDOFVals[0], fwdK, chainNum);
+        currentPos = fwdK[chainVec[chainNum]->getNumLinks() - 1];
+        //compute the deltaPR, the difference of the position and orientation
+        vec3 dtLocation, dtOrientation;
+        dtLocation = targetPos.translation() - currentPos.translation();
 
-		v1 = vec3(m1.element(0,0), m1.element(0,1), m1.element(0,2));
-		v2 = vec3(m2.element(0,0), m2.element(0,1), m2.element(0,2));
-		dtOrientation = v1 * v2;
-		v1 = vec3(m1.element(1,0), m1.element(1,1), m1.element(1,2));
-		v2 = vec3(m2.element(1,0), m2.element(1,1), m2.element(1,2));
-		dtOrientation += v1 * v2;
-		v1 = vec3(m1.element(2,0), m1.element(2,1), m1.element(2,2));
-		v2 = vec3(m2.element(2,0), m2.element(2,1), m2.element(2,2));
-		dtOrientation += v1 * v2;
-		dtOrientation *= 0.5;
+        vec3 v1, v2;
+        mat3 m1, m2;
+        currentPos.rotation().ToRotationMatrix(m1);
+        targetPos.rotation().ToRotationMatrix(m2);
 
-		deltaPR.elem(0,0) = dtLocation[0];
-		deltaPR.elem(1,0) = dtLocation[1];
-		deltaPR.elem(2,0) = dtLocation[2];
-		deltaPR.elem(3,0) = dtOrientation[0];
-		deltaPR.elem(4,0) = dtOrientation[1];
-		deltaPR.elem(5,0) = dtOrientation[2];
+        v1 = vec3(m1.element(0, 0), m1.element(0, 1), m1.element(0, 2));
+        v2 = vec3(m2.element(0, 0), m2.element(0, 1), m2.element(0, 2));
+        dtOrientation = v1 * v2;
+        v1 = vec3(m1.element(1, 0), m1.element(1, 1), m1.element(1, 2));
+        v2 = vec3(m2.element(1, 0), m2.element(1, 1), m2.element(1, 2));
+        dtOrientation += v1 * v2;
+        v1 = vec3(m1.element(2, 0), m1.element(2, 1), m1.element(2, 2));
+        v2 = vec3(m2.element(2, 0), m2.element(2, 1), m2.element(2, 2));
+        dtOrientation += v1 * v2;
+        dtOrientation *= 0.5;
 
-		Matrix m = chainVec[chainNum]->actuatedJacobian(chainVec[chainNum]->linkJacobian(true));
-		Matrix jointJacobian = m.getSubMatrix(m.rows() - 6, 0, 6, chainVec[chainNum]->getNumJoints());
-		Matrix jointToDOFJacobian = getJacobianJointToDOF(chainNum);
-		Matrix DOFJacobian = Matrix(jointJacobian.rows(), jointToDOFJacobian.cols());
-		matrixMultiply(jointJacobian, jointToDOFJacobian, DOFJacobian);
+        deltaPR.elem(0, 0) = dtLocation[0];
+        deltaPR.elem(1, 0) = dtLocation[1];
+        deltaPR.elem(2, 0) = dtLocation[2];
+        deltaPR.elem(3, 0) = dtOrientation[0];
+        deltaPR.elem(4, 0) = dtOrientation[1];
+        deltaPR.elem(5, 0) = dtOrientation[2];
 
-/*		for(int i = 0; i < DOFJacobian.rows(); ++i){
-			for(int j = 0; j < DOFJacobian.cols(); ++j){
-				DBGA(DOFJacobian.elem(i,j) << " ");
-			}
-			std::cout << std::endl;
-		}
+        Matrix m = chainVec[chainNum]->actuatedJacobian(chainVec[chainNum]->linkJacobian(true));
+        Matrix jointJacobian = m.getSubMatrix(m.rows() - 6, 0, 6, chainVec[chainNum]->getNumJoints());
+        Matrix jointToDOFJacobian = getJacobianJointToDOF(chainNum);
+        Matrix DOFJacobian = Matrix(jointJacobian.rows(), jointToDOFJacobian.cols());
+        matrixMultiply(jointJacobian, jointToDOFJacobian, DOFJacobian);
 
-		for(int i = 0; i < deltaPR.rows(); ++i){
-			for(int j = 0; j < deltaPR.cols(); ++j){
-				DBGA(deltaPR.elem(i,j) << " ");
-			}
-			DBGA("");
-		}
-*/
-		//underDeterminedSolveMPInv(DOFJacobian, deltaPR, deltaDOF);
-		underDeterminedSolveQR(DOFJacobian, deltaPR, deltaDOF);
-/*		std::cout << "results: \n";
-		for(int i = 0; i < deltaDOF.rows(); ++i){
-			for(int j = 0; j < deltaDOF.cols(); ++j){
-				std::cout << deltaDOF.elem(i,j) << " ";
-			}
-			std::cout << std::endl;
-		}
-*/
-		//apply the change to the robot and continue
-		for(int i = 0; i < numDOF; ++i){
-			//modify the dof's
-			currentDOFVals[i] += deltaDOF.elem(i,0);
-			//rounded the dof's within 360 degree
-			currentDOFVals[i] -= (int)(currentDOFVals[i]/(2*M_PI)) * 2 * M_PI;
-		}
+        /*      for(int i = 0; i < DOFJacobian.rows(); ++i){
+                    for(int j = 0; j < DOFJacobian.cols(); ++j){
+                        DBGA(DOFJacobian.elem(i,j) << " ");
+                    }
+                    std::cout << std::endl;
+                }
 
-		//check the maximum of the joint change
-		factor = -1.0;
-		for(int i = 0; i < deltaDOF.cols(); ++i){
-			factor = factor > fabs(deltaDOF.elem(i,0)) ? factor : fabs(deltaDOF.elem(i,0));
-		}
+                for(int i = 0; i < deltaPR.rows(); ++i){
+                    for(int j = 0; j < deltaPR.cols(); ++j){
+                        DBGA(deltaPR.elem(i,j) << " ");
+                    }
+                    DBGA("");
+                }
+        */
+        //underDeterminedSolveMPInv(DOFJacobian, deltaPR, deltaDOF);
+        underDeterminedSolveQR(DOFJacobian, deltaPR, deltaDOF);
+        /*      std::cout << "results: \n";
+                for(int i = 0; i < deltaDOF.rows(); ++i){
+                    for(int j = 0; j < deltaDOF.cols(); ++j){
+                        std::cout << deltaDOF.elem(i,j) << " ";
+                    }
+                    std::cout << std::endl;
+                }
+        */
+        //apply the change to the robot and continue
+        for (int i = 0; i < numDOF; ++i) {
+            //modify the dof's
+            currentDOFVals[i] += deltaDOF.elem(i, 0);
+            //rounded the dof's within 360 degree
+            currentDOFVals[i] -= (int)(currentDOFVals[i] / (2 * M_PI)) * 2 * M_PI;
+        }
 
-		//check the convergence
-		if(factor < epsilon){
-			for(int k = 0; k < numDOF; ++k){
-				//std::cout << "from: " << dofVals[k] << " to: " << currentJointVals[k];
-				//check if the joint value jumps to another one which is too far away of the previous one
-				if(fabs(dofVals[k] - currentDOFVals[k]) > upperBound){
-					std::cout << "exceeds the upper bound at DOF: " << k << " , jumping to another pose\n";
-					return FAILURE;
-				}
-				dofVals[k] = currentDOFVals[k];
-			}
-			break;
-		}
-	}
-	//check that all the joints are within the legal range
-	for(int i = 0; i < numChains; ++i){
-		for(int j = 0; j < chainVec[i]->getNumJoints(); ++j){
-			double jnt = dofVals[chainVec[i]->getJoint(j)->getDOFNum()] *
-				chainVec[i]->getJoint(j)->getCouplingRatio();
-			if(jnt > chainVec[i]->getJoint(j)->getMax() ||
-				jnt < chainVec[i]->getJoint(j)->getMin()){
-					std::cout << "inverse kinematics in invalid joint value: " << i << "th chain, " << j << "th joint\n";
-					return FAILURE;
-				}
-		}
-	}
+        //check the maximum of the joint change
+        factor = -1.0;
+        for (int i = 0; i < deltaDOF.cols(); ++i) {
+            factor = factor > fabs(deltaDOF.elem(i, 0)) ? factor : fabs(deltaDOF.elem(i, 0));
+        }
 
-	if(safeguard >= safeGuardUpperBound){
-		std::cout << "safeguard hit\n";
-		return FAILURE;
-	}
-	/*
-	chainVec[chainNum]->fwdKinematics(&currentJointVals[0], fwdK);
-	currentPos = fwdK[chainVec[chainNum]->getNumLinks() - 1];
-	std::cout << "in: " << currentPos.translation().x() << " " <<
-	currentPos.translation().y() << " " <<
-	currentPos.translation().z() << " " <<
-	currentPos.rotation().w << " " <<
-	currentPos.rotation().x << " " <<
-	currentPos.rotation().y << " " <<
-	currentPos.rotation().z << " " << "\n";
-	*/
-	return SUCCESS;
+        //check the convergence
+        if (factor < epsilon) {
+            for (int k = 0; k < numDOF; ++k) {
+                //std::cout << "from: " << dofVals[k] << " to: " << currentJointVals[k];
+                //check if the joint value jumps to another one which is too far away of the previous one
+                if (fabs(dofVals[k] - currentDOFVals[k]) > upperBound) {
+                    std::cout << "exceeds the upper bound at DOF: " << k << " , jumping to another pose\n";
+                    return FAILURE;
+                }
+                dofVals[k] = currentDOFVals[k];
+            }
+            break;
+        }
+    }
+    //check that all the joints are within the legal range
+    for (int i = 0; i < numChains; ++i) {
+        for (int j = 0; j < chainVec[i]->getNumJoints(); ++j) {
+            double jnt = dofVals[chainVec[i]->getJoint(j)->getDOFNum()] *
+                         chainVec[i]->getJoint(j)->getCouplingRatio();
+            if (jnt > chainVec[i]->getJoint(j)->getMax() ||
+                    jnt < chainVec[i]->getJoint(j)->getMin()) {
+                std::cout << "inverse kinematics in invalid joint value: " << i << "th chain, " << j << "th joint\n";
+                return FAILURE;
+            }
+        }
+    }
+
+    if (safeguard >= safeGuardUpperBound) {
+        std::cout << "safeguard hit\n";
+        return FAILURE;
+    }
+    /*
+        chainVec[chainNum]->fwdKinematics(&currentJointVals[0], fwdK);
+        currentPos = fwdK[chainVec[chainNum]->getNumLinks() - 1];
+        std::cout << "in: " << currentPos.translation().x() << " " <<
+        currentPos.translation().y() << " " <<
+        currentPos.translation().z() << " " <<
+        currentPos.rotation().w << " " <<
+        currentPos.rotation().x << " " <<
+        currentPos.rotation().y << " " <<
+        currentPos.rotation().z << " " << "\n";
+    */
+    return SUCCESS;
 }
 
 /*!
-This is an internal method called by contactsPreventMotion.  Given a
-motion transform for an entire robot that is defined with respect to the
-base frame of the robot, it recursively checks all of the
-kinematic chains of the robot and any robots connected to them to
-determine if any contacts will prevent the motion.
+    This is an internal method called by contactsPreventMotion.  Given a
+    motion transform for an entire robot that is defined with respect to the
+    base frame of the robot, it recursively checks all of the
+    kinematic chains of the robot and any robots connected to them to
+    determine if any contacts will prevent the motion.
 */
 bool
-Robot::simpleContactsPreventMotion(const transf& motion) const
-{
-	transf linkMotion;
-	transf baseToLink;
+Robot::simpleContactsPreventMotion(const transf &motion) const {
+    transf linkMotion;
+    transf baseToLink;
 
-	for (int i=0;i<numChains;i++) {
-		for (int j=0; j<chainVec[i]->getNumLinks();j++) {
-			if (chainVec[i]->getLink(j)->getNumContacts()) {
-				baseToLink = chainVec[i]->getLink(j)->getTran() * base->getTran().inverse();
-				linkMotion = baseToLink * motion * baseToLink.inverse();
-				if (chainVec[i]->getLink(j)->externalContactsPreventMotion(linkMotion))
-					return true;
-			}
-		}
-		// recursively check the motion for any robots attached to this chain
-		for (int j=0;j<chainVec[i]->getNumAttachedRobots();j++) {
-			baseToLink = chainVec[i]->getAttachedRobot(j)->getBase()->getTran() * base->getTran().inverse();
-			linkMotion = baseToLink * motion * baseToLink.inverse();
-			if (chainVec[i]->getAttachedRobot(j)->simpleContactsPreventMotion(linkMotion))
-				return true;
-		}
-	}
-	return false;
+    for (int i = 0; i < numChains; i++) {
+        for (int j = 0; j < chainVec[i]->getNumLinks(); j++) {
+            if (chainVec[i]->getLink(j)->getNumContacts()) {
+                baseToLink = chainVec[i]->getLink(j)->getTran() * base->getTran().inverse();
+                linkMotion = baseToLink * motion * baseToLink.inverse();
+                if (chainVec[i]->getLink(j)->externalContactsPreventMotion(linkMotion))
+                    return true;
+            }
+        }
+        // recursively check the motion for any robots attached to this chain
+        for (int j = 0; j < chainVec[i]->getNumAttachedRobots(); j++) {
+            baseToLink = chainVec[i]->getAttachedRobot(j)->getBase()->getTran() * base->getTran().inverse();
+            linkMotion = baseToLink * motion * baseToLink.inverse();
+            if (chainVec[i]->getAttachedRobot(j)->simpleContactsPreventMotion(linkMotion))
+                return true;
+        }
+    }
+    return false;
 }
 
 
 /*!
-Examines all of the contacts on every link of this robot, and each
-child robot connected to this one, to determine if the desired motion
-can be performed.  It also performs the inverse kinematics of the
-parent robot to see if any of those link motions will be prevented by
-contacts on those links.  The motion is expressed with respect to the
-base frame of the robot.  This is only used when dynamics are off.
+    Examines all of the contacts on every link of this robot, and each
+    child robot connected to this one, to determine if the desired motion
+    can be performed.  It also performs the inverse kinematics of the
+    parent robot to see if any of those link motions will be prevented by
+    contacts on those links.  The motion is expressed with respect to the
+    base frame of the robot.  This is only used when dynamics are off.
 */
 bool
-Robot::contactsPreventMotion(const transf& motion) const
-{
-	int l;
-	transf linkMotion;
+Robot::contactsPreventMotion(const transf &motion) const {
+    int l;
+    transf linkMotion;
 
-	// check if we can move the base link
-	if (base->externalContactsPreventMotion(motion)) return true;
-	if (mountPiece && mountPiece->contactsPreventMotion(motion)) return true;
+    // check if we can move the base link
+    if (base->externalContactsPreventMotion(motion)) return true;
+    if (mountPiece && mountPiece->contactsPreventMotion(motion)) return true;
 
-	// check if we can move all the kinematic chains and the robots connected to them
-	if (simpleContactsPreventMotion(motion)) return true;
+    // check if we can move all the kinematic chains and the robots connected to them
+    if (simpleContactsPreventMotion(motion)) return true;
 
-	// if this robot is connected to another before it, try to do inv kinematics
-	// and check if contacts on any of those links will prevent this motion
-	if (parent) {
-		transf newTran = tranToParentEnd*motion*base->getTran();// * parent->getBase()->getTran().inverse();
-		KinematicChain *chain = parent->getChain(parentChainNum);
-		std::vector<transf> parentTrVec(chain->getNumLinks());    
-		double *dofVals = new double[parent->getNumDOF()];
+    // if this robot is connected to another before it, try to do inv kinematics
+    // and check if contacts on any of those links will prevent this motion
+    if (parent) {
+        transf newTran = tranToParentEnd * motion * base->getTran(); // * parent->getBase()->getTran().inverse();
+        KinematicChain *chain = parent->getChain(parentChainNum);
+        std::vector<transf> parentTrVec(chain->getNumLinks());
+        double *dofVals = new double[parent->getNumDOF()];
 
-		if (parent->invKinematics(newTran,dofVals,parentChainNum)==FAILURE){
-			delete [] dofVals;
-			return true;
-		}
+        if (parent->invKinematics(newTran, dofVals, parentChainNum) == FAILURE) {
+            delete [] dofVals;
+            return true;
+        }
 
-		parent->fwdKinematics(dofVals,parentTrVec,parentChainNum);
-		delete [] dofVals;
+        parent->fwdKinematics(dofVals, parentTrVec, parentChainNum);
+        delete [] dofVals;
 
-		for (l=0;l<chain->getNumLinks();l++) {      
-			if (chain->getLink(l)->getNumContacts()) {
-				linkMotion = parentTrVec[l] * chain->getLink(l)->getTran().inverse();
-				if (chain->getLink(l)->contactsPreventMotion(linkMotion)) {
-					return true;
-				}
-			}
-		} 
-	}
-	return false;
+        for (l = 0; l < chain->getNumLinks(); l++) {
+            if (chain->getLink(l)->getNumContacts()) {
+                linkMotion = parentTrVec[l] * chain->getLink(l)->getTran().inverse();
+                if (chain->getLink(l)->contactsPreventMotion(linkMotion)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 }
 
 /*! Breaks all the contacts formed on the links or the base of this robot */
 void
-Robot::breakContacts()
-{
-	for (int f=0; f<getNumChains(); f++) {
-		for (int l=0; l<getChain(f)->getNumLinks(); l++) {
-			getChain(f)->getLink(l)->breakContacts();
-		}
-	}
-	base->breakContacts();
-	if (mountPiece) mountPiece->breakContacts();
+Robot::breakContacts() {
+    for (int f = 0; f < getNumChains(); f++) {
+        for (int l = 0; l < getChain(f)->getNumLinks(); l++) {
+            getChain(f)->getLink(l)->breakContacts();
+        }
+    }
+    base->breakContacts();
+    if (mountPiece) mountPiece->breakContacts();
 }
 
 
-/*! This can be used to disable / enable the automatic render requests from this robot. 
-If this is disabled, changes to the robot pose or posture should not trigger an
-automatic render request through Coin. The robot however is still part of the scene 
-graph, so whenever a render request comes from someplace else, the robot is rendered
-in its most current state. See also the option in the World class to completely
-remove a robot from the scene graph.
+/*! This can be used to disable / enable the automatic render requests from this robot.
+    If this is disabled, changes to the robot pose or posture should not trigger an
+    automatic render request through Coin. The robot however is still part of the scene
+    graph, so whenever a render request comes from someplace else, the robot is rendered
+    in its most current state. See also the option in the World class to completely
+    remove a robot from the scene graph.
 */
 void
-Robot::setRenderGeometry(bool s)
-{
-	mRenderGeometry = s;
-	if (parent) parent->setRenderGeometry(s);
-	for (int c=0; c<numChains; c++) {
-		for (int j=0; j<chainVec[c]->getNumAttachedRobots(); j++) {
-			chainVec[c]->getAttachedRobot(j)->setRenderGeometry(s);
-		}
-	}
-	for (int f=0; f<getNumChains(); f++) {
-		for (int l=0; l<getChain(f)->getNumLinks(); l++) {
-			getChain(f)->getLink(l)->setRenderGeometry(s);
-		}
-	}
-	base->setRenderGeometry(s);
-	if (mountPiece) mountPiece->setRenderGeometry(s);
+Robot::setRenderGeometry(bool s) {
+    mRenderGeometry = s;
+    if (parent) parent->setRenderGeometry(s);
+    for (int c = 0; c < numChains; c++) {
+        for (int j = 0; j < chainVec[c]->getNumAttachedRobots(); j++) {
+            chainVec[c]->getAttachedRobot(j)->setRenderGeometry(s);
+        }
+    }
+    for (int f = 0; f < getNumChains(); f++) {
+        for (int l = 0; l < getChain(f)->getNumLinks(); l++) {
+            getChain(f)->getLink(l)->setRenderGeometry(s);
+        }
+    }
+    base->setRenderGeometry(s);
+    if (mountPiece) mountPiece->setRenderGeometry(s);
 }
 
 /*! This attempt to set the pose of the robot base to tr.  It does not check
-	for collisions, but it will check the inverse kinematics of a parent
-	robot (if it exists) to determine whether the move is valid.  If it is
-	valid the DOF's of the parent are set, and this robot and all of its
-	children are moved.
+    for collisions, but it will check the inverse kinematics of a parent
+    robot (if it exists) to determine whether the move is valid.  If it is
+    valid the DOF's of the parent are set, and this robot and all of its
+    children are moved.
 */
 int
-Robot::setTran(const transf& tr)
-{
-  if (parent) {
-    double *dofVals = new double[parent->getNumDOF()];
-    transf parentBaseToEnd = tranToParentEnd*tr;
-	if (parent->invKinematics(parentBaseToEnd,dofVals,parentChainNum)==FAILURE) {
-	  delete [] dofVals;
-      return FAILURE;
+Robot::setTran(const transf &tr) {
+    if (parent) {
+        double *dofVals = new double[parent->getNumDOF()];
+        transf parentBaseToEnd = tranToParentEnd * tr;
+        if (parent->invKinematics(parentBaseToEnd, dofVals, parentChainNum) == FAILURE) {
+            delete [] dofVals;
+            return FAILURE;
+        }
+        parent->forceDOFVals(dofVals);
+        delete [] dofVals;
     }
-    parent->forceDOFVals(dofVals);
-	delete [] dofVals;
-  } else {
-    simpleSetTran(tr);  
-  }
-  return SUCCESS;
+    else {
+        simpleSetTran(tr);
+    }
+    return SUCCESS;
 }
 
 /*! Returns the total number of links of this robot, including the palm and
-the mount piece (if any).
+    the mount piece (if any).
 */
 int
-Robot::getNumLinks() const
-{
-	int links=0;
-	for (int k=0; k<getNumChains(); k++) {
-		links += chainVec[k]->getNumLinks();
-	}
-	links++; //palm
-	if (mountPiece) links++;
-	return links;
+Robot::getNumLinks() const {
+    int links = 0;
+    for (int k = 0; k < getNumChains(); k++) {
+        links += chainVec[k]->getNumLinks();
+    }
+    links++; //palm
+    if (mountPiece) links++;
+    return links;
 }
 
 /*! Returns the total number of contacts on this robot, including all links
-	and the palm. If \a body is NULL it returns the total number of contacts
-	on this robot regardless of who they are against.
+    and the palm. If \a body is NULL it returns the total number of contacts
+    on this robot regardless of who they are against.
 */
 int
-Robot::getNumContacts(Body *body)
-{
-	int c = getBase()->getNumContacts(body);
-	for (int f=0; f<getNumChains(); f++) {
-		c += getChain(f)->getNumContacts(body);
-	}
-	return c;
+Robot::getNumContacts(Body *body) {
+    int c = getBase()->getNumContacts(body);
+    for (int f = 0; f < getNumChains(); f++) {
+        c += getChain(f)->getNumContacts(body);
+    }
+    return c;
 }
 
-/*! Returns the list of contacts on this robot against the Body \a body, including 
-	contacts on all robot links and the palm. If \a body is NULL it returns all the
-	contacts on this robot regardless of who they are against.
+/*! Returns the list of contacts on this robot against the Body \a body, including
+    contacts on all robot links and the palm. If \a body is NULL it returns all the
+    contacts on this robot regardless of who they are against.
 */
-std::list<Contact*> 
-Robot::getContacts(Body* body)
-{
-	std::list<Contact*> contacts;
-	std::list<Contact*> chainContacts = getBase()->getContacts(body);
-	contacts.insert(contacts.end(),chainContacts.begin(), chainContacts.end());
-	for (int f=0; f<getNumChains(); f++) {
-		chainContacts = getChain(f)->getContacts(body);
-		contacts.insert(contacts.end(),chainContacts.begin(), chainContacts.end());
-	}
-	return contacts;
+std::list<Contact *>
+Robot::getContacts(Body *body) {
+    std::list<Contact *> contacts;
+    std::list<Contact *> chainContacts = getBase()->getContacts(body);
+    contacts.insert(contacts.end(), chainContacts.begin(), chainContacts.end());
+    for (int f = 0; f < getNumChains(); f++) {
+        chainContacts = getChain(f)->getContacts(body);
+        contacts.insert(contacts.end(), chainContacts.begin(), chainContacts.end());
+    }
+    return contacts;
 }
 
-/*! Returns the total number of virtual contacts on this robot, including all 
-links and the palm.
+/*! Returns the total number of virtual contacts on this robot, including all
+    links and the palm.
 */
 int
-Robot::getNumVirtualContacts()
-{
-	int c = getBase()->getNumVirtualContacts();
-	for (int f=0; f<getNumChains(); f++) {
-		for (int l=0; l<getChain(f)->getNumLinks(); l++) {
-			c += getChain(f)->getLink(l)->getNumVirtualContacts();
-		}
-	}
-	return c;
+Robot::getNumVirtualContacts() {
+    int c = getBase()->getNumVirtualContacts();
+    for (int f = 0; f < getNumChains(); f++) {
+        for (int l = 0; l < getChain(f)->getNumLinks(); l++) {
+            c += getChain(f)->getLink(l)->getNumVirtualContacts();
+        }
+    }
+    return c;
 }
 
 /*! Shows or hides the virtual contact on this robot (which can be shown
-as thin red cylinders). They are usually hidden so they don't trigger
-a redraw when not wanted, although we now have a better mechanism 
-for that using setRenderGeometry on the entire robot 
+    as thin red cylinders). They are usually hidden so they don't trigger
+    a redraw when not wanted, although we now have a better mechanism
+    for that using setRenderGeometry on the entire robot
 */
 void
-Robot::showVirtualContacts(bool on)
-{
-	int s; bool b;
-	if (on) s = 1;
-	else s = 2;
-	b = getBase()->frictionConesShown();
-	getBase()->showFrictionCones(b, s);
-	for (int f=0; f<getNumChains(); f++) {
-		for (int l=0; l<getChain(f)->getNumLinks(); l++) {
-			b = getChain(f)->getLink(l)->frictionConesShown();
-			getChain(f)->getLink(l)->showFrictionCones( b, s );
-		}
-	}
+Robot::showVirtualContacts(bool on) {
+    int s;
+    bool b;
+    if (on) s = 1;
+    else s = 2;
+    b = getBase()->frictionConesShown();
+    getBase()->showFrictionCones(b, s);
+    for (int f = 0; f < getNumChains(); f++) {
+        for (int l = 0; l < getChain(f)->getNumLinks(); l++) {
+            b = getChain(f)->getLink(l)->frictionConesShown();
+            getChain(f)->getLink(l)->showFrictionCones(b, s);
+        }
+    }
 }
 
 //----------------------------------save and load state-------------------------
 
-/*! Saves the current state of the robot, which can be restored later. 
-Overwrites any previously saved state. Maybe at some point we will 
-unify this with the stack of dynamic states which can hold any number
-of states for a body.
+/*! Saves the current state of the robot, which can be restored later.
+    Overwrites any previously saved state. Maybe at some point we will
+    unify this with the stack of dynamic states which can hold any number
+    of states for a body.
 */
-void 
-Robot::saveState()
-{
-	savedTran = getTran();
-	savedDOF.clear();
-	QTextStream stream(&savedDOF,QIODevice::ReadWrite);
-	writeDOFVals(stream);
-	savedState = true;
+void
+Robot::saveState() {
+    savedTran = getTran();
+    savedDOF.clear();
+    QTextStream stream(&savedDOF, QIODevice::ReadWrite);
+    writeDOFVals(stream);
+    savedState = true;
 }
 
 /*! Restores the previously saved state of this robot. If no state has been
-saved since the last restore, is prints out a warning, but does not
-die in pain.
+    saved since the last restore, is prints out a warning, but does not
+    die in pain.
 */
 void
-Robot::restoreState()
-{
-	if (!savedState) {
-		DBGA("Warning: hand state not saved!");
-		if (savedDOF.size()==0) {
-			DBGA("Saved DOF data absent; can not restore");
-			return;
-		}
-	}
-	savedState = false;
-	setTran( savedTran );
-	QTextStream stream(&savedDOF,QIODevice::ReadOnly);
-	readDOFVals(stream);
+Robot::restoreState() {
+    if (!savedState) {
+        DBGA("Warning: hand state not saved!");
+        if (savedDOF.size() == 0) {
+            DBGA("Saved DOF data absent; can not restore");
+            return;
+        }
+    }
+    savedState = false;
+    setTran(savedTran);
+    QTextStream stream(&savedDOF, QIODevice::ReadOnly);
+    readDOFVals(stream);
 }
 
-/*! Reads DOF values from a text stream (usually from a saved world file or an 
-internally saved state) and sets them
+/*! Reads DOF values from a text stream (usually from a saved world file or an
+    internally saved state) and sets them
 */
-QTextStream&
-Robot::readDOFVals(QTextStream &is)
-{
-	for (int d=0; d<numDOF; d++) {
-		if (!dofVec[d]->readFromStream(is)) {
-			DBGA("Failed to read DOF " << d << " from stream");
-			return is;
-		}
-	}
+QTextStream &
+Robot::readDOFVals(QTextStream &is) {
+    for (int d = 0; d < numDOF; d++) {
+        if (!dofVec[d]->readFromStream(is)) {
+            DBGA("Failed to read DOF " << d << " from stream");
+            return is;
+        }
+    }
 
-	// This is a somewhat contorted way of doing things, but this is the only mechanism available
-	// for actually moving the DOFs 
-	double *jointVals = new double[numJoints];
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->getJointValues(jointVals);
-	}
-	setJointValuesAndUpdate(jointVals);
-	delete [] jointVals;
-	return is;
+    // This is a somewhat contorted way of doing things, but this is the only mechanism available
+    // for actually moving the DOFs
+    double *jointVals = new double[numJoints];
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->getJointValues(jointVals);
+    }
+    setJointValuesAndUpdate(jointVals);
+    delete [] jointVals;
+    return is;
 }
 
-/*! Writes DOF values to a text stream (usually a world save file or the 
-internally saved state)
+/*! Writes DOF values to a text stream (usually a world save file or the
+    internally saved state)
 */
-QTextStream&
-Robot::writeDOFVals(QTextStream &os)
-{
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->writeToStream(os);
-		os << " ";
-	}
-	return os;
+QTextStream &
+Robot::writeDOFVals(QTextStream &os) {
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->writeToStream(os);
+        os << " ";
+    }
+    return os;
 }
 
 //---------------------------------- STATIC MOVEMENT FUNCTIONS--------
 
-/*! Asks the chains to set the new joint values in \a jointVals. It is 
-	expected that this vector is of size equal to the number of joints of 
-	this robot. Does NOT ask the chains to also update the poses of the links.
+/*! Asks the chains to set the new joint values in \a jointVals. It is
+    expected that this vector is of size equal to the number of joints of
+    this robot. Does NOT ask the chains to also update the poses of the links.
 */
-void Robot::setJointValues(const double* jointVals)
-{
-	for (int c=0; c<numChains; c++) {
-		chainVec[c]->setJointValues(jointVals);
-	}
+void Robot::setJointValues(const double *jointVals) {
+    for (int c = 0; c < numChains; c++) {
+        chainVec[c]->setJointValues(jointVals);
+    }
 }
 
-/*! Asks the chains to set the new joint values in \a jointVals. It is 
-	expected that this vector is of size equal to the number of joints 
-	of this robot. Also asks the chains to also update the poses of the 
-	links.
+/*! Asks the chains to set the new joint values in \a jointVals. It is
+    expected that this vector is of size equal to the number of joints
+    of this robot. Also asks the chains to also update the poses of the
+    links.
 */
-void Robot::setJointValuesAndUpdate(const double* jointVals)
-{
-	for (int c=0; c<numChains; c++) {
-		chainVec[c]->setJointValues(jointVals);
-		chainVec[c]->updateLinkPoses();
-	}
+void Robot::setJointValuesAndUpdate(const double *jointVals) {
+    for (int c = 0; c < numChains; c++) {
+        chainVec[c]->setJointValues(jointVals);
+        chainVec[c]->updateLinkPoses();
+    }
 }
 
 
 /*! This is one of the core function used for moving the DOF's of a robot in statics.
-Its purpose is to solve a collision: given an initial set of joint values, which
-should be collision-free, and a set of final joint values that result in a collision,
-it will interpolate between the two to find the initial moment of contact (where 
-the bodies are not inter-penetrating, but are separated by less then the contat
-threshold.
+    Its purpose is to solve a collision: given an initial set of joint values, which
+    should be collision-free, and a set of final joint values that result in a collision,
+    it will interpolate between the two to find the initial moment of contact (where
+    the bodies are not inter-penetrating, but are separated by less then the contat
+    threshold.
 
-In order to be efficient, it only checks the bodies that are given in the 
-\a colReport. If other bodies are also colliding at any point during the interpolation,
-this function will never know about it.
+    In order to be efficient, it only checks the bodies that are given in the
+    \a colReport. If other bodies are also colliding at any point during the interpolation,
+    this function will never know about it.
 
-Returns 0 if the interpolation fails (usually because the starting configuration
-is also in collision, or 1 if its succeeds. In case of success, \a
-interpolationTime will hold the interpolation coefficient that resulted in the
-original contact.
-*/	
+    Returns 0 if the interpolation fails (usually because the starting configuration
+    is also in collision, or 1 if its succeeds. In case of success, \a
+    interpolationTime will hold the interpolation coefficient that resulted in the
+    original contact.
+*/
 int
-Robot::interpolateJoints(double *initialVals, double *finalVals, 
-						 CollisionReport *colReport, double *interpolationTime)
-{
-	double *currentVals = new double[ getNumJoints() ];
-	double minDist,t = 0.0,deltat = 1.0;
-	while (deltat > 1.0e-20 && t >= 0) {
+Robot::interpolateJoints(double *initialVals, double *finalVals,
+                         CollisionReport *colReport, double *interpolationTime) {
+    double *currentVals = new double[ getNumJoints() ];
+    double minDist, t = 0.0, deltat = 1.0;
+    while (deltat > 1.0e-20 && t >= 0) {
 
-		DBGP("DOF joint interpolation cycle")
-			deltat *= 0.5;
-		for (int j=0; j<getNumJoints(); j++) {
-			currentVals[j] = t*finalVals[j] + (1.0-t)*initialVals[j];
-		}
-		setJointValuesAndUpdate(currentVals);
+        DBGP("DOF joint interpolation cycle")
+        deltat *= 0.5;
+        for (int j = 0; j < getNumJoints(); j++) {
+            currentVals[j] = t * finalVals[j] + (1.0 - t) * initialVals[j];
+        }
+        setJointValuesAndUpdate(currentVals);
 
-		minDist = 1.0e10;
-		for (int i=0; i<(int)colReport->size(); i++) {
-			minDist = MIN(minDist,myWorld->getDist( (*colReport)[i].first, (*colReport)[i].second));
-			if ( minDist <= 0 ) {
-				t -= deltat;
-				break;
-			}
-		}
-		if (minDist > 0) {
-			if (minDist < 0.5 * Contact::THRESHOLD) break;
-			t += deltat;
-		}
-	}
+        minDist = 1.0e10;
+        for (int i = 0; i < (int)colReport->size(); i++) {
+            minDist = MIN(minDist, myWorld->getDist((*colReport)[i].first, (*colReport)[i].second));
+            if (minDist <= 0) {
+                t -= deltat;
+                break;
+            }
+        }
+        if (minDist > 0) {
+            if (minDist < 0.5 * Contact::THRESHOLD) break;
+            t += deltat;
+        }
+    }
 
-	int retVal;
-	if (deltat < 1.0e-20 || t < 0) {
-#ifdef GRASPITDBG
-		std::cerr << "t: " << t << "  d: " << deltat << std::endl;
-		std::cerr << "I am " << getName().latin1() << std::endl;
-		for (int i=0; i<(int)colReport->size(); i++) {
-			std::cerr << (*colReport)[i].first->getName().latin1()<<" -- " 
-				<< (*colReport)[i].second->getName().latin1() << std::endl;
-		}
-		std::cerr << "min dist: " << minDist << std::endl << std::endl;
-#endif
-		DBGA("Robot joint interpolation error");
-		retVal = 0;
-	} else {
-		DBGP("Interpolation to t=" << t << " (deltat=" << deltat << ")");
-		retVal = 1;
-	}
-	delete [] currentVals;
-	*interpolationTime = t;
-	return retVal;
+    int retVal;
+    if (deltat < 1.0e-20 || t < 0) {
+        #ifdef GRASPITDBG
+        std::cerr << "t: " << t << "  d: " << deltat << std::endl;
+        std::cerr << "I am " << getName().latin1() << std::endl;
+        for (int i = 0; i < (int)colReport->size(); i++) {
+            std::cerr << (*colReport)[i].first->getName().latin1() << " -- "
+                      << (*colReport)[i].second->getName().latin1() << std::endl;
+        }
+        std::cerr << "min dist: " << minDist << std::endl << std::endl;
+        #endif
+        DBGA("Robot joint interpolation error");
+        retVal = 0;
+    }
+    else {
+        DBGP("Interpolation to t=" << t << " (deltat=" << deltat << ")");
+        retVal = 1;
+    }
+    delete [] currentVals;
+    *interpolationTime = t;
+    return retVal;
 }
 
 /*! A utility function for the main static DOF movement functions. Given a link
-that is stopped (presumably due to some contact) it will mark all the joints
-that affect that link as stopped. This is done by setting the a bit in the 
-entry that correspinds to a given joint in the vector \a stoppedJoints. 
-\a stoppedJoints is assumed to be large enough for all the joints in the robot.
+    that is stopped (presumably due to some contact) it will mark all the joints
+    that affect that link as stopped. This is done by setting the a bit in the
+    entry that correspinds to a given joint in the vector \a stoppedJoints.
+    \a stoppedJoints is assumed to be large enough for all the joints in the robot.
 */
-void Robot::stopJointsFromLink(Link *link, double *desiredJointVals, int *stoppedJoints)
-{
-	if (link->getChainNum()<0) return; //it's the base
-	KinematicChain *chain = chainVec[link->getChainNum()];
-	for (int j=chain->getLastJoint( link->getLinkNum() ); j>=0; j--) {
-		int jnum = chain->getJoint(j)->getNum();
-		if (desiredJointVals[jnum] > chain->getJoint(j)->getVal()) {
-			//stopped in the positive direction
-			stoppedJoints[jnum] |= 1;
-		} else if (desiredJointVals[jnum] < chain->getJoint(j)->getVal()){
-			//stopped in the negative direction
-			stoppedJoints[jnum] |= 2;
-		}
-	}
+void Robot::stopJointsFromLink(Link *link, double *desiredJointVals, int *stoppedJoints) {
+    if (link->getChainNum() < 0) return; //it's the base
+    KinematicChain *chain = chainVec[link->getChainNum()];
+    for (int j = chain->getLastJoint(link->getLinkNum()); j >= 0; j--) {
+        int jnum = chain->getJoint(j)->getNum();
+        if (desiredJointVals[jnum] > chain->getJoint(j)->getVal()) {
+            //stopped in the positive direction
+            stoppedJoints[jnum] |= 1;
+        }
+        else if (desiredJointVals[jnum] < chain->getJoint(j)->getVal()) {
+            //stopped in the negative direction
+            stoppedJoints[jnum] |= 2;
+        }
+    }
 }
 
 /*! One of the main functions for moving DOF's in statics. Given a set of \a
-desiredDofVals, this will ask the DOF's what values should be given to the
-joints. The vector \a stoppedJoints contains information about which joints
-have been stopped due to contacts. On exit, \a jointVals will contain the 
-needed joint values, and \a actualDofVals will contain the DOF values that
-were actually set (which might be different from \a desireDofVals because
-contacts might prevent the desired motion.
+    desiredDofVals, this will ask the DOF's what values should be given to the
+    joints. The vector \a stoppedJoints contains information about which joints
+    have been stopped due to contacts. On exit, \a jointVals will contain the
+    needed joint values, and \a actualDofVals will contain the DOF values that
+    were actually set (which might be different from \a desireDofVals because
+    contacts might prevent the desired motion.
 
-The main reason for this implementation is that different types of DOF's 
-react different to contacts and implement coupling in their own differnt
-way.
+    The main reason for this implementation is that different types of DOF's
+    react different to contacts and implement coupling in their own differnt
+    way.
 
-Returns \a true if at least on the joints of the robot is still moving, or
-\false if contacts prevent all motion, limits have been reached and no more
-movement is possible.
+    Returns \a true if at least on the joints of the robot is still moving, or
+    \false if contacts prevent all motion, limits have been reached and no more
+    movement is possible.
 */
 bool
-Robot::getJointValuesFromDOF(const double *desiredDofVals, double *actualDofVals, 
-							 double *jointVals, int *stoppedJoints)
-{
-	bool done,moving;
-	std::vector<transf> newLinkTran;
-	DBGP("Getting joint movement from DOFs");
-	do {
-		moving = false; done = true;
-		getJointValues(jointVals);
-		//compute the aggregate move for all DOF's
-		for (int d=0;d<numDOF;d++){
-			//this check is now done by each DOF independently
-			//if ( fabs(dofVals[d] - dofVec[d]->getVal()) < 1.0e-5) continue;
-			if (dofVec[d]->accumulateMove(desiredDofVals[d], jointVals,stoppedJoints)) {
-				moving = true;
-				actualDofVals[d] = desiredDofVals[d];
-				DBGP("DOF " << d << " is moving");
-			} else {
-				actualDofVals[d] = dofVec[d]->getVal();
-			}
-		}
-		if (!moving) {
-			DBGP("No DOF movement; done.");
-			break;
-		}
-		//see if motion is allowed by existing contacts
-		for (int c = 0; c < getNumChains(); c++) {
-			KinematicChain *chain = getChain(c);
-			newLinkTran.resize(chain->getNumLinks(), transf::IDENTITY);
-			chain->infinitesimalMotion(jointVals, newLinkTran);
-			for (int l=0; l<chain->getNumLinks(); l++){
-				Link *link = chain->getLink(l);
-				transf motion = newLinkTran[l];
-				if ( link->contactsPreventMotion(motion) ) {
-					DBGP("Chain " << link->getChainNum() << " link " << link->getLinkNum() << " is blocked.");
-					//we stop all joints that are in the same chain before the stopped link
-					stopJointsFromLink(link, jointVals, stoppedJoints);
-					done = false;
-					//once proximal links in a chain have been stopped, let's process distal links again
-					//before making a decision on them, as their movement will be different
-					break;
-				}
-			}
-		}
-		if (done) {
-			DBGP("All movement OK; done.");
-		}
-	} while (!done);
-	return moving;
+Robot::getJointValuesFromDOF(const double *desiredDofVals, double *actualDofVals,
+                             double *jointVals, int *stoppedJoints) {
+    bool done, moving;
+    std::vector<transf> newLinkTran;
+    DBGP("Getting joint movement from DOFs");
+    do {
+        moving = false;
+        done = true;
+        getJointValues(jointVals);
+        //compute the aggregate move for all DOF's
+        for (int d = 0; d < numDOF; d++) {
+            //this check is now done by each DOF independently
+            //if ( fabs(dofVals[d] - dofVec[d]->getVal()) < 1.0e-5) continue;
+            if (dofVec[d]->accumulateMove(desiredDofVals[d], jointVals, stoppedJoints)) {
+                moving = true;
+                actualDofVals[d] = desiredDofVals[d];
+                DBGP("DOF " << d << " is moving");
+            }
+            else {
+                actualDofVals[d] = dofVec[d]->getVal();
+            }
+        }
+        if (!moving) {
+            DBGP("No DOF movement; done.");
+            break;
+        }
+        //see if motion is allowed by existing contacts
+        for (int c = 0; c < getNumChains(); c++) {
+            KinematicChain *chain = getChain(c);
+            newLinkTran.resize(chain->getNumLinks(), transf::IDENTITY);
+            chain->infinitesimalMotion(jointVals, newLinkTran);
+            for (int l = 0; l < chain->getNumLinks(); l++) {
+                Link *link = chain->getLink(l);
+                transf motion = newLinkTran[l];
+                if (link->contactsPreventMotion(motion)) {
+                    DBGP("Chain " << link->getChainNum() << " link " << link->getLinkNum() << " is blocked.");
+                    //we stop all joints that are in the same chain before the stopped link
+                    stopJointsFromLink(link, jointVals, stoppedJoints);
+                    done = false;
+                    //once proximal links in a chain have been stopped, let's process distal links again
+                    //before making a decision on them, as their movement will be different
+                    break;
+                }
+            }
+        }
+        if (done) {
+            DBGP("All movement OK; done.");
+        }
+    }
+    while (!done);
+    return moving;
 }
 
 /*! The core of the robot DOF movement in statics. Given a set of \a desiredVals for the
-DOF's, it will set the DOF's to that value. If the result is free of contact, we are
-done. If the result is in collision, it will interpolate to find the exact moment
-of contact and set the DOF's at that value. \a stoppedJoints marks any joints that
-can not move (presumably due to some contact discovered earlier). Returns the number
-of collisions found (and resolved) in \a numCols.
+    DOF's, it will set the DOF's to that value. If the result is free of contact, we are
+    done. If the result is in collision, it will interpolate to find the exact moment
+    of contact and set the DOF's at that value. \a stoppedJoints marks any joints that
+    can not move (presumably due to some contact discovered earlier). Returns the number
+    of collisions found (and resolved) in \a numCols.
 
-After completing the move, it will also mark all the new contacts that have appeared
-due to the move. It will also mark as stopped the joints of the links that are now in 
-contact, by setting the appropriate bits in \a stoppedJoints.
+    After completing the move, it will also mark all the new contacts that have appeared
+    due to the move. It will also mark as stopped the joints of the links that are now in
+    contact, by setting the appropriate bits in \a stoppedJoints.
 
-In theory, this function should always leave the robot in a legal state, with no
-inter-penetrations. 
+    In theory, this function should always leave the robot in a legal state, with no
+    inter-penetrations.
 
-Returns \a true if the move had been performed successfully. Returns \a false if either
-no motion was performed because all dofs are already at the desired values, or contacts
-prevent all motion. Also returns \a false if there is an error in the interpolation.
+    Returns \a true if the move had been performed successfully. Returns \a false if either
+    no motion was performed because all dofs are already at the desired values, or contacts
+    prevent all motion. Also returns \a false if there is an error in the interpolation.
 
-A final note of warning: this rather involved way of doing this was dictated by multiple
-problems: always avoid leaving the robot in an illegal state; allow different dof's to
-react to stopped joints in their own way; don't compute contacts more often then you
-have to (it's expensive); make sure the dof's move together, and not one by one; handle
-the case where the collision detection engine finds a collision, but fails to detect a 
-contact after it's solved (happens very rarely, but it does); etc. In general, this whole
-process is more complicated than it appears at first. We would love a general and robust
-solution to this, but tread carefully here.
+    A final note of warning: this rather involved way of doing this was dictated by multiple
+    problems: always avoid leaving the robot in an illegal state; allow different dof's to
+    react to stopped joints in their own way; don't compute contacts more often then you
+    have to (it's expensive); make sure the dof's move together, and not one by one; handle
+    the case where the collision detection engine finds a collision, but fails to detect a
+    contact after it's solved (happens very rarely, but it does); etc. In general, this whole
+    process is more complicated than it appears at first. We would love a general and robust
+    solution to this, but tread carefully here.
 */
 bool
-Robot::jumpDOFToContact(double *desiredVals, int *stoppedJoints, int *numCols)
-{
-	CollisionReport colReport, lateContacts;
+Robot::jumpDOFToContact(double *desiredVals, int *stoppedJoints, int *numCols) {
+    CollisionReport colReport, lateContacts;
 
-	//get new joint values and see which dof's are moving
-	double *newDofVals = new double[ getNumDOF() ];
-	double *initialDofVals = new double [ getNumDOF() ];
-	getDOFVals(initialDofVals);
+    //get new joint values and see which dof's are moving
+    double *newDofVals = new double[ getNumDOF() ];
+    double *initialDofVals = new double [ getNumDOF() ];
+    getDOFVals(initialDofVals);
 
-	double *newJointVals = new double[ getNumJoints() ];
-	double *initialJointVals = new double[ getNumJoints() ];
-	getJointValues(initialJointVals);
+    double *newJointVals = new double[ getNumJoints() ];
+    double *initialJointVals = new double[ getNumJoints() ];
+    getJointValues(initialJointVals);
 
-	if (!getJointValuesFromDOF(desiredVals, newDofVals, newJointVals, stoppedJoints)) {
-		DBGP("No movement of DOFs; forceDOFTo returning false");
-		if (numCols) *numCols = 0;
-		delete [] initialJointVals;	delete [] newJointVals;
-		delete [] initialDofVals; delete [] newDofVals;
-		return false;
-	}
+    if (!getJointValuesFromDOF(desiredVals, newDofVals, newJointVals, stoppedJoints)) {
+        DBGP("No movement of DOFs; forceDOFTo returning false");
+        if (numCols) *numCols = 0;
+        delete [] initialJointVals;
+        delete [] newJointVals;
+        delete [] initialDofVals;
+        delete [] newDofVals;
+        return false;
+    }
 
-	//compute list of links that have actually moved
-	//question: should the dof's compute this?
-	std::vector<Body*> interestList;
-	for (int c=0; c<numChains; c++) {
-		for (int l=0; l<chainVec[c]->getNumLinks(); l++) {
-			int j = chainVec[c]->getLastJoint(l);
-			if ( !stoppedJoints[ chainVec[c]->getJoint(j)->getNum() ] ) {
-				interestList.push_back( chainVec[c]->getLink(l) );
-			}
-		}
-	}
+    //compute list of links that have actually moved
+    //question: should the dof's compute this?
+    std::vector<Body *> interestList;
+    for (int c = 0; c < numChains; c++) {
+        for (int l = 0; l < chainVec[c]->getNumLinks(); l++) {
+            int j = chainVec[c]->getLastJoint(l);
+            if (!stoppedJoints[ chainVec[c]->getJoint(j)->getNum() ]) {
+                interestList.push_back(chainVec[c]->getLink(l));
+            }
+        }
+    }
 
-	setJointValuesAndUpdate(newJointVals);
-	bool interpolationError = false;
-	double interpolationTime;
-	while (1) {
-		myWorld->getCollisionReport(&colReport, &interestList);
-		//if we are free of collision, we are done
-		if (colReport.empty()) break;
-		//if not, we need to interpolate
-		//goal is to interpolate to current joint values
-		getJointValues(newJointVals);
-		if (!interpolateJoints(initialJointVals, newJointVals, &colReport, &interpolationTime)) {
-			DBGA("Interpolation failed!");
-			interpolationError = true;
-			break;
-		}
-		//save the list of contacting bodies
-		lateContacts.clear();
-		for (int i=0;i<(int)colReport.size();i++) {
-			lateContacts.push_back( colReport[i] );
-			DBGP("Contact: " << colReport[i].first->getName().latin1() << "--" << 
-				colReport[i].second->getName().latin1());
-		}
-		for (int d=0; d<numDOF; d++) {
-			DBGP("Dof " << d << "initial " << initialDofVals[d] << " new " << newDofVals[d]);
-			newDofVals[d] =     newDofVals[d] * interpolationTime + 
-				initialDofVals[d] * ( 1.0 - interpolationTime);
-			DBGP("Interpolated: " << newDofVals[d]);
-		}
-	}
+    setJointValuesAndUpdate(newJointVals);
+    bool interpolationError = false;
+    double interpolationTime;
+    while (1) {
+        myWorld->getCollisionReport(&colReport, &interestList);
+        //if we are free of collision, we are done
+        if (colReport.empty()) break;
+        //if not, we need to interpolate
+        //goal is to interpolate to current joint values
+        getJointValues(newJointVals);
+        if (!interpolateJoints(initialJointVals, newJointVals, &colReport, &interpolationTime)) {
+            DBGA("Interpolation failed!");
+            interpolationError = true;
+            break;
+        }
+        //save the list of contacting bodies
+        lateContacts.clear();
+        for (int i = 0; i < (int)colReport.size(); i++) {
+            lateContacts.push_back(colReport[i]);
+            DBGP("Contact: " << colReport[i].first->getName().latin1() << "--" <<
+                 colReport[i].second->getName().latin1());
+        }
+        for (int d = 0; d < numDOF; d++) {
+            DBGP("Dof " << d << "initial " << initialDofVals[d] << " new " << newDofVals[d]);
+            newDofVals[d] =     newDofVals[d] * interpolationTime +
+                                initialDofVals[d] * (1.0 - interpolationTime);
+            DBGP("Interpolated: " << newDofVals[d]);
+        }
+    }
 
-	if (!interpolationError) {
-		DBGP("ForceDOFTo done");
-		myWorld->findContacts(lateContacts);
-		for (int i=0; i<(int)lateContacts.size(); i++) {
-			if (lateContacts[i].first->getOwner()==this) {
-				stopJointsFromLink( (Link*)lateContacts[i].first, newJointVals, stoppedJoints);
-			}
-			if (lateContacts[i].second->getOwner()==this) {
-				stopJointsFromLink( (Link*)lateContacts[i].second, newJointVals, stoppedJoints);
-			}
-		}
-		updateDofVals(newDofVals);
-		if (numCols) *numCols = (int)lateContacts.size();
-	}
+    if (!interpolationError) {
+        DBGP("ForceDOFTo done");
+        myWorld->findContacts(lateContacts);
+        for (int i = 0; i < (int)lateContacts.size(); i++) {
+            if (lateContacts[i].first->getOwner() == this) {
+                stopJointsFromLink((Link *)lateContacts[i].first, newJointVals, stoppedJoints);
+            }
+            if (lateContacts[i].second->getOwner() == this) {
+                stopJointsFromLink((Link *)lateContacts[i].second, newJointVals, stoppedJoints);
+            }
+        }
+        updateDofVals(newDofVals);
+        if (numCols) *numCols = (int)lateContacts.size();
+    }
 
-	delete [] initialDofVals; delete [] newDofVals;
-	delete [] initialJointVals; delete [] newJointVals;
+    delete [] initialDofVals;
+    delete [] newDofVals;
+    delete [] initialJointVals;
+    delete [] newJointVals;
 
-	if (!interpolationError) return true;
-	else return false;
+    if (!interpolationError) return true;
+    else return false;
 }
 
 
 /*! This is the only interface for the user to perform robot DOF movement in statics.
-The desired dof vals are specified in \a desiredVals, which should be of size
-equal to the number of dofs of this robot.
+    The desired dof vals are specified in \a desiredVals, which should be of size
+    equal to the number of dofs of this robot.
 
-The most important aspect is that the motion can be broken down in small steps, to
-make sure that no collisions are missed along the way by "jumping through" an obstacle.
-The other important aspect is that, when a contact is found and a DOF is stopped,
-the other DOF's can continue to move.
+    The most important aspect is that the motion can be broken down in small steps, to
+    make sure that no collisions are missed along the way by "jumping through" an obstacle.
+    The other important aspect is that, when a contact is found and a DOF is stopped,
+    the other DOF's can continue to move.
 
-\a desiredSteps holds the size of the desired steps for each DOF. We usually use 10 
-degrees	for rotational DOFs and 50*Contact::THRESHOLD for translational DOF's. You can 
-use WorldElement::ONE_STEP if no stepping is to be performed. If \a desiredSteps is 
-NULL it has the same effect as setting all entried to ONE_STEP.
+    \a desiredSteps holds the size of the desired steps for each DOF. We usually use 10
+    degrees for rotational DOFs and 50*Contact::THRESHOLD for translational DOF's. You can
+    use WorldElement::ONE_STEP if no stepping is to be performed. If \a desiredSteps is
+    NULL it has the same effect as setting all entried to ONE_STEP.
 
-If \a stopAtContact is true, all movement ends as soon as the first contact is detected.
-If not, movement proceeds until all DOF's have either reached the desired value, reached
-their limit, or have been stopped due to contact.
+    If \a stopAtContact is true, all movement ends as soon as the first contact is detected.
+    If not, movement proceeds until all DOF's have either reached the desired value, reached
+    their limit, or have been stopped due to contact.
 
-Works by breaking down the motion in small time steps and uses the internal forceDOFTo 
-function repeatedly for each step.Returns true if the joints were moved; if no movement 
-was possible from the beginning, it returns false.
+    Works by breaking down the motion in small time steps and uses the internal forceDOFTo
+    function repeatedly for each step.Returns true if the joints were moved; if no movement
+    was possible from the beginning, it returns false.
 
-Note that the desired steps are treated as absolute values; this function will
-automatically choose the right sign for the steps based on the direction of movement.
-In the past, the sign of the desired step used to matter, so some functions inside
-GraspIt still check for that themselves; that should no be necessary anymore.
+    Note that the desired steps are treated as absolute values; this function will
+    automatically choose the right sign for the steps based on the direction of movement.
+    In the past, the sign of the desired step used to matter, so some functions inside
+    GraspIt still check for that themselves; that should no be necessary anymore.
 */
 
-bool 
-Robot::moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtContact, bool renderIt)
-{
-	//	PROF_RESET_ALL;
-	//	PROF_START_TIMER(MOVE_DOF);
-	PROF_TIMER_FUNC(MOVE_DOF);
+bool
+Robot::moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtContact, bool renderIt) {
+    //  PROF_RESET_ALL;
+    //  PROF_START_TIMER(MOVE_DOF);
+    PROF_TIMER_FUNC(MOVE_DOF);
 
-	int i,d;
-	CollisionReport result;
+    int i, d;
+    CollisionReport result;
 
-	double *stepSize= new double[numDOF];
-	double *currVals = new double[numDOF];
-	double *newVals = new double[numDOF];
+    double *stepSize = new double[numDOF];
+    double *currVals = new double[numDOF];
+    double *newVals = new double[numDOF];
 
-	for (i=0;i<numDOF;i++) {
-		if (!desiredSteps || desiredSteps[i] == WorldElement::ONE_STEP ) {
-			stepSize[i] = desiredVals[i] - dofVec[i]->getVal();
-		} else if (desiredSteps[i]!=0.0) {
-		        //make sure the steps are pointing in the right direction
-		        double factor = 1.0;
-			if (desiredVals[i] < dofVec[i]->getVal()) factor = -1.0;
-			stepSize[i] = factor * fabs(desiredSteps[i]);
-		} else {
-			stepSize[i] = 0.0;
-			desiredVals[i] = dofVec[i]->getVal();
-		}
-		DBGP("from " << dofVec[i]->getVal() << " to " << desiredVals[i] << " in " << stepSize[i] << " steps");
-	}
+    for (i = 0; i < numDOF; i++) {
+        if (!desiredSteps || desiredSteps[i] == WorldElement::ONE_STEP) {
+            stepSize[i] = desiredVals[i] - dofVec[i]->getVal();
+        }
+        else if (desiredSteps[i] != 0.0) {
+            //make sure the steps are pointing in the right direction
+            double factor = 1.0;
+            if (desiredVals[i] < dofVec[i]->getVal()) factor = -1.0;
+            stepSize[i] = factor * fabs(desiredSteps[i]);
+        }
+        else {
+            stepSize[i] = 0.0;
+            desiredVals[i] = dofVec[i]->getVal();
+        }
+        DBGP("from " << dofVec[i]->getVal() << " to " << desiredVals[i] << " in " << stepSize[i] << " steps");
+    }
 
-	//this vector will keep tracked of the joints that have been stopped
-	//at previous time steps due to contacts.
-	int *stoppedJoints = new int[numJoints];
-	for (int j=0; j<numJoints; j++) {
-		stoppedJoints[j] = 0;
-	}
+    //this vector will keep tracked of the joints that have been stopped
+    //at previous time steps due to contacts.
+    int *stoppedJoints = new int[numJoints];
+    for (int j = 0; j < numJoints; j++) {
+        stoppedJoints[j] = 0;
+    }
 
-	//loop until termination conditions are met
-	int numCols,itercount = 0;
-	bool moved = false;
-	do {
-		itercount++;
-		DBGP("Move to contact cycle");
-		getDOFVals(currVals);
-		for (d=0;d<numDOF;d++) {
-			newVals[d] = currVals[d] + stepSize[d];
-			DBGP("  Current value (a): " << currVals[d] << "; new value: " << newVals[d] << 
-			     "; step size: " << stepSize[d]);
-			if (stepSize[d] > 0 && newVals[d] > desiredVals[d])
-				newVals[d] = desiredVals[d];
-			else if (stepSize[d] < 0 && newVals[d] < desiredVals[d])
-				newVals[d] = desiredVals[d];
-			DBGP("  Current value (b): " << currVals[d] << "; new value: " << newVals[d]);
-		}
-		//perform one more step. jumpDOFToContact will inform us if no more
-		//movement is done (or possible) and we can exit.
-		if (!jumpDOFToContact(newVals, stoppedJoints, &numCols)){
-			DBGP("ForceDOFTo reports no movement is possible");
-			break;
-		}
-		moved = true;
-		bool stopRequest = false;
-		//inform whoever is listening a step has been performed
-		Q_EMIT moveDOFStepTaken(numCols, stopRequest);
-		if (stopRequest) {
-			DBGP("Receiver of movement signal requests early exit");
-			break;
-		}
-		//check if we stop at first contact
-		if (stopAtContact && numCols != 0) {
-			DBGP("Stopping at first contact");
-			break;
-		}
-		if (itercount > 500) {
-			DBGA("MoveDOF failsafe hit");
-			break;
-		}
-		if (renderIt && (itercount%25==0) && graspItGUI && graspItGUI->getIVmgr()->getWorld()==myWorld) {
-			graspItGUI->getIVmgr()->getViewer()->render();
-		}
-	} while (1);
+    //loop until termination conditions are met
+    int numCols, itercount = 0;
+    bool moved = false;
+    do {
+        itercount++;
+        DBGP("Move to contact cycle");
+        getDOFVals(currVals);
+        for (d = 0; d < numDOF; d++) {
+            newVals[d] = currVals[d] + stepSize[d];
+            DBGP("  Current value (a): " << currVals[d] << "; new value: " << newVals[d] <<
+                 "; step size: " << stepSize[d]);
+            if (stepSize[d] > 0 && newVals[d] > desiredVals[d])
+                newVals[d] = desiredVals[d];
+            else if (stepSize[d] < 0 && newVals[d] < desiredVals[d])
+                newVals[d] = desiredVals[d];
+            DBGP("  Current value (b): " << currVals[d] << "; new value: " << newVals[d]);
+        }
+        //perform one more step. jumpDOFToContact will inform us if no more
+        //movement is done (or possible) and we can exit.
+        if (!jumpDOFToContact(newVals, stoppedJoints, &numCols)) {
+            DBGP("ForceDOFTo reports no movement is possible");
+            break;
+        }
+        moved = true;
+        bool stopRequest = false;
+        //inform whoever is listening a step has been performed
+        Q_EMIT moveDOFStepTaken(numCols, stopRequest);
+        if (stopRequest) {
+            DBGP("Receiver of movement signal requests early exit");
+            break;
+        }
+        //check if we stop at first contact
+        if (stopAtContact && numCols != 0) {
+            DBGP("Stopping at first contact");
+            break;
+        }
+        if (itercount > 500) {
+            DBGA("MoveDOF failsafe hit");
+            break;
+        }
+        if (renderIt && (itercount % 25 == 0) && graspItGUI && graspItGUI->getIVmgr()->getWorld() == myWorld) {
+            graspItGUI->getIVmgr()->getViewer()->render();
+        }
+    }
+    while (1);
 
-	//	PROF_STOP_TIMER(MOVE_DOF);
-	//	PROF_PRINT_ALL;
+    //  PROF_STOP_TIMER(MOVE_DOF);
+    //  PROF_PRINT_ALL;
 
-	delete [] currVals;
-	delete [] newVals;
-	delete [] stepSize;
-	delete [] stoppedJoints;
-	return moved;
+    delete [] currVals;
+    delete [] newVals;
+    delete [] stepSize;
+    delete [] stoppedJoints;
+    return moved;
 }
 
-/*! This function checks if the path to the desired vals is legal. Breaks 
-down motion into steps and does each step. As soon as any collision is 
-detected, it returns false. Duplicates a lot of the functionality of 
-moveDOFToContacts. This is not a very good implementation and should
-probably be cleaned up in the future.
+/*! This function checks if the path to the desired vals is legal. Breaks
+    down motion into steps and does each step. As soon as any collision is
+    detected, it returns false. Duplicates a lot of the functionality of
+    moveDOFToContacts. This is not a very good implementation and should
+    probably be cleaned up in the future.
 */
 bool
-Robot::checkDOFPath(double *desiredVals, double desiredStep)
-{
-	int d;
-	bool done, success = true;
+Robot::checkDOFPath(double *desiredVals, double desiredStep) {
+    int d;
+    bool done, success = true;
 
-	double *stepSize= new double[numDOF];
-	double *currVals = new double[numDOF];
-	double *newVals = new double[numDOF];
+    double *stepSize = new double[numDOF];
+    double *currVals = new double[numDOF];
+    double *newVals = new double[numDOF];
 
-	for (d=0;d<numDOF;d++) {
-		if (desiredStep == WorldElement::ONE_STEP )
-			stepSize[d] = desiredVals[d] - dofVec[d]->getVal();
-		else if ( desiredVals[d] >= dofVec[d]->getVal() )
-			stepSize[d] = desiredStep;
-		else stepSize[d] = - desiredStep;
-	}
+    for (d = 0; d < numDOF; d++) {
+        if (desiredStep == WorldElement::ONE_STEP)
+            stepSize[d] = desiredVals[d] - dofVec[d]->getVal();
+        else if (desiredVals[d] >= dofVec[d]->getVal())
+            stepSize[d] = desiredStep;
+        else stepSize[d] = - desiredStep;
+    }
 
-	do {
-		DBGP("Move to contact cycle")
-			getDOFVals(currVals);
-		for (d=0;d<numDOF;d++) {
-			newVals[d] = currVals[d] + stepSize[d];
-			if (stepSize[d] > 0 && newVals[d] > desiredVals[d])
-				newVals[d] = desiredVals[d];
-			else if (stepSize[d] < 0 && newVals[d] < desiredVals[d])
-				newVals[d] = desiredVals[d];
-		}
+    do {
+        DBGP("Move to contact cycle")
+        getDOFVals(currVals);
+        for (d = 0; d < numDOF; d++) {
+            newVals[d] = currVals[d] + stepSize[d];
+            if (stepSize[d] > 0 && newVals[d] > desiredVals[d])
+                newVals[d] = desiredVals[d];
+            else if (stepSize[d] < 0 && newVals[d] < desiredVals[d])
+                newVals[d] = desiredVals[d];
+        }
 
-		forceDOFVals(newVals);
+        forceDOFVals(newVals);
 
-		if ( !myWorld->noCollision() ) {
-			success = false;
-			break;
-		}
+        if (!myWorld->noCollision()) {
+            success = false;
+            break;
+        }
 
-		done = true;
-		for (d=0;d<numDOF;d++) {
-			if (newVals[d] != desiredVals[d]) done = false;
-		}
+        done = true;
+        for (d = 0; d < numDOF; d++) {
+            if (newVals[d] != desiredVals[d]) done = false;
+        }
 
-	} while (!done);
+    }
+    while (!done);
 
-	delete [] currVals;
-	delete [] newVals;
-	delete [] stepSize;
-	return success;
+    delete [] currVals;
+    delete [] newVals;
+    delete [] stepSize;
+    return success;
 }
 
 //-----------------------------static joint torques computations------------------------
 
-/*! Returns the static torques on all the joints of this robot. This is 
-relevant for underactuated compliant hands only, should be zero in all 
-other cases. See the CompliantDOF class for details.
+/*! Returns the static torques on all the joints of this robot. This is
+    relevant for underactuated compliant hands only, should be zero in all
+    other cases. See the CompliantDOF class for details.
 
-If \useDynamicDofForce is set, the static joint torques are computed using
-the dynamic force currently set by each DOF. If not, the minimum values for
-balancing the system are computed. This is somewhat hacky as this is done
-in statics, not dynamics, but we needed a way of computing static joint 
-torques for some pre-specified level of DOF force.
+    If \useDynamicDofForce is set, the static joint torques are computed using
+    the dynamic force currently set by each DOF. If not, the minimum values for
+    balancing the system are computed. This is somewhat hacky as this is done
+    in statics, not dynamics, but we needed a way of computing static joint
+    torques for some pre-specified level of DOF force.
 */
-Matrix 
-Robot::staticJointTorques(bool useDynamicDofForce)
-{
-	std::vector<double> jointTorques(getNumJoints(), 0.0);
-	for (int d=0; d<numDOF; d++) {
-		double dofForce = -1;
-		if (useDynamicDofForce) {
-			dofForce = dofVec[d]->getForce();
-		}
-		dofVec[d]->computeStaticJointTorques(&jointTorques[0], dofForce);
-	}
-	return Matrix(&jointTorques[0], getNumJoints(), 1, true);
+Matrix
+Robot::staticJointTorques(bool useDynamicDofForce) {
+    std::vector<double> jointTorques(getNumJoints(), 0.0);
+    for (int d = 0; d < numDOF; d++) {
+        double dofForce = -1;
+        if (useDynamicDofForce) {
+            dofForce = dofVec[d]->getForce();
+        }
+        dofVec[d]->computeStaticJointTorques(&jointTorques[0], dofForce);
+    }
+    return Matrix(&jointTorques[0], getNumJoints(), 1, true);
 }
 
 //---------------------- miscellaneous functions ---------------------------
 
 /*! Tells us how far along the pre-specified approach distance a certain object is.
-Since the approach direction might never intersect the given body, it also
-needs a cap telling is how far to look. This cap is \a maxDist. Therefore,
-a return value of \a maxDist might mean that the object is never hit by moving
-along the approach direction.
+    Since the approach direction might never intersect the given body, it also
+    needs a cap telling is how far to look. This cap is \a maxDist. Therefore,
+    a return value of \a maxDist might mean that the object is never hit by moving
+    along the approach direction.
 */
 double
-Robot::getApproachDistance(Body *object, double maxDist)
-{
-	position p0 = position(0,0,0) * getApproachTran() * getTran();
-	position p = p0;
-	vec3 app = vec3(0,0,1) * getApproachTran() * getTran();
-	bool done = false;
-	double totalDist = 0;
-	vec3 direction;
-	int loops = 0;
-	while (!done) {
-		loops++;
-		//compute shortest distance between current point and object;
-		direction = myWorld->pointDistanceToBody(p, object);
+Robot::getApproachDistance(Body *object, double maxDist) {
+    position p0 = position(0, 0, 0) * getApproachTran() * getTran();
+    position p = p0;
+    vec3 app = vec3(0, 0, 1) * getApproachTran() * getTran();
+    bool done = false;
+    double totalDist = 0;
+    vec3 direction;
+    int loops = 0;
+    while (!done) {
+        loops++;
+        //compute shortest distance between current point and object;
+        direction = myWorld->pointDistanceToBody(p, object);
 
-		//current closest point on the object
-		position pc = p; pc+=direction;
-		//and its direction rel. to approach direction
-		if ( normalise(pc-p0) % app > 0.86 ) {
-			done = true;
-		}
-		//advance along approach direction
-		double d = direction.len();
-		totalDist += d;
-		p += d * app;
-		if (totalDist > maxDist) done = true;
-		if (loops > 10) {
-			done = true;
-			totalDist = maxDist+1;
-			DBGA("Force exit from gettAppDist");
-		}
-	}
-	//if (totalDist > maxDist) {DBGA("Object far away in " << loops << " loop(s)");}
-	//else {DBGA("Object at " << totalDist << " in " << loops << " loop(s)");}
-	return totalDist;
+        //current closest point on the object
+        position pc = p;
+        pc += direction;
+        //and its direction rel. to approach direction
+        if (normalise(pc - p0) % app > 0.86) {
+            done = true;
+        }
+        //advance along approach direction
+        double d = direction.len();
+        totalDist += d;
+        p += d * app;
+        if (totalDist > maxDist) done = true;
+        if (loops > 10) {
+            done = true;
+            totalDist = maxDist + 1;
+            DBGA("Force exit from gettAppDist");
+        }
+    }
+    //if (totalDist > maxDist) {DBGA("Object far away in " << loops << " loop(s)");}
+    //else {DBGA("Object at " << totalDist << " in " << loops << " loop(s)");}
+    return totalDist;
 }
 
-/*!	This function snaps a kinematic chain out of collision with an object and into 
-contact - if possible. It moves the chain "out" (in the opposite direction of 
-autograsp) a little bit. If this is a valid	position, it interpolates between 
-it and the original collision position to find the moment of contact.
+/*! This function snaps a kinematic chain out of collision with an object and into
+    contact - if possible. It moves the chain "out" (in the opposite direction of
+    autograsp) a little bit. If this is a valid position, it interpolates between
+    it and the original collision position to find the moment of contact.
 */
 bool
-Robot::snapChainToContacts(int chainNum, CollisionReport colReport)
-{
-	bool persistent = true;
+Robot::snapChainToContacts(int chainNum, CollisionReport colReport) {
+    bool persistent = true;
 
-	KinematicChain *chain = getChain(chainNum);
-	chain->filterCollisionReport(colReport);
-	if (colReport.empty()) {
-		DBGP("Snap to chain "<<chainNum<<" done from the start - no collisions");
-		return true;
-	}
+    KinematicChain *chain = getChain(chainNum);
+    chain->filterCollisionReport(colReport);
+    if (colReport.empty()) {
+        DBGP("Snap to chain " << chainNum << " done from the start - no collisions");
+        return true;
+    }
 
-	std::vector<double> openVals(numDOF);
-	std::vector<double> closedVals(numDOF);
-	std::vector<double> openJointVals(numJoints);
-	std::vector<double> closedJointVals(numJoints);
-	CollisionReport openColReport;
+    std::vector<double> openVals(numDOF);
+    std::vector<double> closedVals(numDOF);
+    std::vector<double> openJointVals(numJoints);
+    std::vector<double> closedJointVals(numJoints);
+    CollisionReport openColReport;
 
-	getDOFVals(&closedVals[0]);
-	getDOFVals(&openVals[0]);
-	getJointValues(&closedJointVals[0]);
+    getDOFVals(&closedVals[0]);
+    getDOFVals(&openVals[0]);
+    getJointValues(&closedJointVals[0]);
 
-	double SNAP = 0.1;
-	while (1) {
-		bool limitHit = true;
-		int l = chain->getNumLinks() - 1;
-		for (int j=chain->getLastJoint(l); j>=0; j--) {
-			int d = chain->getJoint(j)->getDOFNum();
-			double current = dofVec[d]->getVal();
-			double target;
-			if (dofVec[d]->getDefaultVelocity() < 0) {
-				target = current + SNAP;
-				if ( target > dofVec[d]->getMax() ) target = dofVec[d]->getMax();
-				else limitHit = false;
-			} else if (dofVec[d]->getDefaultVelocity() > 0) {
-				target = current - SNAP;
-				if ( target < dofVec[d]->getMin()) target = dofVec[d]->getMin();
-				else limitHit = false;
-			} else target = current;
-			openVals[d] = target;
-		}
+    double SNAP = 0.1;
+    while (1) {
+        bool limitHit = true;
+        int l = chain->getNumLinks() - 1;
+        for (int j = chain->getLastJoint(l); j >= 0; j--) {
+            int d = chain->getJoint(j)->getDOFNum();
+            double current = dofVec[d]->getVal();
+            double target;
+            if (dofVec[d]->getDefaultVelocity() < 0) {
+                target = current + SNAP;
+                if (target > dofVec[d]->getMax()) target = dofVec[d]->getMax();
+                else limitHit = false;
+            }
+            else if (dofVec[d]->getDefaultVelocity() > 0) {
+                target = current - SNAP;
+                if (target < dofVec[d]->getMin()) target = dofVec[d]->getMin();
+                else limitHit = false;
+            }
+            else target = current;
+            openVals[d] = target;
+        }
 
-		forceDOFVals(&openVals[0]);
-		myWorld->getCollisionReport(&openColReport);
-		chainVec[chainNum]->filterCollisionReport(openColReport);
-		if ( !openColReport.empty() ) {
-			if (persistent && !limitHit) {
-				//try again
-				forceDOFVals(&closedVals[0]);
-				SNAP += 0.1;
-			}
-			else break;
-		} else {
-			break;
-		}
-	}
-	if (!openColReport.empty()) {
-		DBGP("Snap to chain "<<chainNum<<" done - open position in collision");
-		forceDOFVals(&closedVals[0]);
-		return false;
-	}
+        forceDOFVals(&openVals[0]);
+        myWorld->getCollisionReport(&openColReport);
+        chainVec[chainNum]->filterCollisionReport(openColReport);
+        if (!openColReport.empty()) {
+            if (persistent && !limitHit) {
+                //try again
+                forceDOFVals(&closedVals[0]);
+                SNAP += 0.1;
+            }
+            else break;
+        }
+        else {
+            break;
+        }
+    }
+    if (!openColReport.empty()) {
+        DBGP("Snap to chain " << chainNum << " done - open position in collision");
+        forceDOFVals(&closedVals[0]);
+        return false;
+    }
 
-	DBGP("Open values valid");
-	getJointValues(&openJointVals[0]);
-	double time;
-	if (!interpolateJoints(&openJointVals[0], &closedJointVals[0], &colReport, &time)) {
-		DBGP("Snap to chain "<<chainNum<<" interpolation failed");
-		forceDOFVals(&closedVals[0]);
-		return false;
-	} else {
-		//set dof vals according to interpolation time
-		for (int d=0; d<numDOF; d++) {
-			closedVals[d] = closedVals[d] * time +  openVals[d] * ( 1.0 - time);
-		}
-		updateDofVals(&closedVals[0]);
-	}
-	DBGP("Snap to chain "<<chainNum<<" success");
-	myWorld->findContacts(colReport);
-	return true;
+    DBGP("Open values valid");
+    getJointValues(&openJointVals[0]);
+    double time;
+    if (!interpolateJoints(&openJointVals[0], &closedJointVals[0], &colReport, &time)) {
+        DBGP("Snap to chain " << chainNum << " interpolation failed");
+        forceDOFVals(&closedVals[0]);
+        return false;
+    }
+    else {
+        //set dof vals according to interpolation time
+        for (int d = 0; d < numDOF; d++) {
+            closedVals[d] = closedVals[d] * time +  openVals[d] * (1.0 - time);
+        }
+        updateDofVals(&closedVals[0]);
+    }
+    DBGP("Snap to chain " << chainNum << " success");
+    myWorld->findContacts(colReport);
+    return true;
 }
 
 
 //-----------------------DYNAMICS-------------------------------
 
 /*! This is the main function for moving the robot DOF's in dynamics. All the
-user can do is set the desired dof vals. This function will compute a smooth 
-trajectory for each joint so that each has a smooth acceleration and velocity
-profile. The intermediate values become the setpoints for each
-joint controller.
+    user can do is set the desired dof vals. This function will compute a smooth
+    trajectory for each joint so that each has a smooth acceleration and velocity
+    profile. The intermediate values become the setpoints for each
+    joint controller.
 
-After that, we rely on the simulation world to run each dynamic time step and
-call the robot's dof controllers which will set dof dynamic forces based on
-the desired dof values. The next dynamic time step will then move the links
-based on the forces applied by the dof's.
+    After that, we rely on the simulation world to run each dynamic time step and
+    call the robot's dof controllers which will set dof dynamic forces based on
+    the desired dof values. The next dynamic time step will then move the links
+    based on the forces applied by the dof's.
 
-In practice, the dof controllers are tricky and I've never been able to make
-them very robust. They work reasonably well, but not in all cases.
+    In practice, the dof controllers are tricky and I've never been able to make
+    them very robust. They work reasonably well, but not in all cases.
 */
 void
-Robot::setDesiredDOFVals(double *dofVals)
-{
-	int i,j,d,numSteps;
-	double timeNeeded;
-	double t;
-	double coeffs[5];    
-	double tpow,q1,q0,qd0,qd1;
-	double *traj;
+Robot::setDesiredDOFVals(double *dofVals) {
+    int i, j, d, numSteps;
+    double timeNeeded;
+    double t;
+    double coeffs[5];
+    double tpow, q1, q0, qd0, qd1;
+    double *traj;
 
-	for (d=0;d<numDOF;d++) {
-		if (dofVec[d]->getDefaultVelocity() == 0.0) continue;
+    for (d = 0; d < numDOF; d++) {
+        if (dofVec[d]->getDefaultVelocity() == 0.0) continue;
 
-		DBGP("DOF "<<d<<" trajectory");
-		dofVec[d]->setDesiredPos(dofVals[d]);
-		if (dofVec[d]->getVal() != dofVals[d]) {
+        DBGP("DOF " << d << " trajectory");
+        dofVec[d]->setDesiredPos(dofVals[d]);
+        if (dofVec[d]->getVal() != dofVals[d]) {
 
-			q0 = dofVec[d]->getVal();
-			q1 = dofVals[d];
-			qd0 = 0.0;//dofVec[d]->getActualVelocity();
-			qd1 = 0.0;
+            q0 = dofVec[d]->getVal();
+            q1 = dofVals[d];
+            qd0 = 0.0;//dofVec[d]->getActualVelocity();
+            qd1 = 0.0;
 
-			timeNeeded = fabs(dofVals[d]-dofVec[d]->getVal()) / fabs( dofVec[d]->getDesiredVelocity() );
+            timeNeeded = fabs(dofVals[d] - dofVec[d]->getVal()) / fabs(dofVec[d]->getDesiredVelocity());
 
-			//make this a whole number of timesteps
-			numSteps = (int)ceil(timeNeeded/myWorld->getTimeStep());
-			timeNeeded = numSteps*myWorld->getTimeStep();
+            //make this a whole number of timesteps
+            numSteps = (int)ceil(timeNeeded / myWorld->getTimeStep());
+            timeNeeded = numSteps * myWorld->getTimeStep();
 
-			DBGP("numSteps: "<< numSteps << " time needed: " << timeNeeded);
-			traj = new double[numSteps];
+            DBGP("numSteps: " << numSteps << " time needed: " << timeNeeded);
+            traj = new double[numSteps];
 
-			for (i=0;i<numSteps;i++) {
-				t = (double)i/(double)(numSteps-1);
-				coeffs[4] = 6.0*(q1 - q0) - 3.0*(qd1+qd0)*timeNeeded;
-				coeffs[3] = -15.0*(q1 - q0) + (8.0*qd0 + 7.0*qd1)*timeNeeded;
-				coeffs[2] = 10.0*(q1 - q0) - (6.0*qd0 + 4.0*qd1)*timeNeeded;
-				coeffs[1] = 0.0;
-				coeffs[0] = qd0*timeNeeded; 
-				traj[i] = q0;
+            for (i = 0; i < numSteps; i++) {
+                t = (double)i / (double)(numSteps - 1);
+                coeffs[4] = 6.0 * (q1 - q0) - 3.0 * (qd1 + qd0) * timeNeeded;
+                coeffs[3] = -15.0 * (q1 - q0) + (8.0 * qd0 + 7.0 * qd1) * timeNeeded;
+                coeffs[2] = 10.0 * (q1 - q0) - (6.0 * qd0 + 4.0 * qd1) * timeNeeded;
+                coeffs[1] = 0.0;
+                coeffs[0] = qd0 * timeNeeded;
+                traj[i] = q0;
 
-				tpow = 1.0;
-				for (j=0;j<5;j++) {
-					tpow *= t;
-					traj[i] += tpow*coeffs[j];
-				}
-				DBGP(i << " " << t << " " << traj[i]);
-			}
-			dofVec[d]->setTrajectory(traj,numSteps);
-			delete [] traj;
-		}
-	}
+                tpow = 1.0;
+                for (j = 0; j < 5; j++) {
+                    tpow *= t;
+                    traj[i] += tpow * coeffs[j];
+                }
+                DBGP(i << " " << t << " " << traj[i]);
+            }
+            dofVec[d]->setTrajectory(traj, numSteps);
+            delete [] traj;
+        }
+    }
 }
 
 /*!
-Given a kinematic chain number and a vector of chain end poses, this
-computes the inverse kinematics for each pose, and computes a smooth
-trajectory for each DOF to reach each pose.
+    Given a kinematic chain number and a vector of chain end poses, this
+    computes the inverse kinematics for each pose, and computes a smooth
+    trajectory for each DOF to reach each pose.
 */
 void
-Robot::setChainEndTrajectory(std::vector<transf>& traj,int chainNum)
-{
-	int i,j,numPts = traj.size();
-	double *dofVals = new double[numDOF];
-	bool *dofInChain = new bool[numDOF];
+Robot::setChainEndTrajectory(std::vector<transf> &traj, int chainNum) {
+    int i, j, numPts = traj.size();
+    double *dofVals = new double[numDOF];
+    bool *dofInChain = new bool[numDOF];
 
-	if (numPts < 1 || chainNum < 0 || chainNum > numChains-1) return;
-	for (j=0;j<numDOF;j++)
-		dofInChain[j] = false;
+    if (numPts < 1 || chainNum < 0 || chainNum > numChains - 1) return;
+    for (j = 0; j < numDOF; j++)
+        dofInChain[j] = false;
 
-	for (j=0;j<chainVec[chainNum]->getNumJoints();j++)
-		dofInChain[chainVec[chainNum]->getJoint(j)->getDOFNum()] = true;
+    for (j = 0; j < chainVec[chainNum]->getNumJoints(); j++)
+        dofInChain[chainVec[chainNum]->getJoint(j)->getDOFNum()] = true;
 
-	invKinematics(traj[0],dofVals,chainNum);
-	for (j=0;j<numDOF;j++)
-		if (dofInChain[j]) dofVec[j]->setTrajectory(&dofVals[j],1);
+    invKinematics(traj[0], dofVals, chainNum);
+    for (j = 0; j < numDOF; j++)
+        if (dofInChain[j]) dofVec[j]->setTrajectory(&dofVals[j], 1);
 
-	for (i=1;i<numPts;i++) {
-		invKinematics(traj[i],dofVals,chainNum);
-		for (j=0;j<numDOF;j++)
-			if (dofInChain[j]) dofVec[j]->addToTrajectory(&dofVals[j],1);
-	}
-	delete [] dofVals;
-	delete [] dofInChain;
+    for (i = 1; i < numPts; i++) {
+        invKinematics(traj[i], dofVals, chainNum);
+        for (j = 0; j < numDOF; j++)
+            if (dofInChain[j]) dofVec[j]->addToTrajectory(&dofVals[j], 1);
+    }
+    delete [] dofVals;
+    delete [] dofInChain;
 }
 
 
 /*!
-Given a start and end pose, this creates a number of intermediate poses
-that linearly interpolate between the two in cartesian space.  The
-start and end velocities of the end effector default to 0 but can be
-changed.  If the time needed for the move is not set, the trajectory
-will have an average velocity equal to the \a defaultTranVel and
-\a defaultRotVel.  The number of poses generated is determined by the
-amount of time needed for the move divided by the default dyanmic time
-step length.
+    Given a start and end pose, this creates a number of intermediate poses
+    that linearly interpolate between the two in cartesian space.  The
+    start and end velocities of the end effector default to 0 but can be
+    changed.  If the time needed for the move is not set, the trajectory
+    will have an average velocity equal to the \a defaultTranVel and
+    \a defaultRotVel.  The number of poses generated is determined by the
+    amount of time needed for the move divided by the default dyanmic time
+    step length.
 */
 void
 Robot::generateCartesianTrajectory(const transf &startTr, const transf &endTr,
-								   std::vector<transf> &traj,
-								   double startVel, double endVel,
-								   double timeNeeded)
-{
-	int i,j,numSteps;
-	double t,tpow,dist,angle,coeffs[5];    
-	vec3 newPos,axis;
-	Quaternion newRot;
+                                   std::vector<transf> &traj,
+                                   double startVel, double endVel,
+                                   double timeNeeded) {
+    int i, j, numSteps;
+    double t, tpow, dist, angle, coeffs[5];
+    vec3 newPos, axis;
+    Quaternion newRot;
 
-	(endTr.rotation() * startTr.rotation().inverse()).ToAngleAxis(angle,axis);
+    (endTr.rotation() * startTr.rotation().inverse()).ToAngleAxis(angle, axis);
 
-	if (timeNeeded <= 0.0) {
-		if (defaultTranslVel == 0.0 || defaultRotVel == 0.0) return;
-		timeNeeded =
-			MAX((endTr.translation() - startTr.translation()).len()/defaultTranslVel,
-			fabs(angle)/defaultRotVel);
-	}
+    if (timeNeeded <= 0.0) {
+        if (defaultTranslVel == 0.0 || defaultRotVel == 0.0) return;
+        timeNeeded =
+            MAX((endTr.translation() - startTr.translation()).len() / defaultTranslVel,
+                fabs(angle) / defaultRotVel);
+    }
 
-	//make this a whole number of timesteps
-	numSteps = (int)ceil(timeNeeded/myWorld->getTimeStep());
-	timeNeeded = numSteps*myWorld->getTimeStep();
-	DBGP("Desired Tran Traj numSteps " << numSteps);  
+    //make this a whole number of timesteps
+    numSteps = (int)ceil(timeNeeded / myWorld->getTimeStep());
+    timeNeeded = numSteps * myWorld->getTimeStep();
+    DBGP("Desired Tran Traj numSteps " << numSteps);
 
-	if (numSteps) {
-		traj.clear();
-		traj.reserve(numSteps);
-	}
+    if (numSteps) {
+        traj.clear();
+        traj.reserve(numSteps);
+    }
 
-	for (i=0;i<numSteps;i++) {
-		t = (double)i/(double)(numSteps-1);
+    for (i = 0; i < numSteps; i++) {
+        t = (double)i / (double)(numSteps - 1);
 
-		coeffs[4] = 6.0 - 3.0*(startVel+endVel)*timeNeeded;
-		coeffs[3] = -15.0 + (8.0*startVel + 7.0*endVel)*timeNeeded;
-		coeffs[2] = 10.0 - (6.0*startVel + 4.0*endVel)*timeNeeded;
-		coeffs[1] = 0.0;
-		coeffs[0] = startVel*timeNeeded; 
+        coeffs[4] = 6.0 - 3.0 * (startVel + endVel) * timeNeeded;
+        coeffs[3] = -15.0 + (8.0 * startVel + 7.0 * endVel) * timeNeeded;
+        coeffs[2] = 10.0 - (6.0 * startVel + 4.0 * endVel) * timeNeeded;
+        coeffs[1] = 0.0;
+        coeffs[0] = startVel * timeNeeded;
 
-		dist = 0.0;    
-		tpow = 1.0;
-		for (j=0;j<5;j++) {
-			tpow *= t;
-			dist += tpow*coeffs[j];
-		}
-		newRot = Quaternion::Slerp(dist,startTr.rotation(),endTr.rotation());
-		newPos = (1.0-dist)*startTr.translation() + dist*endTr.translation();
-		traj.push_back(transf(newRot,newPos));
-	}
+        dist = 0.0;
+        tpow = 1.0;
+        for (j = 0; j < 5; j++) {
+            tpow *= t;
+            dist += tpow * coeffs[j];
+        }
+        newRot = Quaternion::Slerp(dist, startTr.rotation(), endTr.rotation());
+        newPos = (1.0 - dist) * startTr.translation() + dist * endTr.translation();
+        traj.push_back(transf(newRot, newPos));
+    }
 }
 
 /*!
-This is only called when dynamics is on.  It updates the joint values
-of the dynamic joints. It is important that this be called after each 
-dynamic movement because other function then look at joint->getVal()
-for many different reasons.
+    This is only called when dynamics is on.  It updates the joint values
+    of the dynamic joints. It is important that this be called after each
+    dynamic movement because other function then look at joint->getVal()
+    for many different reasons.
 */
 void
-Robot::updateJointValuesFromDynamics()
-{
-	double *jointVals = new double[ getNumJoints() ];
-	//accumulate joint values as decided by the dynamics
-	for (int f=0;f<numChains;f++) {
-		for (int l=0;l<chainVec[f]->getNumLinks();l++) {
-			if (chainVec[f]->getLink(l)->getDynJoint())
-				chainVec[f]->getLink(l)->getDynJoint()->updateValues();
-		}
-		for (int j=0; j<chainVec[f]->getNumJoints(); j++) {
-			jointVals[ chainVec[f]->getJoint(j)->getNum() ] = chainVec[f]->getJoint(j)->getDynamicsVal();
-		}
-	}
-	//set the joint themselves
-	setJointValues(jointVals);
+Robot::updateJointValuesFromDynamics() {
+    double *jointVals = new double[ getNumJoints() ];
+    //accumulate joint values as decided by the dynamics
+    for (int f = 0; f < numChains; f++) {
+        for (int l = 0; l < chainVec[f]->getNumLinks(); l++) {
+            if (chainVec[f]->getLink(l)->getDynJoint())
+                chainVec[f]->getLink(l)->getDynJoint()->updateValues();
+        }
+        for (int j = 0; j < chainVec[f]->getNumJoints(); j++) {
+            jointVals[ chainVec[f]->getJoint(j)->getNum() ] = chainVec[f]->getJoint(j)->getDynamicsVal();
+        }
+    }
+    //set the joint themselves
+    setJointValues(jointVals);
 
-	//we no longer set the DOFs according to what the dynamic joints look like
-	//we just do it once when the dynamics are turned off
-	//however, the PD controller still needs to do it and relies on jont vals having
-	//been set here
-	delete [] jointVals;
+    //we no longer set the DOFs according to what the dynamic joints look like
+    //we just do it once when the dynamics are turned off
+    //however, the PD controller still needs to do it and relies on jont vals having
+    //been set here
+    delete [] jointVals;
 }
 
 /*!
-Applies joint friction forces as a pair of equal and opposite forces
-to links connected at each joint.  Frictional forces resist the
-direction of motion of the joint and uses a viscous friction model
-with the coefficients defined in the robot configuration file.
+    Applies joint friction forces as a pair of equal and opposite forces
+    to links connected at each joint.  Frictional forces resist the
+    direction of motion of the joint and uses a viscous friction model
+    with the coefficients defined in the robot configuration file.
 
-Also applies other passive forces, such as spring forces for compliant
-joints. Spring coefficients are also read from config file.
+    Also applies other passive forces, such as spring forces for compliant
+    joints. Spring coefficients are also read from config file.
 */
 void
-Robot::applyJointPassiveInternalWrenches()
-{
-	for (int c=0; c<numChains; c++) {
-		for (int j=0; j<getChain(c)->getNumJoints(); j++) {
-			getChain(c)->getJoint(j)->applyPassiveInternalWrenches();
-		}
-	}
+Robot::applyJointPassiveInternalWrenches() {
+    for (int c = 0; c < numChains; c++) {
+        for (int j = 0; j < getChain(c)->getNumJoints(); j++) {
+            getChain(c)->getJoint(j)->applyPassiveInternalWrenches();
+        }
+    }
 }
 
-/*! Transparently goes to each DOF and asks them to build the limit 
-constraints however they want. See the corresponding DOF functions 
-and users manual for dynamics for details.
-*/
-void 
-Robot::buildDOFLimitConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-								double* H, double *g, int &hcn)
-{
-	for (int d=0; d<numDOF; d++) {
-		dofVec[d]->buildDynamicLimitConstraints(islandIndices, numBodies, H, g, hcn);
-	}
-}
-
-/*! Transparently goes to each DOF and asks them to build the coupling 
-constraints however they want. See the corresponding DOF functions 
-and users manual for dynamics for details.
+/*! Transparently goes to each DOF and asks them to build the limit
+    constraints however they want. See the corresponding DOF functions
+    and users manual for dynamics for details.
 */
 void
-Robot::buildDOFCouplingConstraints(std::map<Body*,int> &islandIndices, int numBodies, 
-								   double* Nu, double *eps, int &ncn)
-{	
-	for(int d=0; d<numDOF; d++) {
-		dofVec[d]->buildDynamicCouplingConstraints(islandIndices, numBodies, Nu, eps, ncn);
-	}
-	return;
+Robot::buildDOFLimitConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                double *H, double *g, int &hcn) {
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->buildDynamicLimitConstraints(islandIndices, numBodies, H, g, hcn);
+    }
+}
+
+/*! Transparently goes to each DOF and asks them to build the coupling
+    constraints however they want. See the corresponding DOF functions
+    and users manual for dynamics for details.
+*/
+void
+Robot::buildDOFCouplingConstraints(std::map<Body *, int> &islandIndices, int numBodies,
+                                   double *Nu, double *eps, int &ncn) {
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->buildDynamicCouplingConstraints(islandIndices, numBodies, Nu, eps, ncn);
+    }
+    return;
 }
 
 /*!
-If the current simulation time is past the DOF setpoint update time
-this updates the DOF set points.  Then the PD position controller for
-each DOF computes the control force for the DOF given the length of the
-current timestep.
+    If the current simulation time is past the DOF setpoint update time
+    this updates the DOF set points.  Then the PD position controller for
+    each DOF computes the control force for the DOF given the length of the
+    current timestep.
 */
 void
-Robot::DOFController(double timeStep)
-{
-	DBGP(" in Robot controller");
-	if (myWorld->getWorldTime() > dofUpdateTime) {
-		DBGP("Updating setpoints");
-		for (int d=0;d<numDOF;d++) {
-			dofVec[d]->updateSetPoint();
-		}
-		dofUpdateTime += myWorld->getTimeStep();
-	}
-	for (int d=0;d<numDOF;d++) {
-		dofVec[d]->callController(timeStep);
-	}
+Robot::DOFController(double timeStep) {
+    DBGP(" in Robot controller");
+    if (myWorld->getWorldTime() > dofUpdateTime) {
+        DBGP("Updating setpoints");
+        for (int d = 0; d < numDOF; d++) {
+            dofVec[d]->updateSetPoint();
+        }
+        dofUpdateTime += myWorld->getTimeStep();
+    }
+    for (int d = 0; d < numDOF; d++) {
+        dofVec[d]->callController(timeStep);
+    }
 }
 
 
 /*! A specialized function that attempts to see if the autograsp has completed,
-when executed dynamically. Does not do a great job at it, as this turned out
-to be a much trickier problem than expected.
+    when executed dynamically. Does not do a great job at it, as this turned out
+    to be a much trickier problem than expected.
 */
-bool 
-Robot::dynamicAutograspComplete()
-{
-	for (int c=0; c<numChains; c++) {
-		Link *l = chainVec[c]->getLink( chainVec[c]->getNumLinks()-1 );
-		//if the last link has a contact, the autograsp *might* have ended
-		if (l->getNumContacts()) continue;
-		int jNum = chainVec[c]->getLastJoint(chainVec[c]->getNumLinks()-1);
-		Joint *j = chainVec[c]->getJoint(jNum);
-		double limit;
-		//which joint limit are we going towards
-		if (dofVec[j->getDOFNum()]->getDefaultVelocity() > 0) {
-			if (j->getCouplingRatio() > 0) {
-				limit = j->getMax();
-			} else {
-				limit = j->getMin();
-			}
-		} else if (dofVec[j->getDOFNum()]->getDefaultVelocity() < 0) {
-			if (j->getCouplingRatio() < 0) {
-				limit = j->getMax();
-			} else {
-				limit = j->getMin();
-			}
-		} else {
-			assert(0);
-		}
-		//if this joint has hit its limit, it is possible that the autograsp is done
-		if (fabs(j->getDynamicsVal() - limit) < 3.0e-2) continue;
-		//if none or the above are true, the autograsp definitely is still going
-		DBGP("Autograsp going on chain " << c << " joint " << jNum << ": val " 
-			<< j->getDynamicsVal() << "; limit " << limit);
-		return false;
-	}
-	return true;		
+bool
+Robot::dynamicAutograspComplete() {
+    for (int c = 0; c < numChains; c++) {
+        Link *l = chainVec[c]->getLink(chainVec[c]->getNumLinks() - 1);
+        //if the last link has a contact, the autograsp *might* have ended
+        if (l->getNumContacts()) continue;
+        int jNum = chainVec[c]->getLastJoint(chainVec[c]->getNumLinks() - 1);
+        Joint *j = chainVec[c]->getJoint(jNum);
+        double limit;
+        //which joint limit are we going towards
+        if (dofVec[j->getDOFNum()]->getDefaultVelocity() > 0) {
+            if (j->getCouplingRatio() > 0) {
+                limit = j->getMax();
+            }
+            else {
+                limit = j->getMin();
+            }
+        }
+        else if (dofVec[j->getDOFNum()]->getDefaultVelocity() < 0) {
+            if (j->getCouplingRatio() < 0) {
+                limit = j->getMax();
+            }
+            else {
+                limit = j->getMin();
+            }
+        }
+        else {
+            assert(0);
+        }
+        //if this joint has hit its limit, it is possible that the autograsp is done
+        if (fabs(j->getDynamicsVal() - limit) < 3.0e-2) continue;
+        //if none or the above are true, the autograsp definitely is still going
+        DBGP("Autograsp going on chain " << c << " joint " << jNum << ": val "
+             << j->getDynamicsVal() << "; limit " << limit);
+        return false;
+    }
+    return true;
 }
 
 /*! Looks at dynamics LCP parameters to determine if any of the contacts are slipping
-during dynamic simulation. Does not do a great job at it, as this turned out
-to be a much trickier problem than expected.
+    during dynamic simulation. Does not do a great job at it, as this turned out
+    to be a much trickier problem than expected.
 */
 bool
-Robot::contactSlip()
-{
-	double linearThreshold = 100.0;
-	double angularThreshold = 2.0;
-	for (int c=0; c<numChains; c++) {
-		for (int l=0; l<getChain(c)->getNumLinks(); l++) {
-			Link *link = getChain(c)->getLink(l);
-			if (!link->getNumContacts()) continue;
-			const double *v = link->getVelocity();
-			double magn = 0.0;
-			for (int i=0; i<3; i++) {
-				magn += v[i] * v[i];
-			}
-			if (magn > linearThreshold * linearThreshold) {
-				DBGA("Chain " << c << " link " << l << " moving with linear vel. magnitude " << magn);
-				return true;
-			}
-			magn = 0.0;
-			for (int i=3; i<6; i++) {
-				magn += v[i] * v[i];
-			}
-			if (magn > angularThreshold * angularThreshold) {
-				DBGA("Chain " << c << " link " << l << " moving with angular vel. magnitude " << magn);
-				return true;
-			}
-		}
-	}
-	return false;
+Robot::contactSlip() {
+    double linearThreshold = 100.0;
+    double angularThreshold = 2.0;
+    for (int c = 0; c < numChains; c++) {
+        for (int l = 0; l < getChain(c)->getNumLinks(); l++) {
+            Link *link = getChain(c)->getLink(l);
+            if (!link->getNumContacts()) continue;
+            const double *v = link->getVelocity();
+            double magn = 0.0;
+            for (int i = 0; i < 3; i++) {
+                magn += v[i] * v[i];
+            }
+            if (magn > linearThreshold * linearThreshold) {
+                DBGA("Chain " << c << " link " << l << " moving with linear vel. magnitude " << magn);
+                return true;
+            }
+            magn = 0.0;
+            for (int i = 3; i < 6; i++) {
+                magn += v[i] * v[i];
+            }
+            if (magn > angularThreshold * angularThreshold) {
+                DBGA("Chain " << c << " link " << l << " moving with angular vel. magnitude " << magn);
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2216,175 +2189,178 @@ Robot::contactSlip()
 //////////////////////////////////////////////////////////////////////////////
 
 /*! Simply creates a new grasp object */
-Hand::Hand(World *w,const char *name) : Robot(w,name)
-{
-	grasp = new Grasp(this);
+Hand::Hand(World *w, const char *name) : Robot(w, name) {
+    grasp = new Grasp(this);
 }
 
 /*! Deletes the associate grasp object */
-Hand::~Hand()
-{
-	std::cout << "Deleting Hand: " << std::endl;
-	delete grasp;
+Hand::~Hand() {
+    std::cout << "Deleting Hand: " << std::endl;
+    delete grasp;
 }
 
 /*! Calls the Robot's clone fctn, but also sets this hand's grasp
-to point to the same object as the original's
+    to point to the same object as the original's
 */
 void
-Hand::cloneFrom(Hand *original)
-{
-	Robot::cloneFrom(original);
-	grasp->setObjectNoUpdate( original->getGrasp()->getObject() );
-	grasp->setGravity( original->getGrasp()->isGravitySet() );
+Hand::cloneFrom(Hand *original) {
+    Robot::cloneFrom(original);
+    grasp->setObjectNoUpdate(original->getGrasp()->getObject());
+    grasp->setGravity(original->getGrasp()->isGravitySet());
 }
 
 /*!
-Closes each DOF at a rate equal to \a speedFactor * its default velocity.
-The closing continues until a joint limit is reached or a contact
-prevents further motion.  The larger the \a speedFactor, the larger the
-individual steps will be and increases the likelyhood that a collision
-may be missed.  The \a renderIt flag controls whether the intermediate
-steps will be rendered.
+    Closes each DOF at a rate equal to \a speedFactor * its default velocity.
+    The closing continues until a joint limit is reached or a contact
+    prevents further motion.  The larger the \a speedFactor, the larger the
+    individual steps will be and increases the likelyhood that a collision
+    may be missed.  The \a renderIt flag controls whether the intermediate
+    steps will be rendered.
 
-If \a stopAtContact is set and the execution is in static mode, movement
-will stop as soon as any contact is made. Otherwise, movement will continue
-untill all joints have been stopped and no movement is possible.
+    If \a stopAtContact is set and the execution is in static mode, movement
+    will stop as soon as any contact is made. Otherwise, movement will continue
+    untill all joints have been stopped and no movement is possible.
 
-If you want the opposite motion, just pass a negative \a speedFactor.
+    If you want the opposite motion, just pass a negative \a speedFactor.
 */
 bool
-Hand::autoGrasp(bool renderIt, double speedFactor, bool stopAtContact)
-{
-	int i;
-	double *desiredVals = new double[numDOF];
+Hand::autoGrasp(bool renderIt, double speedFactor, bool stopAtContact) {
+    int i;
+    double *desiredVals = new double[numDOF];
 
-	if (myWorld->dynamicsAreOn()) {
-		for (i=0;i<numDOF;i++) {
-			if (speedFactor * dofVec[i]->getDefaultVelocity() > 0)
-				desiredVals[i] = dofVec[i]->getMax();
-			else if (speedFactor * dofVec[i]->getDefaultVelocity() < 0)
-				desiredVals[i] = dofVec[i]->getMin();		
-			else desiredVals[i] = dofVec[i]->getVal();
-			DBGP("Desired val "<<i<<" "<<desiredVals[i]);
-			//for now
-			dofVec[i]->setDesiredVelocity(speedFactor * dofVec[i]->getDefaultVelocity());
-		}
-		setDesiredDOFVals(desiredVals);
-		delete [] desiredVals;
-		return true;
-	}
+    if (myWorld->dynamicsAreOn()) {
+        for (i = 0; i < numDOF; i++) {
+            if (speedFactor * dofVec[i]->getDefaultVelocity() > 0)
+                desiredVals[i] = dofVec[i]->getMax();
+            else if (speedFactor * dofVec[i]->getDefaultVelocity() < 0)
+                desiredVals[i] = dofVec[i]->getMin();
+            else desiredVals[i] = dofVec[i]->getVal();
+            DBGP("Desired val " << i << " " << desiredVals[i]);
+            //for now
+            dofVec[i]->setDesiredVelocity(speedFactor * dofVec[i]->getDefaultVelocity());
+        }
+        setDesiredDOFVals(desiredVals);
+        delete [] desiredVals;
+        return true;
+    }
 
-	double *stepSize= new double[numDOF];
-	for (i=0;i<numDOF;i++) {
-		if (speedFactor * dofVec[i]->getDefaultVelocity() >= 0) desiredVals[i] = dofVec[i]->getMax();
-		else desiredVals[i] = dofVec[i]->getMin();
-		stepSize[i] = dofVec[i]->getDefaultVelocity()*speedFactor*AUTO_GRASP_TIME_STEP;
-	}
+    double *stepSize = new double[numDOF];
+    for (i = 0; i < numDOF; i++) {
+        if (speedFactor * dofVec[i]->getDefaultVelocity() >= 0) desiredVals[i] = dofVec[i]->getMax();
+        else desiredVals[i] = dofVec[i]->getMin();
+        stepSize[i] = dofVec[i]->getDefaultVelocity() * speedFactor * AUTO_GRASP_TIME_STEP;
+    }
 
-	bool moved = moveDOFToContacts(desiredVals, stepSize, stopAtContact, renderIt);
-	delete [] desiredVals;
-	delete [] stepSize;
-	return moved;
+    bool moved = moveDOFToContacts(desiredVals, stepSize, stopAtContact, renderIt);
+    delete [] desiredVals;
+    delete [] stepSize;
+    return moved;
 }
 
 /*
-This is a shortcut (read "hack") that opens the hand (in the opposite direction 
-of autoGrasp), in increments of speedFactor * each DOF range. Does it until no 
-collision is detected. It does it in chunks, never does interpolation, if it can 
-not find a collision-free pose it just returns false.
+    This is a shortcut (read "hack") that opens the hand (in the opposite direction
+    of autoGrasp), in increments of speedFactor * each DOF range. Does it until no
+    collision is detected. It does it in chunks, never does interpolation, if it can
+    not find a collision-free pose it just returns false.
 */
 bool
-Hand::quickOpen(double speedFactor)
-{
-	double *desiredVals = new double[numDOF];
-	getDOFVals(desiredVals);
-	double *desiredSteps = new double[numDOF];
-	for (int i=0; i<numDOF; i++) {
-		double d = -1 * dofVec[i]->getDefaultVelocity();
-		if ( d > 0 ) {
-			desiredSteps[i] = d * speedFactor * (dofVec[i]->getMax() - desiredVals[i]);
-		} else if ( d < 0 ) {
-			desiredSteps[i] = d * speedFactor * (desiredVals[i] - dofVec[i]->getMin() );
-		} else {
-			desiredSteps[i] = 0;
-		}
-	}
-	bool done = false, success = false;
-	int loops = 0;
-	while (!done) {
-		loops++;
-		//we move out at least once
-		done = true;
-		for (int i=0; i<numDOF; i++) {
-			desiredVals[i] += desiredSteps[i];
+Hand::quickOpen(double speedFactor) {
+    double *desiredVals = new double[numDOF];
+    getDOFVals(desiredVals);
+    double *desiredSteps = new double[numDOF];
+    for (int i = 0; i < numDOF; i++) {
+        double d = -1 * dofVec[i]->getDefaultVelocity();
+        if (d > 0) {
+            desiredSteps[i] = d * speedFactor * (dofVec[i]->getMax() - desiredVals[i]);
+        }
+        else if (d < 0) {
+            desiredSteps[i] = d * speedFactor * (desiredVals[i] - dofVec[i]->getMin());
+        }
+        else {
+            desiredSteps[i] = 0;
+        }
+    }
+    bool done = false, success = false;
+    int loops = 0;
+    while (!done) {
+        loops++;
+        //we move out at least once
+        done = true;
+        for (int i = 0; i < numDOF; i++) {
+            desiredVals[i] += desiredSteps[i];
 
-			if ( desiredVals[i] > dofVec[i]->getMax() ) {desiredVals[i] = dofVec[i]->getMax();}
-			else if ( desiredVals[i] < dofVec[i]->getMin() ){ desiredVals[i] = dofVec[i]->getMin();}
-			else if (desiredSteps[i] != 0) {done = false;} //we can do at least another loop
-			//DBGA("DOF " << i << " to " << desiredVals[i]);
-		}
-		forceDOFVals(desiredVals);
-		if ( myWorld->noCollision() ) {
-			done = true;
-			success = true;
-		}		
-	}
-	if (loops > 20) DBGA("Open finger loops: " << loops << " Hand: " << myName.latin1());
-	delete [] desiredVals;
-	delete [] desiredSteps;
-	return success;
+            if (desiredVals[i] > dofVec[i]->getMax()) {
+                desiredVals[i] = dofVec[i]->getMax();
+            }
+            else if (desiredVals[i] < dofVec[i]->getMin()) {
+                desiredVals[i] = dofVec[i]->getMin();
+            }
+            else if (desiredSteps[i] != 0) {
+                done = false;   //we can do at least another loop
+            }
+            //DBGA("DOF " << i << " to " << desiredVals[i]);
+        }
+        forceDOFVals(desiredVals);
+        if (myWorld->noCollision()) {
+            done = true;
+            success = true;
+        }
+    }
+    if (loops > 20) DBGA("Open finger loops: " << loops << " Hand: " << myName.latin1());
+    delete [] desiredVals;
+    delete [] desiredSteps;
+    return success;
 }
 
-/*! Moves the palm (robot) in the direction specified by approachDirection. It 
-stops if an object has been touched, or the maximum distance of \a moveDist
-has been covered. Returns true if object has been hit. It expects an initial
-state that is collision-free.
+/*! Moves the palm (robot) in the direction specified by approachDirection. It
+    stops if an object has been touched, or the maximum distance of \a moveDist
+    has been covered. Returns true if object has been hit. It expects an initial
+    state that is collision-free.
 */
 bool
-Hand::approachToContact(double moveDist, bool oneStep)
-{
-	transf newTran = translate_transf(vec3(0,0,moveDist) * getApproachTran()) * getTran();
-	bool result;
-	if (oneStep) {
-		result = moveTo(newTran, WorldElement::ONE_STEP, WorldElement::ONE_STEP);
-	} else {
-		result = moveTo(newTran, 50*Contact::THRESHOLD, M_PI/36.0);
-	}
-	if (result) {
-		DBGP("Approach no contact");
-		return false;
-	} else {
-		DBGP("Approach results in contact");
-		return true;
-	}
+Hand::approachToContact(double moveDist, bool oneStep) {
+    transf newTran = translate_transf(vec3(0, 0, moveDist) * getApproachTran()) * getTran();
+    bool result;
+    if (oneStep) {
+        result = moveTo(newTran, WorldElement::ONE_STEP, WorldElement::ONE_STEP);
+    }
+    else {
+        result = moveTo(newTran, 50 * Contact::THRESHOLD, M_PI / 36.0);
+    }
+    if (result) {
+        DBGP("Approach no contact");
+        return false;
+    }
+    else {
+        DBGP("Approach results in contact");
+        return true;
+    }
 }
 
-/*! Moves the hand back along its approach direction until it is collision free, 
-then forward until it finds the exact moment of contact. It moves forward at 
-most \a moveDist. It can accept	an initial state that is in collision, as it 
-will move back until collision is resolved.
+/*! Moves the hand back along its approach direction until it is collision free,
+    then forward until it finds the exact moment of contact. It moves forward at
+    most \a moveDist. It can accept an initial state that is in collision, as it
+    will move back until collision is resolved.
 */
-bool 
-Hand::findInitialContact(double moveDist)
-{
-	CollisionReport colReport;
-	while (myWorld->getCollisionReport(&colReport)) {
-		transf newTran = translate_transf(vec3(0,0,-moveDist / 2.0) * 
-			getApproachTran()) * getTran();
-		setTran(newTran);
-	}
-	return approachToContact(moveDist, false);
+bool
+Hand::findInitialContact(double moveDist) {
+    CollisionReport colReport;
+    while (myWorld->getCollisionReport(&colReport)) {
+        transf newTran = translate_transf(vec3(0, 0, -moveDist / 2.0) *
+                                          getApproachTran()) * getTran();
+        setTran(newTran);
+    }
+    return approachToContact(moveDist, false);
 }
 
 Matrix
-Robot::getJacobianJointToDOF(int chainNum){
-	Matrix m = Matrix(chainVec[chainNum]->getNumJoints(), numDOF);
-	//initialy they are irrelevant to each other
-	m.setAllElements(0.0);
-	for(int i = 0; i < m.rows(); ++i){
-		//for each joint i
-		m.elem(i,chainVec[chainNum]->getJoint(i)->getDOFNum()) = chainVec[chainNum]->getJoint(i)->getCouplingRatio();
-	}
-	return m;
+Robot::getJacobianJointToDOF(int chainNum) {
+    Matrix m = Matrix(chainVec[chainNum]->getNumJoints(), numDOF);
+    //initialy they are irrelevant to each other
+    m.setAllElements(0.0);
+    for (int i = 0; i < m.rows(); ++i) {
+        //for each joint i
+        m.elem(i, chainVec[chainNum]->getJoint(i)->getDOFNum()) = chainVec[chainNum]->getJoint(i)->getCouplingRatio();
+    }
+    return m;
 }

--- a/src/scanSimulator.cpp
+++ b/src/scanSimulator.cpp
@@ -33,118 +33,120 @@
 #include "world.h"
 #include "matvec3D.h"
 
-ScanSimulator::ScanSimulator()
-{
-        setPosition( position(0,0,0), vec3(0,0,1), vec3(0,-1,0), STEREO_CAMERA );
-	mHMin = -70; mHMax = 70; mHLines = 140;
-	mVMin = -30; mVMax = 30; mVLines = 60;
-	mType = SCANNER_COORDINATES;
+ScanSimulator::ScanSimulator() {
+    setPosition(position(0, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0), STEREO_CAMERA);
+    mHMin = -70;
+    mHMax = 70;
+    mHLines = 140;
+    mVMin = -30;
+    mVMax = 30;
+    mVLines = 60;
+    mType = SCANNER_COORDINATES;
 }
 
-void ScanSimulator::setPosition(transf tr, AxesConvention convention)
-{
-  mTran = tr;
-  mTranInv = mTran.inverse();
-  mPosition.set(tr.translation());
-  switch (convention) {
-  case STEREO_CAMERA:
-    mDirection = tr.affine().row(2);
-    mUp = -1.0 * tr.affine().row(1);
-    mHorizDirection = mUp * mDirection;
-    break;
-  }
-}
-
-void ScanSimulator::setPosition(position p, vec3 optical_axis, vec3 up_axis, AxesConvention convention)
-{
-	mPosition = p; mDirection = normalise(optical_axis); mUp = normalise(up_axis);
-        mHorizDirection = normalise(mUp * mDirection); 
-        mUp = mDirection * mHorizDirection;
-        switch (convention) {
+void ScanSimulator::setPosition(transf tr, AxesConvention convention) {
+    mTran = tr;
+    mTranInv = mTran.inverse();
+    mPosition.set(tr.translation());
+    switch (convention) {
         case STEREO_CAMERA:
-          mTran = transf( mat3(-1.0 * mHorizDirection, -1.0 * mUp, mDirection),
-                          vec3(mPosition.x(), mPosition.y(), mPosition.z() ) );
-          mTranInv = mTran.inverse();
-          break;
+            mDirection = tr.affine().row(2);
+            mUp = -1.0 * tr.affine().row(1);
+            mHorizDirection = mUp * mDirection;
+            break;
+    }
+}
+
+void ScanSimulator::setPosition(position p, vec3 optical_axis, vec3 up_axis, AxesConvention convention) {
+    mPosition = p;
+    mDirection = normalise(optical_axis);
+    mUp = normalise(up_axis);
+    mHorizDirection = normalise(mUp * mDirection);
+    mUp = mDirection * mHorizDirection;
+    switch (convention) {
+        case STEREO_CAMERA:
+            mTran = transf(mat3(-1.0 * mHorizDirection, -1.0 * mUp, mDirection),
+                           vec3(mPosition.x(), mPosition.y(), mPosition.z()));
+            mTranInv = mTran.inverse();
+            break;
+    }
+}
+
+void ScanSimulator::scan(std::vector<position> *cloud, std::vector<RawScanPoint> *rawData) {
+    float hfov = (mHMax - mHMin) * M_PI / 180.0;
+    float vfov = (mVMax - mVMin) * M_PI / 180.0;
+
+    assert(hfov >= 0 && vfov >= 0);
+    assert(mHLines > 0 && mVLines > 0);
+
+    float hstep = hfov / mHLines;
+    float vstep = vfov / mVLines;
+
+    fprintf(stderr, "Vfov %f and vstep %f and lines %d\n", vfov, vstep, mVLines);
+
+    float hAngle;
+    float vAngle = - vfov / 2.0;
+
+    vec3 rayDirection;
+    position rayPoint;
+    RawScanPoint rawPoint;
+
+    while (vAngle < vfov / 2.0) {
+        hAngle = - hfov / 2.0;
+        while (hAngle < hfov / 2.0) {
+
+            computeRayDirection(hAngle, vAngle, rayDirection);
+            rawPoint.hAngle = hAngle;
+            rawPoint.vAngle = vAngle;
+            rawPoint.dx = rayDirection.x();
+            rawPoint.dy = rayDirection.y();
+            rawPoint.dz = rayDirection.z();
+
+            if (shootRay(rayDirection, rayPoint)) {
+                vec3 dist = rayPoint - mPosition;
+                rawPoint.distance = dist.len();
+
+                //we get the point in world coordinates
+                if (mType == SCANNER_COORDINATES) {
+                    rayPoint = rayPoint * mTranInv;
+                }
+                cloud->push_back(rayPoint);
+
+
+            }
+            else {
+                rawPoint.distance = -1;
+            }
+
+            if (rawData) {
+                rawData->push_back(rawPoint);
+            }
+
+            hAngle += hstep;
         }
+        vAngle += vstep;
+        fprintf(stderr, "Vangle: %f\n", vAngle);
+    }
 }
 
-void ScanSimulator::scan(std::vector<position> *cloud, std::vector<RawScanPoint> *rawData)
-{
-	float hfov = (mHMax - mHMin) * M_PI / 180.0;
-	float vfov = (mVMax - mVMin) * M_PI / 180.0;
-
-	assert(hfov>=0 && vfov>=0);
-	assert( mHLines > 0 && mVLines > 0);
-
-	float hstep = hfov / mHLines;
-	float vstep = vfov / mVLines;
-
-	fprintf(stderr,"Vfov %f and vstep %f and lines %d\n",vfov,vstep,mVLines);
-
-	float hAngle;
-	float vAngle = - vfov / 2.0;
-
-	vec3 rayDirection;
-	position rayPoint;
-	RawScanPoint rawPoint;
-
-	while( vAngle < vfov / 2.0) {
-		hAngle = - hfov / 2.0;
-		while (hAngle < hfov / 2.0) {
-			
-			computeRayDirection( hAngle, vAngle, rayDirection);
-			rawPoint.hAngle = hAngle; rawPoint.vAngle = vAngle;
-			rawPoint.dx = rayDirection.x();
-			rawPoint.dy = rayDirection.y();
-			rawPoint.dz = rayDirection.z();
-
-			if ( shootRay( rayDirection, rayPoint ) ) {
-				vec3 dist = rayPoint - mPosition;
-				rawPoint.distance = dist.len();
-
-				//we get the point in world coordinates
-				if (mType == SCANNER_COORDINATES) {
-					rayPoint = rayPoint * mTranInv;
-				}
-				cloud->push_back(rayPoint);
-
-
-			} else {
-				rawPoint.distance = -1;
-			}
-			
-			if (rawData) {
-				rawData->push_back( rawPoint );
-			}
-
-			hAngle += hstep;
-		}
-		vAngle += vstep;
-		fprintf(stderr,"Vangle: %f\n",vAngle);
-	}
+void ScanSimulator::computeRayDirection(float hAngle, float vAngle, vec3 &rayDirection) {
+    Quaternion r1(vAngle, mHorizDirection);
+    Quaternion r2(hAngle, r1 * mUp);
+    rayDirection = r2 * r1 * mDirection;
 }
 
-void ScanSimulator::computeRayDirection(float hAngle, float vAngle, vec3 &rayDirection)
-{
-	Quaternion r1(vAngle, mHorizDirection );
-	Quaternion r2(hAngle, r1 * mUp);
-	rayDirection = r2 * r1 * mDirection;
-}
+bool ScanSimulator::shootRay(const vec3 &rayDirection, position &rayPoint) {
+    SoRayPickAction action(graspItGUI->getIVmgr()->getViewer()->getViewportRegion());
 
-bool ScanSimulator::shootRay(const vec3 &rayDirection, position &rayPoint)
-{
-	SoRayPickAction action( graspItGUI->getIVmgr()->getViewer()->getViewportRegion() );
+    action.setRay(mPosition.toSbVec3f(), rayDirection.toSbVec3f(), 0.0, -1.0);
+    action.setPickAll(false);
 
-	action.setRay( mPosition.toSbVec3f(), rayDirection.toSbVec3f(), 0.0, -1.0 );
-	action.setPickAll(false);
+    action.apply((SoNode *)graspItGUI->getIVmgr()->getWorld()->getIVRoot());
 
-	action.apply( (SoNode*)graspItGUI->getIVmgr()->getWorld()->getIVRoot() );
+    SoPickedPoint *pp = action.getPickedPoint();
+    if (!pp) return false;
 
-	SoPickedPoint *pp = action.getPickedPoint();
-	if (!pp) return false;
-
-	rayPoint = position( pp->getPoint() );
-	return true;
+    rayPoint = position(pp->getPoint());
+    return true;
 }
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -23,8 +23,8 @@
 //
 //######################################################################
 
-/*! \file 
-\brief Implements the simulation world....
+/*! \file
+    \brief Implements the simulation world....
 */
 
 #include <string>
@@ -84,7 +84,7 @@
 #include "dmalloc.h"
 #endif
 
-FILE *errFP=NULL;
+FILE *errFP = NULL;
 
 #include "debug.h"
 
@@ -105,2105 +105,2076 @@ PROF_DECLARE(DYNAMICS);
 char graspitVersionStr[] = "GraspIt! version 2.1";
 
 /*! Prepares an empty world. \a mgr is the instance of the inventor manager
-that will handle all user interaction. Also initialized collision detection
-system and reads in global settings such as friction coefficients 
+    that will handle all user interaction. Also initialized collision detection
+    system and reads in global settings such as friction coefficients
 */
-World::World(QObject *parent, const char *name, IVmgr *mgr) : QObject(parent,name)
-{
-	myIVmgr = mgr;
+World::World(QObject *parent, const char *name, IVmgr *mgr) : QObject(parent, name) {
+    myIVmgr = mgr;
 
-	numBodies = numGB = numRobots = numHands = 0;
-	numSelectedBodyElements = numSelectedRobotElements = 0;
-	numSelectedElements = 0;
-	numSelectedBodies = 0;
-	currentHand = NULL;
+    numBodies = numGB = numRobots = numHands = 0;
+    numSelectedBodyElements = numSelectedRobotElements = 0;
+    numSelectedElements = 0;
+    numSelectedBodies = 0;
+    currentHand = NULL;
 
-	isTendonSelected = false;
-	selectedTendon = NULL;
+    isTendonSelected = false;
+    selectedTendon = NULL;
 
-	worldTime = 0.0;
-	modified = false;
+    worldTime = 0.0;
+    modified = false;
 
-	allCollisionsOFF = false;
-	softContactsON = true;
+    allCollisionsOFF = false;
+    softContactsON = true;
 
-	cofTable=kcofTable=NULL;
-	// set up the world parameters 
-	readSettings();  
+    cofTable = kcofTable = NULL;
+    // set up the world parameters
+    readSettings();
 
-#ifdef PQP_COLLISION
-  mCollisionInterface = new PQPCollision();
-#endif
-#ifdef GRASPIT_COLLISION
-  mCollisionInterface = new GraspitCollision();
-#endif
+    #ifdef PQP_COLLISION
+    mCollisionInterface = new PQPCollision();
+    #endif
+    #ifdef GRASPIT_COLLISION
+    mCollisionInterface = new GraspitCollision();
+    #endif
 
-	IVRoot = new SoSeparator;
-	IVRoot->ref();
+    IVRoot = new SoSeparator;
+    IVRoot->ref();
 
-	idleSensor = NULL;
-	dynamicsOn = false;
+    idleSensor = NULL;
+    dynamicsOn = false;
 
-        // This has to happen at runtime, so it's placed here
-        // maybe we can find a better solution at some point.
-        WorldElementFactory::registerBuiltinCreators();
+    // This has to happen at runtime, so it's placed here
+    // maybe we can find a better solution at some point.
+    WorldElementFactory::registerBuiltinCreators();
 
-#ifdef GRASPIT_DYNAMICS
-  mDynamicsEngine = new GraspitDynamics(this);
-#endif
-#ifdef BULLET_DYNAMICS
-  mDynamicsEngine = new BulletDynamics(this);
-#endif
+    #ifdef GRASPIT_DYNAMICS
+    mDynamicsEngine = new GraspitDynamics(this);
+    #endif
+    #ifdef BULLET_DYNAMICS
+    mDynamicsEngine = new BulletDynamics(this);
+    #endif
 }
 
 /*! Saves the global settings and parameters and deletes the world
-along with all the objects that populate it.
+    along with all the objects that populate it.
 */
-World::~World()
-{
-	int i;
-	DBGP("Deleting world");
+World::~World() {
+    int i;
+    DBGP("Deleting world");
 
-	saveSettings();
+    saveSettings();
 
-	for (i=0;i<numMaterials;i++) {
-		free(cofTable[i]);
-		free(kcofTable[i]);
-	}
-	free(cofTable);
-	free(kcofTable);
+    for (i = 0; i < numMaterials; i++) {
+        free(cofTable[i]);
+        free(kcofTable[i]);
+    }
+    free(cofTable);
+    free(kcofTable);
 
-	for (i=numRobots-1;i>=0;i--)
-		destroyElement(robotVec[i]);
+    for (i = numRobots - 1; i >= 0; i--)
+        destroyElement(robotVec[i]);
 
-	for (i=numBodies-1;i>=0;i--) {
-		DBGP("Deleting body: " << i <<" "<<bodyVec[i]->getName().latin1());
-		destroyElement(bodyVec[i]);
-	}
+    for (i = numBodies - 1; i >= 0; i--) {
+        DBGP("Deleting body: " << i << " " << bodyVec[i]->getName().latin1());
+        destroyElement(bodyVec[i]);
+    }
 
-	if (idleSensor) delete idleSensor;
-	delete mCollisionInterface;
+    if (idleSensor) delete idleSensor;
+    delete mCollisionInterface;
     delete mDynamicsEngine;
-	IVRoot->unref();
+    IVRoot->unref();
 }
 
-/*! Returns the material id of a material with name \a matName 
+/*! Returns the material id of a material with name \a matName
 */
 int
-World::getMaterialIdx(const QString &matName) const
-{
-	for (int i=0; i<numMaterials; i++) {
-		if (materialNames[i] == matName) return i;
-	}
-	return -1;
+World::getMaterialIdx(const QString &matName) const {
+    for (int i = 0; i < numMaterials; i++) {
+        if (materialNames[i] == matName) return i;
+    }
+    return -1;
 }
 
 
-/*! Returns the material name of a material with id \a matIdx 
+/*! Returns the material name of a material with id \a matIdx
 */
 /**
-int
-World::getMaterialName(int matIdx, QString &matName) const
-{
-	if(i<0||i>=numMaterials)
-		return FAILURE;
-	matName = materialNames[i];
-	return SUCCESS;
-}
+    int
+    World::getMaterialName(int matIdx, QString &matName) const
+    {
+    if(i<0||i>=numMaterials)
+        return FAILURE;
+    matName = materialNames[i];
+    return SUCCESS;
+    }
 */
 
 /*! Sets all the default (hard-coded) coefficients and parameters. If the user later
-changes them, they are saved when the world is destroyed, and automatically loaded
-later, when the application is started again.
+    changes them, they are saved when the world is destroyed, and automatically loaded
+    later, when the application is started again.
 */
 void
-World::setDefaults()
-{
-	int i;
-	dynamicsTimeStep = 0.0025;
+World::setDefaults() {
+    int i;
+    dynamicsTimeStep = 0.0025;
 
-	if (cofTable) {
-		for (i=0;i<numMaterials;i++) {
-			free(cofTable[i]);
-			free(kcofTable[i]);
-		}
-		free(cofTable);
-		free(kcofTable);
-	}
+    if (cofTable) {
+        for (i = 0; i < numMaterials; i++) {
+            free(cofTable[i]);
+            free(kcofTable[i]);
+        }
+        free(cofTable);
+        free(kcofTable);
+    }
 
-	numMaterials = 7;
-	cofTable = (double **)malloc(numMaterials*sizeof(double *));
-	kcofTable = (double **)malloc(numMaterials*sizeof(double *));
-	for (i=0;i<numMaterials;i++) {
-		cofTable[i] = (double *)malloc(numMaterials*sizeof(double));
-		kcofTable[i] = (double *)malloc(numMaterials*sizeof(double));
-	}
+    numMaterials = 7;
+    cofTable = (double **)malloc(numMaterials * sizeof(double *));
+    kcofTable = (double **)malloc(numMaterials * sizeof(double *));
+    for (i = 0; i < numMaterials; i++) {
+        cofTable[i] = (double *)malloc(numMaterials * sizeof(double));
+        kcofTable[i] = (double *)malloc(numMaterials * sizeof(double));
+    }
 
-	materialNames.clear();
-	materialNames.push_back("frictionless");
-	materialNames.push_back("glass");
-	materialNames.push_back("metal");
-	materialNames.push_back("plastic");
-	materialNames.push_back("wood");
-	materialNames.push_back("rubber");
-	materialNames.push_back("stone");
+    materialNames.clear();
+    materialNames.push_back("frictionless");
+    materialNames.push_back("glass");
+    materialNames.push_back("metal");
+    materialNames.push_back("plastic");
+    materialNames.push_back("wood");
+    materialNames.push_back("rubber");
+    materialNames.push_back("stone");
 
-	//frictionless
-	for (i=0;i<7;i++) {
-		cofTable[0][i] = cofTable[i][0] = 0.0;
-		kcofTable[0][i] = kcofTable[i][0] = 0.0;
-	}
+    //frictionless
+    for (i = 0; i < 7; i++) {
+        cofTable[0][i] = cofTable[i][0] = 0.0;
+        kcofTable[0][i] = kcofTable[i][0] = 0.0;
+    }
 
-	//stone
-	cofTable[6][6] = 0.7;
-	cofTable[6][1] = cofTable[1][6] = 0.3;
-	cofTable[6][2] = cofTable[2][6] = 0.4;
-	cofTable[6][3] = cofTable[3][6] = 0.4;
-	cofTable[6][4] = cofTable[4][6] = 0.6;
-	cofTable[6][5] = cofTable[5][6] = 1.5;
-	kcofTable[6][6] = 0.6;
-	kcofTable[6][1] = kcofTable[1][6] = 0.2;
-	kcofTable[6][2] = kcofTable[2][6] = 0.3;
-	kcofTable[6][3] = kcofTable[3][6] = 0.3;
-	kcofTable[6][4] = kcofTable[4][6] = 0.5;
-	kcofTable[6][5] = kcofTable[5][6] = 1.4;
+    //stone
+    cofTable[6][6] = 0.7;
+    cofTable[6][1] = cofTable[1][6] = 0.3;
+    cofTable[6][2] = cofTable[2][6] = 0.4;
+    cofTable[6][3] = cofTable[3][6] = 0.4;
+    cofTable[6][4] = cofTable[4][6] = 0.6;
+    cofTable[6][5] = cofTable[5][6] = 1.5;
+    kcofTable[6][6] = 0.6;
+    kcofTable[6][1] = kcofTable[1][6] = 0.2;
+    kcofTable[6][2] = kcofTable[2][6] = 0.3;
+    kcofTable[6][3] = kcofTable[3][6] = 0.3;
+    kcofTable[6][4] = kcofTable[4][6] = 0.5;
+    kcofTable[6][5] = kcofTable[5][6] = 1.4;
 
-	//glass
-	cofTable[1][1] = 0.2;
-	cofTable[1][2] = cofTable[2][1] = 0.2;
-	cofTable[1][3] = cofTable[3][1] = 0.2;
-	cofTable[1][4] = cofTable[4][1] = 0.3;
-	cofTable[1][5] = cofTable[5][1] = 1.0;
-	kcofTable[1][1] = 0.1;
-	kcofTable[1][2] = kcofTable[2][1] = 0.1;
-	kcofTable[1][3] = kcofTable[3][1] = 0.1;
-	kcofTable[1][4] = kcofTable[4][1] = 0.2;
-	kcofTable[1][5] = kcofTable[5][1] = 0.9;
+    //glass
+    cofTable[1][1] = 0.2;
+    cofTable[1][2] = cofTable[2][1] = 0.2;
+    cofTable[1][3] = cofTable[3][1] = 0.2;
+    cofTable[1][4] = cofTable[4][1] = 0.3;
+    cofTable[1][5] = cofTable[5][1] = 1.0;
+    kcofTable[1][1] = 0.1;
+    kcofTable[1][2] = kcofTable[2][1] = 0.1;
+    kcofTable[1][3] = kcofTable[3][1] = 0.1;
+    kcofTable[1][4] = kcofTable[4][1] = 0.2;
+    kcofTable[1][5] = kcofTable[5][1] = 0.9;
 
-	//metal
-	cofTable[2][2] = 0.2;
-	cofTable[2][3] = cofTable[3][2] = 0.2;
-	cofTable[2][4] = cofTable[4][2] = 0.3;
-	cofTable[2][5] = cofTable[5][2] = 1.0;
-	kcofTable[2][2] = 0.1;
-	kcofTable[2][3] = kcofTable[3][2] = 0.1;
-	kcofTable[2][4] = kcofTable[4][2] = 0.2;
-	kcofTable[2][5] = kcofTable[5][2] = 0.9;
+    //metal
+    cofTable[2][2] = 0.2;
+    cofTable[2][3] = cofTable[3][2] = 0.2;
+    cofTable[2][4] = cofTable[4][2] = 0.3;
+    cofTable[2][5] = cofTable[5][2] = 1.0;
+    kcofTable[2][2] = 0.1;
+    kcofTable[2][3] = kcofTable[3][2] = 0.1;
+    kcofTable[2][4] = kcofTable[4][2] = 0.2;
+    kcofTable[2][5] = kcofTable[5][2] = 0.9;
 
-	//plastic
-	cofTable[3][3] = 0.3;
-	cofTable[3][4] = cofTable[4][3] = 0.4;
-	cofTable[3][5] = cofTable[5][3] = 1.0;
-	kcofTable[3][3] = 0.2;
-	kcofTable[3][4] = kcofTable[4][3] = 0.3;
-	kcofTable[3][5] = kcofTable[5][3] = 0.9;
+    //plastic
+    cofTable[3][3] = 0.3;
+    cofTable[3][4] = cofTable[4][3] = 0.4;
+    cofTable[3][5] = cofTable[5][3] = 1.0;
+    kcofTable[3][3] = 0.2;
+    kcofTable[3][4] = kcofTable[4][3] = 0.3;
+    kcofTable[3][5] = kcofTable[5][3] = 0.9;
 
-	//wood
-	cofTable[4][4] = 0.4;
-	cofTable[4][5] = cofTable[5][4] = 1.0;
-	kcofTable[4][4] = 0.3;
-	kcofTable[4][5] = kcofTable[5][4] = 0.9;
+    //wood
+    cofTable[4][4] = 0.4;
+    cofTable[4][5] = cofTable[5][4] = 1.0;
+    kcofTable[4][4] = 0.3;
+    kcofTable[4][5] = kcofTable[5][4] = 0.9;
 
-	//rubber
-	cofTable[5][5] = 2.0;
-	kcofTable[5][5] = 1.9;
+    //rubber
+    cofTable[5][5] = 2.0;
+    kcofTable[5][5] = 1.9;
 }
 
 /*! Reads in previously saved coefficients and parameters, if they exist. In Windows,
-they are read from the registry, in Linux they should be read from a file. It seems 
-that currently only the Window implementation is here. If they don't exist, the 
-default values are used.
+    they are read from the registry, in Linux they should be read from a file. It seems
+    that currently only the Window implementation is here. If they don't exist, the
+    default values are used.
 */
 void
-World::readSettings()
-{
-	QSettings settings;
-	int i,j,newNumMaterials;
-	double **newcofTable,**newkcofTable;
-	std::vector<QString> newMaterialNames;
+World::readSettings() {
+    QSettings settings;
+    int i, j, newNumMaterials;
+    double **newcofTable, **newkcofTable;
+    std::vector<QString> newMaterialNames;
 
-	setDefaults();
+    setDefaults();
 
-	settings.insertSearchPath(QSettings::Windows, COMPANY_KEY);
+    settings.insertSearchPath(QSettings::Windows, COMPANY_KEY);
 
-	dynamicsTimeStep = settings.readDoubleEntry(APP_KEY + QString("World/dynamicsTimeStep"),dynamicsTimeStep);
+    dynamicsTimeStep = settings.readDoubleEntry(APP_KEY + QString("World/dynamicsTimeStep"), dynamicsTimeStep);
 
-	newNumMaterials = settings.readNumEntry(APP_KEY + QString("World/numMaterials"),numMaterials);
+    newNumMaterials = settings.readNumEntry(APP_KEY + QString("World/numMaterials"), numMaterials);
 
-	newcofTable = (double **)malloc(newNumMaterials*sizeof(double *));
-	newkcofTable = (double **)malloc(newNumMaterials*sizeof(double *));
-	newMaterialNames.resize(newNumMaterials, QString::null);
+    newcofTable = (double **)malloc(newNumMaterials * sizeof(double *));
+    newkcofTable = (double **)malloc(newNumMaterials * sizeof(double *));
+    newMaterialNames.resize(newNumMaterials, QString::null);
 
-	for (i=0;i<newNumMaterials;i++) {
-		newcofTable[i] = (double *)malloc(newNumMaterials*sizeof(double));
-		newkcofTable[i] = (double *)malloc(newNumMaterials*sizeof(double));
-	}
+    for (i = 0; i < newNumMaterials; i++) {
+        newcofTable[i] = (double *)malloc(newNumMaterials * sizeof(double));
+        newkcofTable[i] = (double *)malloc(newNumMaterials * sizeof(double));
+    }
 
-	for (i=0;i<numMaterials;i++) {
-		newMaterialNames[i] = settings.readEntry(APP_KEY + QString("World/material%1").arg(i),materialNames[i]);
+    for (i = 0; i < numMaterials; i++) {
+        newMaterialNames[i] = settings.readEntry(APP_KEY + QString("World/material%1").arg(i), materialNames[i]);
 
-		for (j=i;j<numMaterials;j++) {
-			newcofTable[i][j] = newcofTable[j][i] =
-				settings.readDoubleEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j),cofTable[i][j]);
+        for (j = i; j < numMaterials; j++) {
+            newcofTable[i][j] = newcofTable[j][i] =
+                                    settings.readDoubleEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j), cofTable[i][j]);
 
-			newkcofTable[i][j] = newkcofTable[j][i] =
-				settings.readDoubleEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j),kcofTable[i][j]);
-		}
+            newkcofTable[i][j] = newkcofTable[j][i] =
+                                     settings.readDoubleEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j), kcofTable[i][j]);
+        }
 
-		for (;j<newNumMaterials;j++) {
-			newcofTable[i][j] = newcofTable[j][i] =
-				settings.readDoubleEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j));
+        for (; j < newNumMaterials; j++) {
+            newcofTable[i][j] = newcofTable[j][i] =
+                                    settings.readDoubleEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j));
 
-			newkcofTable[i][j] = newkcofTable[j][i] =
-				settings.readDoubleEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j));
-		}
-	}
-	for (;i<newNumMaterials;i++){
-		newMaterialNames.push_back(settings.readEntry(APP_KEY + QString("World/material%1").arg(i)));
+            newkcofTable[i][j] = newkcofTable[j][i] =
+                                     settings.readDoubleEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j));
+        }
+    }
+    for (; i < newNumMaterials; i++) {
+        newMaterialNames.push_back(settings.readEntry(APP_KEY + QString("World/material%1").arg(i)));
 
-		for (j=i;j<newNumMaterials;j++) {
-			newcofTable[i][j] = newcofTable[j][i] =
-				settings.readDoubleEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j));
+        for (j = i; j < newNumMaterials; j++) {
+            newcofTable[i][j] = newcofTable[j][i] =
+                                    settings.readDoubleEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j));
 
-			newkcofTable[i][j] = newkcofTable[j][i] =
-				settings.readDoubleEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j));
-		}
-	}
+            newkcofTable[i][j] = newkcofTable[j][i] =
+                                     settings.readDoubleEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j));
+        }
+    }
 
-	for (i=0;i<numMaterials;i++) {
-		free(cofTable[i]);
-		free(kcofTable[i]);
-	}
+    for (i = 0; i < numMaterials; i++) {
+        free(cofTable[i]);
+        free(kcofTable[i]);
+    }
 
-	free(cofTable);
-	free(kcofTable);
-	materialNames = newMaterialNames;
-	numMaterials = newNumMaterials;
-	cofTable = newcofTable;
-	kcofTable = newkcofTable;
+    free(cofTable);
+    free(kcofTable);
+    materialNames = newMaterialNames;
+    numMaterials = newNumMaterials;
+    cofTable = newcofTable;
+    kcofTable = newkcofTable;
 }
 
 /*! Saves current global settings to the registry */
 void
-World::saveSettings()
-{
-	int i,j;
-	QSettings settings;
-	settings.insertSearchPath(QSettings::Windows, COMPANY_KEY);
+World::saveSettings() {
+    int i, j;
+    QSettings settings;
+    settings.insertSearchPath(QSettings::Windows, COMPANY_KEY);
 
-	settings.writeEntry(APP_KEY + QString("World/numMaterials"),numMaterials);
-	for (i=0;i<numMaterials;i++) {
-		settings.writeEntry(APP_KEY + QString("World/material%1").arg(i),materialNames[i]);
-		for (j=i;j<numMaterials;j++) { 
-			settings.writeEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j),cofTable[i][j]);
-			settings.writeEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j),kcofTable[i][j]);
-		}
-	}
+    settings.writeEntry(APP_KEY + QString("World/numMaterials"), numMaterials);
+    for (i = 0; i < numMaterials; i++) {
+        settings.writeEntry(APP_KEY + QString("World/material%1").arg(i), materialNames[i]);
+        for (j = i; j < numMaterials; j++) {
+            settings.writeEntry(APP_KEY + QString("World/cof%1%2").arg(i).arg(j), cofTable[i][j]);
+            settings.writeEntry(APP_KEY + QString("World/kcof%1%2").arg(i).arg(j), kcofTable[i][j]);
+        }
+    }
 }
 
 /*! Removes a world element (a robot or any kind of body) from the World.
-Also removes it from the scene graph and the collision detection system.
-If \a deleteElement is true, it also deletes it at the end. If it is a 
-graspable body and there is a grasp that references it, it associates 
-the grasp with the first GB or NULL if none are left.
+    Also removes it from the scene graph and the collision detection system.
+    If \a deleteElement is true, it also deletes it at the end. If it is a
+    graspable body and there is a grasp that references it, it associates
+    the grasp with the first GB or NULL if none are left.
 */
 void
-World::destroyElement(WorldElement *e, bool deleteElement)
-{
-	std::vector<Body *>::iterator bp;
-	std::vector<GraspableBody *>::iterator gp;
-	std::vector<Robot *>::iterator rp;
-	std::vector<Hand *>::iterator hp;
-	DBGP("In remove element: " << e->className());
+World::destroyElement(WorldElement *e, bool deleteElement) {
+    std::vector<Body *>::iterator bp;
+    std::vector<GraspableBody *>::iterator gp;
+    std::vector<Robot *>::iterator rp;
+    std::vector<Hand *>::iterator hp;
+    DBGP("In remove element: " << e->className());
 
-	if (e->inherits("Body")) {
-		DBGP("found a body");
-		mCollisionInterface->removeBody( (Body*) e);
-		for (bp=bodyVec.begin();bp!=bodyVec.end();bp++) {
-			if (*bp == e) {
-				bodyVec.erase(bp); numBodies--;
-				DBGP("removed body "<<((Body *)e)->getName()<<" from world");
-				break;
-			}
-		}
-		for (gp=GBVec.begin();gp!=GBVec.end();gp++)  {
-			if (*gp == e) {
-				GBVec.erase(gp); numGB--;
-				for (hp=handVec.begin();hp!=handVec.end();hp++) {
-					if ((*hp)->getGrasp()->getObject() == e) {
-						if (numGB > 0)
-							(*hp)->getGrasp()->setObject(GBVec[0]);
-						else
-							(*hp)->getGrasp()->setObject(NULL);
-					}
-				}
-				DBGP("removed GB " << ((Body *)e)->getName()<<" from world");
-				break;
-			}
-		}
-	}
+    if (e->inherits("Body")) {
+        DBGP("found a body");
+        mCollisionInterface->removeBody((Body *) e);
+        for (bp = bodyVec.begin(); bp != bodyVec.end(); bp++) {
+            if (*bp == e) {
+                bodyVec.erase(bp);
+                numBodies--;
+                DBGP("removed body " << ((Body *)e)->getName() << " from world");
+                break;
+            }
+        }
+        for (gp = GBVec.begin(); gp != GBVec.end(); gp++)  {
+            if (*gp == e) {
+                GBVec.erase(gp);
+                numGB--;
+                for (hp = handVec.begin(); hp != handVec.end(); hp++) {
+                    if ((*hp)->getGrasp()->getObject() == e) {
+                        if (numGB > 0)
+                            (*hp)->getGrasp()->setObject(GBVec[0]);
+                        else
+                            (*hp)->getGrasp()->setObject(NULL);
+                    }
+                }
+                DBGP("removed GB " << ((Body *)e)->getName() << " from world");
+                break;
+            }
+        }
+    }
 
-	if (e->inherits("Robot")) {
-		DBGP(" found a robot");
-		for (hp=handVec.begin();hp!=handVec.end();hp++)  {
-			if (*hp == e) {
-				handVec.erase(hp); numHands--;
-				if (currentHand == e) {
-					if (numHands > 0) currentHand = handVec[0];
-					else currentHand = NULL;
-				}
-				DBGP("removed hand " << ((Robot *)e)->getName() << " from world");  
-				Q_EMIT handRemoved();
-				break;
-			}
-		}
-		for (rp=robotVec.begin();rp!=robotVec.end();rp++) {
-			if (*rp == e) {
-				robotVec.erase(rp); numRobots--;
-				DBGP("removed robot " << ((Robot *)e)->getName() << " from world"); 
-				break;
-			}
-		}
-	}
+    if (e->inherits("Robot")) {
+        DBGP(" found a robot");
+        for (hp = handVec.begin(); hp != handVec.end(); hp++)  {
+            if (*hp == e) {
+                handVec.erase(hp);
+                numHands--;
+                if (currentHand == e) {
+                    if (numHands > 0) currentHand = handVec[0];
+                    else currentHand = NULL;
+                }
+                DBGP("removed hand " << ((Robot *)e)->getName() << " from world");
+                Q_EMIT handRemoved();
+                break;
+            }
+        }
+        for (rp = robotVec.begin(); rp != robotVec.end(); rp++) {
+            if (*rp == e) {
+                robotVec.erase(rp);
+                numRobots--;
+                DBGP("removed robot " << ((Robot *)e)->getName() << " from world");
+                break;
+            }
+        }
+    }
 
-	int idx = IVRoot->findChild(e->getIVRoot());
-	if (deleteElement) delete e;
-	else e->getIVRoot()->ref();
-	if (idx > -1)
-		IVRoot->removeChild(idx);
-	if (!deleteElement) e->getIVRoot()->unrefNoDelete();
+    int idx = IVRoot->findChild(e->getIVRoot());
+    if (deleteElement) delete e;
+    else e->getIVRoot()->ref();
+    if (idx > -1)
+        IVRoot->removeChild(idx);
+    if (!deleteElement) e->getIVRoot()->unrefNoDelete();
 
-	Q_EMIT numElementsChanged();
-	modified = true;
+    Q_EMIT numElementsChanged();
+    modified = true;
 }
 
 /*! Loads a simulation world file. These usually consists of one or more robots,
-	graspable bodies and obstacles, each with its own transform. Optionally, 
-	a camera position might also be specified. Also restores any connections
-	between robots.
+    graspable bodies and obstacles, each with its own transform. Optionally,
+    a camera position might also be specified. Also restores any connections
+    between robots.
 */
 int
-World::load(const QString &filename)
-{
-	QString graspitRoot = getenv("GRASPIT");
-	graspitRoot.replace("\\","/");
-	if (graspitRoot.at(graspitRoot.size()-1)!='/') {
-		graspitRoot += "/";
-	}
-	//load the graspit specific information in XML format
-	TiXmlDocument doc(filename);
-	if(doc.LoadFile()==false){
-		QTWARNING("Could not open file " + filename);
-		return FAILURE;
-	}
-	const TiXmlElement*  root = doc.RootElement();
-	if(root==NULL){
-		QTWARNING("Empty XML");
-		return FAILURE;	
-	}
-	if (loadFromXml(root,graspitRoot) == FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+World::load(const QString &filename) {
+    QString graspitRoot = getenv("GRASPIT");
+    graspitRoot.replace("\\", "/");
+    if (graspitRoot.at(graspitRoot.size() - 1) != '/') {
+        graspitRoot += "/";
+    }
+    //load the graspit specific information in XML format
+    TiXmlDocument doc(filename);
+    if (doc.LoadFile() == false) {
+        QTWARNING("Could not open file " + filename);
+        return FAILURE;
+    }
+    const TiXmlElement  *root = doc.RootElement();
+    if (root == NULL) {
+        QTWARNING("Empty XML");
+        return FAILURE;
+    }
+    if (loadFromXml(root, graspitRoot) == FAILURE) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 int
-World::loadFromXml(const TiXmlElement* root,QString rootPath)
-{
-	const TiXmlElement* child = root->FirstChildElement();
-	const TiXmlElement* xmlElement;
-	QString buf, elementType, matStr, elementPath, elementName,mountFilename;
-	Link *mountPiece;
-	QString line;
-	WorldElement *element=NULL;
-	transf tr;
-	int prevRobNum,chainNum,nextRobNum;
-	bool cameraFound;
-	while(child!=NULL){
-		elementType = child->Value();
-		if(elementType.isNull()){
-			QTWARNING("Empty Element Type");
-		}
-		if (elementType == "obstacle") {
-			xmlElement = findXmlElement(child, "filename");
-			bool loadFromFile=false;
-			if(xmlElement){
-				elementName = xmlElement->GetText();
-				elementPath = rootPath + elementName;
-				elementPath = elementPath.stripWhiteSpace();
-				DBGP("importing " << elementPath.latin1());
-				element = importBody("Body",elementPath);
-				if (!element) {
-					QTWARNING("Could not open " + elementPath);
-					return FAILURE;
-				}
-				loadFromFile = true;
-			}
-			xmlElement = findXmlElement(child, "body");
-			if(loadFromFile){
-				if(xmlElement) {
-					QTWARNING("Contains both filename and body info: Load From File");
-				}
-			} else{//load from body info
-				if(!xmlElement){
-					QTWARNING("Neither filename nor body info found");
-					return FAILURE;
-				}
-				DBGP("importing obstacle from body info");
-				element = importBodyFromXml("Body", xmlElement,rootPath);
-				if (!element) {
-					QTWARNING("Could not open file " + elementPath);
-					return FAILURE;
-				}
-			}
-			xmlElement = findXmlElement(child,"transform");
-			if(xmlElement){
-				if (getTransform(xmlElement,tr)==false) {
-					QTWARNING("Obstacle transformation Error");
-					return FAILURE;
-				}
-				element->setTran(tr);
-			}
-		}
-		else if (elementType == "graspableBody") {
-			xmlElement = findXmlElement(child, "filename");
-			bool loadFromFile = false;
-			if(xmlElement){
-				elementName = xmlElement->GetText();
-				elementPath = rootPath + elementName;
-				elementPath = elementPath.stripWhiteSpace();
-				DBGP("importing " << elementPath.latin1());
-				element = importBody("GraspableBody",elementPath);
-				if (!element) {
-					QTWARNING("Could not open " + elementPath);
-					return FAILURE;
-				}
-				loadFromFile = true;
-			}
-			xmlElement = findXmlElement(child, "body");
-			if(loadFromFile){
-				if(xmlElement) {
-					QTWARNING("Contains both filename and body info: Load From File");
-				}
-			}
-			else{//load from body info
-				if(!xmlElement){
-					QTWARNING("Neither filename nor body info found");
-					return FAILURE;
-				}
-				DBGP("importing graspable body from body info");
-				element = importBodyFromXml("GraspableBody", xmlElement,rootPath);
-				if (!element) {
-					QTWARNING("Could not open " + elementPath);
-					return FAILURE;
-				}
-			}
-			xmlElement = findXmlElement(child,"transform");
-			if(xmlElement){
-				if (getTransform(xmlElement,tr)==false) {
-					QTWARNING("GraspableBody transformation Error");
-					return FAILURE;
-				}
-				element->setTran(tr);
-			}			
-		}
-		else if (elementType == "robot") {
-			Robot *robot;
-			xmlElement = findXmlElement(child, "filename");
-			if(!xmlElement){
-				QTWARNING("Robot filename not found");
-				return FAILURE;
-			}
-			elementName = xmlElement->GetText();	
-			elementPath = rootPath + elementName;
-			DBGP("importing " << elementPath.latin1());
-			if ((robot = importRobot(elementPath))==NULL){
-				QTWARNING("Could not open " + elementPath);
-				return FAILURE;
-			}
-			element = robot;
-			xmlElement = findXmlElement(child,"dofValues");
-			if(xmlElement){
-				QString dofValues =  xmlElement->GetText();
-				dofValues = dofValues.stripWhiteSpace().simplifyWhiteSpace();
-				QTextStream lineStream(&dofValues,QIODevice::ReadOnly);
-				robot->readDOFVals(lineStream);
-			}
-			xmlElement = findXmlElement(child,"transform");
-			if(xmlElement){
-				if (getTransform(xmlElement,tr)==false) {
-					QTWARNING("Robot transformation Error");
-					return FAILURE;
-				}
-				element->setTran(tr);
-			}	
-		}
-		else if (elementType == "connection") {
-			if(!getInt(child, "parentRobot", prevRobNum)){
-				QTWARNING("Failed to load Parent Robot Number");
-				return FAILURE;
-			}
-			if(!getInt(child, "parentChain", chainNum)){
-				QTWARNING("Failed to load Parent Robot's Chain Number");
-				return FAILURE;
-			}
-			if(!getInt(child, "childRobot", nextRobNum)){
-				QTWARNING("Failed to load Child Robot Number");
-				return FAILURE;
-			}
-			if (prevRobNum < 0 || prevRobNum >= numRobots || nextRobNum < 0 ||
-				nextRobNum >= numRobots || chainNum < 0 || 
-				chainNum >= robotVec[prevRobNum]->getNumChains()) {
-                    QTWARNING("Error reading connection transform"); break;
-			}
-			xmlElement = findXmlElement( child, "transform");
-			if(xmlElement){
-				if (!getTransform(xmlElement,tr)) {
-					QTWARNING("Error reading connection transform"); break;
-				}
-			}
-			DBGP("offset tran " << tr);
-			xmlElement = findXmlElement(child, "mountFilename");
-			if(xmlElement){
-				mountFilename = xmlElement->GetText();
-				if (!mountFilename.isEmpty()) {
-					mountFilename = mountFilename.stripWhiteSpace();
-					KinematicChain *prevChain= robotVec[prevRobNum]->getChain(chainNum);
-					mountFilename = rootPath + mountFilename;
-					DBGA("Mount filename: " << mountFilename.latin1());
-					if ((mountPiece = robotVec[nextRobNum]->importMountPiece(mountFilename))) {
-						addLink(mountPiece);
-						toggleCollisions(false, prevChain->getLink(prevChain->getNumLinks()-1), mountPiece);
-						toggleCollisions(false, mountPiece,robotVec[nextRobNum]->getBase());
-					}
-					mountFilename=(char *)NULL;
-				}
-			}
-			robotVec[prevRobNum]->attachRobot(robotVec[nextRobNum],chainNum,tr);
-		}
-		else if (elementType == "camera" ) {
-			double px, py, pz, q1, q2, q3, q4, fd;
-			QStringList l;
-			xmlElement = findXmlElement(child,"position");
-			if(!xmlElement){
-				QTWARNING("Camera Position not found");
-				return FAILURE;
-			}
-			QString position = xmlElement->GetText();
-			position = position.simplifyWhiteSpace().stripWhiteSpace();
-			l = QStringList::split(' ', position);
-			if(l.count()!=3){
-				QTWARNING("Invalid camera position input");
-				return FAILURE;
-			}
-			bool ok1,ok2,ok3, ok4;
-			px = l[0].toDouble(&ok1);
-			py = l[1].toDouble(&ok2);
-			pz = l[2].toDouble(&ok3);
-			if(!ok1 || !ok2 || !ok3){
-				QTWARNING("Invalid camera position input");
-				return FAILURE;
-			}
-			xmlElement = findXmlElement(child,"orientation");
-			if(!xmlElement){
-				QTWARNING("Camera orientation not found");
-				return FAILURE;
-			}
-			QString orientation = xmlElement->GetText();
-			position = orientation.simplifyWhiteSpace().stripWhiteSpace();
-			l = QStringList::split(' ', orientation);
-			if(l.count()!=4){
-				QTWARNING("Invalid camera orientation input");
-				return FAILURE;
-			}
-			q1 = l[0].toDouble(&ok1);
-			q2 = l[1].toDouble(&ok2);
-			q3 = l[2].toDouble(&ok3);
-			q4 = l[3].toDouble(&ok4);
-			if(!ok1 || !ok2 || !ok3 || !ok4){
-				QTWARNING("Invalid camera position input");
-				return FAILURE;
-			}
-			if(!getDouble(child, "focalDistance", fd)){
-				QTWARNING("Failed to load focal distance");
-				return FAILURE;				
-			}
-			myIVmgr->setCamera(px, py, pz, q1, q2, q3, q4, fd);
-			cameraFound = true;
-		}
-		else {
-			QTWARNING(elementType + " is not a valid WorldElement type");
-			return FAILURE;
-		}
-		child = child->NextSiblingElement();
-	}
+World::loadFromXml(const TiXmlElement *root, QString rootPath) {
+    const TiXmlElement *child = root->FirstChildElement();
+    const TiXmlElement *xmlElement;
+    QString buf, elementType, matStr, elementPath, elementName, mountFilename;
+    Link *mountPiece;
+    QString line;
+    WorldElement *element = NULL;
+    transf tr;
+    int prevRobNum, chainNum, nextRobNum;
+    bool cameraFound;
+    while (child != NULL) {
+        elementType = child->Value();
+        if (elementType.isNull()) {
+            QTWARNING("Empty Element Type");
+        }
+        if (elementType == "obstacle") {
+            xmlElement = findXmlElement(child, "filename");
+            bool loadFromFile = false;
+            if (xmlElement) {
+                elementName = xmlElement->GetText();
+                elementPath = rootPath + elementName;
+                elementPath = elementPath.stripWhiteSpace();
+                DBGP("importing " << elementPath.latin1());
+                element = importBody("Body", elementPath);
+                if (!element) {
+                    QTWARNING("Could not open " + elementPath);
+                    return FAILURE;
+                }
+                loadFromFile = true;
+            }
+            xmlElement = findXmlElement(child, "body");
+            if (loadFromFile) {
+                if (xmlElement) {
+                    QTWARNING("Contains both filename and body info: Load From File");
+                }
+            }
+            else { //load from body info
+                if (!xmlElement) {
+                    QTWARNING("Neither filename nor body info found");
+                    return FAILURE;
+                }
+                DBGP("importing obstacle from body info");
+                element = importBodyFromXml("Body", xmlElement, rootPath);
+                if (!element) {
+                    QTWARNING("Could not open file " + elementPath);
+                    return FAILURE;
+                }
+            }
+            xmlElement = findXmlElement(child, "transform");
+            if (xmlElement) {
+                if (getTransform(xmlElement, tr) == false) {
+                    QTWARNING("Obstacle transformation Error");
+                    return FAILURE;
+                }
+                element->setTran(tr);
+            }
+        }
+        else if (elementType == "graspableBody") {
+            xmlElement = findXmlElement(child, "filename");
+            bool loadFromFile = false;
+            if (xmlElement) {
+                elementName = xmlElement->GetText();
+                elementPath = rootPath + elementName;
+                elementPath = elementPath.stripWhiteSpace();
+                DBGP("importing " << elementPath.latin1());
+                element = importBody("GraspableBody", elementPath);
+                if (!element) {
+                    QTWARNING("Could not open " + elementPath);
+                    return FAILURE;
+                }
+                loadFromFile = true;
+            }
+            xmlElement = findXmlElement(child, "body");
+            if (loadFromFile) {
+                if (xmlElement) {
+                    QTWARNING("Contains both filename and body info: Load From File");
+                }
+            }
+            else { //load from body info
+                if (!xmlElement) {
+                    QTWARNING("Neither filename nor body info found");
+                    return FAILURE;
+                }
+                DBGP("importing graspable body from body info");
+                element = importBodyFromXml("GraspableBody", xmlElement, rootPath);
+                if (!element) {
+                    QTWARNING("Could not open " + elementPath);
+                    return FAILURE;
+                }
+            }
+            xmlElement = findXmlElement(child, "transform");
+            if (xmlElement) {
+                if (getTransform(xmlElement, tr) == false) {
+                    QTWARNING("GraspableBody transformation Error");
+                    return FAILURE;
+                }
+                element->setTran(tr);
+            }
+        }
+        else if (elementType == "robot") {
+            Robot *robot;
+            xmlElement = findXmlElement(child, "filename");
+            if (!xmlElement) {
+                QTWARNING("Robot filename not found");
+                return FAILURE;
+            }
+            elementName = xmlElement->GetText();
+            elementPath = rootPath + elementName;
+            DBGP("importing " << elementPath.latin1());
+            if ((robot = importRobot(elementPath)) == NULL) {
+                QTWARNING("Could not open " + elementPath);
+                return FAILURE;
+            }
+            element = robot;
+            xmlElement = findXmlElement(child, "dofValues");
+            if (xmlElement) {
+                QString dofValues =  xmlElement->GetText();
+                dofValues = dofValues.stripWhiteSpace().simplifyWhiteSpace();
+                QTextStream lineStream(&dofValues, QIODevice::ReadOnly);
+                robot->readDOFVals(lineStream);
+            }
+            xmlElement = findXmlElement(child, "transform");
+            if (xmlElement) {
+                if (getTransform(xmlElement, tr) == false) {
+                    QTWARNING("Robot transformation Error");
+                    return FAILURE;
+                }
+                element->setTran(tr);
+            }
+        }
+        else if (elementType == "connection") {
+            if (!getInt(child, "parentRobot", prevRobNum)) {
+                QTWARNING("Failed to load Parent Robot Number");
+                return FAILURE;
+            }
+            if (!getInt(child, "parentChain", chainNum)) {
+                QTWARNING("Failed to load Parent Robot's Chain Number");
+                return FAILURE;
+            }
+            if (!getInt(child, "childRobot", nextRobNum)) {
+                QTWARNING("Failed to load Child Robot Number");
+                return FAILURE;
+            }
+            if (prevRobNum < 0 || prevRobNum >= numRobots || nextRobNum < 0 ||
+                    nextRobNum >= numRobots || chainNum < 0 ||
+                    chainNum >= robotVec[prevRobNum]->getNumChains()) {
+                QTWARNING("Error reading connection transform");
+                break;
+            }
+            xmlElement = findXmlElement(child, "transform");
+            if (xmlElement) {
+                if (!getTransform(xmlElement, tr)) {
+                    QTWARNING("Error reading connection transform");
+                    break;
+                }
+            }
+            DBGP("offset tran " << tr);
+            xmlElement = findXmlElement(child, "mountFilename");
+            if (xmlElement) {
+                mountFilename = xmlElement->GetText();
+                if (!mountFilename.isEmpty()) {
+                    mountFilename = mountFilename.stripWhiteSpace();
+                    KinematicChain *prevChain = robotVec[prevRobNum]->getChain(chainNum);
+                    mountFilename = rootPath + mountFilename;
+                    DBGA("Mount filename: " << mountFilename.latin1());
+                    if ((mountPiece = robotVec[nextRobNum]->importMountPiece(mountFilename))) {
+                        addLink(mountPiece);
+                        toggleCollisions(false, prevChain->getLink(prevChain->getNumLinks() - 1), mountPiece);
+                        toggleCollisions(false, mountPiece, robotVec[nextRobNum]->getBase());
+                    }
+                    mountFilename = (char *)NULL;
+                }
+            }
+            robotVec[prevRobNum]->attachRobot(robotVec[nextRobNum], chainNum, tr);
+        }
+        else if (elementType == "camera") {
+            double px, py, pz, q1, q2, q3, q4, fd;
+            QStringList l;
+            xmlElement = findXmlElement(child, "position");
+            if (!xmlElement) {
+                QTWARNING("Camera Position not found");
+                return FAILURE;
+            }
+            QString position = xmlElement->GetText();
+            position = position.simplifyWhiteSpace().stripWhiteSpace();
+            l = QStringList::split(' ', position);
+            if (l.count() != 3) {
+                QTWARNING("Invalid camera position input");
+                return FAILURE;
+            }
+            bool ok1, ok2, ok3, ok4;
+            px = l[0].toDouble(&ok1);
+            py = l[1].toDouble(&ok2);
+            pz = l[2].toDouble(&ok3);
+            if (!ok1 || !ok2 || !ok3) {
+                QTWARNING("Invalid camera position input");
+                return FAILURE;
+            }
+            xmlElement = findXmlElement(child, "orientation");
+            if (!xmlElement) {
+                QTWARNING("Camera orientation not found");
+                return FAILURE;
+            }
+            QString orientation = xmlElement->GetText();
+            position = orientation.simplifyWhiteSpace().stripWhiteSpace();
+            l = QStringList::split(' ', orientation);
+            if (l.count() != 4) {
+                QTWARNING("Invalid camera orientation input");
+                return FAILURE;
+            }
+            q1 = l[0].toDouble(&ok1);
+            q2 = l[1].toDouble(&ok2);
+            q3 = l[2].toDouble(&ok3);
+            q4 = l[3].toDouble(&ok4);
+            if (!ok1 || !ok2 || !ok3 || !ok4) {
+                QTWARNING("Invalid camera position input");
+                return FAILURE;
+            }
+            if (!getDouble(child, "focalDistance", fd)) {
+                QTWARNING("Failed to load focal distance");
+                return FAILURE;
+            }
+            myIVmgr->setCamera(px, py, pz, q1, q2, q3, q4, fd);
+            cameraFound = true;
+        }
+        else {
+            QTWARNING(elementType + " is not a valid WorldElement type");
+            return FAILURE;
+        }
+        child = child->NextSiblingElement();
+    }
 
-	if (!cameraFound) {
-		myIVmgr->getViewer()->viewAll();
-	}
-	findAllContacts();
-	modified = false;
-	resetDynamics();
-	return SUCCESS;
+    if (!cameraFound) {
+        myIVmgr->getViewer()->viewAll();
+    }
+    findAllContacts();
+    modified = false;
+    resetDynamics();
+    return SUCCESS;
 }
 
-/*! Saves this world to a file. This includes all the world elements as well as 
-positions in the world, and the positions and orientation of the camera. It
-does not save the dynamic state of the bodies.
+/*! Saves this world to a file. This includes all the world elements as well as
+    positions in the world, and the positions and orientation of the camera. It
+    does not save the dynamic state of the bodies.
 */
 int
-World::save(const QString &filename)
-{
-	QFile file(filename);
-	int i,j,k,l;
+World::save(const QString &filename) {
+    QFile file(filename);
+    int i, j, k, l;
 
-	if (!file.open(QIODevice::WriteOnly)) {
-		QTWARNING("could not open " + filename + "for writing");
-		return FAILURE;
-	}
-	QTextStream stream( &file );
-	stream << "<?xml version=\"1.0\" ?>" <<endl;
-	stream << "<world>" << endl;
-	for (i=0;i<numBodies;i++) {
-		if (bodyVec[i]->isA("Body")) {
-			stream<<"\t<obstacle>"<<endl;
-			if(bodyVec[i]->getFilename()=="unspecified"){
-				stream<<"\t\t<body>"<<endl;
-				if(bodyVec[i]->saveToXml(stream)==FAILURE){
-					QTWARNING("Failed to save body info");
-					return FAILURE;
-				}
-				stream<<"\t\t</body>"<<endl;
-			}
-			else
-				stream<<"\t\t<filename>"<<bodyVec[i]->getFilename().latin1()<<"</filename>"<<endl;
-			stream<<"\t\t<transform>" <<endl;
-			stream<< "\t\t\t<fullTransform>"<< bodyVec[i]->getTran() << "</fullTransform>" << endl;
-			stream<<"\t\t</transform>" <<endl;
-			stream<<"\t</obstacle>"<<endl;
-		}
-		else if (bodyVec[i]->inherits("GraspableBody")) {
-			stream<<"\t<graspableBody>"<<endl;
-			if(bodyVec[i]->getFilename()=="unspecified"){
-				stream<<"\t\t<body>"<<endl;
-				if(bodyVec[i]->saveToXml(stream)==FAILURE){
-					QTWARNING("Failed to save body info");
-					return FAILURE;
-				}
-				stream<<"\t\t</body>"<<endl;
-			}
-			else
-				stream<<"\t\t<filename>"<<bodyVec[i]->getFilename().latin1()<<"</filename>"<<endl;
-			stream<<"\t\t<transform>" <<endl;
-			stream<< "\t\t\t<fullTransform>"<< bodyVec[i]->getTran() << "</fullTransform>" << endl;
-			stream<<"\t\t</transform>" <<endl;
-			stream<<"\t</graspableBody>"<<endl;
-		}
-	}
+    if (!file.open(QIODevice::WriteOnly)) {
+        QTWARNING("could not open " + filename + "for writing");
+        return FAILURE;
+    }
+    QTextStream stream(&file);
+    stream << "<?xml version=\"1.0\" ?>" << endl;
+    stream << "<world>" << endl;
+    for (i = 0; i < numBodies; i++) {
+        if (bodyVec[i]->isA("Body")) {
+            stream << "\t<obstacle>" << endl;
+            if (bodyVec[i]->getFilename() == "unspecified") {
+                stream << "\t\t<body>" << endl;
+                if (bodyVec[i]->saveToXml(stream) == FAILURE) {
+                    QTWARNING("Failed to save body info");
+                    return FAILURE;
+                }
+                stream << "\t\t</body>" << endl;
+            }
+            else
+                stream << "\t\t<filename>" << bodyVec[i]->getFilename().latin1() << "</filename>" << endl;
+            stream << "\t\t<transform>" << endl;
+            stream << "\t\t\t<fullTransform>" << bodyVec[i]->getTran() << "</fullTransform>" << endl;
+            stream << "\t\t</transform>" << endl;
+            stream << "\t</obstacle>" << endl;
+        }
+        else if (bodyVec[i]->inherits("GraspableBody")) {
+            stream << "\t<graspableBody>" << endl;
+            if (bodyVec[i]->getFilename() == "unspecified") {
+                stream << "\t\t<body>" << endl;
+                if (bodyVec[i]->saveToXml(stream) == FAILURE) {
+                    QTWARNING("Failed to save body info");
+                    return FAILURE;
+                }
+                stream << "\t\t</body>" << endl;
+            }
+            else
+                stream << "\t\t<filename>" << bodyVec[i]->getFilename().latin1() << "</filename>" << endl;
+            stream << "\t\t<transform>" << endl;
+            stream << "\t\t\t<fullTransform>" << bodyVec[i]->getTran() << "</fullTransform>" << endl;
+            stream << "\t\t</transform>" << endl;
+            stream << "\t</graspableBody>" << endl;
+        }
+    }
 
-	for (i=0;i<numRobots;i++) {
-		stream<<"\t<robot>"<<endl;
-		stream<<"\t\t<filename>"<<robotVec[i]->getFilename().latin1()<<"</filename>"<<endl;
-		stream<<"\t\t<dofValues>";
-		robotVec[i]->writeDOFVals(stream);
-		stream << "</dofValues>" << endl;
-		stream<<"\t\t<transform>" <<endl;
-		stream<< "\t\t\t<fullTransform>"<< robotVec[i]->getTran() << "</fullTransform>" << endl;
-		stream<<"\t\t</transform>" <<endl;
-		stream<<"\t</robot>"<<endl;
-	}
+    for (i = 0; i < numRobots; i++) {
+        stream << "\t<robot>" << endl;
+        stream << "\t\t<filename>" << robotVec[i]->getFilename().latin1() << "</filename>" << endl;
+        stream << "\t\t<dofValues>";
+        robotVec[i]->writeDOFVals(stream);
+        stream << "</dofValues>" << endl;
+        stream << "\t\t<transform>" << endl;
+        stream << "\t\t\t<fullTransform>" << robotVec[i]->getTran() << "</fullTransform>" << endl;
+        stream << "\t\t</transform>" << endl;
+        stream << "\t</robot>" << endl;
+    }
 
-	for(i=0;i<numRobots;i++) {
-		for (j=0;j<robotVec[i]->getNumChains();j++) {
-			KinematicChain *chain = robotVec[i]->getChain(j);
-			for (k=0;k<chain->getNumAttachedRobots();k++) {	
-				stream<<"\t<connection>"<<endl;
-				stream<< "\t\t<parentRobot>" << i << "</parentRobot>" << endl; 
-				stream<< "\t\t<parentChain>" << j << "</parentChain>" << endl;
-				for (l=0;l<numRobots;l++)
-					if (chain->getAttachedRobot(k) == robotVec[l]) break;
-				stream<< "\t\t<childRobot>" << l << "</childRobot>" << endl;	
-				if (chain->getAttachedRobot(k)->getMountPiece()) {
-					stream<< "\t\t<mountFilename>" << chain->getAttachedRobot(k)->getMountPiece()->getFilename() << "</mountFilename>" << endl;
-				}
-				stream<<"\t\t<transform>" <<endl;
-				stream<< "\t\t\t<fullTransform>"<< chain->getAttachedRobotOffset(k) << "</fullTransform>" << endl;
-				stream<<"\t\t</transform>" <<endl;
-				stream<<"\t</connection>"<<endl;
-			}
-		}
-	}
-	stream<<"\t<camera>"<<endl;
-	float px, py, pz, q1, q2, q3, q4, fd;
-	if (myIVmgr) {
-		myIVmgr->getCamera(px, py, pz, q1, q2, q3, q4, fd);
-		stream<<"\t\t<position>"<<px<<" "<<py<<" "<<pz<<"</position>"<<endl;
-		stream<<"\t\t<orientation>"<<q1<<" "<<q2<<" "<<q3<<" "<<q4<<"</orientation>"<<endl;
-		stream<<"\t\t<focalDistance>"<<fd<<"</focalDistance>"<<endl;
-	}
-	stream<<"\t</camera>"<<endl;
-	stream<<"</world>"<<endl;
-	file.close();
-	modified = false;
-	return SUCCESS;
+    for (i = 0; i < numRobots; i++) {
+        for (j = 0; j < robotVec[i]->getNumChains(); j++) {
+            KinematicChain *chain = robotVec[i]->getChain(j);
+            for (k = 0; k < chain->getNumAttachedRobots(); k++) {
+                stream << "\t<connection>" << endl;
+                stream << "\t\t<parentRobot>" << i << "</parentRobot>" << endl;
+                stream << "\t\t<parentChain>" << j << "</parentChain>" << endl;
+                for (l = 0; l < numRobots; l++)
+                    if (chain->getAttachedRobot(k) == robotVec[l]) break;
+                stream << "\t\t<childRobot>" << l << "</childRobot>" << endl;
+                if (chain->getAttachedRobot(k)->getMountPiece()) {
+                    stream << "\t\t<mountFilename>" << chain->getAttachedRobot(k)->getMountPiece()->getFilename() << "</mountFilename>" << endl;
+                }
+                stream << "\t\t<transform>" << endl;
+                stream << "\t\t\t<fullTransform>" << chain->getAttachedRobotOffset(k) << "</fullTransform>" << endl;
+                stream << "\t\t</transform>" << endl;
+                stream << "\t</connection>" << endl;
+            }
+        }
+    }
+    stream << "\t<camera>" << endl;
+    float px, py, pz, q1, q2, q3, q4, fd;
+    if (myIVmgr) {
+        myIVmgr->getCamera(px, py, pz, q1, q2, q3, q4, fd);
+        stream << "\t\t<position>" << px << " " << py << " " << pz << "</position>" << endl;
+        stream << "\t\t<orientation>" << q1 << " " << q2 << " " << q3 << " " << q4 << "</orientation>" << endl;
+        stream << "\t\t<focalDistance>" << fd << "</focalDistance>" << endl;
+    }
+    stream << "\t</camera>" << endl;
+    stream << "</world>" << endl;
+    file.close();
+    modified = false;
+    return SUCCESS;
 }
 
-/*! Imports a body which is loaded from a file. \bodyType must be a class name 
-from the Body hierarchy (e.g. "Body", "DynamicBody", etc). \a filename is
-the complete path to the file containing the body. The new body is created,
-loaded from the file, initialized, and added to the collision detection and 
-scene graph.
+/*! Imports a body which is loaded from a file. \bodyType must be a class name
+    from the Body hierarchy (e.g. "Body", "DynamicBody", etc). \a filename is
+    the complete path to the file containing the body. The new body is created,
+    loaded from the file, initialized, and added to the collision detection and
+    scene graph.
 */
 Body *
-World::importBody(QString bodyType,QString filename)
-{ 
-  Body *newBody = (Body *) getWorldElementFactory().createElement(bodyType.toStdString(), this, NULL);
-  if (!newBody) return NULL;
-  if (newBody->load(filename)==FAILURE) return NULL;
-  newBody->addToIvc();
-  addBody(newBody);
-  return newBody;
+World::importBody(QString bodyType, QString filename) {
+    Body *newBody = (Body *) getWorldElementFactory().createElement(bodyType.toStdString(), this, NULL);
+    if (!newBody) return NULL;
+    if (newBody->load(filename) == FAILURE) return NULL;
+    newBody->addToIvc();
+    addBody(newBody);
+    return newBody;
 }
 
-/*! Imports a body which is loaded from a xml file. \bodyType must be a class name 
-from the Body hierarchy (e.g. "Body", "DynamicBody", etc). \a rootPath and \a  
-child are parsed to loadFromXml. The new body is created, loaded from the 
-XML element, initialized, and added to the collision detection and scene graph.
+/*! Imports a body which is loaded from a xml file. \bodyType must be a class name
+    from the Body hierarchy (e.g. "Body", "DynamicBody", etc). \a rootPath and \a
+    child are parsed to loadFromXml. The new body is created, loaded from the
+    XML element, initialized, and added to the collision detection and scene graph.
 */
 Body *
-World::importBodyFromXml(QString bodyType, const TiXmlElement* child, QString rootPath)
-{ 
-  Body *newBody = (Body *) getWorldElementFactory().createElement(bodyType.toStdString(), this, NULL);
-  if (!newBody) return NULL;
-  if (newBody->loadFromXml(child, rootPath)==FAILURE) return NULL;
-  newBody->addIVMat();
-  newBody->addToIvc();
-  addBody(newBody);
-  return newBody;
+World::importBodyFromXml(QString bodyType, const TiXmlElement *child, QString rootPath) {
+    Body *newBody = (Body *) getWorldElementFactory().createElement(bodyType.toStdString(), this, NULL);
+    if (!newBody) return NULL;
+    if (newBody->loadFromXml(child, rootPath) == FAILURE) return NULL;
+    newBody->addIVMat();
+    newBody->addToIvc();
+    addBody(newBody);
+    return newBody;
 }
 
 /*! Adds to this world a body that is already created, initialized and somehow
-populated. This usually means a body obtained by loading from a file or 
-cloning another body. It does NOT add the new body to the collision detection 
-system, it is the caller's responsability to do that. Also does not initialize 
-dynamics.
+    populated. This usually means a body obtained by loading from a file or
+    cloning another body. It does NOT add the new body to the collision detection
+    system, it is the caller's responsability to do that. Also does not initialize
+    dynamics.
 */
 void
-World::addBody(Body *newBody)
-{
-	newBody->setDefaultViewingParameters();
-	bodyVec.push_back(newBody);
-	numBodies++;
-	if (newBody->inherits("GraspableBody")) {
-		GBVec.push_back((GraspableBody *)newBody);
-		if (numGB == 0) {
-			for (int i=0;i<numHands;i++) {
-				handVec[i]->getGrasp()->setObject((GraspableBody *)newBody);
-			}
-		}
-		numGB++;
-	}
-	IVRoot->addChild(newBody->getIVRoot());
-	modified = true;
-	Q_EMIT numElementsChanged();
+World::addBody(Body *newBody) {
+    newBody->setDefaultViewingParameters();
+    bodyVec.push_back(newBody);
+    numBodies++;
+    if (newBody->inherits("GraspableBody")) {
+        GBVec.push_back((GraspableBody *)newBody);
+        if (numGB == 0) {
+            for (int i = 0; i < numHands; i++) {
+                handVec[i]->getGrasp()->setObject((GraspableBody *)newBody);
+            }
+        }
+        numGB++;
+    }
+    IVRoot->addChild(newBody->getIVRoot());
+    modified = true;
+    Q_EMIT numElementsChanged();
     mDynamicsEngine->addBody(newBody);
 }
 
-/*! Adds a robot link. No need to add it to scene graph, since the robot 
-will add it to its own tree. The robot will also init dynamics and
-add the link to collision detection.
+/*! Adds a robot link. No need to add it to scene graph, since the robot
+    will add it to its own tree. The robot will also init dynamics and
+    add the link to collision detection.
 */
 void
-World::addLink(Link *newLink)
-{
-	bodyVec.push_back(newLink);
-	numBodies++;
+World::addLink(Link *newLink) {
+    bodyVec.push_back(newLink);
+    numBodies++;
     mDynamicsEngine->addBody(newLink);
 }
 
 /*! Loads a robot from a file and adds it to the world. \a filename must
-	contain the full path to the robot. The file is expected to be in XML
-	format. This function will open the file and read the robot file so
-	that it initializes an instance of the correct class. It will then
-	pass the XML root of the robot structure to the robot who will load
-	its own information from the file.
+    contain the full path to the robot. The file is expected to be in XML
+    format. This function will open the file and read the robot file so
+    that it initializes an instance of the correct class. It will then
+    pass the XML root of the robot structure to the robot who will load
+    its own information from the file.
 */
 Robot *
-World::importRobot(QString filename)
-{
-  TiXmlDocument doc(filename);
-  if(doc.LoadFile()==false){
-    QTWARNING("Could not open " + filename);
-    return NULL;
-  }
-  
-  const TiXmlElement* root = doc.RootElement();
-  if(root==NULL){
-    QTWARNING("Empty XML");
-    return NULL;	
-  }
-  
-  QString line = root->Attribute("type");
-  if(line.isNull()){
-    QTWARNING("Class Type not found");
-    return NULL;
-  }
-  line = line.stripWhiteSpace();
-  
-  Robot *robot = (Robot *) getWorldElementFactory().createElement(line.toStdString(), this, NULL);
-  
-  if (!robot) {
-    QTWARNING("Unable to create robot of class " + line);
-    return NULL;
-  }
-  
-  QString rootPath = filename.section('/',0,-2,QString::SectionIncludeTrailingSep);
-  robot->setName(filename.section('/',-1).section('.',0,0));
-  QString myFilename = relativePath(filename,getenv("GRASPIT"));
-  robot->setFilename(myFilename);
-  if (robot->loadFromXml(root,rootPath) == FAILURE) {
-    QTWARNING("Failed to load robot from file");
-    delete robot;
-    return NULL;
-  }
-  addRobot(robot);
-  return robot;
+World::importRobot(QString filename) {
+    TiXmlDocument doc(filename);
+    if (doc.LoadFile() == false) {
+        QTWARNING("Could not open " + filename);
+        return NULL;
+    }
+
+    const TiXmlElement *root = doc.RootElement();
+    if (root == NULL) {
+        QTWARNING("Empty XML");
+        return NULL;
+    }
+
+    QString line = root->Attribute("type");
+    if (line.isNull()) {
+        QTWARNING("Class Type not found");
+        return NULL;
+    }
+    line = line.stripWhiteSpace();
+
+    Robot *robot = (Robot *) getWorldElementFactory().createElement(line.toStdString(), this, NULL);
+
+    if (!robot) {
+        QTWARNING("Unable to create robot of class " + line);
+        return NULL;
+    }
+
+    QString rootPath = filename.section('/', 0, -2, QString::SectionIncludeTrailingSep);
+    robot->setName(filename.section('/', -1).section('.', 0, 0));
+    QString myFilename = relativePath(filename, getenv("GRASPIT"));
+    robot->setFilename(myFilename);
+    if (robot->loadFromXml(root, rootPath) == FAILURE) {
+        QTWARNING("Failed to load robot from file");
+        delete robot;
+        return NULL;
+    }
+    addRobot(robot);
+    return robot;
 }
 
 /*! Adds to this world a robot that is already created, initialized and somehow
-populated. This usually means a robot obtained by loading from a file or 
-cloning another body. It only adds the new robot to the scene graph of
-\a addToScene is true. Can be used when robots are clones and clones are set
-to work, but we don't necessarily want to see them.
+    populated. This usually means a robot obtained by loading from a file or
+    cloning another body. It only adds the new robot to the scene graph of
+    \a addToScene is true. Can be used when robots are clones and clones are set
+    to work, but we don't necessarily want to see them.
 
-Collisions between links in the same chain are always disables, as geometry
-files are usually imperfect and as joints move, the meshes then to hit each
-other at the joints, which would make the robot unusable.
+    Collisions between links in the same chain are always disables, as geometry
+    files are usually imperfect and as joints move, the meshes then to hit each
+    other at the joints, which would make the robot unusable.
 */
 void
-World::addRobot(Robot *robot, bool addToScene)
-{
-	robotVec.push_back(robot);
-	numRobots++;
+World::addRobot(Robot *robot, bool addToScene) {
+    robotVec.push_back(robot);
+    numRobots++;
 
-	if (robot->getBase()) {
-		addLink(robot->getBase());
-	}
+    if (robot->getBase()) {
+        addLink(robot->getBase());
+    }
 
-	for (int f=0; f<robot->getNumChains(); f++) {
-		for (int l=0; l<robot->getChain(f)->getNumLinks(); l++) {
-			addLink(robot->getChain(f)->getLink(l));
-		}
-	}
-	for (int f=0; f<robot->getNumChains(); f++) {
-		mCollisionInterface->activatePair(robot->getChain(f)->getLink(0), robot->getBase(), false);   
-		for (int l=0; l<robot->getChain(f)->getNumLinks(); l++) {
-			for(int l2 = 0; l2<robot->getChain(f)->getNumLinks();l2++) {
-				if (l==l2) continue;
-				mCollisionInterface->activatePair(robot->getChain(f)->getLink(l), 
-					robot->getChain(f)->getLink(l2), false);
-			}
-		}
-	}
-	if (robot->inherits("Hand")) {    
-		handVec.push_back((Hand *)robot);
-		if (numGB > 0) ((Hand *)robot)->getGrasp()->setObject(GBVec[0]);
-		numHands++;
-		if (numHands==1) setCurrentHand((Hand *)robot);
-	}
-	for (int d=0;d<robot->getNumDOF();d++) {
-		robot->getDOF(d)->setDesiredPos(robot->getDOF(d)->getVal());
-	}
+    for (int f = 0; f < robot->getNumChains(); f++) {
+        for (int l = 0; l < robot->getChain(f)->getNumLinks(); l++) {
+            addLink(robot->getChain(f)->getLink(l));
+        }
+    }
+    for (int f = 0; f < robot->getNumChains(); f++) {
+        mCollisionInterface->activatePair(robot->getChain(f)->getLink(0), robot->getBase(), false);
+        for (int l = 0; l < robot->getChain(f)->getNumLinks(); l++) {
+            for (int l2 = 0; l2 < robot->getChain(f)->getNumLinks(); l2++) {
+                if (l == l2) continue;
+                mCollisionInterface->activatePair(robot->getChain(f)->getLink(l),
+                                                  robot->getChain(f)->getLink(l2), false);
+            }
+        }
+    }
+    if (robot->inherits("Hand")) {
+        handVec.push_back((Hand *)robot);
+        if (numGB > 0)((Hand *)robot)->getGrasp()->setObject(GBVec[0]);
+        numHands++;
+        if (numHands == 1) setCurrentHand((Hand *)robot);
+    }
+    for (int d = 0; d < robot->getNumDOF(); d++) {
+        robot->getDOF(d)->setDesiredPos(robot->getDOF(d)->getVal());
+    }
 
-	if (addToScene) {
-		addElementToSceneGraph(robot);
-	}
+    if (addToScene) {
+        addElementToSceneGraph(robot);
+    }
 
-	modified = true;
-	Q_EMIT numElementsChanged();
+    modified = true;
+    Q_EMIT numElementsChanged();
     mDynamicsEngine->addRobot(robot);
 }
 
 
 /*! Removes a robot from the world and also deletes it. */
 void
-World::removeRobot(Robot *robot)
-{
-	removeElementFromSceneGraph(robot);
-	std::vector<Robot *>::iterator rp;
-	std::vector<Hand *>::iterator hp;
-	for (rp=robotVec.begin();rp!=robotVec.end();rp++) {
-		if (*rp == robot) {
-			robotVec.erase(rp);
-			numRobots--;
-			break;
-		}
-	}
-	if (robot->inherits("Hand")) {
-		for (hp=handVec.begin();hp!=handVec.end();hp++) {
-			if (*hp == robot) {
-				handVec.erase(hp);
-				numHands--;
-				break;
-			}
-		}
-	}
-	delete robot;
+World::removeRobot(Robot *robot) {
+    removeElementFromSceneGraph(robot);
+    std::vector<Robot *>::iterator rp;
+    std::vector<Hand *>::iterator hp;
+    for (rp = robotVec.begin(); rp != robotVec.end(); rp++) {
+        if (*rp == robot) {
+            robotVec.erase(rp);
+            numRobots--;
+            break;
+        }
+    }
+    if (robot->inherits("Hand")) {
+        for (hp = handVec.begin(); hp != handVec.end(); hp++) {
+            if (*hp == robot) {
+                handVec.erase(hp);
+                numHands--;
+                break;
+            }
+        }
+    }
+    delete robot;
 }
 
 /*! Adds an element to the Scene Graph; the element must already be part of the
-world. Used when removeElementFromSceneGraph has previously been called on
-this element.
+    world. Used when removeElementFromSceneGraph has previously been called on
+    this element.
 */
 void
-World::addElementToSceneGraph(WorldElement *e)
-{
-	if (IVRoot->findChild( e->getIVRoot() ) >= 0) {
-		DBGA("Element is already in scene graph");
-		return;
-	}
-	unsigned int i;
-	if (e->inherits("Robot")) {
-		for (i=0; i< robotVec.size(); i++) {
-			if (robotVec[i] == e) break;
-		}
-		if ( i==robotVec.size() ) {
-			DBGA("Robot not a part of the world");
-			return;
-		}
-	} else if (e->inherits("Body")) {
-		for (i=0; i< bodyVec.size(); i++) {
-			if (GBVec[i] == e) break;
-		}	
-		if ( i==GBVec.size() ) {
-			DBGA("Body not a part of the world");
-			return;
-		}
-	}
-	IVRoot->addChild( e->getIVRoot() );
+World::addElementToSceneGraph(WorldElement *e) {
+    if (IVRoot->findChild(e->getIVRoot()) >= 0) {
+        DBGA("Element is already in scene graph");
+        return;
+    }
+    unsigned int i;
+    if (e->inherits("Robot")) {
+        for (i = 0; i < robotVec.size(); i++) {
+            if (robotVec[i] == e) break;
+        }
+        if (i == robotVec.size()) {
+            DBGA("Robot not a part of the world");
+            return;
+        }
+    }
+    else if (e->inherits("Body")) {
+        for (i = 0; i < bodyVec.size(); i++) {
+            if (GBVec[i] == e) break;
+        }
+        if (i == GBVec.size()) {
+            DBGA("Body not a part of the world");
+            return;
+        }
+    }
+    IVRoot->addChild(e->getIVRoot());
 }
 
-/*! Remove an element that is part of this world from the Scene Graph; 
-the element remains a part of the world and can be used in simulations; 
-it is just not rendered anymore.
+/*! Remove an element that is part of this world from the Scene Graph;
+    the element remains a part of the world and can be used in simulations;
+    it is just not rendered anymore.
 */
 void
-World::removeElementFromSceneGraph(WorldElement *e)
-{
-	int c = IVRoot->findChild( e->getIVRoot() );
-	if (c<0) {
-		DBGA("Element not part of the scene graph");
-		return;
-	}
-	e->getIVRoot()->ref();
-	IVRoot->removeChild(c);
-	e->getIVRoot()->unrefNoDelete();
+World::removeElementFromSceneGraph(WorldElement *e) {
+    int c = IVRoot->findChild(e->getIVRoot());
+    if (c < 0) {
+        DBGA("Element not part of the scene graph");
+        return;
+    }
+    e->getIVRoot()->ref();
+    IVRoot->removeChild(c);
+    e->getIVRoot()->unrefNoDelete();
 }
 
 /*! Makes a static element into a dynamic body by creating a DynamicBody
-from it and initializing default dynamic properties. The geometry is 
-not loaded again, but it is added to the collision detection again.
+    from it and initializing default dynamic properties. The geometry is
+    not loaded again, but it is added to the collision detection again.
 */
 DynamicBody *
-World::makeBodyDynamic(Body *b, double mass)
-{ 
-	DynamicBody *dynBod = new DynamicBody(*b,mass);
-	dynBod->addToIvc();
-	addBody(dynBod);
-	destroyElement(b, true);
-	findContacts(dynBod);
-	return dynBod;
+World::makeBodyDynamic(Body *b, double mass) {
+    DynamicBody *dynBod = new DynamicBody(*b, mass);
+    dynBod->addToIvc();
+    addBody(dynBod);
+    destroyElement(b, true);
+    findContacts(dynBod);
+    return dynBod;
 }
 
 /*! Selects a world element. If the element is a Robot, also selects all of its
-links, plus the base. If it is a Body, it is also added to the list of
-selectedBodies.
+    links, plus the base. If it is a Body, it is also added to the list of
+    selectedBodies.
 */
 void
-World::selectElement(WorldElement *e)
-{
-	std::list<WorldElement *>::iterator ep;
-	int c,l;
+World::selectElement(WorldElement *e) {
+    std::list<WorldElement *>::iterator ep;
+    int c, l;
 
-	DBGP("selecting element "<<e->getName().latin1());
-	if (e->inherits("Body")) {DBGP(" with collision id " << ((Body*)e)->getId());}
+    DBGP("selecting element " << e->getName().latin1());
+    if (e->inherits("Body")) {
+        DBGP(" with collision id " << ((Body *)e)->getId());
+    }
 
-	if (e->inherits("Body")) numSelectedBodyElements++;
-	else if (e->inherits("Robot")) numSelectedRobotElements++;
-	numSelectedElements++;
+    if (e->inherits("Body")) numSelectedBodyElements++;
+    else if (e->inherits("Robot")) numSelectedRobotElements++;
+    numSelectedElements++;
 
-	selectedElementList.push_back(e);
+    selectedElementList.push_back(e);
 
-	selectedBodyVec.clear();
-	for (ep=selectedElementList.begin();ep!=selectedElementList.end();ep++) {
-		if ((*ep)->inherits("Body")) selectedBodyVec.push_back((Body *)(*ep));
-		else if ((*ep)->inherits("Robot")) {
-			Robot *r = (Robot *)(*ep);
-			selectedBodyVec.push_back(r->getBase());
-			for (c=0;c<r->getNumChains();c++){
-				for (l=0;l<r->getChain(c)->getNumLinks();l++) {
-					selectedBodyVec.push_back(r->getChain(c)->getLink(l));
-				}
-			}
-		}
-	}
-	numSelectedBodies = selectedBodyVec.size();
+    selectedBodyVec.clear();
+    for (ep = selectedElementList.begin(); ep != selectedElementList.end(); ep++) {
+        if ((*ep)->inherits("Body")) selectedBodyVec.push_back((Body *)(*ep));
+        else if ((*ep)->inherits("Robot")) {
+            Robot *r = (Robot *)(*ep);
+            selectedBodyVec.push_back(r->getBase());
+            for (c = 0; c < r->getNumChains(); c++) {
+                for (l = 0; l < r->getChain(c)->getNumLinks(); l++) {
+                    selectedBodyVec.push_back(r->getChain(c)->getLink(l));
+                }
+            }
+        }
+    }
+    numSelectedBodies = selectedBodyVec.size();
 
-	DBGP("selected elements "<<numSelectedElements);
-	DBGP("selected bodies "<<numSelectedBodies);
+    DBGP("selected elements " << numSelectedElements);
+    DBGP("selected bodies " << numSelectedBodies);
 
-	Q_EMIT selectionsChanged();
+    Q_EMIT selectionsChanged();
 }
 
-/*! Deselects a world element. If the element is a Robot, also deselects all of 
-its links, plus the base.
+/*! Deselects a world element. If the element is a Robot, also deselects all of
+    its links, plus the base.
 */
 void
-World::deselectElement(WorldElement *e)
-{
-	std::list<WorldElement *>::iterator ep;
-	int c,l;
+World::deselectElement(WorldElement *e) {
+    std::list<WorldElement *>::iterator ep;
+    int c, l;
 
-	DBGP("deselecting element "<<e->getName().latin1());
-	if (e->inherits("Body")) numSelectedBodyElements--;
-	else if (e->inherits("Robot")) numSelectedRobotElements--;
-	numSelectedElements--;
+    DBGP("deselecting element " << e->getName().latin1());
+    if (e->inherits("Body")) numSelectedBodyElements--;
+    else if (e->inherits("Robot")) numSelectedRobotElements--;
+    numSelectedElements--;
 
-	selectedElementList.remove(e);
+    selectedElementList.remove(e);
 
-	selectedBodyVec.clear();
-	for (ep=selectedElementList.begin();ep!=selectedElementList.end();ep++) {
-		if ((*ep)->inherits("Body")) selectedBodyVec.push_back((Body *)(*ep));
-		else if ((*ep)->inherits("Robot")) {
-			Robot *r = (Robot *)(*ep);
-			selectedBodyVec.push_back(r->getBase());
-			for (c=0;c<r->getNumChains();c++)
-				for (l=0;l<r->getChain(c)->getNumLinks();l++)
-					selectedBodyVec.push_back(r->getChain(c)->getLink(l));
-		}
-	}
-	numSelectedBodies = selectedBodyVec.size();
-	DBGP("selected elements "<<numSelectedElements);
-	DBGP("selected bodies "<<numSelectedBodies);
-	Q_EMIT selectionsChanged();
+    selectedBodyVec.clear();
+    for (ep = selectedElementList.begin(); ep != selectedElementList.end(); ep++) {
+        if ((*ep)->inherits("Body")) selectedBodyVec.push_back((Body *)(*ep));
+        else if ((*ep)->inherits("Robot")) {
+            Robot *r = (Robot *)(*ep);
+            selectedBodyVec.push_back(r->getBase());
+            for (c = 0; c < r->getNumChains(); c++)
+                for (l = 0; l < r->getChain(c)->getNumLinks(); l++)
+                    selectedBodyVec.push_back(r->getChain(c)->getLink(l));
+        }
+    }
+    numSelectedBodies = selectedBodyVec.size();
+    DBGP("selected elements " << numSelectedElements);
+    DBGP("selected bodies " << numSelectedBodies);
+    Q_EMIT selectionsChanged();
 }
 
 /*! Clears the list of selected element and deselects all */
 void
-World::deselectAll()
-{
-	selectedElementList.clear();
-	selectedBodyVec.clear();
+World::deselectAll() {
+    selectedElementList.clear();
+    selectedBodyVec.clear();
 
-	numSelectedElements = numSelectedBodyElements = numSelectedRobotElements = 0;
-	numSelectedBodies = 0;
-	Q_EMIT selectionsChanged();
+    numSelectedElements = numSelectedBodyElements = numSelectedRobotElements = 0;
+    numSelectedBodies = 0;
+    Q_EMIT selectionsChanged();
 }
 
-/*! Checks whether an element is currently selected by looking in the 
-selectedElementList
+/*! Checks whether an element is currently selected by looking in the
+    selectedElementList
 */
 bool
-World::isSelected(WorldElement *e) const
-{
-	std::list<WorldElement *>::const_iterator ep;
-	for (ep=selectedElementList.begin();ep!=selectedElementList.end();ep++)
-		if (*ep == e) return true;
-	return false;
+World::isSelected(WorldElement *e) const {
+    std::list<WorldElement *>::const_iterator ep;
+    for (ep = selectedElementList.begin(); ep != selectedElementList.end(); ep++)
+        if (*ep == e) return true;
+    return false;
 }
 
 /*! Toggles all collisions. If \a on is false, all collisions in the world are
-disabled. If \a on is true, they are re-enabled.
+    disabled. If \a on is true, they are re-enabled.
 */
 void
-World::toggleAllCollisions(bool on)
-{
-	DBGA("TOGGLING COLLISIONS");
-	bool off = !on;
-	if (numSelectedElements == 0) {
-		allCollisionsOFF = off;
-	} else if (numSelectedElements == 2) {
-		if (off) toggleCollisions(false, selectedElementList.front(), selectedElementList.back());
-		else toggleCollisions(true, selectedElementList.front(),  selectedElementList.back());
-	} else {
-		std::list<WorldElement *>::iterator ep;
-		for (ep=selectedElementList.begin();ep!=selectedElementList.end();ep++) {
-			if (off) toggleCollisions(false, *ep);
-			else toggleCollisions(true, *ep);
-		}
-	}
-	findAllContacts();
+World::toggleAllCollisions(bool on) {
+    DBGA("TOGGLING COLLISIONS");
+    bool off = !on;
+    if (numSelectedElements == 0) {
+        allCollisionsOFF = off;
+    }
+    else if (numSelectedElements == 2) {
+        if (off) toggleCollisions(false, selectedElementList.front(), selectedElementList.back());
+        else toggleCollisions(true, selectedElementList.front(),  selectedElementList.back());
+    }
+    else {
+        std::list<WorldElement *>::iterator ep;
+        for (ep = selectedElementList.begin(); ep != selectedElementList.end(); ep++) {
+            if (off) toggleCollisions(false, *ep);
+            else toggleCollisions(true, *ep);
+        }
+    }
+    findAllContacts();
 }
 
 bool
-World::robotCollisionsAreOff(Robot *r1, WorldElement *e)
-{
-	if (e->inherits("Body")) {
-		Body *b1 = (Body*) e;
-		if (mCollisionInterface->isActive( b1, r1->getBase() ) ) {
-			return false;
-		}
-		for (int f=0; f<r1->getNumChains(); f++) {
-			for (int l=0; l<r1->getChain(f)->getNumLinks(); l++) {
-				if ( mCollisionInterface->isActive(b1, r1->getChain(f)->getLink(l)) )
-					return false;
-			}
-		}
-		return true;
-	} else if (e->inherits("Robot")) {
-		Robot *r2 = (Robot*) e;
-		if ( mCollisionInterface->isActive(r1->getBase(), r2->getBase()) )
-			return false;
+World::robotCollisionsAreOff(Robot *r1, WorldElement *e) {
+    if (e->inherits("Body")) {
+        Body *b1 = (Body *) e;
+        if (mCollisionInterface->isActive(b1, r1->getBase())) {
+            return false;
+        }
+        for (int f = 0; f < r1->getNumChains(); f++) {
+            for (int l = 0; l < r1->getChain(f)->getNumLinks(); l++) {
+                if (mCollisionInterface->isActive(b1, r1->getChain(f)->getLink(l)))
+                    return false;
+            }
+        }
+        return true;
+    }
+    else if (e->inherits("Robot")) {
+        Robot *r2 = (Robot *) e;
+        if (mCollisionInterface->isActive(r1->getBase(), r2->getBase()))
+            return false;
 
-		for (int f2=0; f2<r2->getNumChains(); f2++) 
-			for (int l2=0; l2<r2->getChain(f2)->getNumLinks(); l2++)
-				if ( mCollisionInterface->isActive(r1->getBase(), r2->getChain(f2)->getLink(l2) ) )
-					return false;
+        for (int f2 = 0; f2 < r2->getNumChains(); f2++)
+            for (int l2 = 0; l2 < r2->getChain(f2)->getNumLinks(); l2++)
+                if (mCollisionInterface->isActive(r1->getBase(), r2->getChain(f2)->getLink(l2)))
+                    return false;
 
-		for (int f=0; f<r1->getNumChains(); f++) 
-			for (int l=0; l<r1->getChain(f)->getNumLinks(); l++) { 
-				if ( mCollisionInterface->isActive(r1->getChain(f)->getLink(l),r2->getBase() ) )
-					return false;
-				for (int f2=0; f2<r2->getNumChains(); f2++) 
-					for (int l2=0; l2<r2->getChain(f2)->getNumLinks(); l2++)
-						if ( mCollisionInterface->isActive(r1->getChain(f)->getLink(l), r2->getChain(f2)->getLink(l2) ) )
-							return false;
-			}
-			return true;
-	}
-	return true;
+        for (int f = 0; f < r1->getNumChains(); f++)
+            for (int l = 0; l < r1->getChain(f)->getNumLinks(); l++) {
+                if (mCollisionInterface->isActive(r1->getChain(f)->getLink(l), r2->getBase()))
+                    return false;
+                for (int f2 = 0; f2 < r2->getNumChains(); f2++)
+                    for (int l2 = 0; l2 < r2->getChain(f2)->getNumLinks(); l2++)
+                        if (mCollisionInterface->isActive(r1->getChain(f)->getLink(l), r2->getChain(f2)->getLink(l2)))
+                            return false;
+            }
+        return true;
+    }
+    return true;
 }
 
 /*! Checks whether collisions are off. Options for passing arguments are the same
-as for toggleCollisions.
+    as for toggleCollisions.
 */
 bool
-World::collisionsAreOff(WorldElement *e1,WorldElement *e2)
-{
-	int f,l;
-	Body *b1,*b2;
-	Robot *r1,*r2;
+World::collisionsAreOff(WorldElement *e1, WorldElement *e2) {
+    int f, l;
+    Body *b1, *b2;
+    Robot *r1, *r2;
 
-	if (e1 == NULL) {
-		assert(e2 == NULL);
-		return allCollisionsOFF;
-	}
-	if (e1->inherits("Body")) {
-		b1 = (Body *)e1;
-		if (e2) {
-			if (e2->inherits("Body")) {
-				b2 = (Body *)e2;  
-				return !mCollisionInterface->isActive(b1, b2);
-			} else if (e2->inherits("Robot")) {
-				r2 = (Robot*)e2;
-				return robotCollisionsAreOff(r2,e1);
-			} else {
-				return false;
-			}
-		} else return !mCollisionInterface->isActive(b1);
-	} else if (e1->inherits("Robot")) {
-		r1 = (Robot *)e1;
-		if (e2) {
-			return robotCollisionsAreOff(r1,e2);
-		} else {
-			if ( mCollisionInterface->isActive(r1->getBase()) ) return false;
-			for (f=0;f<r1->getNumChains();f++) 
-				for (l=0;l<r1->getChain(f)->getNumLinks();l++)
-					if ( mCollisionInterface->isActive(r1->getChain(f)->getLink(l)) )
-						return false;
-		}
-	}
-	return true;	
+    if (e1 == NULL) {
+        assert(e2 == NULL);
+        return allCollisionsOFF;
+    }
+    if (e1->inherits("Body")) {
+        b1 = (Body *)e1;
+        if (e2) {
+            if (e2->inherits("Body")) {
+                b2 = (Body *)e2;
+                return !mCollisionInterface->isActive(b1, b2);
+            }
+            else if (e2->inherits("Robot")) {
+                r2 = (Robot *)e2;
+                return robotCollisionsAreOff(r2, e1);
+            }
+            else {
+                return false;
+            }
+        }
+        else return !mCollisionInterface->isActive(b1);
+    }
+    else if (e1->inherits("Robot")) {
+        r1 = (Robot *)e1;
+        if (e2) {
+            return robotCollisionsAreOff(r1, e2);
+        }
+        else {
+            if (mCollisionInterface->isActive(r1->getBase())) return false;
+            for (f = 0; f < r1->getNumChains(); f++)
+                for (l = 0; l < r1->getChain(f)->getNumLinks(); l++)
+                    if (mCollisionInterface->isActive(r1->getChain(f)->getLink(l)))
+                        return false;
+        }
+    }
+    return true;
 }
 
 /*! If \a e2 is NULL, is toggles collisions for \a e1 in general. Otherwise, it
-toggles collisions between \a e1 and \a e2. Remember that toggling collisions
-for a robot means applying the change to all of its links and the base
+    toggles collisions between \a e1 and \a e2. Remember that toggling collisions
+    for a robot means applying the change to all of its links and the base
 */
 void
-World::toggleCollisions(bool on, WorldElement *e1,WorldElement *e2)
-{
-	int f,l,f2,l2;
-	Body *b1,*b2;
-	Robot *r1,*r2;
+World::toggleCollisions(bool on, WorldElement *e1, WorldElement *e2) {
+    int f, l, f2, l2;
+    Body *b1, *b2;
+    Robot *r1, *r2;
 
-	assert(e1);
-	if (e1->inherits("Body")) {
-		b1 = (Body *)e1;
-		if (e2) {
-			if (e2->inherits("Body")) {
-				b2 = (Body *)e2;
-				mCollisionInterface->activatePair(b1,b2,on);
-			} else if (e2->inherits("Robot")) {
-				r2 = (Robot *)e2;
-				mCollisionInterface->activatePair(b1,r2->getBase(),on);
-				for (f=0;f<r2->getNumChains();f++) 
-					for (l=0;l<r2->getChain(f)->getNumLinks();l++)
-						mCollisionInterface->activatePair(b1, r2->getChain(f)->getLink(l), on);
-			}	    
-		}
-		else mCollisionInterface->activateBody(b1,on);
-	} else if (e1->inherits("Robot")) {
-		r1 = (Robot *)e1;
-		if (e2) {
-			if (e2->inherits("Body")) {
-				b2 = (Body *)e2;
-				mCollisionInterface->activatePair(r1->getBase(), b2, on);
-				for (f=0;f<r1->getNumChains();f++) 
-					for (l=0;l<r1->getChain(f)->getNumLinks();l++)
-						mCollisionInterface->activatePair(r1->getChain(f)->getLink(l), b2, on);
-			}
-			else if (e2->inherits("Robot")) {
-				r2 = (Robot *)e2;
-				mCollisionInterface->activatePair(r1->getBase(), r2->getBase(), on);
+    assert(e1);
+    if (e1->inherits("Body")) {
+        b1 = (Body *)e1;
+        if (e2) {
+            if (e2->inherits("Body")) {
+                b2 = (Body *)e2;
+                mCollisionInterface->activatePair(b1, b2, on);
+            }
+            else if (e2->inherits("Robot")) {
+                r2 = (Robot *)e2;
+                mCollisionInterface->activatePair(b1, r2->getBase(), on);
+                for (f = 0; f < r2->getNumChains(); f++)
+                    for (l = 0; l < r2->getChain(f)->getNumLinks(); l++)
+                        mCollisionInterface->activatePair(b1, r2->getChain(f)->getLink(l), on);
+            }
+        }
+        else mCollisionInterface->activateBody(b1, on);
+    }
+    else if (e1->inherits("Robot")) {
+        r1 = (Robot *)e1;
+        if (e2) {
+            if (e2->inherits("Body")) {
+                b2 = (Body *)e2;
+                mCollisionInterface->activatePair(r1->getBase(), b2, on);
+                for (f = 0; f < r1->getNumChains(); f++)
+                    for (l = 0; l < r1->getChain(f)->getNumLinks(); l++)
+                        mCollisionInterface->activatePair(r1->getChain(f)->getLink(l), b2, on);
+            }
+            else if (e2->inherits("Robot")) {
+                r2 = (Robot *)e2;
+                mCollisionInterface->activatePair(r1->getBase(), r2->getBase(), on);
 
-				for (f2=0;f2<r2->getNumChains();f2++) 
-					for (l2=0;l2<r2->getChain(f2)->getNumLinks();l2++)
-						mCollisionInterface->activatePair(r1->getBase(), r2->getChain(f2)->getLink(l2),on);
+                for (f2 = 0; f2 < r2->getNumChains(); f2++)
+                    for (l2 = 0; l2 < r2->getChain(f2)->getNumLinks(); l2++)
+                        mCollisionInterface->activatePair(r1->getBase(), r2->getChain(f2)->getLink(l2), on);
 
-				for (f=0;f<r1->getNumChains();f++) 
-					for (l=0;l<r1->getChain(f)->getNumLinks();l++) {
-						mCollisionInterface->activatePair(r1->getChain(f)->getLink(l), r2->getBase(), on);
+                for (f = 0; f < r1->getNumChains(); f++)
+                    for (l = 0; l < r1->getChain(f)->getNumLinks(); l++) {
+                        mCollisionInterface->activatePair(r1->getChain(f)->getLink(l), r2->getBase(), on);
 
-						for (f2=0;f2<r2->getNumChains();f2++) 
-							for (l2=0;l2<r2->getChain(f2)->getNumLinks();l2++)
-								mCollisionInterface->activatePair(r1->getChain(f)->getLink(l), r2->getChain(f2)->getLink(l2), on);
-					}
-			}
-		}else {
-			mCollisionInterface->activateBody(r1->getBase(),on);
-			for (f=0;f<r1->getNumChains();f++) 
-				for (l=0;l<r1->getChain(f)->getNumLinks();l++)
-					mCollisionInterface->activateBody(r1->getChain(f)->getLink(l),on);	
-		}
-	}
+                        for (f2 = 0; f2 < r2->getNumChains(); f2++)
+                            for (l2 = 0; l2 < r2->getChain(f2)->getNumLinks(); l2++)
+                                mCollisionInterface->activatePair(r1->getChain(f)->getLink(l), r2->getChain(f2)->getLink(l2), on);
+                    }
+            }
+        }
+        else {
+            mCollisionInterface->activateBody(r1->getBase(), on);
+            for (f = 0; f < r1->getNumChains(); f++)
+                for (l = 0; l < r1->getChain(f)->getNumLinks(); l++)
+                    mCollisionInterface->activateBody(r1->getChain(f)->getLink(l), on);
+        }
+    }
 }
 
-/*! Returns true if the element \a e is not colliding with anything else. 
-Attempts to do it fast by returning as soon as any collision is found, 
-and only looking at potential collisions that involve \a e.
+/*! Returns true if the element \a e is not colliding with anything else.
+    Attempts to do it fast by returning as soon as any collision is found,
+    and only looking at potential collisions that involve \a e.
 */
 bool
-World::noCollision(WorldElement *e)
-{
-	PROF_TIMER_FUNC(WORLD_NO_COLLISION);
-	if (allCollisionsOFF) return true;
+World::noCollision(WorldElement *e) {
+    PROF_TIMER_FUNC(WORLD_NO_COLLISION);
+    if (allCollisionsOFF) return true;
 
-	if (!e) {
-		if (mCollisionInterface->allCollisions(CollisionInterface::FAST_COLLISION,NULL,NULL)) return false;
-		return true;
-	}
+    if (!e) {
+        if (mCollisionInterface->allCollisions(CollisionInterface::FAST_COLLISION, NULL, NULL)) return false;
+        return true;
+    }
 
-	std::vector<Body*> interestList;
-	if (e->inherits("Body")) {
-		interestList.push_back( (Body*)e );
-	} else if (e->inherits("Robot")) {
-		Robot *r = (Robot*)e;
-		for (int c=0; c < r->getNumChains(); c++) {
-			for (int l=0; l < r->getChain(c)->getNumLinks(); l++) {
-				interestList.push_back( r->getChain(c)->getLink(l) );
-			}
-		}
-		interestList.push_back( r->getBase() );
-		if (r->getMountPiece()) interestList.push_back(r->getMountPiece());
-	} else {
-		DBGA("Unknown case in World::noCollision");
-	}
+    std::vector<Body *> interestList;
+    if (e->inherits("Body")) {
+        interestList.push_back((Body *)e);
+    }
+    else if (e->inherits("Robot")) {
+        Robot *r = (Robot *)e;
+        for (int c = 0; c < r->getNumChains(); c++) {
+            for (int l = 0; l < r->getChain(c)->getNumLinks(); l++) {
+                interestList.push_back(r->getChain(c)->getLink(l));
+            }
+        }
+        interestList.push_back(r->getBase());
+        if (r->getMountPiece()) interestList.push_back(r->getMountPiece());
+    }
+    else {
+        DBGA("Unknown case in World::noCollision");
+    }
 
-	int col = mCollisionInterface->allCollisions(CollisionInterface::FAST_COLLISION, NULL, &interestList);
-	if (col) return false;
-	return true;
+    int col = mCollisionInterface->allCollisions(CollisionInterface::FAST_COLLISION, NULL, &interestList);
+    if (col) return false;
+    return true;
 }
 
 /*! Returns a full collision report for the bodies in the \a interestList.
-Check collision interface documentation for details on what the report
-contains. If \a interestList is NULL, is returns a collision report
-for all the bodies in the world.
+    Check collision interface documentation for details on what the report
+    contains. If \a interestList is NULL, is returns a collision report
+    for all the bodies in the world.
 */
 int
-World::getCollisionReport(CollisionReport *colReport, const std::vector<Body*> *interestList)
-{
-	PROF_TIMER_FUNC(WORLD_COLLISION_REPORT);
-	DBGP("Get COLLISION REPORT")
-		colReport->clear();
-	if (allCollisionsOFF) return 0;
+World::getCollisionReport(CollisionReport *colReport, const std::vector<Body *> *interestList) {
+    PROF_TIMER_FUNC(WORLD_COLLISION_REPORT);
+    DBGP("Get COLLISION REPORT")
+    colReport->clear();
+    if (allCollisionsOFF) return 0;
 
-	int numCols;
-	numCols = mCollisionInterface->allCollisions(CollisionInterface::ALL_COLLISIONS, colReport, interestList);
-	return numCols;
+    int numCols;
+    numCols = mCollisionInterface->allCollisions(CollisionInterface::ALL_COLLISIONS, colReport, interestList);
+    return numCols;
 }
 
-void 
-World::getBvs(Body *b, int depth, std::vector<BoundingBox> *bvs)
-{
-	mCollisionInterface->getBoundingVolumes(b, depth, bvs);
+void
+World::getBvs(Body *b, int depth, std::vector<BoundingBox> *bvs) {
+    mCollisionInterface->getBoundingVolumes(b, depth, bvs);
 }
 
-/*! Returns a vector that is the shortest distance from the point \a p 
-to the body \a b. If \a normal is not NULL, it is set to the surface
-normal of body \a b at the point closest to \a p. Everything is 
-expressed in world coordinates.
+/*! Returns a vector that is the shortest distance from the point \a p
+    to the body \a b. If \a normal is not NULL, it is set to the surface
+    normal of body \a b at the point closest to \a p. Everything is
+    expressed in world coordinates.
 */
 vec3
-World::pointDistanceToBody(position p, Body *b, vec3 *normal)
-{
-	PROF_TIMER_FUNC(WORLD_POINT_TO_BODY_DISTANCE);
-	position cp; vec3 cn;
-	mCollisionInterface->pointToBodyDistance(b, p, cp, cn);
-	if (normal) {
-		*normal = cn;
-	}
-	return cp - p;
+World::pointDistanceToBody(position p, Body *b, vec3 *normal) {
+    PROF_TIMER_FUNC(WORLD_POINT_TO_BODY_DISTANCE);
+    position cp;
+    vec3 cn;
+    mCollisionInterface->pointToBodyDistance(b, p, cp, cn);
+    if (normal) {
+        *normal = cn;
+    }
+    return cp - p;
 }
 
-/*! Returns the distance between two bodies \a b1 and \a b2 
-  Deprecated by version below which runs of more general world elements
+/*! Returns the distance between two bodies \a b1 and \a b2
+    Deprecated by version below which runs of more general world elements
 */
 /*
-double
-World::getDist(Body *b1,Body *b2)
-{
-	PROF_TIMER_FUNC(WORLD_GET_DIST);
-	position p1,p2;
-	return mCollisionInterface->bodyToBodyDistance(b1,b2,p1,p2);
-}
+    double
+    World::getDist(Body *b1,Body *b2)
+    {
+    PROF_TIMER_FUNC(WORLD_GET_DIST);
+    position p1,p2;
+    return mCollisionInterface->bodyToBodyDistance(b1,b2,p1,p2);
+    }
 */
 
 /*! Returns the distance between two world elements. If one (or both) are robots,
-  will compute the smallest distance between all links of the robot (plus the palm)
-  and the other element.
- */
+    will compute the smallest distance between all links of the robot (plus the palm)
+    and the other element.
+*/
 double
-World::getDist(WorldElement *e1, WorldElement *e2)
-{
-  double dist = -1;
-  if (e1->inherits("Robot")) {
-    //Robot <-> Something distance
-    //break it down into multiple Something <-> Robot Part distance
-    Robot *r = static_cast<Robot*>(e1);
-    dist = getDist(e2, r->getBase());
-    for (int c=0; c<r->getNumChains(); c++) {
-      for (int l=0; l<r->getChain(c)->getNumLinks(); l++) {
-	//careful to swap order here!
-	dist = std::min(dist, getDist(e2, r->getChain(c)->getLink(l)));
-      }
+World::getDist(WorldElement *e1, WorldElement *e2) {
+    double dist = -1;
+    if (e1->inherits("Robot")) {
+        //Robot <-> Something distance
+        //break it down into multiple Something <-> Robot Part distance
+        Robot *r = static_cast<Robot *>(e1);
+        dist = getDist(e2, r->getBase());
+        for (int c = 0; c < r->getNumChains(); c++) {
+            for (int l = 0; l < r->getChain(c)->getNumLinks(); l++) {
+                //careful to swap order here!
+                dist = std::min(dist, getDist(e2, r->getChain(c)->getLink(l)));
+            }
+        }
     }
-  } else if (e1->inherits("Body")) {
-    if (e2->inherits("Robot")) {
-      // Body <-> Robot distance
-      // turn it around as Robot <-> Body and let previous case take care of it
-      return getDist(e2, e1);
-    } else if (e2->inherits("Body")){
-      // Body <-> Body distance
-      // only case actually computed here
-      position p1, p2;
-      Body *b1 = static_cast<Body*>(e1);
-      Body *b2 = static_cast<Body*>(e2);
-      PROF_TIMER_FUNC(WORLD_GET_DIST);
-      return mCollisionInterface->bodyToBodyDistance(b1,b2,p1,p2);
-    } else {
-      DBGA("Non-robot and non-body world element in getDist");
-      return -1;
+    else if (e1->inherits("Body")) {
+        if (e2->inherits("Robot")) {
+            // Body <-> Robot distance
+            // turn it around as Robot <-> Body and let previous case take care of it
+            return getDist(e2, e1);
+        }
+        else if (e2->inherits("Body")) {
+            // Body <-> Body distance
+            // only case actually computed here
+            position p1, p2;
+            Body *b1 = static_cast<Body *>(e1);
+            Body *b2 = static_cast<Body *>(e2);
+            PROF_TIMER_FUNC(WORLD_GET_DIST);
+            return mCollisionInterface->bodyToBodyDistance(b1, b2, p1, p2);
+        }
+        else {
+            DBGA("Non-robot and non-body world element in getDist");
+            return -1;
+        }
     }
-  } else {
-    DBGA("Non-robot and non-body world element in getDist");
-    return -1;
-  }
-  return dist;
+    else {
+        DBGA("Non-robot and non-body world element in getDist");
+        return -1;
+    }
+    return dist;
 }
 
 /*! Returns the distance between two bodies \a b1 and \a b2 and sets
-\a p1 and \a p2 to the locations of the two points, one on each
-body, that are closest to each other
+    \a p1 and \a p2 to the locations of the two points, one on each
+    body, that are closest to each other
 */
 double
-World::getDist(Body *b1,Body *b2, position &p1, position &p2)
-{
-	PROF_TIMER_FUNC(WORLD_GET_DIST);
-	return mCollisionInterface->bodyToBodyDistance(b1,b2,p1,p2);
+World::getDist(Body *b1, Body *b2, position &p1, position &p2) {
+    PROF_TIMER_FUNC(WORLD_GET_DIST);
+    return mCollisionInterface->bodyToBodyDistance(b1, b2, p1, p2);
 }
 
 void
-World::findVirtualContacts(Hand *hand, Body *object)
-{
-	PROF_TIMER_FUNC(WORLD_FIND_VIRTUAL_CONTACTS);
-	ContactReport contactSet;
-	for (int f=0; f<hand->getNumFingers(); f++) {
-		for (int l=0; l<hand->getFinger(f)->getNumLinks(); l++) {
-			Link *link = hand->getFinger(f)->getLink(l);
-			link->breakVirtualContacts();
-			ContactData pc = findVirtualContact(link, object);
-			contactSet.clear();
-			contactSet.insert( contactSet.begin(), pc);
-			addVirtualContacts(link, f, l, object, contactSet, false);
-		}
-	}
+World::findVirtualContacts(Hand *hand, Body *object) {
+    PROF_TIMER_FUNC(WORLD_FIND_VIRTUAL_CONTACTS);
+    ContactReport contactSet;
+    for (int f = 0; f < hand->getNumFingers(); f++) {
+        for (int l = 0; l < hand->getFinger(f)->getNumLinks(); l++) {
+            Link *link = hand->getFinger(f)->getLink(l);
+            link->breakVirtualContacts();
+            ContactData pc = findVirtualContact(link, object);
+            contactSet.clear();
+            contactSet.insert(contactSet.begin(), pc);
+            addVirtualContacts(link, f, l, object, contactSet, false);
+        }
+    }
 
-	hand->getPalm()->breakVirtualContacts();
-	ContactData pc = findVirtualContact(hand->getPalm(), object);
-	contactSet.clear();
-	contactSet.insert( contactSet.begin(), pc);
-	addVirtualContacts(hand->getPalm(), -1, 0, object, contactSet, false);
+    hand->getPalm()->breakVirtualContacts();
+    ContactData pc = findVirtualContact(hand->getPalm(), object);
+    contactSet.clear();
+    contactSet.insert(contactSet.begin(), pc);
+    addVirtualContacts(hand->getPalm(), -1, 0, object, contactSet, false);
 }
 
 ContactData
-World::findVirtualContact(Link *link, Body *object)
-{
-	position p1, p2;
-	getDist(link, object, p1, p2);
-	vec3 n = p1 * link->getTran() - p2 * object->getTran();
-	n = normalise(n);
-	n = n * link->getTran().inverse();
+World::findVirtualContact(Link *link, Body *object) {
+    position p1, p2;
+    getDist(link, object, p1, p2);
+    vec3 n = p1 * link->getTran() - p2 * object->getTran();
+    n = normalise(n);
+    n = n * link->getTran().inverse();
 
-	return ContactData(p1, p2, n, -n) ;
+    return ContactData(p1, p2, n, -n) ;
 }
 
 /*! Asks each grasp to update itself (i.e. recompute its wrench spaces),
-presumably due to some change in  contact geometry.
+    presumably due to some change in  contact geometry.
 */
 void
-World::updateGrasps()
-{
-	bool graspChanged = false;
-	for (int i=0;i<numHands;i++) {
-		if (handVec[i]->contactsChanged()) {
-			handVec[i]->getGrasp()->update();
-			graspChanged = true;
-		}
-	}
-	if (graspChanged) {
-		Q_EMIT graspsUpdated();
-	}
+World::updateGrasps() {
+    bool graspChanged = false;
+    for (int i = 0; i < numHands; i++) {
+        if (handVec[i]->contactsChanged()) {
+            handVec[i]->getGrasp()->update();
+            graspChanged = true;
+        }
+    }
+    if (graspChanged) {
+        Q_EMIT graspsUpdated();
+    }
 }
 
-/*! Finds all the contacts between the bodies listed in the \a colReport. 
-Usually, the \a colReport is populated by the caller, based on a set
-of bodies that were in collision before, but now are assumed to be out
-of collision and potentially just touching.
+/*! Finds all the contacts between the bodies listed in the \a colReport.
+    Usually, the \a colReport is populated by the caller, based on a set
+    of bodies that were in collision before, but now are assumed to be out
+    of collision and potentially just touching.
 
-A contact occurs when bodies are separated by a distance less than the 
-contact threshold.  This routine uses the collision detection system to 
-find the points of contact between each body and at each one creates a 
-pair of contact objects which are added to the individual bodies.
+    A contact occurs when bodies are separated by a distance less than the
+    contact threshold.  This routine uses the collision detection system to
+    find the points of contact between each body and at each one creates a
+    pair of contact objects which are added to the individual bodies.
 */
 void
-World::findContacts(CollisionReport &colReport)
-{
-	PROF_TIMER_FUNC(WORLD_FIND_CONTACTS);
-	CollisionReport::iterator it = colReport.begin();
-	while(it!=colReport.end()) {
-		CollisionReport::iterator it2;
-		bool duplicate = false;
-		for (it2 = colReport.begin(); it2<it; it2++) {
-			if ( (*it).first == (*it2).first && (*it).second == (*it2).second) {
-				duplicate = true;
-				break;
-			}
-		}
-		if (duplicate) {
-			DBGP("duplicate: " << (*it).first->getName().latin1() << "--" <<  (*it).second->getName().latin1());
-			it = colReport.erase(it);
-			continue;
-		}
+World::findContacts(CollisionReport &colReport) {
+    PROF_TIMER_FUNC(WORLD_FIND_CONTACTS);
+    CollisionReport::iterator it = colReport.begin();
+    while (it != colReport.end()) {
+        CollisionReport::iterator it2;
+        bool duplicate = false;
+        for (it2 = colReport.begin(); it2 < it; it2++) {
+            if ((*it).first == (*it2).first && (*it).second == (*it2).second) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            DBGP("duplicate: " << (*it).first->getName().latin1() << "--" << (*it).second->getName().latin1());
+            it = colReport.erase(it);
+            continue;
+        }
 
-		if ( getDist( (*it).first, (*it).second ) > Contact::THRESHOLD ) {
-			DBGP("no contact: " << (*it).first->getName().latin1() << "--" << (*it).second->getName().latin1());
-			it = colReport.erase(it);
-			continue;
-		}
-		it++;
-	}
+        if (getDist((*it).first, (*it).second) > Contact::THRESHOLD) {
+            DBGP("no contact: " << (*it).first->getName().latin1() << "--" << (*it).second->getName().latin1());
+            it = colReport.erase(it);
+            continue;
+        }
+        it++;
+    }
 
-	ContactReport cres;
-	for (int i=0; i<(int)colReport.size(); i++) {
-		std::list<Contact*> contacts = colReport[i].first->getContacts();
-		std::list<Contact*>::iterator it;
-		for (it = contacts.begin(); it!=contacts.end(); it++) {
-			if ( (*it)->getBody1() == colReport[i].first && (*it)->getBody2() == colReport[i].second) {
-				colReport[i].first->removeContact(*it);
-			}
-		}
-		cres.clear();
-		mCollisionInterface->contact(&cres, Contact::THRESHOLD, colReport[i].first, colReport[i].second);
-		addContacts(colReport[i].first, colReport[i].second, cres, softContactsAreOn());
-	}
+    ContactReport cres;
+    for (int i = 0; i < (int)colReport.size(); i++) {
+        std::list<Contact *> contacts = colReport[i].first->getContacts();
+        std::list<Contact *>::iterator it;
+        for (it = contacts.begin(); it != contacts.end(); it++) {
+            if ((*it)->getBody1() == colReport[i].first && (*it)->getBody2() == colReport[i].second) {
+                colReport[i].first->removeContact(*it);
+            }
+        }
+        cres.clear();
+        mCollisionInterface->contact(&cres, Contact::THRESHOLD, colReport[i].first, colReport[i].second);
+        addContacts(colReport[i].first, colReport[i].second, cres, softContactsAreOn());
+    }
 }
 
-/*! Finds all the contact on body \a b. A pair of contact objects is created 
-for each contact and are added to the individual bodies that are in contact.
+/*! Finds all the contact on body \a b. A pair of contact objects is created
+    for each contact and are added to the individual bodies that are in contact.
 */
 void
-World::findContacts(Body *b)
-{
-	PROF_TIMER_FUNC(WORLD_FIND_CONTACTS);
-	ContactReport contactReport;
-	for (int i=0;i<numBodies;i++) {
-		if (bodyVec[i] != b) {
-			mCollisionInterface->contact(&contactReport, Contact::THRESHOLD, b, bodyVec[i]);
-			addContacts(b, bodyVec[i], contactReport, softContactsAreOn());
-		}
-	}
+World::findContacts(Body *b) {
+    PROF_TIMER_FUNC(WORLD_FIND_CONTACTS);
+    ContactReport contactReport;
+    for (int i = 0; i < numBodies; i++) {
+        if (bodyVec[i] != b) {
+            mCollisionInterface->contact(&contactReport, Contact::THRESHOLD, b, bodyVec[i]);
+            addContacts(b, bodyVec[i], contactReport, softContactsAreOn());
+        }
+    }
 }
 
-/*! Finds and adds all the contacts between any two bodies in the world. 
-A pair of contact objects is created for each contact and are added 
-to the individual bodies that are in contact.
+/*! Finds and adds all the contacts between any two bodies in the world.
+    A pair of contact objects is created for each contact and are added
+    to the individual bodies that are in contact.
 */
 void
-World::findAllContacts()
-{
-	PROF_TIMER_FUNC(WORLD_FIND_CONTACTS);
-	for (int i=0;i<numBodies;i++) {
-		bodyVec[i]->resetContactList();
-	}
-	if (allCollisionsOFF) return;
-	CollisionReport report;
-	int numContacts;
-	numContacts = mCollisionInterface->allContacts(&report, Contact::THRESHOLD, NULL);
-	DBGP("found " << numContacts << " contacts. Adding...");
-	for (int i=0;i<numContacts;i++) {
-		addContacts( report[i].first, report[i].second, report[i].contacts, softContactsAreOn());
-		DBGP( report[i].first->getName().latin1() << " - " << report[i].second->getName().latin1() );
-	}
+World::findAllContacts() {
+    PROF_TIMER_FUNC(WORLD_FIND_CONTACTS);
+    for (int i = 0; i < numBodies; i++) {
+        bodyVec[i]->resetContactList();
+    }
+    if (allCollisionsOFF) return;
+    CollisionReport report;
+    int numContacts;
+    numContacts = mCollisionInterface->allContacts(&report, Contact::THRESHOLD, NULL);
+    DBGP("found " << numContacts << " contacts. Adding...");
+    for (int i = 0; i < numContacts; i++) {
+        addContacts(report[i].first, report[i].second, report[i].contacts, softContactsAreOn());
+        DBGP(report[i].first->getName().latin1() << " - " << report[i].second->getName().latin1());
+    }
 }
 
 
-/*! Takes a point and sends it to the collision detection system to find 
-the neighborhood of that point on a body, used in soft contacts for the
-input for the paraboloid fitter.
+/*! Takes a point and sends it to the collision detection system to find
+    the neighborhood of that point on a body, used in soft contacts for the
+    input for the paraboloid fitter.
 */
-void World::FindRegion( const Body *body, position point, vec3 normal, double radius,
-					   Neighborhood *neighborhood)
-{
-	PROF_TIMER_FUNC(WORLD_FIND_REGION);
-	mCollisionInterface->bodyRegion(body, point, normal, radius, neighborhood);
+void World::FindRegion(const Body *body, position point, vec3 normal, double radius,
+                       Neighborhood *neighborhood) {
+    PROF_TIMER_FUNC(WORLD_FIND_REGION);
+    mCollisionInterface->bodyRegion(body, point, normal, radius, neighborhood);
 }
 
 /*! Starts dynamic simulation. This is all the user has to do; from now
-on, dynamic steps are triggered automatically by an idle sensor.
-The only way to determine the motion of the bodies is to set desired
-values for the robot dofs and let the world time step computations and
-the robot dof controllers do the rest.
+    on, dynamic steps are triggered automatically by an idle sensor.
+    The only way to determine the motion of the bodies is to set desired
+    values for the robot dofs and let the world time step computations and
+    the robot dof controllers do the rest.
 
-Use the resetDynamics routine to fix the base robot of every collection 
-of robots so that it does not fall under gravity and to set the desired 
-pose of each robot to be it's current state so that the controllers try
-to maintain the current positions until the user requests something
-different.
+    Use the resetDynamics routine to fix the base robot of every collection
+    of robots so that it does not fall under gravity and to set the desired
+    pose of each robot to be it's current state so that the controllers try
+    to maintain the current positions until the user requests something
+    different.
 */
 void
-World::turnOnDynamics()
-{
-	//PROF_RESET_ALL;
-	//PROF_START_TIMER(DYNAMICS);
-	dynamicsOn = true;
+World::turnOnDynamics() {
+    //PROF_RESET_ALL;
+    //PROF_START_TIMER(DYNAMICS);
+    dynamicsOn = true;
     mDynamicsEngine->turnOnDynamics();
-	if (idleSensor) delete idleSensor;
-	idleSensor = new SoIdleSensor(dynamicsCB,this);
-	idleSensor->schedule();
+    if (idleSensor) delete idleSensor;
+    idleSensor = new SoIdleSensor(dynamicsCB, this);
+    idleSensor->schedule();
 }
 
 /*! Pauses dynamic simulation; no more time steps are computed*/
 void
-World::turnOffDynamics()
-{
-	//PROF_STOP_TIMER(DYNAMICS);
-	//PROF_PRINT_ALL;
-	if (idleSensor) delete idleSensor;
-	idleSensor = NULL;
-	dynamicsOn = false;
+World::turnOffDynamics() {
+    //PROF_STOP_TIMER(DYNAMICS);
+    //PROF_PRINT_ALL;
+    if (idleSensor) delete idleSensor;
+    idleSensor = NULL;
+    dynamicsOn = false;
     mDynamicsEngine->turnOffDynamics();
-	for (int i=0; i<numRobots; i++) {
-		//actually set joint values
-		robotVec[i]->updateJointValuesFromDynamics();
-		//try to approximate robot dof values based on where the joints ended up
-		robotVec[i]->updateDOFFromJoints(NULL);
-	}
-	updateGrasps();
+    for (int i = 0; i < numRobots; i++) {
+        //actually set joint values
+        robotVec[i]->updateJointValuesFromDynamics();
+        //try to approximate robot dof values based on where the joints ended up
+        robotVec[i]->updateDOFFromJoints(NULL);
+    }
+    updateGrasps();
 }
 
-/*! Resets the velocities and accelerations of all bodies; fixes the base 
-robot of every collection of robots so that it is not affected by gravity 
-and sets the desired pose of each robot to be it's current state so that 
-the controllers try to maintain the current positions until the user 
-requests something different.
+/*! Resets the velocities and accelerations of all bodies; fixes the base
+    robot of every collection of robots so that it is not affected by gravity
+    and sets the desired pose of each robot to be it's current state so that
+    the controllers try to maintain the current positions until the user
+    requests something different.
 */
-void World::resetDynamics()
-{
-	int i,d;
-	std::vector<double> zeroes(6,0.0);
-	//clear the dynamic stack of all objects
-	for (i=0;i<numBodies;i++) {
-		if (bodyVec[i]->isDynamic()) {
-			((DynamicBody *)bodyVec[i])->clearState();
-			((DynamicBody *)bodyVec[i])->setAccel(&zeroes[0]);
-			((DynamicBody *)bodyVec[i])->setVelocity(&zeroes[0]);
-		}
-	}
+void World::resetDynamics() {
+    int i, d;
+    std::vector<double> zeroes(6, 0.0);
+    //clear the dynamic stack of all objects
+    for (i = 0; i < numBodies; i++) {
+        if (bodyVec[i]->isDynamic()) {
+            ((DynamicBody *)bodyVec[i])->clearState();
+            ((DynamicBody *)bodyVec[i])->setAccel(&zeroes[0]);
+            ((DynamicBody *)bodyVec[i])->setVelocity(&zeroes[0]);
+        }
+    }
 
-	//push the initial dynamic state
-	pushDynamicState();
+    //push the initial dynamic state
+    pushDynamicState();
 
-	for (i=0;i<numRobots;i++) {
-		//set robot desired position to current position
-		for (d=0;d<robotVec[i]->getNumDOF();d++) {
-			robotVec[i]->getDOF(d)->setDesiredPos(robotVec[i]->getDOF(d)->getVal());
-		}
-	}   
+    for (i = 0; i < numRobots; i++) {
+        //set robot desired position to current position
+        for (d = 0; d < robotVec[i]->getNumDOF(); d++) {
+            robotVec[i]->getDOF(d)->setDesiredPos(robotVec[i]->getDOF(d)->getVal());
+        }
+    }
 }
 
 void
-World::dynamicsCB(void *data,SoSensor *)
-{
-	World *myWorld = (World *)data;
-	myWorld->stepDynamics();
+World::dynamicsCB(void *data, SoSensor *) {
+    World *myWorld = (World *)data;
+    myWorld->stepDynamics();
 }
 
 /*! Saves the current dynamic state (velocities and accelerations of
-all bodies) onto a stack.
+    all bodies) onto a stack.
 */
 void
-World::pushDynamicState()
-{
-	for (int i=0;i<numBodies;i++)
-		if (bodyVec[i]->isDynamic())
-			((DynamicBody *)bodyVec[i])->pushState();
+World::pushDynamicState() {
+    for (int i = 0; i < numBodies; i++)
+        if (bodyVec[i]->isDynamic())
+            ((DynamicBody *)bodyVec[i])->pushState();
 }
 
 /*! Restores the dynamic state currently at the top of the stack */
 void
-World::popDynamicState()
-{
-	bool stackEmpty = false;
-	for (int i=0;i<numBodies;i++) {
-		if (bodyVec[i]->isDynamic()) {
-			if (!((DynamicBody *)bodyVec[i])->popState()) stackEmpty = true;
-		}
-	}
-	if (stackEmpty) {
-		DBGA("Resetting dynamics");
-		resetDynamics();
-	}
+World::popDynamicState() {
+    bool stackEmpty = false;
+    for (int i = 0; i < numBodies; i++) {
+        if (bodyVec[i]->isDynamic()) {
+            if (!((DynamicBody *)bodyVec[i])->popState()) stackEmpty = true;
+        }
+    }
+    if (stackEmpty) {
+        DBGA("Resetting dynamics");
+        resetDynamics();
+    }
 }
 
-/*! One of the two main functions of the dynamics time step. This function is 
-called to move the bodies according to the velocities and accelerations found
-in the previous step. The move is attempted for the duration of the time step 
-given in \a timeStep.
+/*! One of the two main functions of the dynamics time step. This function is
+    called to move the bodies according to the velocities and accelerations found
+    in the previous step. The move is attempted for the duration of the time step
+    given in \a timeStep.
 
-After all the bodies are moved, then collisions are checked. If any collisions
-are found, the move is traced back and the value of the times step is 
-interpolated until the exact moment of contact is found. The actual value
-of the time step until contact is made is returned. If interpolation fails,
-a negative actual time step is returned. All the resulting contacts are added
-to the bodies that are in contact to be used for subsequent computations.
+    After all the bodies are moved, then collisions are checked. If any collisions
+    are found, the move is traced back and the value of the times step is
+    interpolated until the exact moment of contact is found. The actual value
+    of the time step until contact is made is returned. If interpolation fails,
+    a negative actual time step is returned. All the resulting contacts are added
+    to the bodies that are in contact to be used for subsequent computations.
 
-The same procedure is carried out if, by executing a full time step, a joint
-ends up outside of its legal range.
+    The same procedure is carried out if, by executing a full time step, a joint
+    ends up outside of its legal range.
 */
 double
-World::moveDynamicBodies(double timeStep)
-{
-	int i,numDynBodies,numCols,moveErrCode;
-	std::vector<DynamicBody *> dynBodies;
-	static CollisionReport colReport;
-	bool jointLimitHit;
-	double contactTime,delta,tmpDist,minDist,dofLimitDist;
+World::moveDynamicBodies(double timeStep) {
+    int i, numDynBodies, numCols, moveErrCode;
+    std::vector<DynamicBody *> dynBodies;
+    static CollisionReport colReport;
+    bool jointLimitHit;
+    double contactTime, delta, tmpDist, minDist, dofLimitDist;
 
-	//save the initial position
-	for (i=0;i<numBodies;i++) {
-		if (bodyVec[i]->isDynamic()) {
-			dynBodies.push_back((DynamicBody *)bodyVec[i]);
-			((DynamicBody *)bodyVec[i])->markState();
-		}
-	}
-	numDynBodies = dynBodies.size();
+    //save the initial position
+    for (i = 0; i < numBodies; i++) {
+        if (bodyVec[i]->isDynamic()) {
+            dynBodies.push_back((DynamicBody *)bodyVec[i]);
+            ((DynamicBody *)bodyVec[i])->markState();
+        }
+    }
+    numDynBodies = dynBodies.size();
 
-	//call to the dynamics engine to perform the move by the full time step
-	DBGP("moving bodies with timestep: " << timeStep);
-	moveErrCode = moveBodies(numDynBodies,dynBodies,timeStep);
-	if (moveErrCode == 1){ // object out of bounds
-		popDynamicState();
-		turnOffDynamics();
-		return -1.0 ;
-	}
+    //call to the dynamics engine to perform the move by the full time step
+    DBGP("moving bodies with timestep: " << timeStep);
+    moveErrCode = moveBodies(numDynBodies, dynBodies, timeStep);
+    if (moveErrCode == 1) { // object out of bounds
+        popDynamicState();
+        turnOffDynamics();
+        return -1.0 ;
+    }
 
-	//this sets the joints internal values according to how bodies have moved
-	for (i=0;i<numRobots;i++) {
-		robotVec[i]->updateJointValuesFromDynamics();
-	}
+    //this sets the joints internal values according to how bodies have moved
+    for (i = 0; i < numRobots; i++) {
+        robotVec[i]->updateJointValuesFromDynamics();
+    }
 
-	//check if we have collisions
-	if (numDynBodies > 0) numCols = getCollisionReport(&colReport);
-	else numCols = 0;
+    //check if we have collisions
+    if (numDynBodies > 0) numCols = getCollisionReport(&colReport);
+    else numCols = 0;
 
-	//check if we have joint limits exceeded
-	jointLimitHit = false;
-	for (i=0;i<numRobots;i++) {
-		if (robotVec[i]->jointLimitDist() < 0.0) jointLimitHit = true;
-	}
+    //check if we have joint limits exceeded
+    jointLimitHit = false;
+    for (i = 0; i < numRobots; i++) {
+        if (robotVec[i]->jointLimitDist() < 0.0) jointLimitHit = true;
+    }
 
-	//if so, we must interpolate until the exact moment of contact or limit hit
-	if (numCols || jointLimitHit) {
-		//return to initial position
-		for (i=0;i<numDynBodies;i++) {
-			dynBodies[i]->returnToMarkedState();
-		}
-		minDist = 1.0e+255;
-		dofLimitDist = 1.0e+255;
+    //if so, we must interpolate until the exact moment of contact or limit hit
+    if (numCols || jointLimitHit) {
+        //return to initial position
+        for (i = 0; i < numDynBodies; i++) {
+            dynBodies[i]->returnToMarkedState();
+        }
+        minDist = 1.0e+255;
+        dofLimitDist = 1.0e+255;
 
-#ifdef GRASPITDBG
-		if (numCols) {
-			std::cout << "COLLIDE!" << std::endl;
-			for (i=0;i<numCols;i++) {
-				std::cout << colReport[i].first->getName() << " collided with " << 
-					colReport[i].second->getName() << std::endl;
-			}
+        #ifdef GRASPITDBG
+        if (numCols) {
+            std::cout << "COLLIDE!" << std::endl;
+            for (i = 0; i < numCols; i++) {
+                std::cout << colReport[i].first->getName() << " collided with " <<
+                          colReport[i].second->getName() << std::endl;
+            }
 
-			for (i=0;i<numCols;i++) {
-				tmpDist = getDist(colReport[i].first,colReport[i].second);
-				if (tmpDist < minDist) minDist = tmpDist;	
-				std::cout << "minDist: " << tmpDist <<" between " << std::endl;
-				std::cout << colReport[i].first->getName() << " and " <<
-					colReport[i].second->getName() << std::endl;
-			}      
-		}
-#endif      
+            for (i = 0; i < numCols; i++) {
+                tmpDist = getDist(colReport[i].first, colReport[i].second);
+                if (tmpDist < minDist) minDist = tmpDist;
+                std::cout << "minDist: " << tmpDist << " between " << std::endl;
+                std::cout << colReport[i].first->getName() << " and " <<
+                          colReport[i].second->getName() << std::endl;
+            }
+        }
+        #endif
 
-		//this section refines the timestep until the objects are separated
-		//by a distance less than CONTACT_THRESHOLD
-		bool done = false;
-		contactTime = timeStep;
-		delta = contactTime/2;
-		contactTime -= delta;
+        //this section refines the timestep until the objects are separated
+        //by a distance less than CONTACT_THRESHOLD
+        bool done = false;
+        contactTime = timeStep;
+        delta = contactTime / 2;
+        contactTime -= delta;
 
-		while (!done) {
-			delta /= 2.0;	  
-			for (i=0;i<numDynBodies;i++) {
-				dynBodies[i]->returnToMarkedState();
-			}
-			DBGP("moving bodies with timestep: " << contactTime);
-			moveErrCode = moveBodies(numDynBodies,dynBodies,contactTime);
+        while (!done) {
+            delta /= 2.0;
+            for (i = 0; i < numDynBodies; i++) {
+                dynBodies[i]->returnToMarkedState();
+            }
+            DBGP("moving bodies with timestep: " << contactTime);
+            moveErrCode = moveBodies(numDynBodies, dynBodies, contactTime);
 
-			if (moveErrCode == 1){ // object out of bounds
-				popDynamicState();
-				turnOffDynamics();
-				return -1.0;
-			}
+            if (moveErrCode == 1) { // object out of bounds
+                popDynamicState();
+                turnOffDynamics();
+                return -1.0;
+            }
 
-			const char *min_body_1,*min_body_2;
+            const char *min_body_1, *min_body_2;
 
-			//this computes joints values according to how dynamic bodies have moved
-			for (i=0;i<numRobots;i++) {
-				robotVec[i]->updateJointValuesFromDynamics();
-			}
+            //this computes joints values according to how dynamic bodies have moved
+            for (i = 0; i < numRobots; i++) {
+                robotVec[i]->updateJointValuesFromDynamics();
+            }
 
-			if (numCols) {
-				minDist = 1.0e+255;
-				for (i=0;i<numCols;i++) {
-					tmpDist = getDist(colReport[i].first,colReport[i].second);
-					if (tmpDist < minDist) {
-						minDist = tmpDist;
-						min_body_1 = colReport[i].first->getName().latin1();
-						min_body_2 = colReport[i].second->getName().latin1();
-						DBGP("minDist: " << minDist << " between " << colReport[i].first->getName() << 
-							" and " << colReport[i].second->getName());
-					}
-				}
-			}
+            if (numCols) {
+                minDist = 1.0e+255;
+                for (i = 0; i < numCols; i++) {
+                    tmpDist = getDist(colReport[i].first, colReport[i].second);
+                    if (tmpDist < minDist) {
+                        minDist = tmpDist;
+                        min_body_1 = colReport[i].first->getName().latin1();
+                        min_body_2 = colReport[i].second->getName().latin1();
+                        DBGP("minDist: " << minDist << " between " << colReport[i].first->getName() <<
+                             " and " << colReport[i].second->getName());
+                    }
+                }
+            }
 
-			if (jointLimitHit) {
-				dofLimitDist = 1.0e10;
-				for (i=0; i<numRobots; i++) {
-					dofLimitDist = MIN( dofLimitDist, robotVec[i]->jointLimitDist() );
-				}
-			}
+            if (jointLimitHit) {
+                dofLimitDist = 1.0e10;
+                for (i = 0; i < numRobots; i++) {
+                    dofLimitDist = MIN(dofLimitDist, robotVec[i]->jointLimitDist());
+                }
+            }
 
-			if (minDist <= 0.0 || dofLimitDist < -resabs)
-				contactTime -= delta;
-			else if (minDist > Contact::THRESHOLD * 0.5 && dofLimitDist > 0.01) //why is this not resabs
-				contactTime += delta;
-			else break;
+            if (minDist <= 0.0 || dofLimitDist < -resabs)
+                contactTime -= delta;
+            else if (minDist > Contact::THRESHOLD * 0.5 && dofLimitDist > 0.01) //why is this not resabs
+                contactTime += delta;
+            else break;
 
-			if (fabs(delta) < 1.0E-15 || contactTime < 1.0e-7) {
-				if (minDist <= 0) {
-					fprintf(stderr,"Delta failsafe due to collision: %s and %s\n",min_body_1,min_body_2);
-				} else {
-					fprintf(stderr,"Delta failsafe due to joint\n");
-				}
-				done = true;  // failsafe
-			}
-		}
+            if (fabs(delta) < 1.0E-15 || contactTime < 1.0e-7) {
+                if (minDist <= 0) {
+                    fprintf(stderr, "Delta failsafe due to collision: %s and %s\n", min_body_1, min_body_2);
+                }
+                else {
+                    fprintf(stderr, "Delta failsafe due to joint\n");
+                }
+                done = true;  // failsafe
+            }
+        }
 
-		// COULD NOT FIND COLLISION TIME
-		if (done && contactTime < 1.0E-7) {
-			DBGP("!! could not find contact time !!");
-			for (i=0;i<numDynBodies;i++)
-				dynBodies[i]->returnToMarkedState();    
-		}
-		worldTime += contactTime;
-	}
-	else { // if no collision
-		worldTime += timeStep;
-		contactTime = timeStep;
-	}
+        // COULD NOT FIND COLLISION TIME
+        if (done && contactTime < 1.0E-7) {
+            DBGP("!! could not find contact time !!");
+            for (i = 0; i < numDynBodies; i++)
+                dynBodies[i]->returnToMarkedState();
+        }
+        worldTime += contactTime;
+    }
+    else { // if no collision
+        worldTime += timeStep;
+        contactTime = timeStep;
+    }
 
-#ifdef GRASPITDBG
-	std::cout << "CHECKING COLLISIONS AT MIDDLE OF STEP: ";
-	numCols = getCollisionReport(colReport);
+    #ifdef GRASPITDBG
+    std::cout << "CHECKING COLLISIONS AT MIDDLE OF STEP: ";
+    numCols = getCollisionReport(colReport);
 
-	if (!numCols){ 
-		std::cout << "None." << std::endl;
-	}
-	else {
-		std::cout << numCols <<" found!!!" << std::endl;
-		for (i=0;i<numCols;i++) {
-			std::cout << colReport[i].first->getName() << " collided with " <<
-				colReport[i].second->getName() << std::endl;
-		}
-	}
-#endif
+    if (!numCols) {
+        std::cout << "None." << std::endl;
+    }
+    else {
+        std::cout << numCols << " found!!!" << std::endl;
+        for (i = 0; i < numCols; i++) {
+            std::cout << colReport[i].first->getName() << " collided with " <<
+                      colReport[i].second->getName() << std::endl;
+        }
+    }
+    #endif
 
-	if (numDynBodies > 0)
-		findAllContacts();
+    if (numDynBodies > 0)
+        findAllContacts();
 
-	for (i=0; i<numRobots; i++){
-          if ( robotVec[i]->inherits("HumanHand") ) ((HumanHand*)robotVec[i])->updateTendonGeometry();
-          robotVec[i]->emitConfigChange();
-	}
-	Q_EMIT tendonDetailsChanged();
+    for (i = 0; i < numRobots; i++) {
+        if (robotVec[i]->inherits("HumanHand"))((HumanHand *)robotVec[i])->updateTendonGeometry();
+        robotVec[i]->emitConfigChange();
+    }
+    Q_EMIT tendonDetailsChanged();
 
-	if (contactTime<1.0E-7) return -1.0;
-	return contactTime;
+    if (contactTime < 1.0E-7) return -1.0;
+    return contactTime;
 }
 
 /*! Asks the dynamics engine to compute the velocities of all bodies at
-the current time step. These will be used in the next time step when
-the bodies are moved by World::moveDynamicBodies.
+    the current time step. These will be used in the next time step when
+    the bodies are moved by World::moveDynamicBodies.
 
-The bodies are separated into "islands" of bodies connected by contacts 
-or joints.	Two dynamic bodies are connected if they share a contact or
-a joint.  Then for each island, this calls the iterate dynamics routine
-to build and solve the LCP to find the velocities of all the bodies
-in the next iteration.
-*/	
+    The bodies are separated into "islands" of bodies connected by contacts
+    or joints.  Two dynamic bodies are connected if they share a contact or
+    a joint.  Then for each island, this calls the iterate dynamics routine
+    to build and solve the LCP to find the velocities of all the bodies
+    in the next iteration.
+*/
 int
-World::computeNewVelocities(double timeStep)
-{
-	bool allDynamicsComputed;
-	static std::list<Contact *> contactList;
-	std::list<Contact *>::iterator cp;
-	std::vector<DynamicBody *> robotLinks;
-	std::vector<DynamicBody *> dynIsland;
-	std::vector<Robot *> islandRobots;
-	int i,j,numLinks,numDynBodies,lemkeErrCode;
+World::computeNewVelocities(double timeStep) {
+    bool allDynamicsComputed;
+    static std::list<Contact *> contactList;
+    std::list<Contact *>::iterator cp;
+    std::vector<DynamicBody *> robotLinks;
+    std::vector<DynamicBody *> dynIsland;
+    std::vector<Robot *> islandRobots;
+    int i, j, numLinks, numDynBodies, lemkeErrCode;
 
-#ifdef GRASPITDBG
-	int islandCount = 0;
-#endif
+    #ifdef GRASPITDBG
+    int islandCount = 0;
+    #endif
 
-	do {
-		// seed the island with one dynamic body
-		for (i=0;i<numBodies;i++)
-			if (bodyVec[i]->isDynamic() &&
-				!((DynamicBody *)bodyVec[i])->dynamicsComputed()) {
+    do {
+        // seed the island with one dynamic body
+        for (i = 0; i < numBodies; i++)
+            if (bodyVec[i]->isDynamic() &&
+                    !((DynamicBody *)bodyVec[i])->dynamicsComputed()) {
 
-					// if this body is a link, add all robots connected to the link
-					if (bodyVec[i]->inherits("Link")) {
-						Robot *robot = ((Robot *)((Link *)bodyVec[i])->getOwner())->getBaseRobot();
-						robot->getAllLinks(dynIsland);
-						robot->getAllAttachedRobots(islandRobots);
-					}
-					else
-						dynIsland.push_back((DynamicBody *)bodyVec[i]);
-					break;
-			}
-			numDynBodies = dynIsland.size();
-			for (i=0;i<numDynBodies;i++)
-				dynIsland[i]->setDynamicsFlag();
+                // if this body is a link, add all robots connected to the link
+                if (bodyVec[i]->inherits("Link")) {
+                    Robot *robot = ((Robot *)((Link *)bodyVec[i])->getOwner())->getBaseRobot();
+                    robot->getAllLinks(dynIsland);
+                    robot->getAllAttachedRobots(islandRobots);
+                }
+                else
+                    dynIsland.push_back((DynamicBody *)bodyVec[i]);
+                break;
+            }
+        numDynBodies = dynIsland.size();
+        for (i = 0; i < numDynBodies; i++)
+            dynIsland[i]->setDynamicsFlag();
 
-			// add any bodies that contact any body already in the dynamic island
-			for (i=0;i<numDynBodies;i++) {
-				contactList = dynIsland[i]->getContacts();
-				for (cp=contactList.begin();cp!=contactList.end();cp++) {
-					//if the contacting body is dynamic and not already in the list, add it
-					if ((*cp)->getBody2()->isDynamic() &&
-						!((DynamicBody *)(*cp)->getBody2())->dynamicsComputed()) {
-							DynamicBody *contactedBody = (DynamicBody *)(*cp)->getBody2();
+        // add any bodies that contact any body already in the dynamic island
+        for (i = 0; i < numDynBodies; i++) {
+            contactList = dynIsland[i]->getContacts();
+            for (cp = contactList.begin(); cp != contactList.end(); cp++) {
+                //if the contacting body is dynamic and not already in the list, add it
+                if ((*cp)->getBody2()->isDynamic() &&
+                        !((DynamicBody *)(*cp)->getBody2())->dynamicsComputed()) {
+                    DynamicBody *contactedBody = (DynamicBody *)(*cp)->getBody2();
 
-							// is this body is a link, add all robots connected to the link
-							if (contactedBody->isA("Link")) {
-								Robot *robot = ((Robot *)((Link *)contactedBody)->getOwner())->getBaseRobot();
-								robot->getAllLinks(robotLinks);
-								robot->getAllAttachedRobots(islandRobots);
-								numLinks = robotLinks.size();
-								for (j=0;j<numLinks;j++)
-									if (!robotLinks[j]->dynamicsComputed()) {
-										dynIsland.push_back(robotLinks[j]);
-										robotLinks[j]->setDynamicsFlag();
-										numDynBodies++;
-									}
-									robotLinks.clear();
-							}
-							else {
-								dynIsland.push_back(contactedBody);
-								contactedBody->setDynamicsFlag();
-								numDynBodies++;
-							}
-					}
-				}
-			}
+                    // is this body is a link, add all robots connected to the link
+                    if (contactedBody->isA("Link")) {
+                        Robot *robot = ((Robot *)((Link *)contactedBody)->getOwner())->getBaseRobot();
+                        robot->getAllLinks(robotLinks);
+                        robot->getAllAttachedRobots(islandRobots);
+                        numLinks = robotLinks.size();
+                        for (j = 0; j < numLinks; j++)
+                            if (!robotLinks[j]->dynamicsComputed()) {
+                                dynIsland.push_back(robotLinks[j]);
+                                robotLinks[j]->setDynamicsFlag();
+                                numDynBodies++;
+                            }
+                        robotLinks.clear();
+                    }
+                    else {
+                        dynIsland.push_back(contactedBody);
+                        contactedBody->setDynamicsFlag();
+                        numDynBodies++;
+                    }
+                }
+            }
+        }
 
-#ifdef GRASPITDBG
-			std::cout << "Island "<< ++islandCount<<" Bodies: ";
-			for (i=0;i<numDynBodies;i++)
-				std::cout << dynIsland[i]->getName() <<" ";
-			std::cout << std::endl;
-			std::cout << "Island Robots"<< islandCount<<" Robots: ";
-			for (i=0;i<islandRobots.size();;i++)
-				std::cout << islandRobots[i]->getName() <<" ";
-			std::cout << std::endl << std::endl;
-#endif  
+        #ifdef GRASPITDBG
+        std::cout << "Island " << ++islandCount << " Bodies: ";
+        for (i = 0; i < numDynBodies; i++)
+            std::cout << dynIsland[i]->getName() << " ";
+        std::cout << std::endl;
+        std::cout << "Island Robots" << islandCount << " Robots: ";
+        for (i = 0; i < islandRobots.size();; i++)
+            std::cout << islandRobots[i]->getName() << " ";
+        std::cout << std::endl << std::endl;
+        #endif
 
-			for (i=0;i<numDynBodies;i++)
-				dynIsland[i]->markState();
+        for (i = 0; i < numDynBodies; i++)
+            dynIsland[i]->markState();
 
-			DynamicParameters dp;
-			if (numDynBodies > 0) {
-				dp.timeStep = timeStep;
-				dp.useContactEps = true;
-				dp.gravityMultiplier = 1.0;
-				lemkeErrCode = iterateDynamics(islandRobots,dynIsland,&dp);
+        DynamicParameters dp;
+        if (numDynBodies > 0) {
+            dp.timeStep = timeStep;
+            dp.useContactEps = true;
+            dp.gravityMultiplier = 1.0;
+            lemkeErrCode = iterateDynamics(islandRobots, dynIsland, &dp);
 
-				if (lemkeErrCode == 1){ // dynamics could not be solved
-					std::cerr << "LCP COULD NOT BE SOLVED!"<<std::endl<<std::endl;
-					turnOffDynamics();
-					return -1;
-				}
-			}
+            if (lemkeErrCode == 1) { // dynamics could not be solved
+                std::cerr << "LCP COULD NOT BE SOLVED!" << std::endl << std::endl;
+                turnOffDynamics();
+                return -1;
+            }
+        }
 
-			dynIsland.clear(); 
-			islandRobots.clear();
-			allDynamicsComputed = true;
-			for (i=0;i<numBodies;i++)
-				if (bodyVec[i]->isDynamic() &&
-					!((DynamicBody *)bodyVec[i])->dynamicsComputed()) {
-						allDynamicsComputed = false;
-						break;
-				}
-	}  while (!allDynamicsComputed);
+        dynIsland.clear();
+        islandRobots.clear();
+        allDynamicsComputed = true;
+        for (i = 0; i < numBodies; i++)
+            if (bodyVec[i]->isDynamic() &&
+                    !((DynamicBody *)bodyVec[i])->dynamicsComputed()) {
+                allDynamicsComputed = false;
+                break;
+            }
+    }
+    while (!allDynamicsComputed);
 
-	// clear all the dynamicsComputed flags
-	for (i=0;i<numBodies;i++)
-		if (bodyVec[i]->isDynamic())
-			((DynamicBody *)bodyVec[i])->resetDynamicsFlag();
+    // clear all the dynamicsComputed flags
+    for (i = 0; i < numBodies; i++)
+        if (bodyVec[i]->isDynamic())
+            ((DynamicBody *)bodyVec[i])->resetDynamicsFlag();
 
-	Q_EMIT dynamicStepTaken();
-	return 0;
+    Q_EMIT dynamicStepTaken();
+    return 0;
 }
 
 void
-World::resetDynamicWrenches()
-{
-	for (int i=0; i<numBodies; i++) {
-		if (bodyVec[i]->isDynamic()) {
-			((DynamicBody*)bodyVec[i])->resetExtWrenchAcc();
-		}
-	}
+World::resetDynamicWrenches() {
+    for (int i = 0; i < numBodies; i++) {
+        if (bodyVec[i]->isDynamic()) {
+            ((DynamicBody *)bodyVec[i])->resetExtWrenchAcc();
+        }
+    }
 }
 
 /*! A complete dynamics step:
-- moveDynamicBodies moves the bodies according to velocities computed
-at the previous time step.
+    - moveDynamicBodies moves the bodies according to velocities computed
+    at the previous time step.
 
-- active and passive joint forces are applied; contacts are detected
+    - active and passive joint forces are applied; contacts are detected
 
-- computeNewVelocities computes the velocities according to contact and
-joint constraints, for the next time step.
+    - computeNewVelocities computes the velocities according to contact and
+    joint constraints, for the next time step.
 */
 void
-World::stepDynamics()
-{
+World::stepDynamics() {
     int ret;
-    ret=mDynamicsEngine->stepDynamics();
-    if(ret==-1){
-      return;
+    ret = mDynamicsEngine->stepDynamics();
+    if (ret == -1) {
+        return;
     }
-	if (idleSensor) idleSensor->schedule();
+    if (idleSensor) idleSensor->schedule();
 }
 
-void World::selectTendon(Tendon *t)
-{
-	if (isTendonSelected)
-		selectedTendon->deselect();
+void World::selectTendon(Tendon *t) {
+    if (isTendonSelected)
+        selectedTendon->deselect();
 
-	isTendonSelected = true;
-	selectedTendon = t;
-	selectedTendon->select();
+    isTendonSelected = true;
+    selectedTendon = t;
+    selectedTendon->select();
 
-	//we need to change selected hand to the hand that owns currently selected tendon
-	//so we can populate the drop-down tendon list in the GUI
-	if ( getCurrentHand() != (Hand*)selectedTendon->getRobot() ) setCurrentHand( (Hand*)t->getRobot() );
+    //we need to change selected hand to the hand that owns currently selected tendon
+    //so we can populate the drop-down tendon list in the GUI
+    if (getCurrentHand() != (Hand *)selectedTendon->getRobot()) setCurrentHand((Hand *)t->getRobot());
 
-	Q_EMIT tendonSelectionChanged();
+    Q_EMIT tendonSelectionChanged();
 }
 
-void World::selectTendon(int i)
-{
-	if (isTendonSelected)
-		selectedTendon->deselect();
+void World::selectTendon(int i) {
+    if (isTendonSelected)
+        selectedTendon->deselect();
 
-	// i is supposed to be an index into the currently selected hand's list of tendons
-	if (!currentHand)
-	{
-		printf("ERROR: no hand selected\n");
-		return;
-	}
-	if (! currentHand->inherits("HumanHand") )
-	{
-		printf("ERROR: selected hand is not tendon-actuated\n");
-		return;
-	}
+    // i is supposed to be an index into the currently selected hand's list of tendons
+    if (!currentHand) {
+        printf("ERROR: no hand selected\n");
+        return;
+    }
+    if (! currentHand->inherits("HumanHand")) {
+        printf("ERROR: selected hand is not tendon-actuated\n");
+        return;
+    }
 
-	if ( ((HumanHand*)currentHand)->getNumTendons() <= i)
-	{
-		printf("ERROR: selected hand has fewer tendons than passed parameter\n");
-		return;
-	}
+    if (((HumanHand *)currentHand)->getNumTendons() <= i) {
+        printf("ERROR: selected hand has fewer tendons than passed parameter\n");
+        return;
+    }
 
-	if (isTendonSelected)
-		selectedTendon->deselect();
+    if (isTendonSelected)
+        selectedTendon->deselect();
 
-	isTendonSelected = true;
-	selectedTendon = ((HumanHand*)currentHand)->getTendon(i);
-	selectedTendon->select();
-	Q_EMIT tendonSelectionChanged();
+    isTendonSelected = true;
+    selectedTendon = ((HumanHand *)currentHand)->getTendon(i);
+    selectedTendon->select();
+    Q_EMIT tendonSelectionChanged();
 }
 
-void World::deselectTendon()
-{
-	isTendonSelected = false;
-	if (selectedTendon)
-		selectedTendon->deselect();
-	selectedTendon = NULL;
-	Q_EMIT tendonSelectionChanged();
+void World::deselectTendon() {
+    isTendonSelected = false;
+    if (selectedTendon)
+        selectedTendon->deselect();
+    selectedTendon = NULL;
+    Q_EMIT tendonSelectionChanged();
 }
 
-int World::getCurrentHandNumberTendons()
-{
-	if (!currentHand)
-		return 0;
-	if (! currentHand->inherits("HumanHand") )
-		return 0;
+int World::getCurrentHandNumberTendons() {
+    if (!currentHand)
+        return 0;
+    if (! currentHand->inherits("HumanHand"))
+        return 0;
 
-	return ((HumanHand*)currentHand)->getNumTendons();
+    return ((HumanHand *)currentHand)->getNumTendons();
 }
 
-QString World::getSelectedHandTendonName(int i)
-{
-	/*return the name of the i-th tendon of the currently selected hand*/
-	if (i>=getCurrentHandNumberTendons())
-		return QString("Error reading name");
+QString World::getSelectedHandTendonName(int i) {
+    /*return the name of the i-th tendon of the currently selected hand*/
+    if (i >= getCurrentHandNumberTendons())
+        return QString("Error reading name");
 
-	return ((HumanHand*)currentHand)->getTendon(i)->getName();
+    return ((HumanHand *)currentHand)->getTendon(i)->getName();
 }

--- a/src/worldElement.cpp
+++ b/src/worldElement.cpp
@@ -24,9 +24,9 @@
 //######################################################################
 
 
-/*! \file 
-  \brief Implements the world element base class
- */
+/*! \file
+    \brief Implements the world element base class
+*/
 #include "worldElement.h"
 #include "matvec3D.h"
 #include "world.h"
@@ -47,258 +47,255 @@
 const double WorldElement::ONE_STEP = 1.0e6;
 
 /*!
-  Protected constructor should only be called by subclasses.
-  It initializes an empty worldElement.
+    Protected constructor should only be called by subclasses.
+    It initializes an empty worldElement.
 */
-WorldElement::WorldElement(World *w,const char *name) : QObject((QObject *)w,name)
-{
-  myWorld=w; IVRoot=NULL;
-  if (!name) myName = "unnamed";
-  else myName = name;
-  myFilename = "unspecified";
-  contactsChangedFlag=false;
+WorldElement::WorldElement(World *w, const char *name) : QObject((QObject *)w, name) {
+    myWorld = w;
+    IVRoot = NULL;
+    if (!name) myName = "unnamed";
+    else myName = name;
+    myFilename = "unspecified";
+    contactsChangedFlag = false;
 }
 
 
 /*!
-  Protected copy constructor (should not be called by user)
+    Protected copy constructor (should not be called by user)
 */
-WorldElement::WorldElement(const WorldElement &e) : QObject((QObject *)e.myWorld,e.name())
-{
-  myWorld = e.myWorld;
-  myName = e.myName;
-  IVRoot = e.IVRoot;
-  myFilename = e.myFilename;
-  contactsChangedFlag = e.contactsChangedFlag;
+WorldElement::WorldElement(const WorldElement &e) : QObject((QObject *)e.myWorld, e.name()) {
+    myWorld = e.myWorld;
+    myName = e.myName;
+    IVRoot = e.IVRoot;
+    myFilename = e.myFilename;
+    contactsChangedFlag = e.contactsChangedFlag;
 }
 
 
 /*!
-  Protected destructor should only be called by subclasses
-  Currently this is simply a stub.
+    Protected destructor should only be called by subclasses
+    Currently this is simply a stub.
 */
-WorldElement::~WorldElement()
-{
+WorldElement::~WorldElement() {
 
 }
 
 /*! Given a start position which is expected to be collision-free, and a
-  new position which which causes inter-penetration, it interpolates
-  between the two to find the exact moment of contact. Returns false if
-  the interpolation fails (usually because the starting point is also in
-  collision).
-  
-  Only looks at possible collisions in \a colReport, which the caller must
-  determine before calling this.
+    new position which which causes inter-penetration, it interpolates
+    between the two to find the exact moment of contact. Returns false if
+    the interpolation fails (usually because the starting point is also in
+    collision).
+
+    Only looks at possible collisions in \a colReport, which the caller must
+    determine before calling this.
 */
-bool 
-WorldElement::interpolateTo(transf lastTran, transf newTran, const CollisionReport &colReport)
-{
-  vec3 nextTranslation;
-  Quaternion nextRotation;
-  transf nextTran;
-  int numCols = colReport.size();
-  
-  //this causes the interpolation to first check the original transform
-  //since in many cases the original position is actually the one in contact, this can save a lot of computation
-  //as well as machine precision problems
-  //technically, it allows t to become negative, but in practice this should never happen as long as the initial position
-  //is collision free
-  double t = 0.0, deltat = 1.0, minDist;
-  bool done = false;
-  
-  while (!done && deltat > 1.0e-20 && t >= 0) {
-    DBGP("move interpolation cycle")
-      deltat /= 2.0;
-    
-    nextTranslation = (1.0-t)*lastTran.translation() + t*newTran.translation();
-    nextRotation = Quaternion::Slerp(t,lastTran.rotation(),newTran.rotation());
-    nextTran = transf(nextRotation,nextTranslation);
-    DBGP("moving to time : " << t);
-    if (setTran(nextTran) == FAILURE) {
-      deltat = 0;
-      break;
+bool
+WorldElement::interpolateTo(transf lastTran, transf newTran, const CollisionReport &colReport) {
+    vec3 nextTranslation;
+    Quaternion nextRotation;
+    transf nextTran;
+    int numCols = colReport.size();
+
+    //this causes the interpolation to first check the original transform
+    //since in many cases the original position is actually the one in contact, this can save a lot of computation
+    //as well as machine precision problems
+    //technically, it allows t to become negative, but in practice this should never happen as long as the initial position
+    //is collision free
+    double t = 0.0, deltat = 1.0, minDist;
+    bool done = false;
+
+    while (!done && deltat > 1.0e-20 && t >= 0) {
+        DBGP("move interpolation cycle")
+        deltat /= 2.0;
+
+        nextTranslation = (1.0 - t) * lastTran.translation() + t * newTran.translation();
+        nextRotation = Quaternion::Slerp(t, lastTran.rotation(), newTran.rotation());
+        nextTran = transf(nextRotation, nextTranslation);
+        DBGP("moving to time : " << t);
+        if (setTran(nextTran) == FAILURE) {
+            deltat = 0;
+            break;
+        }
+
+        minDist = myWorld->getDist(colReport[0].first, colReport[0].second);
+        for (int i = 1; i < numCols; i++) {
+            double dist = myWorld->getDist(colReport[i].first, colReport[i].second);
+            minDist = MIN(minDist, dist);
+        }
+        DBGP("minDist: " << minDist);
+        if (minDist > 0) {
+            if (minDist < Contact::THRESHOLD * 0.5)
+                break;
+            t += deltat;
+        }
+        else
+            t -= deltat;
+
+        //debug code
+        if (deltat <= 1.0e-20 || t < 0) {
+            for (int i = 0; i < numCols; i++) {
+                double dist = myWorld->getDist(colReport[i].first, colReport[i].second);
+                DBGA(colReport[i].first->getName().latin1() << " -- " <<
+                     colReport[i].second->getName().latin1() << " is " << dist);
+            }
+        }
+
     }
-    
-    minDist = myWorld->getDist(colReport[0].first,colReport[0].second);
-    for (int i=1; i<numCols; i++) {
-      double dist = myWorld->getDist(colReport[i].first,colReport[i].second);
-			minDist = MIN(minDist,dist);
+    if (deltat < 1.0e-20 || t < 0) {
+        DBGP("deltat failsafe or negative t hit; interpolate failure");
+        fprintf(stdout, "WorldElement interpolation error!\n");
+        return false;
     }
-    DBGP("minDist: " << minDist);
-    if (minDist > 0) {
-      if (minDist < Contact::THRESHOLD * 0.5)
-        break;
-      t += deltat;
+    else {
+        DBGP("deltat: " << deltat << "; minDist: " << minDist << "; interpolate success.");
+        return true;
     }
-    else
-      t -= deltat;
-    
-    //debug code
-    if ( deltat <= 1.0e-20 || t < 0) {
-      for (int i=0; i<numCols; i++) {
-        double dist = myWorld->getDist(colReport[i].first,colReport[i].second);
-        DBGA(colReport[i].first->getName().latin1() << " -- " <<
-             colReport[i].second->getName().latin1() << " is " << dist);			
-      }
-    }
-    
-  }
-  if (deltat < 1.0e-20 || t < 0) {
-    DBGP("deltat failsafe or negative t hit; interpolate failure");
-    fprintf(stdout,"WorldElement interpolation error!\n");
-    return false;
-  } else {
-    DBGP("deltat: " << deltat << "; minDist: " << minDist <<"; interpolate success.");
-    return true;
-  }  
 }
 
 /*! Attempts to move the element from its current pose to the new pose
-  in \a newTran in a single step. If the final pose if collision-free
-  it is done. If not, it interpolates to find the exact moment of contact.
-  Returns \a false if the interpolation fails.
+    in \a newTran in a single step. If the final pose if collision-free
+    it is done. If not, it interpolates to find the exact moment of contact.
+    Returns \a false if the interpolation fails.
 */
-bool WorldElement::jumpTo(transf newTran, CollisionReport *contactReport)
-{
-  int i, numCols;
-  bool success;
-  CollisionReport colReport;
-  transf lastTran = getTran();
-  if ( setTran(newTran) == FAILURE) return false;
-  //we are only interested in collisions involving this body
-  std::vector<Body*> interestList;
-  //a robot will place all of its links in here
-  getBodyList(&interestList);
-  contactReport->clear();
-  while (1) {
-    numCols = myWorld->getCollisionReport(&colReport, &interestList);
-    if (!numCols) {
-      return true;
-    }
-    
-#ifdef GRASPITDBG
-    for (i=0; i<numCols; i++) {
-      std::cerr << colReport[i].first->getName().latin1()<<" -- " 
-                << colReport[i].second->getName().latin1() << std::endl;
-    }
-    DBGP("I am " << myName.latin1() );
-#endif
-    
-    success = interpolateTo(lastTran, getTran(), colReport );
-    if (!success) {
-      return false;
-    }
+bool WorldElement::jumpTo(transf newTran, CollisionReport *contactReport) {
+    int i, numCols;
+    bool success;
+    CollisionReport colReport;
+    transf lastTran = getTran();
+    if (setTran(newTran) == FAILURE) return false;
+    //we are only interested in collisions involving this body
+    std::vector<Body *> interestList;
+    //a robot will place all of its links in here
+    getBodyList(&interestList);
     contactReport->clear();
-    for (i=0;i<numCols;i++) {
-      if (myWorld->getDist(colReport[i].first,colReport[i].second) < Contact::THRESHOLD)
-        contactReport->push_back(colReport[i]);
+    while (1) {
+        numCols = myWorld->getCollisionReport(&colReport, &interestList);
+        if (!numCols) {
+            return true;
+        }
+
+        #ifdef GRASPITDBG
+        for (i = 0; i < numCols; i++) {
+            std::cerr << colReport[i].first->getName().latin1() << " -- "
+                      << colReport[i].second->getName().latin1() << std::endl;
+        }
+        DBGP("I am " << myName.latin1());
+        #endif
+
+        success = interpolateTo(lastTran, getTran(), colReport);
+        if (!success) {
+            return false;
+        }
+        contactReport->clear();
+        for (i = 0; i < numCols; i++) {
+            if (myWorld->getDist(colReport[i].first, colReport[i].second) < Contact::THRESHOLD)
+                contactReport->push_back(colReport[i]);
+        }
     }
-  }
 }
 
-/*! 
-  Moves the element from its current pose to the new pose specified by \a tr.
-  This motion is performed in several steps such that the translation
-  between each step does not exceed \a translStepSize and the angle of
-  rotation does not exceed \a rotStepSize (expressed in radians).  The
-  intermediate poses are determined using linear interpolation for the
-  translation and spherical linear interpolation for the rotation.  If
-  a collision is encountered during the motion, the point of first contact
-  is determined and the element is left in that position.  This function
-  returns false if a collision was encountered (or contacts prevented the motion)
-  or true if no collisions were encountered and the move was completed.
+/*!
+    Moves the element from its current pose to the new pose specified by \a tr.
+    This motion is performed in several steps such that the translation
+    between each step does not exceed \a translStepSize and the angle of
+    rotation does not exceed \a rotStepSize (expressed in radians).  The
+    intermediate poses are determined using linear interpolation for the
+    translation and spherical linear interpolation for the rotation.  If
+    a collision is encountered during the motion, the point of first contact
+    is determined and the element is left in that position.  This function
+    returns false if a collision was encountered (or contacts prevented the motion)
+    or true if no collisions were encountered and the move was completed.
 */
 bool
-WorldElement::moveTo(transf &newTran,double translStepSize, double rotStepSize)
-{
-  bool moveFinished = false;
-  transf origTran,nextTran,motion;
-  Quaternion nextRotation;
-  vec3 nextTranslation;
-  double percentComplete,moveIncrement,translationLength;
-  double angle;
-  vec3 axis;
-  bool success;
-  
-  CollisionReport contactReport;
-  
-  //DBGP("moveTo called");
-  
-  origTran = getTran();
-  /*
-    std::cout << "WorldElement origTran: " << origTran.translation().x() << " " <<
-    origTran.translation().y() << " " <<
-    origTran.translation().z() << " " <<
-    origTran.rotation().w << " " <<
-    origTran.rotation().x << " " <<
-    origTran.rotation().y << " " <<
-    origTran.rotation().z << " " << "\n";
-  */
-  //calculate the difference
-  translationLength = (newTran.translation() - origTran.translation()).len();
-  nextRotation = newTran.rotation() * origTran.rotation().inverse();
-  nextRotation.ToAngleAxis(angle,axis);
-  
-  moveIncrement = 1.0;
-  if (translationLength != 0.0) {
-    if (translStepSize == ONE_STEP) 
-      moveIncrement = 1.0;
-    else
-      moveIncrement = MIN(moveIncrement, translStepSize / translationLength);
-  }
-  if (angle != 0.0) {
-    if (rotStepSize == ONE_STEP)
-      moveIncrement = MIN(moveIncrement, 1.0);
-    else
-      moveIncrement = MIN(moveIncrement, rotStepSize / angle);
-  }
-  
-  // check contacts
-  nextTranslation = (1.0-moveIncrement)*origTran.translation() + moveIncrement*newTran.translation();
-  nextRotation = Quaternion::Slerp(moveIncrement,origTran.rotation(), newTran.rotation());
-  nextTran = transf(nextRotation,nextTranslation);
-  motion = nextTran * getTran().inverse();
-  
-  if (contactsPreventMotion(motion)) {
-    DBGP("contacts prevent motion")
-      return false;
-  }
-  
-  percentComplete = 0.0;
-  while (!moveFinished) {
-    percentComplete += moveIncrement;
-    if (percentComplete >= 1.0) {
-      percentComplete = 1.0;
-      moveFinished = true;
-    }
-    
-    nextTranslation = (1.0-percentComplete)*origTran.translation() + percentComplete*newTran.translation();
-    nextRotation = Quaternion::Slerp(percentComplete,origTran.rotation(), newTran.rotation());
-    nextTran = transf(nextRotation,nextTranslation);
+WorldElement::moveTo(transf &newTran, double translStepSize, double rotStepSize) {
+    bool moveFinished = false;
+    transf origTran, nextTran, motion;
+    Quaternion nextRotation;
+    vec3 nextTranslation;
+    double percentComplete, moveIncrement, translationLength;
+    double angle;
+    vec3 axis;
+    bool success;
+
+    CollisionReport contactReport;
+
+    //DBGP("moveTo called");
+
+    origTran = getTran();
     /*
-      std::cout << "moveTo NextTran: " << nextTran.translation().x() << " " <<
-      nextTran.translation().y() << " " <<
-      nextTran.translation().z() << " " <<
-      nextTran.rotation().w << " " <<
-      nextTran.rotation().x << " " <<
-      nextTran.rotation().y << " " <<
-      nextTran.rotation().z << " " << "\n";
+        std::cout << "WorldElement origTran: " << origTran.translation().x() << " " <<
+        origTran.translation().y() << " " <<
+        origTran.translation().z() << " " <<
+        origTran.rotation().w << " " <<
+        origTran.rotation().x << " " <<
+        origTran.rotation().y << " " <<
+        origTran.rotation().z << " " << "\n";
     */
-    success = jumpTo(nextTran, &contactReport);
-    if (!success || contactReport.size() != 0) {
-      moveFinished = true;
+    //calculate the difference
+    translationLength = (newTran.translation() - origTran.translation()).len();
+    nextRotation = newTran.rotation() * origTran.rotation().inverse();
+    nextRotation.ToAngleAxis(angle, axis);
+
+    moveIncrement = 1.0;
+    if (translationLength != 0.0) {
+        if (translStepSize == ONE_STEP)
+            moveIncrement = 1.0;
+        else
+            moveIncrement = MIN(moveIncrement, translStepSize / translationLength);
     }
-  }
-  
-  if (!success) {
-    DBGA("JumpTo error, stopping execution. Object " << myName.latin1() << " in thread " 
-         << getWorld()->getCollisionInterface()->getThreadId());
-  } else {
-    myWorld->findContacts(contactReport);
-  }
-  
-  if (contactReport.size() != 0) return false;
-  return true;
+    if (angle != 0.0) {
+        if (rotStepSize == ONE_STEP)
+            moveIncrement = MIN(moveIncrement, 1.0);
+        else
+            moveIncrement = MIN(moveIncrement, rotStepSize / angle);
+    }
+
+    // check contacts
+    nextTranslation = (1.0 - moveIncrement) * origTran.translation() + moveIncrement * newTran.translation();
+    nextRotation = Quaternion::Slerp(moveIncrement, origTran.rotation(), newTran.rotation());
+    nextTran = transf(nextRotation, nextTranslation);
+    motion = nextTran * getTran().inverse();
+
+    if (contactsPreventMotion(motion)) {
+        DBGP("contacts prevent motion")
+        return false;
+    }
+
+    percentComplete = 0.0;
+    while (!moveFinished) {
+        percentComplete += moveIncrement;
+        if (percentComplete >= 1.0) {
+            percentComplete = 1.0;
+            moveFinished = true;
+        }
+
+        nextTranslation = (1.0 - percentComplete) * origTran.translation() + percentComplete * newTran.translation();
+        nextRotation = Quaternion::Slerp(percentComplete, origTran.rotation(), newTran.rotation());
+        nextTran = transf(nextRotation, nextTranslation);
+        /*
+            std::cout << "moveTo NextTran: " << nextTran.translation().x() << " " <<
+            nextTran.translation().y() << " " <<
+            nextTran.translation().z() << " " <<
+            nextTran.rotation().w << " " <<
+            nextTran.rotation().x << " " <<
+            nextTran.rotation().y << " " <<
+            nextTran.rotation().z << " " << "\n";
+        */
+        success = jumpTo(nextTran, &contactReport);
+        if (!success || contactReport.size() != 0) {
+            moveFinished = true;
+        }
+    }
+
+    if (!success) {
+        DBGA("JumpTo error, stopping execution. Object " << myName.latin1() << " in thread "
+             << getWorld()->getCollisionInterface()->getThreadId());
+    }
+    else {
+        myWorld->findContacts(contactReport);
+    }
+
+    if (contactReport.size() != 0) return false;
+    return true;
 }
 

--- a/src/worldElementFactory.cpp
+++ b/src/worldElementFactory.cpp
@@ -25,9 +25,9 @@
 
 #include "worldElementFactory.h"
 
-/* Since we are using a class down here to register all the built in types
-   at runtime, we have to include all relevant headers here. Maybe we can
-   find a better solution at some point.
+/*  Since we are using a class down here to register all the built in types
+    at runtime, we have to include all relevant headers here. Maybe we can
+    find a better solution at some point.
 */
 #include "robot.h"
 #include "body.h"
@@ -43,44 +43,39 @@
 #include "mcGrip.h"
 #include "robotiq.h"
 
-WorldElementFactory::~WorldElementFactory()
-{
-  for (std::map<std::string, WorldElementCreator*>::iterator it=mCreators.begin(); it!=mCreators.end(); it++)
-  {
-    delete it->second;
-  }
+WorldElementFactory::~WorldElementFactory() {
+    for (std::map<std::string, WorldElementCreator *>::iterator it = mCreators.begin(); it != mCreators.end(); it++) {
+        delete it->second;
+    }
 }
 
-WorldElement* 
-WorldElementFactory::createElement(std::string elementType, World *parent,const char *name)
-{
-  std::map<std::string, WorldElementCreator*>::iterator it = mCreators.find(elementType);
-  if (it==mCreators.end()) return NULL;
-  return (*(it->second))(parent, name);
+WorldElement *
+WorldElementFactory::createElement(std::string elementType, World *parent, const char *name) {
+    std::map<std::string, WorldElementCreator *>::iterator it = mCreators.find(elementType);
+    if (it == mCreators.end()) return NULL;
+    return (*(it->second))(parent, name);
 }
 
-void 
-WorldElementFactory::registerCreator(std::string elementType, WorldElementCreator *creator)
-{
-  mCreators[elementType] = creator;
+void
+WorldElementFactory::registerCreator(std::string elementType, WorldElementCreator *creator) {
+    mCreators[elementType] = creator;
 }
 
-void 
-WorldElementFactory::registerBuiltinCreators()
-{
-  REGISTER_CREATOR("Body",Body);
-  REGISTER_CREATOR("GraspableBody",GraspableBody);
-  REGISTER_CREATOR("Robot",Robot);
-  REGISTER_CREATOR("Hand",Hand);
-  REGISTER_CREATOR("Puma560",Puma560);
-  REGISTER_CREATOR("Barrett",Barrett);
-  REGISTER_CREATOR("Robonaut",Robonaut);
-  REGISTER_CREATOR("Pr2Gripper",Pr2Gripper);
-  REGISTER_CREATOR("Pr2Gripper2010",Pr2Gripper2010);
-  REGISTER_CREATOR("M7",M7);
-  REGISTER_CREATOR("M7Tool",M7Tool);
-  REGISTER_CREATOR("HumanHand",HumanHand);
-  REGISTER_CREATOR("Shadow",Shadow);
-  REGISTER_CREATOR("McGrip",McGrip);
-  REGISTER_CREATOR("RobotIQ",RobotIQ);
+void
+WorldElementFactory::registerBuiltinCreators() {
+    REGISTER_CREATOR("Body", Body);
+    REGISTER_CREATOR("GraspableBody", GraspableBody);
+    REGISTER_CREATOR("Robot", Robot);
+    REGISTER_CREATOR("Hand", Hand);
+    REGISTER_CREATOR("Puma560", Puma560);
+    REGISTER_CREATOR("Barrett", Barrett);
+    REGISTER_CREATOR("Robonaut", Robonaut);
+    REGISTER_CREATOR("Pr2Gripper", Pr2Gripper);
+    REGISTER_CREATOR("Pr2Gripper2010", Pr2Gripper2010);
+    REGISTER_CREATOR("M7", M7);
+    REGISTER_CREATOR("M7Tool", M7Tool);
+    REGISTER_CREATOR("HumanHand", HumanHand);
+    REGISTER_CREATOR("Shadow", Shadow);
+    REGISTER_CREATOR("McGrip", McGrip);
+    REGISTER_CREATOR("RobotIQ", RobotIQ);
 }


### PR DESCRIPTION
@rbtying 
@mateiciocarlie 

Formatted using
astyle include/*.h
astyle src/*.cpp

Using the astylerc pasted below.  This is very easy to rerun with a different formatter.  Left me know if you want me to change any of the settings

#
## astyle configuration file
#

# Insert empty lines around unrelated blocks, labels, classes, ...
#--break-blocks

# Insert space padding around operators. Any end of line comments will remain in the original column, if possible. Note that there is no option to unpad. Once padded, they stay padded.
--pad-oper

# Insert space padding after paren headers only (e.g. 'if', 'for', 'while'...). Any end of line comments will remain in the original column, if possible. This can be used with unpad-paren to remove unwanted spaces.
--pad-header

# Remove unnecessary space padding around parenthesis. This
# can be used in combination with the 'pad' options above.
--unpad-paren

# Remove brackets from a bracketed one line conditional statements.
#--remove-brackets

# Convert tabs to the appropriate number of spaces.
--convert-tabs

# Indent multi-line preprocessor #define statements.
--indent-preproc-define

# Indent preprocessor conditional statements #if/#else/#endif
# to the same level as the source code.
--indent-preproc-cond

# Java style formatting/indenting uses attached brackets.
--style=java

# When used with --style=java, --style=kr, --style=stroustrup, --style=linux, or --style=1tbs, this breaks closing headers (e.g. 'else', 'catch', ...) from their immediately preceding closing brackets. Closing header brackets are always broken with the other styles.
--break-closing-brackets

# Attach brackets to a namespace statement. This is done regardless of the bracket style being used.
--attach-namespaces

# Attach brackets to a class statement. This is done regardless of the bracket style being used.
--attach-classes

# Indent 'class' and 'struct' blocks so that the entire block is indented. The struct blocks are indented only if an access modifier, 'public:', 'protected:' or 'private:', is declared somewhere in the struct. This option is effective for C++ files only.
--indent-classes

# Indent 'class' and 'struct' access modifiers, 'public:', 'protected:' and 'private:', one half indent. The rest of the class is not indented. This option is effective for C++ files only. If used with indent‑classes this option will be ignored.
--indent-modifiers

# Indent 'switch' blocks so that the 'case X:' statements are indented in the switch block. The entire case block is indented.
--indent-switches

# Add extra indentation to namespace blocks. This option has no effect on Java files.
--indent-namespaces

# Add extra indentation to labels so they appear 1 indent less than the current indentation, rather than being flushed to the left.
--indent-labels

# Indent C++ comments beginning in column one. By default C++ comments beginning in column one are not indented. This option will allow the comments to be indented with the code.
--indent-col1-comments

# Set the  maximum of # spaces to indent a continuation line. The # indicates a number of columns and must not be greater than 120. If no # is set, the default value of 40 will be used. A maximum of less than two indent lengths will be ignored. This option will prevent continuation lines from extending too far to the right. Setting a larger value will allow the code to be extended further to the right.
--max-instatement-indent=120

# Attach a pointer or reference operator (*, &, or ^) to either the variable type (left) or variable name (right), or place it between the type and name (middle). The spacing between the type and name will be preserved, if possible. This option is for C/C++, C++/CLI, and C# files. To format references separately use the following align-reference option.
--align-pointer=name

# This option will align references separate from pointers. Pointers are not changes by this option. If pointers and references are to be aligned the same, use the previous align-pointer option. The option align-reference=none will not change the reference alignment. The other options are the same as for align-pointer. This option is for C/C++, C++/CLI, and C# files.
--align-reference=name

# Remove the preceding '*' in a multi-line comment that begins a line. A trailing '*', if present, is also removed. Text that is less than one is indent is indented to one indent. Text greater than one indent is not changed. Multi-line comments that begin a line but without the preceding '*' are indented to one indent for consistency. This can slightly modify the indentation of commented out blocks of code. Lines containing all '*' are left unchanged. Extra spacing is removed from the comment close '*/'.
--remove-comment-prefix

# Append the suffix #### instead of '.orig' to original filename (e.g. --suffix=.bak). If this is to be a file extension, the dot '.' must be included. Otherwise the suffix will be appended to the current file extension.
--suffix=.bak

# Formatted files display mode. Display only the files that have been formatted. Do not display files that are unchanged.
--formatted