### PR TITLE
fixed reenable collisions between two bodies

### DIFF
--- a/src/Collision/Graspit/graspitCollision.cpp
+++ b/src/Collision/Graspit/graspitCollision.cpp
@@ -134,6 +134,24 @@ GraspitCollision::activatePair(const Body* body1, const Body* body2, bool active
 		mDisabledMap.insert( std::pair<const CollisionModel*, const CollisionModel*>(model1, model2) );
 	} else {
 		//remove from list
+	  std::pair<const CollisionModel*, const CollisionModel*> pair(model1, model2);
+
+	  typedef std::multimap<const CollisionModel*, const CollisionModel*>::iterator iterator;
+	  bool found_one = true;
+	  while(found_one)
+	    {
+	      found_one=false;
+	      std::pair<iterator, iterator> iterpair = mDisabledMap.equal_range(model1);
+	      iterator it = iterpair.first;
+	      for (; it != iterpair.second; ++it) {
+                if (it->second == model2) {
+		  mDisabledMap.erase(it);
+		  found_one = true;
+		  break;
+                }
+	      }
+	    }
+
 	}
 }
 


### PR DESCRIPTION
@mateiciocarlie 

I removed pair of bodies from the map of disabled bodies if collision is being reenabled between the two objects. Prior to this PR, the reenabling of pairwise collisions was not implemented.  I tested this by adding in 2 bodies.  Selecting both, disabling, then reenabling collisions.  