### PR TITLE
Reading and writing files with std file streams

### DIFF
--- a/include/contact.h
+++ b/include/contact.h
@@ -507,9 +507,11 @@ public:
 	void setObject(Body *b){body2 = b;}
 
 	//! Writes this contact, including friction edges, to a file
-	void writeToFile(FILE *fp);
+    // Returns false if file cannot be opened for writing
+	void writeToFile(std::ofstream& outfile);
 	//! Loads this contact, including friction edges, from a file
-	void readFromFile(FILE *fp);
+    // Returns false if file cannot be opened for reading 
+	bool readFromFile(std::ifstream& infile);
 
 	//! Wrench computation is done in world coordinates considers the fact that we have no object
 	void computeWrenches(bool useObjectData = false, bool simply = false);
@@ -564,11 +566,11 @@ class VirtualContactOnObject : public VirtualContact
 public:
 	VirtualContactOnObject ();
 	~VirtualContactOnObject ();
-	void readFromFile(FILE * fp);
+	bool readFromFile(std::ifstream& infile);
 #ifdef ARIZONA_PROJECT_ENABLED
 	void readFromRawData(ArizonaRawExp* are, QString file, int index, bool flipNormal = false);
 #endif
-	void writeToFile(FILE * fp);
+	void writeToFile(std::ofstream& outfile);
 };
 #define CONTACT_HXX
 #endif

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -947,25 +947,34 @@ Body::breakContacts()
 int
 Body::loadContactData(QString fn)
 {
-	FILE *fp = fopen(fn.latin1(), "r");
-	if (!fp) {
+    std::ifstream inFile(fn.latin1(), std::ios::in);
+    if (!inFile.is_open())
+    {
 		fprintf(stderr,"Could not open filename %s\n",fn.latin1());
 		return FAILURE;
-	}
+    }
+
 	int numContacts;
 	VirtualContactOnObject *newContact;
-	if(fscanf(fp,"%d",&numContacts) <= 0)
+    inFile >> numContacts;
+    {
+		fprintf(stderr,"Failed to read contacts from %s\n",fn.latin1());
 		return FAILURE;
+    }
 
 	breakVirtualContacts();
 	for (int i=0; i<numContacts; i++) {
 		newContact = new VirtualContactOnObject();
-		newContact->readFromFile(fp);
+		if (!newContact->readFromFile(inFile))
+        {
+		    fprintf(stderr,"Failed to a contacts from %s\n",fn.latin1());
+		    return FAILURE;
+        }
 		newContact->setBody( this );
 		((Contact*)newContact)->computeWrenches();
 		addVirtualContact( newContact );//visualize the contact just read in
 	}
-	fclose(fp);
+    inFile.close();
 	return SUCCESS;
 }
 /*! Removes all virtual contacts. This only removes the virtual contacts.

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -29,6 +29,7 @@
 #include <iomanip>
 #include <QFile>
 #include <QTextStream>
+#include <fstream>
 
 //needed just for the image of the Flock of Birds sensor and the approach direction
 #include "SoArrow.h"
@@ -373,29 +374,36 @@ Robot::loadEigenData(QString filename)
 int 
 Robot::loadContactData(QString filename)
 {
-  FILE *fp = fopen(filename.latin1(), "r");
-  if (!fp) {
-    DBGA("Could not open contact file " << filename.latin1());
+  std::ifstream inFile(filename.latin1(), std::ios::in);
+  if (!inFile.is_open())
+  {
+    fprintf(stderr,"Could not open filename %s\n",filename.latin1());
     return FAILURE;
   }
   
   char robotName[500];
   ; //yes, I know, can seg fault...
-  if(fscanf(fp,"%s",robotName) <= 0)
+  inFile >> robotName;
+  if(inFile.fail())
     {
       DBGA("Robot::loadContactData - failed to read robot name");
       return 0;
     }
   
   int numContacts;
-  if( fscanf(fp,"%d",&numContacts) <= 0){
+  inFile >> numContacts;
+  if(inFile.fail()){
     DBGA("Robot::loadContactData - failed to read number of contacts");
     return -1;
   }
 
   for (int i=0; i<numContacts; i++) {
     VirtualContact* newContact = new VirtualContact();
-    newContact->readFromFile(fp);    
+    if (!newContact->readFromFile(inFile))
+    {
+        DBGA("Robot::loadContactData - failed to read contacts");
+        return -1;
+    }
     int f = newContact->getFingerNum();
     int l = newContact->getLinkNum();
     if ( f >= 0) {
@@ -413,7 +421,7 @@ Robot::loadContactData(QString filename)
     }
     newContact->computeWrenches(false,false);
   }
-  fclose(fp);
+  inFile.close();
   return SUCCESS;
 }
 

--- a/ui/contactExaminerDlg.cpp
+++ b/ui/contactExaminerDlg.cpp
@@ -26,6 +26,7 @@
 #include "contactExaminerDlg.h"
 
 #include <QFileDialog>
+#include <fstream>
 
 #include "world.h"
 #include "robot.h"
@@ -150,24 +151,29 @@ void ContactExaminerDlg::saveButton_clicked()
 		return;
 	}
 
-	FILE *fp = fopen(fn.latin1(), "w");
-	if (!fp) {
+    std::ofstream outFile;
+    outFile.open (fn.latin1(), std::ios::out | std::ios::trunc); 
+    if (!outFile.is_open())
+    {
 		fprintf(stderr,"Failed to open file for writing\n");
-	}
+        return;
+    }
+        
+    fprintf(stderr,"Writing number of marked contacts: %u", (int)mMarkedContacts.size());
 
 	if(handRadioButton->isChecked()){
-		fprintf(fp,"%s\n",mHand->getName().latin1());
-		fprintf(fp,"%d\n",(int)mMarkedContacts.size());
+		outFile << mHand->getName().latin1() << std::endl;
+		outFile << (int)mMarkedContacts.size() << std::endl;
 		for (int i=0; i<(int)mMarkedContacts.size(); i++) {
-			((VirtualContact*)mMarkedContacts[i])->writeToFile(fp);
+			((VirtualContact*)mMarkedContacts[i])->writeToFile(outFile);
 		}
 	} else if (objectRadioButton->isChecked()){
-		fprintf(fp,"%d\n",(int)mMarkedContacts.size());
+        outFile << (int)mMarkedContacts.size() << std::endl;
 		for (int i=0; i<(int)mMarkedContacts.size(); i++) {
-			((VirtualContactOnObject*)mMarkedContacts[i])->writeToFile(fp);
+			((VirtualContactOnObject*)mMarkedContacts[i])->writeToFile(outFile);
 		}
 	}
-	fclose(fp);
+    outFile.close();
 }
 
 void ContactExaminerDlg::exitButton_clicked()


### PR DESCRIPTION
I have added changes to read/write contact points using std file streams instead of fscanf/fprintf. To start, I have adopted this change only for reading/writing contact points. After the general approach is reviewed here, I can also add same changes to all other affected parts in the code base.

Reason for this change: I noticed that on one of my computers, which accidentally was using the German locale, loading of contact points segfaulted. The reason was that the german locale (and probably others) use the comma notation for floating points instead of full-stops.

I think it is a good idea to eventually move away from fscanf/fprintf altogether, as it can cause a number of issues.