### PR TITLE
GraspitGUI->GraspitCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set (GRASPIT_INCLUDEDIR_HEADERS
     ${GSRC}/include/worldElement.h 
     ${GSRC}/include/worldElementFactory.h 
     ${GSRC}/include/world.h 
-    ${GSRC}/include/graspitGUI.h 
+    ${GSRC}/include/graspitCore.h
     ${GSRC}/include/graspitServer.h 
     ${GSRC}/include/graspitApp.h 
     ${GSRC}/include/arch.h
@@ -341,7 +341,7 @@ set (GRASPIT_CORE_SOURCES
     ${GSRC}/src/eigenGrasp.cpp 
     ${GSRC}/src/gloveInterface.cpp 
     ${GSRC}/src/grasp.cpp 
-    ${GSRC}/src/graspitGUI.cpp 
+    ${GSRC}/src/graspitCore.cpp
     ${GSRC}/src/graspitServer.cpp 
     ${GSRC}/src/graspitApp.cpp 
     ${GSRC}/src/graspRecord.cpp 

--- a/include/graspitCore.h
+++ b/include/graspitCore.h
@@ -99,10 +99,8 @@ class GraspitCore
   db_planner::DatabaseManager *mDBMgr;
 
  public:
-  GraspitCore();
+  GraspitCore(int argc, char **argv);
   ~GraspitCore();
-
-  int init(int argc, char **argv);
   
   /*! Returns whether GraspIt! was successfully initialized. */
   bool terminalFailure() const;

--- a/include/graspitCore.h
+++ b/include/graspitCore.h
@@ -93,8 +93,6 @@ class GraspitCore
   //! Idle sensor for calling the plugins from GraspIt's event loop
   SoIdleSensor *mPluginSensor;
 
-  bool headless;
-
   //! The main and only interface for the CGDB; all interaction with the CGDB should go through this.
   db_planner::DatabaseManager *mDBMgr;
 
@@ -134,8 +132,6 @@ class GraspitCore
 
   void startMainLoop();
   void exitMainLoop();
-
-  bool isHeadless(){return headless;}
 
   void emptyWorld();
 

--- a/include/graspitCore.h
+++ b/include/graspitCore.h
@@ -19,15 +19,15 @@
 //
 // Author(s):  Andrew T. Miller 
 //
-// $Id: graspitGUI.h,v 1.5 2010/08/11 02:45:37 cmatei Exp $
+// $Id: graspitCore.h,v 1.5 2010/08/11 02:45:37 cmatei Exp $
 //
 //######################################################################
 
 /*! \file 
-  \brief Defines a graspit user interface class that contains subpieces of the UI.
+  \brief Defines the GraspIt! core class.  It holds pointers the mainwindow, ivmgr, world.
 */
 
-#ifndef GRASPITGUI_HXX
+#ifndef GRASPIT_CORE_H
 
 #include <string>
 #include <vector>
@@ -57,13 +57,16 @@ class World;
   This class can also initialize a task dispatcher which is then in charge of 
   batch execution of tasks based on information form a grasp database.
 */
-class GraspItGUI
+class GraspitCore
 {
   //! A pointer to the MainWindow.
   MainWindow *mainWindow;
 
-  //! A pointer to the IVmgr.
+  //! A pointer to the IVmgr.  This will be NULL if in headless mode.
   IVmgr *ivmgr;
+
+  //! A pointer to the world
+  World *world;
 
   //! A pointer to the Task Dispatcher, if any
   TaskDispatcher *mDispatch;
@@ -88,14 +91,13 @@ class GraspItGUI
 
   bool headless;
 
- protected:
-  int processArgs(int argc, char **argv, cmdline::parser *args);
-
  public:
-  GraspItGUI(int argc, char **argv, cmdline::parser *args);
-  ~GraspItGUI();
+  GraspitCore();
+  ~GraspitCore();
+
+  int init(int argc, char **argv);
   
-  /*! Returns whether the UI pieces were successfully initialized. */
+  /*! Returns whether GraspIt! was successfully initialized. */
   bool terminalFailure() const;
 
   //! Returns the exit code (set internally based on the application)
@@ -104,8 +106,8 @@ class GraspItGUI
   /*! Returns a pointer to the MainWindow. */
   MainWindow *getMainWindow() const {return mainWindow;}
 
-  /*! Returns a pointer to the World (obtained through the main window) */
-  World *getMainWorld() const;
+  /*! Returns a pointer to the World */
+  World *getWorld() const {return world;}
 
   /*! Returns a pointer to the IVmgr. */
   IVmgr *getIVmgr() const {return ivmgr;}
@@ -129,6 +131,9 @@ class GraspItGUI
   void exitMainLoop();
 
   bool isHeadless(){return headless;}
+
+  void emptyWorld();
+
 };
 
 #if defined(WIN32) && !defined(__MINGW32__)
@@ -141,7 +146,7 @@ class GraspItGUI
 #define GRASPIT_API
 #endif
 
-extern GRASPIT_API GraspItGUI *graspItGUI;
+extern GRASPIT_API GraspitCore *graspitCore;
 
-#define GRASPITGUI_HXX
+#define GRASPIT_CORE_H
 #endif

--- a/include/graspitCore.h
+++ b/include/graspitCore.h
@@ -37,6 +37,10 @@ namespace cmdline{
     class parser;
 }
 
+namespace db_planner {
+    class DatabaseManager;
+}
+
 class MainWindow;
 class IVmgr;
 class TaskDispatcher;
@@ -91,6 +95,9 @@ class GraspitCore
 
   bool headless;
 
+  //! The main and only interface for the CGDB; all interaction with the CGDB should go through this.
+  db_planner::DatabaseManager *mDBMgr;
+
  public:
   GraspitCore();
   ~GraspitCore();
@@ -133,6 +140,15 @@ class GraspitCore
   bool isHeadless(){return headless;}
 
   void emptyWorld();
+
+  //! Get the main database manager, when CGDB support is enabled
+  db_planner::DatabaseManager* getDBMgr(){return mDBMgr;}
+  //! Set the main database manager. Should only be called by the DB connection dialog
+#ifdef CGDB_ENABLED
+  void setDBMgr(db_planner::DatabaseManager *mgr){mDBMgr = mgr;}
+#else
+  void setDBMgr(db_planner::DatabaseManager*){}
+#endif
 
 };
 

--- a/include/graspitGUI.h
+++ b/include/graspitGUI.h
@@ -33,6 +33,10 @@
 #include <vector>
 #include <list>
 
+namespace cmdline{
+    class parser;
+}
+
 class MainWindow;
 class IVmgr;
 class TaskDispatcher;
@@ -82,11 +86,13 @@ class GraspItGUI
   //! Idle sensor for calling the plugins from GraspIt's event loop
   SoIdleSensor *mPluginSensor;
 
+  bool headless;
+
  protected:
-  int processArgs(int argc, char **argv);
+  int processArgs(int argc, char **argv, cmdline::parser *args);
 
  public:
-  GraspItGUI(int argc,char **argv);
+  GraspItGUI(int argc, char **argv, cmdline::parser *args);
   ~GraspItGUI();
   
   /*! Returns whether the UI pieces were successfully initialized. */
@@ -121,6 +127,8 @@ class GraspItGUI
 
   void startMainLoop();
   void exitMainLoop();
+
+  bool isHeadless(){return headless;}
 };
 
 #if defined(WIN32) && !defined(__MINGW32__)

--- a/include/graspitParser.h
+++ b/include/graspitParser.h
@@ -20,6 +20,7 @@ public:
     static const std::string obstacle_help;
     static const std::string robot_help;
     static const std::string version_help;
+    static const std::string headless_help;
 
 private:
      cmdline::parser *parser;

--- a/include/ivmgr.h
+++ b/include/ivmgr.h
@@ -77,10 +77,6 @@ class GWSprojection;
 class QualityMeasure;
 struct DraggerInfo;
 
-namespace db_planner {
-	class DatabaseManager;
-}
-
 #define HANDS_DIR "../../hands/"
 #define OBJECTS_DIR "../../objects/"
 #define MAX_POLYTOPES 15
@@ -174,9 +170,6 @@ class IVmgr : public QWidget {
 
   //! Pointer to the material node controlling the color of dynamic force indicatores
   SoMaterial *dynForceMat;
-
-  //! The main and only interface for the CGDB; all interaction with the CGDB should go through this.
-  db_planner::DatabaseManager *mDBMgr;
 
   void setupPointers();
   void transRot(DraggerInfo *dInfo);
@@ -278,14 +271,6 @@ public:
   //! Not implemented
   void flipStereo();
 
-  //! Get the main database manager, when CGDB support is enabled
-  db_planner::DatabaseManager* getDBMgr(){return mDBMgr;}
-  //! Set the main database manager. Should only be called by the DB connection dialog
-#ifdef CGDB_ENABLED
-  void setDBMgr(db_planner::DatabaseManager *mgr){mDBMgr = mgr;}
-#else
-  void setDBMgr(db_planner::DatabaseManager*){}
-#endif
   void setStereoWindow(QWidget *parent);
 };
 #define IVMGR_HXX

--- a/include/ivmgr.h
+++ b/include/ivmgr.h
@@ -239,16 +239,12 @@ public Q_SLOTS:
   void restoreCameraPos();
 
 public:
-  IVmgr(QWidget *parent=0,const char *name=0,bool headless=false, Qt::WFlags f=0);
+  IVmgr(World *w, QWidget *parent=0,const char *name=0, Qt::WFlags f=0);
   ~IVmgr();
 
-  void deselectBody(Body *b);
+  void setWorld(World *w);
 
-  /*! 
-    Returns a pointer to the main World that the user interacts with through
-    this manager.
-   */
-  World *getWorld() const {return world;}
+  void deselectBody(Body *b);
 
   /*!
     Returns a pointer to the Inventor examiner viewer.
@@ -262,7 +258,6 @@ public:
   SoSeparator *getPointers() const {return pointers;}
 
   void setTool(ToolType newTool);
-  void emptyWorld();
   void hilightObjContact(int contactNum);
   void unhilightObjContact(int contactNum);
 

--- a/include/ivmgr.h
+++ b/include/ivmgr.h
@@ -239,7 +239,7 @@ public Q_SLOTS:
   void restoreCameraPos();
 
 public:
-  IVmgr(QWidget *parent=0,const char *name=0,Qt::WFlags f=0);
+  IVmgr(QWidget *parent=0,const char *name=0,bool headless=false, Qt::WFlags f=0);
   ~IVmgr();
 
   void deselectBody(Body *b);

--- a/include/ivmgr.h
+++ b/include/ivmgr.h
@@ -265,7 +265,6 @@ public:
   transf getCameraTransf();
 
   void saveImage(QString filename);
-  void beginMainLoop();
 
   void setStereo(bool s);
   //! Not implemented

--- a/include/world.h
+++ b/include/world.h
@@ -228,7 +228,7 @@ Q_SIGNALS:
 
 public:	
   //! public constructor
-  World(QObject *parent=0,const char *name=0, IVmgr *mgr=NULL);
+  World(QObject *parent=0, const char *name=0);
 
   //! Saves the current user settings in the registry and clears the world
   ~World();

--- a/include/world.h
+++ b/include/world.h
@@ -344,6 +344,9 @@ public:
   //! Sets all world settings to their original default values. 
   void setDefaults();
 
+  //! Sets the ivmgr for the world.
+  void setIVMgr(IVmgr *ivmgr){myIVmgr = ivmgr;}
+
   //! Sets the world modified flag.  Should be done when a change has since the last save. 
   void setModified() {modified = true;}
 

--- a/include/world.h
+++ b/include/world.h
@@ -315,7 +315,7 @@ public:
   SoSeparator *getIVRoot() const {return IVRoot;}
 
   //! Returns axis-aligned bounding box min and max points of the world
-  void getBoundigBox(vec3& minPoint, vec3& maxPoint);
+  void getBoundingBox(vec3& minPoint, vec3& maxPoint);
 
   //! Returns a pointer to the i-th body defined in this world 
   Body *getBody(int i) const {return bodyVec[i];}

--- a/plugins/openclose/openClosePlugin.cpp
+++ b/plugins/openclose/openClosePlugin.cpp
@@ -53,7 +53,7 @@ int OpenClosePlugin::init(int, char**)
 int OpenClosePlugin::mainLoop()
 {
   static int direction = 1.0;
-
+  std::cout <<"in main loop" << std::endl;
   World *world = graspItGUI->getMainWindow()->getMainWorld();
   if (!world) std::cerr << "Open-close plugin main loop: no world?!?\n";
   else if (!world->getCurrentHand()) std::cerr << "Open-close plugin main loop: no hand selected\n";

--- a/plugins/openclose/openClosePlugin.cpp
+++ b/plugins/openclose/openClosePlugin.cpp
@@ -26,7 +26,7 @@
 #include "openClosePlugin.h"
 
 #include "mainWindow.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "world.h"
 #include "robot.h"
 
@@ -54,7 +54,7 @@ int OpenClosePlugin::mainLoop()
 {
   static int direction = 1.0;
   std::cout <<"in main loop" << std::endl;
-  World *world = graspItGUI->getMainWindow()->getMainWorld();
+  World *world = graspitCore->getWorld();
   if (!world) std::cerr << "Open-close plugin main loop: no world?!?\n";
   else if (!world->getCurrentHand()) std::cerr << "Open-close plugin main loop: no hand selected\n";
   else world->getCurrentHand()->autoGrasp(true, direction);

--- a/src/DBase/dbaseDlg.cpp
+++ b/src/DBase/dbaseDlg.cpp
@@ -73,7 +73,7 @@ void DBaseDlg::init()
 	mGraspList.clear();
 	browserGroup->setEnabled(FALSE);
 	graspsGroup->setEnabled(FALSE);
-    mDBMgr = graspitCore->getDBMgr();
+	mDBMgr = graspitCore->getDBMgr();
 	if (mDBMgr) {
 		getModelList();
 	}
@@ -176,7 +176,7 @@ void DBaseDlg::connectButton_clicked()
 		delete mDBMgr;
 		mDBMgr = NULL;
 	}
-    graspitCore->setDBMgr(mDBMgr);
+	graspitCore->setDBMgr(mDBMgr);
 }
 
 PROF_DECLARE(GET_GRASPS);

--- a/src/DBase/dbaseDlg.cpp
+++ b/src/DBase/dbaseDlg.cpp
@@ -35,13 +35,13 @@
 #include <QDir>
 #include <QComboBox>
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "robot.h"
 #include "world.h"
 #include "searchState.h"
 #include "grasp.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "mainWindow.h"
 #include "matvec3D.h"
 
@@ -73,7 +73,7 @@ void DBaseDlg::init()
 	mGraspList.clear();
 	browserGroup->setEnabled(FALSE);
 	graspsGroup->setEnabled(FALSE);
-	mDBMgr = graspItGUI->getIVmgr()->getDBMgr();
+	mDBMgr = graspitCore->getIVmgr()->getDBMgr();
 	if (mDBMgr) {
 		getModelList();
 	}
@@ -92,7 +92,7 @@ void DBaseDlg::destroy()
 void DBaseDlg::exitButton_clicked(){
 	if (mCurrentLoadedModel) {
 		//remove the previously loaded model, but don't delete it
-		graspItGUI->getIVmgr()->getWorld()->destroyElement(mCurrentLoadedModel->getGraspableBody(), false);
+		graspitCore->getWorld()->destroyElement(mCurrentLoadedModel->getGraspableBody(), false);
 	}
 	//delete and release all the memories occupied by the grasps
 	deleteVectorElements<db_planner::Grasp*, GraspitDBGrasp*>(mGraspList);
@@ -146,7 +146,7 @@ void DBaseDlg::getModelList()
 void DBaseDlg::connectButton_clicked()
 {
 	delete mDBMgr;
-	Hand *h = graspItGUI->getIVmgr()->getWorld()->getCurrentHand();
+	Hand *h = graspitCore->getWorld()->getCurrentHand();
 
 #ifndef ROS_DATABASE_MANAGER	
 	mDBMgr = new db_planner::SqlDatabaseManager(hostLineEdit->text().toStdString(),
@@ -176,7 +176,7 @@ void DBaseDlg::connectButton_clicked()
 		delete mDBMgr;
 		mDBMgr = NULL;
 	}
-	graspItGUI->getIVmgr()->setDBMgr(mDBMgr);
+	graspitCore->getIVmgr()->setDBMgr(mDBMgr);
 }
 
 PROF_DECLARE(GET_GRASPS);
@@ -186,7 +186,7 @@ void DBaseDlg::loadGraspButton_clicked(){
 	PROF_RESET_ALL;
 	PROF_START_TIMER(GET_GRASPS);
 	//get the current hand and check its validity
-	Hand *hand = graspItGUI->getIVmgr()->getWorld()->getCurrentHand();
+	Hand *hand = graspitCore->getWorld()->getCurrentHand();
 	if (!hand) {
 		DBGA("Load and select a hand before viewing grasps!");
 		return;
@@ -236,7 +236,7 @@ void DBaseDlg::loadGraspButton_clicked(){
 void DBaseDlg::loadModelButton_clicked(){
 	if (mCurrentLoadedModel) {
 		//remove the previously loaded model, but don't delete it
-		graspItGUI->getIVmgr()->getWorld()->destroyElement(mCurrentLoadedModel->getGraspableBody(), false);
+		graspitCore->getWorld()->destroyElement(mCurrentLoadedModel->getGraspableBody(), false);
 		mCurrentLoadedModel = NULL;
 	}
 	if(mModelList.empty()){
@@ -253,7 +253,7 @@ void DBaseDlg::loadModelButton_clicked(){
 	//check that this model is already loaded into Graspit, if not, load it
 	if (!model->geometryLoaded()) {
 		//this loads the actual geometry in the scene graph of the object
-		if ( model->load(graspItGUI->getIVmgr()->getWorld()) != SUCCESS) {
+		if ( model->load(graspitCore->getWorld()) != SUCCESS) {
 			DBGA("Model load failed");
 			return;
 		}
@@ -263,7 +263,7 @@ void DBaseDlg::loadModelButton_clicked(){
 	//todo: where to dynamic information come from?
 	//model->getGraspableBody()->initDynamics();
 	//this adds the object to the graspit world so that we can see it
-	graspItGUI->getIVmgr()->getWorld()->addBody(model->getGraspableBody());
+	graspitCore->getWorld()->addBody(model->getGraspableBody());
 	//and remember it
 	mCurrentLoadedModel = model;
 	//model->getGraspableBody()->showAxes(false);
@@ -296,7 +296,7 @@ void DBaseDlg::plannerButton_clicked(){
 		return;
 	}
 	//check the hand
-	Hand *h = graspItGUI->getIVmgr()->getWorld()->getCurrentHand();
+	Hand *h = graspitCore->getWorld()->getCurrentHand();
 	if(!h){
 		DBGA("No hand found currently");
 		return;
@@ -376,7 +376,7 @@ void DBaseDlg::sortButton_clicked()
 
 //a shortcut for the GWS display
 void DBaseDlg::createGWSButton_clicked(){
-	graspItGUI->getMainWindow()->graspCreateProjection();
+	graspitCore->getMainWindow()->graspCreateProjection();
 }
 
 //trigger when the selection in the model list combo box is changed, display the corresponding new image
@@ -500,8 +500,8 @@ void DBaseDlg::showGrasp(int i)
 		if(!static_cast<GraspitDBGrasp*>(mGraspList[i])->getFinalGraspPlanningState())//NULL grasp, return
 			return;
 		static_cast<GraspitDBGrasp*>(mGraspList[i])->getFinalGraspPlanningState()->execute();
-		if(graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->isA("Barrett")){
-			graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->autoGrasp(true);
+		if(graspitCore->getWorld()->getCurrentHand()->isA("Barrett")){
+			graspitCore->getWorld()->getCurrentHand()->autoGrasp(true);
 		}
 	}
 
@@ -515,8 +515,8 @@ void DBaseDlg::showGrasp(int i)
 	*/
 
 	//update the world and grasp information
-	graspItGUI->getIVmgr()->getWorld()->findAllContacts();
-	graspItGUI->getIVmgr()->getWorld()->updateGrasps();
+	graspitCore->getWorld()->findAllContacts();
+	graspitCore->getWorld()->updateGrasps();
 	mCurrentFrame = i;
 	updateGraspInfo();
 }

--- a/src/DBase/dbaseDlg.cpp
+++ b/src/DBase/dbaseDlg.cpp
@@ -73,7 +73,7 @@ void DBaseDlg::init()
 	mGraspList.clear();
 	browserGroup->setEnabled(FALSE);
 	graspsGroup->setEnabled(FALSE);
-	mDBMgr = graspitCore->getIVmgr()->getDBMgr();
+    mDBMgr = graspitCore->getDBMgr();
 	if (mDBMgr) {
 		getModelList();
 	}
@@ -176,7 +176,7 @@ void DBaseDlg::connectButton_clicked()
 		delete mDBMgr;
 		mDBMgr = NULL;
 	}
-	graspitCore->getIVmgr()->setDBMgr(mDBMgr);
+    graspitCore->setDBMgr(mDBMgr);
 }
 
 PROF_DECLARE(GET_GRASPS);

--- a/src/DBase/dbasePlannerDlg.cpp
+++ b/src/DBase/dbasePlannerDlg.cpp
@@ -37,7 +37,7 @@
 #include "graspit_db_grasp.h"
 #include "searchState.h"
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "mainWindow.h"
 
 #include "DBPlanner/caching_neighbor_finder.h"
@@ -211,7 +211,7 @@ void DBasePlannerDlg::nextGraspButton_clicked(){
 
 // shortcut for the GWS display
 void DBasePlannerDlg::createGWSButton_clicked(){
-	graspItGUI->getMainWindow()->graspCreateProjection();
+	graspitCore->getMainWindow()->graspCreateProjection();
 }
 
 // put the entries into the distance function combo box
@@ -295,7 +295,7 @@ void DBasePlannerDlg::showGrasp(db_planner::Grasp* grasp){
 	static_cast<GraspitDBModel*>(mPlanningModel)->getGraspableBody()->setTran(transf::IDENTITY);
 	g->getPreGraspPlanningState()->execute();
 	if(mHand->isA("Barrett") && testedGraspRadioButton->isChecked()){
-		graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->autoGrasp(true);
+		graspitCore->getWorld()->getCurrentHand()->autoGrasp(true);
 	}
 	mHand->getWorld()->findAllContacts();
 	mHand->getWorld()->updateGrasps();

--- a/src/DBase/dbase_grasp.cpp
+++ b/src/DBase/dbase_grasp.cpp
@@ -28,7 +28,7 @@
 
 #include "dbase_grasp.h"
 #include "ivmgr.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "world.h"
 #include "searchState.h"
 #include "egPlanner.h"
@@ -43,7 +43,7 @@
 #include "debug.h"
 #include <Inventor/sensors/SoTimerSensor.h>
 
-DBaseBatchPlanner::DBaseBatchPlanner(IVmgr *mgr, GraspItGUI *gui)
+DBaseBatchPlanner::DBaseBatchPlanner(IVmgr *mgr, GraspitCore *gui)
 {
 	ivmgr = mgr;
 	mGui = gui;
@@ -103,7 +103,7 @@ bool DBaseBatchPlanner::processArguments(int argc, char **argv)
 
 	filename = graspitRoot + QString("/models/robots/") + QString(argv[2]) + QString("/") 
 		               + QString(argv[2]) + QString(".xml");
-	mHand = (Hand*)ivmgr->getWorld()->importRobot(filename);
+	mHand = (Hand*)graspitCore->getWorld()->importRobot(filename);
 	if ( !mHand ) {
 		DBGAF(mLogStream,"DBase planner: failed to load robot name " << argv[2] << ", or it is not a Hand");
 		return false;
@@ -116,7 +116,7 @@ bool DBaseBatchPlanner::processArguments(int argc, char **argv)
 		return false;
 	}
 	filename = QString(argv[3]);
-	mObject = static_cast<GraspableBody*>(ivmgr->getWorld()->importBody("GraspableBody",filename));
+	mObject = static_cast<GraspableBody*>(graspitCore->getWorld()->importBody("GraspableBody",filename));
 	((GraspableBody*)mObject)->showAxes(false);
 
 	if (!mObject) {
@@ -281,7 +281,7 @@ void DBaseBatchPlanner::plannerComplete()
 	DBGAF(mLogStream,"Planner completed; starting shutdown");
 
 	if (mType == GRIPPER) {
-		ivmgr->getWorld()->destroyElement(mHand,false);
+		graspitCore->getWorld()->destroyElement(mHand,false);
 		fprintf(stderr,"Taking scans...\n");
 		takeScans();
 	}
@@ -298,7 +298,7 @@ void DBaseBatchPlanner::plannerComplete()
 void DBaseBatchPlanner::sensorCB(void *data, SoSensor*)
 {
 	DBaseBatchPlanner *planner = (DBaseBatchPlanner*)data;
-	GraspItGUI *gui = planner->mGui;
+	GraspitCore *gui = planner->mGui;
 	DBGAF(planner->mLogStream,"Shutdown signal received");
 	delete planner;
 	gui->exitMainLoop();

--- a/src/DBase/dbase_grasp.h
+++ b/src/DBase/dbase_grasp.h
@@ -40,7 +40,7 @@ class EGPlanner;
 class Hand;
 class Body;
 class GraspableBody;
-class GraspItGUI;
+class GraspitCore;
 class GraspPlanningState;
 class SoSensor;
 class SoTimerSensor;
@@ -60,7 +60,7 @@ private:
 	GraspableBody *mObject;
 	Hand *mHand;
 	IVmgr *ivmgr;
-	GraspItGUI *mGui;
+	GraspitCore *mGui;
 	EGPlanner *mPlanner;
 	//maybe one day we'll use streams here...
 	FILE *mResultFile;
@@ -90,7 +90,7 @@ public Q_SLOTS:
 	//this one gets called when the inner planner stops
 	void plannerComplete();
 public:
-	DBaseBatchPlanner(IVmgr *mgr, GraspItGUI *gui);
+	DBaseBatchPlanner(IVmgr *mgr, GraspitCore *gui);
 	~DBaseBatchPlanner();
 	bool processArguments(int argc, char **argv);
 	bool startPlanner();

--- a/src/DBase/graspClusteringTask.cpp
+++ b/src/DBase/graspClusteringTask.cpp
@@ -29,7 +29,7 @@
 
 #include "world.h"
 #include "robot.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "matvec3D.h"
 #include "searchState.h"
 #include "DBPlanner/db_manager.h"
@@ -59,7 +59,7 @@ void GraspClusteringTask::start()
     return;
   }
 
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   Hand *hand;
  
   //check if the currently selected hand is the same as the one we need

--- a/src/DBase/graspPlanningTask.cpp
+++ b/src/DBase/graspPlanningTask.cpp
@@ -28,7 +28,7 @@
 #include <QString>
 
 #include "mytools.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "robot.h"
@@ -74,7 +74,7 @@ void GraspPlanningTask::start()
     return;
   }
 
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
 
   //check if the currently selected hand is the same as the one we need
   //if not, load the hand we need

--- a/src/DBase/graspTransferCheckTask.cpp
+++ b/src/DBase/graspTransferCheckTask.cpp
@@ -25,7 +25,7 @@
 
 #include "graspTransferCheckTask.h"
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "robot.h"
@@ -75,7 +75,7 @@ void GraspTransferCheckTask::start()
     return;
   }
 
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
 
   if ( !world->getNumHands()) {
     QString handPath = mDBMgr->getHandGraspitPath(QString(mPlanningTask.handName.c_str()));
@@ -168,7 +168,7 @@ bool GraspTransferCheckTask::checkGraspCombo(db_planner::Grasp* grasp1, db_plann
   graspState2->execute();
 
   //check for collisions
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   if (!world->noCollision()) {
     DBGA("  initial grasps are in collision");
     return false;

--- a/src/DBase/graspit_db_grasp.h
+++ b/src/DBase/graspit_db_grasp.h
@@ -35,7 +35,7 @@
 #include <vector>
 #include <string>
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "world.h"
 #include "ivmgr.h"
 

--- a/src/DBase/preGraspCheckTask.cpp
+++ b/src/DBase/preGraspCheckTask.cpp
@@ -25,7 +25,7 @@
 
 #include "preGraspCheckTask.h"
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "robot.h"
@@ -66,7 +66,7 @@ void PreGraspCheckTask::emptyGraspList(std::vector<db_planner::Grasp*> &graspLis
 
 void PreGraspCheckTask::loadHand()
 {
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   
   //check if the currently selected hand is the same as the one we need
   //if not, load the hand we need
@@ -96,7 +96,7 @@ void PreGraspCheckTask::loadHand()
 
 void PreGraspCheckTask::loadObject()
 {
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
 
   GraspitDBModel *model = static_cast<GraspitDBModel*>(mPlanningTask.model);
   if (model->load(world) != SUCCESS) {

--- a/src/DBase/tableCheckTask.cpp
+++ b/src/DBase/tableCheckTask.cpp
@@ -25,7 +25,7 @@
 
 #include "tableCheckTask.h"
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "robot.h"
@@ -40,7 +40,7 @@ TableCheckTask::TableCheckTask(TaskDispatcher *disp, db_planner::DatabaseManager
 			       db_planner::TaskRecord rec) : PreGraspCheckTask (disp, mgr, rec)
 {
   //load the table
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   QString path = QString(getenv("GRASPIT")) + QString("/models/objects/plane.xml");
   mTable = world->importBody("Body", path);
   if (!mTable) {
@@ -51,7 +51,7 @@ TableCheckTask::TableCheckTask(TaskDispatcher *disp, db_planner::DatabaseManager
 
 TableCheckTask::~TableCheckTask()
 {
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   if (mTable) {
     world->destroyElement(mTable, true);
   }
@@ -80,7 +80,7 @@ void TableCheckTask::start()
   //and move up until it touches the object
   transf tr( Quaternion::IDENTITY, vec3(0.0, 0.0, 100.0) );
   
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   world->toggleCollisions(false, mHand, mTable);
   mTable->moveTo( tr, 5.0, M_PI/36.0 );
   world->toggleCollisions(true, mHand, mTable);
@@ -129,7 +129,7 @@ double TableCheckTask::getTableClearance(db_planner::Grasp *grasp)
   graspState->execute();  
 
   //check distance for grasp
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   double distance = world->getDist(mHand, mTable);
   if (distance < 0) {
     DBGA(" Grasp is in collision with table");

--- a/src/DBase/taskDispatcher.cpp
+++ b/src/DBase/taskDispatcher.cpp
@@ -32,7 +32,7 @@
 #endif
 #include "DBPlanner/sql_database_manager.h"
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "graspit_db_model.h"
 
 #include "graspPlanningTask.h"
@@ -214,13 +214,13 @@ void TaskDispatcher::mainLoop()
 	}
 	switch(mStatus) {
 	    case DONE:
-		graspItGUI->exitMainLoop();		
+		graspitCore->exitMainLoop();		
 	        return;
 	    case FAILED:
-		graspItGUI->exitMainLoop();		
+		graspitCore->exitMainLoop();		
 	        return;
 	    case NO_TASK:
-		graspItGUI->exitMainLoop();		
+		graspitCore->exitMainLoop();		
 	        return;
  	    case RUNNING:
 	        mSensor->schedule();			

--- a/src/EGPlanner/energy/searchEnergy.cpp
+++ b/src/EGPlanner/energy/searchEnergy.cpp
@@ -35,7 +35,7 @@
 #include "world.h"
 #include "quality.h"
 #include "searchState.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "matrix.h"
 

--- a/src/Planner/grasp_manager.cpp
+++ b/src/Planner/grasp_manager.cpp
@@ -62,7 +62,7 @@
 #endif
 
 /* graspit includes */
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "contact.h"
 #include "world.h"
 #include "ivmgr.h"
@@ -215,12 +215,12 @@ grasp_manager::readCandidateGraspsFile(const QString& filename)
 
   QTextStream stream( &file );
 
-  my_body = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp()->getObject();
+  my_body = graspitCore->getWorld()->getCurrentHand()->getGrasp()->getObject();
 
   if (my_body == NULL){
     int whichObject = 0;
-    if (graspItGUI->getIVmgr()->getWorld()->getNumGB())
-      my_body = graspItGUI->getIVmgr()->getWorld()->getGB(whichObject);
+    if (graspitCore->getWorld()->getNumGB())
+      my_body = graspitCore->getWorld()->getGB(whichObject);
     else{
 #ifdef GRASPITDBG
       std::cout << "PL_OUT: Nothing selected and no graspable bodies exist. Stop." << std::endl;
@@ -278,12 +278,12 @@ grasp_manager::generateGrasps(){
     
     std::list<plannedGrasp*> tmpList;
 
-    my_body = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp()->getObject();
+    my_body = graspitCore->getWorld()->getCurrentHand()->getGrasp()->getObject();
 
     if (my_body == NULL){
 	int whichObject = 0;
-	if (graspItGUI->getIVmgr()->getWorld()->getNumGB())
-	    my_body = graspItGUI->getIVmgr()->getWorld()->getGB(whichObject);
+	if (graspitCore->getWorld()->getNumGB())
+	    my_body = graspitCore->getWorld()->getGB(whichObject);
 	else{
 #ifdef GRASPITDBG
 	    std::cout << "PL_OUT: Nothing selected and no graspable bodies exist. Stop." << std::endl;

--- a/src/Planner/grasp_planner.cpp
+++ b/src/Planner/grasp_planner.cpp
@@ -66,7 +66,7 @@
 
 /* graspit includes */
 #include "contact.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "robot.h"
@@ -101,7 +101,7 @@ extern FILE *debugfile;
 grasp_planner::grasp_planner()
 {
     /* get global stuff */
-  ivmgr = graspItGUI->getIVmgr();
+  ivmgr = graspitCore->getIVmgr();
 
     myViewer = ivmgr->getViewer();
     my_body  = NULL;
@@ -139,7 +139,7 @@ std::list<plannedGrasp*>
 grasp_planner::planIt(GraspableBody* gb,SoGroup *IVPrimitives)
 {
 #ifdef PLAN_GRASP_ON_ALL_BODIES    
-  int numGB = ivmgr->getWorld()->getNumGB();
+  int numGB = graspitCore->getWorld()->getNumGB();
 #endif
   std::list <GraspDirection*> gd_list;
   std::list <plannedGrasp*> graspList;
@@ -666,7 +666,7 @@ grasp_planner::getGlobalPath(SoNode *node)
   /* Search for node */
   saction.setNode(node);
   saction.setInterest(SoSearchAction::ALL);
-  saction.apply(ivmgr->getWorld()->getIVRoot());
+  saction.apply(graspitCore->getWorld()->getIVRoot());
   pl     = saction.getPaths();
   
   //for (int i=0; i<pl.getLength(); i++)

--- a/src/Planner/grasp_presenter.cpp
+++ b/src/Planner/grasp_presenter.cpp
@@ -67,7 +67,7 @@
 #endif
 
 /* graspit includes */
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "contact.h"
 #include "ivmgr.h"
 #include "world.h"
@@ -119,9 +119,9 @@ grasp_presenter::~grasp_presenter(){
 */
 void
 grasp_presenter::updateGlobals(){
-    ivmgr    = graspItGUI->getIVmgr();
+    ivmgr    = graspitCore->getIVmgr();
     myViewer = ivmgr->getViewer();
-    my_world = ivmgr->getWorld();
+    my_world = graspitCore->getWorld();
     my_hand  = my_world->getCurrentHand();
 }
 

--- a/src/Planner/grasp_tester.cpp
+++ b/src/Planner/grasp_tester.cpp
@@ -74,7 +74,7 @@
 #include "matvec3D.h"
 #include "grasp.h"
 #include "quality.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "grasp_visualization.h"
 #include "grasp_tester.h"
 
@@ -93,7 +93,7 @@ extern grasp_tester *myTester;
 */
 grasp_tester::grasp_tester() : QObject() {
 
-	ivmgr = graspItGUI->getIVmgr();
+	ivmgr = graspitCore->getIVmgr();
 
 	projectionViewer = NULL;
     idleSensor = NULL;
@@ -135,7 +135,7 @@ grasp_tester::~grasp_tester(){
 void
 grasp_tester::updateGlobals(){
     myViewer = ivmgr->getViewer();
-    my_world = ivmgr->getWorld();
+    my_world = graspitCore->getWorld();
     my_hand  = my_world->getCurrentHand();
     my_grasp = my_hand->getGrasp();
     

--- a/src/arch.cpp
+++ b/src/arch.cpp
@@ -34,7 +34,7 @@
 #include <Inventor/nodes/SoTranslation.h>
 
 #include "body.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -47,7 +47,7 @@
 #include "dynJoint.h"
 #include "ivmgr.h"
 #include "contact.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "tinyxml.h"
 
 #ifdef PLY_READER
@@ -1248,7 +1248,7 @@ void Body::createAxesGeometry()
 {  
   IVWorstCase = new SoSeparator;  
   IVAxes = new SoSwitch;  
-  if (graspItGUI) {
+  if (graspitCore) {
     SoSeparator *axesSep = new SoSeparator;
     axesTranToCOG = new SoTranslation;
     axesTranToCOG->translation.setValue(0,0,0);
@@ -1258,7 +1258,10 @@ void Body::createAxesGeometry()
     axesScale = new SoScale;
 	axesScale->scaleFactor = SbVec3f(1,1,1);
     axesSep->addChild(axesScale);
-    axesSep->addChild(graspItGUI->getIVmgr()->getPointers()->getChild(2));
+    if(graspitCore->getIVmgr())
+    {
+        axesSep->addChild(graspitCore->getIVmgr()->getPointers()->getChild(2));
+    }
     IVAxes->addChild(axesSep);
   }
   if (!IVRoot) IVRoot = new SoSeparator;

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -61,25 +61,6 @@ int GraspitCore::initResult = SUCCESS;
 //! This is the system wide pointer to the graspit user interface.
 GraspitCore *graspitCore = 0;
 
-
-/*!
-  If this class hasn't been initialized in another instance, it performs
-  the following operations:
-  - creates a new MainWindow,
-  - starts Coin by initializing SoQt,
-  - initializes our Coin add on classes,
-  - creates a new IVmgr,
-  - sets the focus policy of the SoQt viewer so keyboard events are accepted
-  - calls a method to process the command line arguments.
- */
-GraspitCore::GraspitCore() :
-    mDispatch(NULL),
-    ivmgr(NULL),
-    mainWindow(NULL),
-    world(NULL)
-{
-}
-
 /*!
   Deletes both the IVmgr and the MainWindow.
 */
@@ -103,8 +84,11 @@ GraspitCore::~GraspitCore()
 /*!
   Initializes GraspitCore based on the commandline arguments.
 */
-int
-GraspitCore::init(int argc, char **argv)
+GraspitCore::GraspitCore(int argc, char **argv):
+    mDispatch(NULL),
+    ivmgr(NULL),
+    mainWindow(NULL),
+    world(NULL)
 {
     GraspitParser *graspitParser = new GraspitParser();
     graspitParser->parseArgs(argc, argv);
@@ -138,7 +122,8 @@ GraspitCore::init(int argc, char **argv)
     QString graspitRoot = QString(getenv("GRASPIT"));
     if (graspitRoot.isNull() ) {
         std::cerr << "Please set the GRASPIT environment variable to the root directory of graspIt." << std::endl;
-        return FAILURE;
+        initResult =  FAILURE;
+        return;
     }
 
     if(args->exist("plugin"))
@@ -179,13 +164,15 @@ GraspitCore::init(int argc, char **argv)
           mDispatch = new TaskDispatcher();
           if (mDispatch->connect("wgs36",5432,"willow","willow","household_objects")) {
               std::cerr << "DBase dispatch failed to connect to database\n";
-              return TERMINAL_FAILURE;
+              initResult = TERMINAL_FAILURE;
+              return;
           }
           std::cerr << "DBase dispatch connected to database\n";
           mDispatch->mainLoop();
           if (mDispatch->getStatus() != TaskDispatcher::RUNNING) {
               mExitCode = mDispatch->getStatus();
-              return TERMINAL_FAILURE;
+              initResult = TERMINAL_FAILURE;
+              return;
           }
       }
 #endif
@@ -248,11 +235,13 @@ GraspitCore::init(int argc, char **argv)
   if (errorFlag)
   {
       std::cerr << "Failed to Parse args." << std::endl;
-      return FAILURE;
+      initResult =  FAILURE;
+      return;
   }
 
  #endif // Q_WS_X11
-  return SUCCESS;
+  initResult =  SUCCESS;
+  return;
 }
 
 /*!

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -243,6 +243,8 @@ GraspitCore::init(int argc, char **argv)
       }
   }
 
+  mDBMgr = NULL;
+
   if (errorFlag)
   {
       std::cerr << "Failed to Parse args." << std::endl;

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -99,15 +99,17 @@ GraspitCore::GraspitCore(int argc, char **argv):
       mainWindow = new MainWindow;
       SoQt::init(mainWindow->mWindow);
 
+      //Initialize the world.  It has no parent, and ivmgr is not
+      //created until after the world.
       world = new World(NULL, //QObject parent
-                      "mainWorld", // World Name
-                      NULL); //ivmgr
+                      "mainWorld"); // World Name
 
       // initialize Inventor additions
       SoComplexShape::initClass();
       SoArrow::initClass();
       SoTorquePointer::initClass();
 
+      //Do not initialize the IVmgr if we are running headless. ivmgr will stay NULL
       if(!headless){
           ivmgr = new IVmgr(world, (QWidget *)mainWindow->mUI->viewerHolder,"myivmgr");
           ivmgr->getViewer()->getWidget()->setFocusPolicy(Qt::StrongFocus);
@@ -273,7 +275,7 @@ void
 GraspitCore::emptyWorld()
 {
   delete world;
-  world = new World(NULL, "MainWorld", ivmgr);
+  world = new World(NULL, "MainWorld");
   ivmgr->setWorld(world);
 }
 

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -110,7 +110,7 @@ GraspitCore::init(int argc, char **argv)
     graspitParser->parseArgs(argc, argv);
     cmdline::parser *args = graspitParser->parseArgs(argc, argv);
 
-    headless = args->get<bool>("headless");
+    headless = args->exist("headless");
 
       mainWindow = new MainWindow;
       SoQt::init(mainWindow->mWindow);

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -200,7 +200,10 @@ GraspitCore::GraspitCore(int argc, char **argv):
           ++errorFlag;
       }
       else{
-          mainWindow->mUI->worldBox->setTitle(filename);
+          if(!headless)
+          {
+              mainWindow->mUI->worldBox->setTitle(filename);
+          }
       }
   }
 

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -24,7 +24,14 @@
 //######################################################################
 
 /*! \file
-  \brief Implements the graspit user interface.  Responsible for creating both MainWindow and IVmgr.
+  \brief Implements core graspit functionality.
+  Responsible for initializating and holding pointers to the following:
+    world,
+    mainWindow,
+    Dbmgr
+
+  This class is also responsible for managing the SOQT mainloop and managing
+  all plugins.
 */
 
 #include <Q3GroupBox>
@@ -246,7 +253,8 @@ GraspitCore::GraspitCore(int argc, char **argv):
 }
 
 /*!
-  Shows the mainWindow, sets its size, and starts the Qt event loop.
+  Starts the Qt event loop.  If using the user interface, this
+  also shows the mainWindow and sets its size.
 */
 void
 GraspitCore::startMainLoop()
@@ -270,14 +278,24 @@ GraspitCore::exitMainLoop()
   SoQt::exitMainLoop();
 }
 
+/*!
+  Deletes the world, and creates a new one.
+*/
 void
 GraspitCore::emptyWorld()
 {
   delete world;
   world = new World(NULL, "MainWorld");
-  ivmgr->setWorld(world);
+  if(ivmgr)
+  {
+    ivmgr->setWorld(world);
+  }
 }
 
+
+/*!
+  Checks if the initialization of graspitCore resulted in a TERMINAL_FAILURE.
+*/
 bool
 GraspitCore::terminalFailure() const
 {

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -99,8 +99,7 @@ GraspitCore::GraspitCore(int argc, char **argv):
       mainWindow = new MainWindow;
       SoQt::init(mainWindow->mWindow);
 
-      //Initialize the world.  It has no parent, and ivmgr is not
-      //created until after the world.
+      //Initialize the world.  It has no parent,
       world = new World(NULL, //QObject parent
                       "mainWorld"); // World Name
 

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -103,8 +103,13 @@ GraspitCore::GraspitCore(int argc, char **argv):
 
     bool headless = args->exist("headless");
 
-      mainWindow = new MainWindow;
-      SoQt::init(mainWindow->mWindow);
+    if(headless){
+        SoQt::init(argc, argv, "SOQT");
+    }
+    else{
+        mainWindow = new MainWindow;
+        SoQt::init(mainWindow->mWindow);
+    }
 
       //Initialize the world.  It has no parent,
       world = new World(NULL, //QObject parent

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -101,7 +101,7 @@ GraspitCore::GraspitCore(int argc, char **argv):
     graspitParser->parseArgs(argc, argv);
     cmdline::parser *args = graspitParser->parseArgs(argc, argv);
 
-    headless = args->exist("headless");
+    bool headless = args->exist("headless");
 
       mainWindow = new MainWindow;
       SoQt::init(mainWindow->mWindow);
@@ -259,7 +259,7 @@ GraspitCore::GraspitCore(int argc, char **argv):
 void
 GraspitCore::startMainLoop()
 {
-    if(!headless)
+    if(ivmgr)
     {
         mainWindow->setMainWorld(world);
         SoQt::show(mainWindow->mWindow);

--- a/src/graspitParser.cpp
+++ b/src/graspitParser.cpp
@@ -71,6 +71,10 @@ const std::string GraspitParser::robot_help =
 const std::string GraspitParser::version_help =
         "print GraspIt! version\n";
 
+const std::string GraspitParser::headless_help =
+        "Run GraspIt! in headless mode if you do not want"
+        "\n\t\t\t the user interface to display.  IVMgr will be NULL";
+
 GraspitParser::GraspitParser()
 {
 
@@ -84,7 +88,7 @@ GraspitParser::GraspitParser()
     parser->add<std::string>("object", 'o', object_help,  is_required_arg);
     parser->add<std::string>("obstacle", 'b', obstacle_help,  is_required_arg);
     parser->add<std::string>("robot", 'r', robot_help,  is_required_arg);
-    parser->add<bool>("headless", 'c', robot_help,  is_required_arg);
+    parser->add("headless", '\0', headless_help);
     parser->add("version", 'v', version_help);
 
     parser->footer(footer);

--- a/src/graspitParser.cpp
+++ b/src/graspitParser.cpp
@@ -84,6 +84,7 @@ GraspitParser::GraspitParser()
     parser->add<std::string>("object", 'o', object_help,  is_required_arg);
     parser->add<std::string>("obstacle", 'b', obstacle_help,  is_required_arg);
     parser->add<std::string>("robot", 'r', robot_help,  is_required_arg);
+    parser->add<bool>("headless", 'c', robot_help,  is_required_arg);
     parser->add("version", 'v', version_help);
 
     parser->footer(footer);

--- a/src/graspitServer.cpp
+++ b/src/graspitServer.cpp
@@ -30,7 +30,7 @@
 #include <QTextStream>
 #include <iostream>
 #include "graspitServer.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "robot.h"
@@ -62,7 +62,7 @@ ClientSocket::readBodyIndList(std::vector<Body *> &bodyVec)
   QTextStream os(this);
   int i,numBodies,bodNum;
   bool ok;
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   std::cout << "ReadBodyIndList Line:"<<line.latin1() << std::endl;
 
   /* if the index list is empty, use every body and send
@@ -121,7 +121,7 @@ ClientSocket::readRobotIndList(std::vector<Robot *> &robVec)
   QTextStream os(this);
   int i,robNum,numRobots;
   bool ok;
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
   std::cout << "ReadRobotIndList Line:"<<line.latin1() << std::endl;
 
   /* if the index list is empty, use every robot and send
@@ -246,7 +246,7 @@ ClientSocket::readClient()
     }
     
     else if (*strPtr == "render")
-      graspItGUI->getIVmgr()->getViewer()->render();
+      graspitCore->getIVmgr()->getViewer()->render();
     
     else if (*strPtr == "setDOFForces") {
       strPtr++;
@@ -256,7 +256,7 @@ ClientSocket::readClient()
 	if (readDOFForces(robVec[i])==FAILURE) continue;
     }
     else if (*strPtr == "moveToContacts")
-      graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->approachToContact(30, true);
+      graspitCore->getWorld()->getCurrentHand()->approachToContact(30, true);
  
     else if ((*strPtr) == "moveDynamicBodies") {
       strPtr++;
@@ -429,11 +429,11 @@ ClientSocket::readDOFVals()
   if (ok) robNum = (*strPtr).toInt(&ok);
 
   if (!ok || robNum < 0 ||
-    robNum >= graspItGUI->getIVmgr()->getWorld()->getNumRobots()) {
+    robNum >= graspitCore->getWorld()->getNumRobots()) {
 	os <<"Error: Robot does not exist.\n";
     return FAILURE;
   }
-  rob = graspItGUI->getIVmgr()->getWorld()->getRobot(robNum);
+  rob = graspitCore->getWorld()->getRobot(robNum);
 
 #ifdef GRASPITDBG
   std::cout << "robnum: "<<robNum<<std::endl;
@@ -489,8 +489,8 @@ ClientSocket::readDOFVals()
   rob->moveDOFToContacts(val,stepby,true);
 
   // these should be separate commands
-  graspItGUI->getIVmgr()->getWorld()->findAllContacts();
-  graspItGUI->getIVmgr()->getWorld()->updateGrasps();
+  graspitCore->getWorld()->findAllContacts();
+  graspitCore->getWorld()->updateGrasps();
 
   for (i=0;i<rob->getNumDOF();i++) {
     os << rob->getDOF(i)->getVal() << "\n";
@@ -590,10 +590,10 @@ ClientSocket::moveDynamicBodies(double timeStep)
 {
   QTextStream os(this);
   if (timeStep<0)
-    timeStep = graspItGUI->getIVmgr()->getWorld()->getTimeStep();
+    timeStep = graspitCore->getWorld()->getTimeStep();
 
   double actualTimeStep =
-    graspItGUI->getIVmgr()->getWorld()->moveDynamicBodies(timeStep);
+    graspitCore->getWorld()->moveDynamicBodies(timeStep);
   if (actualTimeStep < 0)
     os << "Error: Timestep failsafe reached.\n";
   else 
@@ -609,7 +609,7 @@ void
 ClientSocket::computeNewVelocities(double timeStep)
 {
   QTextStream os(this);
-  int result = graspItGUI->getIVmgr()->getWorld()->computeNewVelocities(timeStep);
+  int result = graspitCore->getWorld()->computeNewVelocities(timeStep);
   os << result << "\n";
 }
 

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -288,7 +288,6 @@ IVmgr::IVmgr(World *w, QWidget *parent, const char *name, Qt::WFlags f) :
 
   myViewer->viewAll();
 
-  mDBMgr = NULL;
 }
 
 //! Not used right now
@@ -364,7 +363,6 @@ IVmgr::setupPointers()
 void
 IVmgr::beginMainLoop()
 {
-  //SoQt::show(MainWindow);
   SoQt::mainLoop();
 }
 

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -218,7 +218,7 @@ IVmgr *IVmgr::ivmgr = 0;
   for draggers and wireframe models, which indicate when bodies are selected,
   are also created.
 */
-IVmgr::IVmgr(QWidget *parent, const char *name, Qt::WFlags f) : 
+IVmgr::IVmgr(QWidget *parent, const char *name, bool headless, Qt::WFlags f) :
   QWidget(parent,name,f)
 {
   ivmgr = this;
@@ -237,55 +237,58 @@ IVmgr::IVmgr(QWidget *parent, const char *name, Qt::WFlags f) :
   world = new World(NULL,"mainWorld", this);
   setupPointers();
 
-  // Create the viewer
-  myViewer = new StereoViewer(parent);
+  if (!headless){
+      // Create the viewer
+      myViewer = new StereoViewer(parent);
 
-  //this->setFocusProxy(myViewer->getWidget());
+      //this->setFocusProxy(myViewer->getWidget());
 
-  sceneRoot = new SoSeparator;
-  sceneRoot->ref();
+      sceneRoot = new SoSeparator;
+      sceneRoot->ref();
 
-  //add this before the mouseEventCB which otherwise captures the click!
-  draggerRoot = new SoSeparator;
-  sceneRoot->addChild(draggerRoot);
+      //add this before the mouseEventCB which otherwise captures the click!
+      draggerRoot = new SoSeparator;
+      sceneRoot->addChild(draggerRoot);
 
-  //add keyboard callback
-  SoEventCallback *keyEventNode = new SoEventCallback;
-  keyEventNode->addEventCallback(SoKeyboardEvent::getClassTypeId(), keyPressedCB,NULL);
-  sceneRoot->addChild(keyEventNode);
+      //add keyboard callback
+      SoEventCallback *keyEventNode = new SoEventCallback;
+      keyEventNode->addEventCallback(SoKeyboardEvent::getClassTypeId(), keyPressedCB,NULL);
+      sceneRoot->addChild(keyEventNode);
 
-  // Add callback to detect if modifier keys are held down during mouse clicks
-  SoEventCallback *mouseEventCB = new SoEventCallback;
-  mouseEventCB->addEventCallback(SoMouseButtonEvent::getClassTypeId(), shiftOrCtrlDownCB);
-  sceneRoot->addChild(mouseEventCB);
+      // Add callback to detect if modifier keys are held down during mouse clicks
+      SoEventCallback *mouseEventCB = new SoEventCallback;
+      mouseEventCB->addEventCallback(SoMouseButtonEvent::getClassTypeId(), shiftOrCtrlDownCB);
+      sceneRoot->addChild(mouseEventCB);
 
-  // an empty separator used in the make handlebox routine
-  junk = new SoSeparator; junk->ref(); 
+      // an empty separator used in the make handlebox routine
+      junk = new SoSeparator; junk->ref();
 
-  // create and set up the selection node
-  selectionRoot = new SoSelection;
-  sceneRoot->addChild(selectionRoot);
+      // create and set up the selection node
+      selectionRoot = new SoSelection;
+      sceneRoot->addChild(selectionRoot);
 
-  // Add selection and deselection callbacks
-  selectionRoot->addSelectionCallback(selectionCB, NULL);
-  selectionRoot->addDeselectionCallback(deselectionCB, NULL);
-  selectionRoot->setPickFilterCallback(pickFilterCB, NULL);
-  selectionRoot->addChild(world->getIVRoot());
+      // Add selection and deselection callbacks
+      selectionRoot->addSelectionCallback(selectionCB, NULL);
+      selectionRoot->addDeselectionCallback(deselectionCB, NULL);
+      selectionRoot->setPickFilterCallback(pickFilterCB, NULL);
+      selectionRoot->addChild(world->getIVRoot());
 
-  wireFrameRoot = new SoSeparator;
-  sceneRoot->addChild(wireFrameRoot);
+      wireFrameRoot = new SoSeparator;
+      sceneRoot->addChild(wireFrameRoot);
 
-  //comment these out if only single-threaded operation will be used
-  //myViewer->setRenderMutex(&mRenderMutex);
-  //world->setRenderMutex(&mRenderMutex);
+      //comment these out if only single-threaded operation will be used
+      //myViewer->setRenderMutex(&mRenderMutex);
+      //world->setRenderMutex(&mRenderMutex);
 
-  myViewer->show();
-  myViewer->setSceneGraph(sceneRoot);
-  myViewer->setTransparencyType(SoGLRenderAction::DELAYED_BLEND);
-  myViewer->setBackgroundColor(SbColor(1,1,1));
+      myViewer->show();
+      myViewer->setSceneGraph(sceneRoot);
+      myViewer->setTransparencyType(SoGLRenderAction::DELAYED_BLEND);
+      myViewer->setBackgroundColor(SbColor(1,1,1));
 
-  myViewer->viewAll();
-  mDBMgr = NULL;
+      myViewer->viewAll();
+  }else{
+      myViewer = NULL;
+  }
   mDBMgr = NULL;
 }
 

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -358,15 +358,6 @@ IVmgr::setupPointers()
 }
 
 /*!
-  Starts the main event loop.
-*/
-void
-IVmgr::beginMainLoop()
-{
-  SoQt::mainLoop();
-}
-
-/*!
 	Draws the force pointers that show the resultant static forces applied
 	to objects as a result of coupled robot dofs touching them.
 */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,8 +85,7 @@ int main(int argc, char **argv)
       }
   }
 
-  GraspitCore core;
-  core.init(argc, argv);
+  GraspitCore core(argc, argv);
   
   //This is the GraspIt TCP server. It can be used to connect to GraspIt from
   //external programs, such as Matlab.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,8 @@
 #include "graspitGUI.h"
 #include "graspitServer.h"
 #include "mainWindow.h"
+#include "cmdline.h"
+#include "graspitParser.h"
 
 #ifdef Q_WS_WIN
 #include <windows.h>
@@ -69,14 +71,21 @@ int main(int argc, char **argv)
 #endif
 #endif
 
+  GraspitParser *graspitParser = new GraspitParser();
+  graspitParser->parseArgs(argc, argv);
+  cmdline::parser *parsed_args = graspitParser->parseArgs(argc, argv);
+
+  bool headless = parsed_args->get<bool>("headless");
+
   GraspItApp app(argc, argv);
- 
-  if (app.splashEnabled()) {
-    app.showSplash();
-    QApplication::setOverrideCursor( Qt::waitCursor );
+  if(!headless){
+      if (app.splashEnabled()) {
+        app.showSplash();
+        QApplication::setOverrideCursor( Qt::waitCursor );
+      }
   }
 
-  GraspItGUI gui(argc,argv);
+  GraspItGUI gui(argc, argv, parsed_args);
   
   //This is the GraspIt TCP server. It can be used to connect to GraspIt from
   //external programs, such as Matlab.
@@ -84,13 +93,18 @@ int main(int argc, char **argv)
   //default
   //GraspItServer server(4765);
  
-  app.setMainWidget(gui.getMainWindow()->mWindow);
+
   QObject::connect(qApp, SIGNAL(lastWindowClosed()), qApp, SLOT(quit()));
 
-  if (app.splashEnabled()) {
-    app.closeSplash();
-    QApplication::restoreOverrideCursor();
+  if(!headless)
+  {
+      app.setMainWidget(gui.getMainWindow()->mWindow);
+      if (app.splashEnabled()) {
+        app.closeSplash();
+        QApplication::restoreOverrideCursor();
+      }
   }
+
 
   if (!gui.terminalFailure()) {
 	  gui.startMainLoop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
   graspitParser->parseArgs(argc, argv);
   cmdline::parser *parsed_args = graspitParser->parseArgs(argc, argv);
 
-  bool headless = parsed_args->get<bool>("headless");
+  bool headless = parsed_args->exist("headless");
 
   GraspItApp app(argc, argv);
   if(!headless){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@
 
 #include <iostream>
 #include <graspitApp.h>
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "graspitServer.h"
 #include "mainWindow.h"
 #include "cmdline.h"
@@ -85,7 +85,8 @@ int main(int argc, char **argv)
       }
   }
 
-  GraspItGUI gui(argc, argv, parsed_args);
+  GraspitCore core;
+  core.init(argc, argv);
   
   //This is the GraspIt TCP server. It can be used to connect to GraspIt from
   //external programs, such as Matlab.
@@ -98,7 +99,7 @@ int main(int argc, char **argv)
 
   if(!headless)
   {
-      app.setMainWidget(gui.getMainWindow()->mWindow);
+      app.setMainWidget(core.getMainWindow()->mWindow);
       if (app.splashEnabled()) {
         app.closeSplash();
         QApplication::restoreOverrideCursor();
@@ -106,8 +107,8 @@ int main(int argc, char **argv)
   }
 
 
-  if (!gui.terminalFailure()) {
-	  gui.startMainLoop();
+  if (!core.terminalFailure()) {
+      core.startMainLoop();
   }
-  return gui.getExitCode();
+  return core.getExitCode();
 }

--- a/src/optimizer/eigenTorques.cpp
+++ b/src/optimizer/eigenTorques.cpp
@@ -40,7 +40,7 @@
 */
 CGDBGraspProcessor::CGDBGraspProcessor(Hand *h) : mHand(h) 
 {
-	mDbMgr = graspitCore->getIVmgr()->getDBMgr();
+    mDbMgr = graspitCore->getDBMgr();
 	mProcessor = new EigenTorqueComputer(mHand);
 	mProcessor = new McGripOptimizer(mHand);
 	//mProcessor = new McGripAnalyzer(mHand);

--- a/src/optimizer/eigenTorques.cpp
+++ b/src/optimizer/eigenTorques.cpp
@@ -22,7 +22,7 @@
 
 #include "robot.h"
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "grasp.h"
 #include "mcGrip.h"
@@ -40,7 +40,7 @@
 */
 CGDBGraspProcessor::CGDBGraspProcessor(Hand *h) : mHand(h) 
 {
-	mDbMgr = graspItGUI->getIVmgr()->getDBMgr();
+	mDbMgr = graspitCore->getIVmgr()->getDBMgr();
 	mProcessor = new EigenTorqueComputer(mHand);
 	mProcessor = new McGripOptimizer(mHand);
 	//mProcessor = new McGripAnalyzer(mHand);

--- a/src/optimizer/optimizerDlg.cpp
+++ b/src/optimizer/optimizerDlg.cpp
@@ -18,7 +18,7 @@
 
 #include "eigenTorques.h"
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 
 #include "debug.h"
@@ -38,7 +38,7 @@ OptimizerDlg::torqueButtonClicked()
 		DBGA("No hand selected");
 		return;
 	}
-	if (!graspItGUI->getIVmgr()->getDBMgr()) {
+	if (!graspitCore->getIVmgr()->getDBMgr()) {
 		DBGA("Connect to database first");
 		return;
 	}

--- a/src/optimizer/optimizerDlg.cpp
+++ b/src/optimizer/optimizerDlg.cpp
@@ -38,7 +38,7 @@ OptimizerDlg::torqueButtonClicked()
 		DBGA("No hand selected");
 		return;
 	}
-	if (!graspitCore->getIVmgr()->getDBMgr()) {
+    if (!graspitCore->getDBMgr()) {
 		DBGA("Connect to database first");
 		return;
 	}

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -43,7 +43,7 @@
 #include "dynJoint.h"
 #include "world.h"
 #include "grasp.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "dynamics.h"
 #include "gloveInterface.h"
@@ -1654,10 +1654,10 @@ Robot::moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtC
 			DBGA("MoveDOF failsafe hit");
 			break;
 		}
-		if (renderIt && (itercount%25==0) && graspItGUI && graspItGUI->getIVmgr()->getWorld()==myWorld) {
-            if(!graspItGUI->isHeadless())
+		if (renderIt && (itercount%25==0) && graspitCore && graspitCore->getWorld()==myWorld) {
+            if(!graspitCore->isHeadless())
             {
-                graspItGUI->getIVmgr()->getViewer()->render();
+                graspitCore->getIVmgr()->getViewer()->render();
             }
 		}
 	} while (1);

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -1655,7 +1655,7 @@ Robot::moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtC
 			break;
 		}
 		if (renderIt && (itercount%25==0) && graspitCore && graspitCore->getWorld()==myWorld) {
-            if(!graspitCore->getIVmgr())
+            if(graspitCore->getIVmgr())
             {
                 graspitCore->getIVmgr()->getViewer()->render();
             }

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -1655,7 +1655,7 @@ Robot::moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtC
 			break;
 		}
 		if (renderIt && (itercount%25==0) && graspitCore && graspitCore->getWorld()==myWorld) {
-            if(!graspitCore->isHeadless())
+            if(!graspitCore->getIVmgr())
             {
                 graspitCore->getIVmgr()->getViewer()->render();
             }

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -1655,7 +1655,10 @@ Robot::moveDOFToContacts(double *desiredVals, double *desiredSteps, bool stopAtC
 			break;
 		}
 		if (renderIt && (itercount%25==0) && graspItGUI && graspItGUI->getIVmgr()->getWorld()==myWorld) {
-			graspItGUI->getIVmgr()->getViewer()->render();
+            if(!graspItGUI->isHeadless())
+            {
+                graspItGUI->getIVmgr()->getViewer()->render();
+            }
 		}
 	} while (1);
 

--- a/src/robots/pr2Gripper.cpp
+++ b/src/robots/pr2Gripper.cpp
@@ -30,7 +30,7 @@
 #include "pr2Gripper.h"
 #include "world.h"
 #include "collisionInterface.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "mainWindow.h"
 #include "contact.h"
 

--- a/src/scanSimulator.cpp
+++ b/src/scanSimulator.cpp
@@ -28,7 +28,7 @@
 #include <Inventor/SoPickedPoint.h>
 
 #include "scanSimulator.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "world.h"
 #include "matvec3D.h"
@@ -134,12 +134,12 @@ void ScanSimulator::computeRayDirection(float hAngle, float vAngle, vec3 &rayDir
 
 bool ScanSimulator::shootRay(const vec3 &rayDirection, position &rayPoint)
 {
-	SoRayPickAction action( graspItGUI->getIVmgr()->getViewer()->getViewportRegion() );
+	SoRayPickAction action( graspitCore->getIVmgr()->getViewer()->getViewportRegion() );
 
 	action.setRay( mPosition.toSbVec3f(), rayDirection.toSbVec3f(), 0.0, -1.0 );
 	action.setPickAll(false);
 
-	action.apply( (SoNode*)graspItGUI->getIVmgr()->getWorld()->getIVRoot() );
+	action.apply( (SoNode*)graspitCore->getWorld()->getIVRoot() );
 
 	SoPickedPoint *pp = action.getPickedPoint();
 	if (!pp) return false;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -879,7 +879,7 @@ World::save(const QString &filename)
             angle = 10;
         }
         vec3 minPoint, maxPoint, center;  // min/max points of AABB
-        getBoundigBox(minPoint, maxPoint);
+        getBoundingBox(minPoint, maxPoint);
         center = (minPoint + maxPoint) * 0.5;
         float xLen = fabs(maxPoint.x()-minPoint.x());  // lenght of BB along x
         float zLen = fabs(maxPoint.z()-minPoint.z());  // lenght of BB along z

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -837,15 +837,16 @@ World::save(const QString &filename)
 			}
 		}
 	}
-	stream<<"\t<camera>"<<endl;
-	float px, py, pz, q1, q2, q3, q4, fd;
+
 	if (myIVmgr) {
+        stream<<"\t<camera>"<<endl;
+        float px, py, pz, q1, q2, q3, q4, fd;
 		myIVmgr->getCamera(px, py, pz, q1, q2, q3, q4, fd);
 		stream<<"\t\t<position>"<<px<<" "<<py<<" "<<pz<<"</position>"<<endl;
 		stream<<"\t\t<orientation>"<<q1<<" "<<q2<<" "<<q3<<" "<<q4<<"</orientation>"<<endl;
 		stream<<"\t\t<focalDistance>"<<fd<<"</focalDistance>"<<endl;
+        stream<<"\t</camera>"<<endl;
 	}
-	stream<<"\t</camera>"<<endl;
 	stream<<"</world>"<<endl;
 	file.close();
 	modified = false;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -108,10 +108,10 @@ char graspitVersionStr[] = "GraspIt! version 2.1";
 that will handle all user interaction. Also initialized collision detection
 system and reads in global settings such as friction coefficients 
 */
-World::World(QObject *parent, const char *name, IVmgr *mgr) : QObject(parent,name)
+World::World(QObject *parent, const char *name) :
+    QObject(parent,name),
+    myIVmgr(NULL)
 {
-	myIVmgr = mgr;
-
 	numBodies = numGB = numRobots = numHands = 0;
 	numSelectedBodyElements = numSelectedRobotElements = 0;
 	numSelectedElements = 0;
@@ -728,7 +728,9 @@ World::loadFromXml(const TiXmlElement* root,QString rootPath)
 				QTWARNING("Failed to load focal distance");
 				return FAILURE;				
 			}
-			myIVmgr->setCamera(px, py, pz, q1, q2, q3, q4, fd);
+            if (myIVmgr) {
+                myIVmgr->setCamera(px, py, pz, q1, q2, q3, q4, fd);
+            }
 			cameraFound = true;
 		}
 		else {
@@ -739,7 +741,9 @@ World::loadFromXml(const TiXmlElement* root,QString rootPath)
 	}
 
 	if (!cameraFound) {
-		myIVmgr->getViewer()->viewAll();
+        if (myIVmgr) {
+            myIVmgr->getViewer()->viewAll();
+        }
 	}
 	findAllContacts();
 	modified = false;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -192,7 +192,7 @@ World::~World()
 
 /*! Returns axis-aligned bounding box min and max points of the world
  */
-void World::getBoundigBox(vec3& minPoint, vec3& maxPoint)
+void World::getBoundingBox(vec3& minPoint, vec3& maxPoint)
 {
     minPoint.set(0,0,0);
     maxPoint.set(0,0,0);

--- a/test/simple_test.cpp
+++ b/test/simple_test.cpp
@@ -5,7 +5,7 @@
 #include <QMutex>
 #include <Inventor/Qt/SoQt.h>
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include <graspitApp.h>
 #include "mainWindow.h"
 #include "ivmgr.h"

--- a/ui/EGPlanner/compliantPlannerDlg.cpp
+++ b/ui/EGPlanner/compliantPlannerDlg.cpp
@@ -40,7 +40,7 @@
 PROF_DECLARE(QS_TOTAL);
 
 //for the bounding box and drawing forces
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 
 //for debug
@@ -171,7 +171,7 @@ CompliantPlannerDlg::generateButtonClicked()
 	}
 	//get object bbox dimensions
 	SoGetBoundingBoxAction *bba = 
-		new SoGetBoundingBoxAction(graspItGUI->getIVmgr()->getViewer()->getViewportRegion());
+		new SoGetBoundingBoxAction(graspitCore->getIVmgr()->getViewer()->getViewportRegion());
 	bba->apply(mObject->getIVGeomRoot());
 	SbVec3f bbmin,bbmax;
 	bba->getBoundingBox().getBounds(bbmin,bbmax);
@@ -299,8 +299,8 @@ CompliantPlannerDlg::testOneButtonClicked()
 	DBGA("Testing pre-grasp #" << num);
 	mPlanner->testState(num);
 	mHand->getWorld()->updateGrasps();
-	graspItGUI->getIVmgr()->drawDynamicForces();
-	graspItGUI->getIVmgr()->drawUnbalancedForces();
+	graspitCore->getIVmgr()->drawDynamicForces();
+	graspitCore->getIVmgr()->drawUnbalancedForces();
 }
 
 void

--- a/ui/EGPlanner/egPlannerDlg.cpp
+++ b/ui/EGPlanner/egPlannerDlg.cpp
@@ -44,7 +44,7 @@
 #include "eigenGrasp.h"
 #include "grasp.h"
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "contactExaminerDlg.h"
 #include "onLinePlanner.h"

--- a/ui/Planner/plannerdlg.cpp
+++ b/ui/Planner/plannerdlg.cpp
@@ -32,7 +32,7 @@
 
 #include "robot.h"
 #include "mainWindow.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "grasp_manager.h"
 #include "grasp_tester.h"
 #include "grasp_planner.h"
@@ -85,7 +85,7 @@ void PlannerDlg::init()
   backstepSizeLine->setValidator(new QDoubleValidator(0,1000,6,this));
   
   qmComboBox->clear();
-  grasp = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp();
+  grasp = graspitCore->getWorld()->getCurrentHand()->getGrasp();
   if (grasp->getNumQM() == 0) GenerateButton->setEnabled(false);
   else {
       for (i=0;i<grasp->getNumQM();i++)
@@ -180,8 +180,8 @@ void PlannerDlg::showGrasp()
 */
 void PlannerDlg::newQM()
 {
-  Grasp *grasp=graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp();
-  graspItGUI->getMainWindow()->graspQualityMeasures();
+  Grasp *grasp=graspitCore->getWorld()->getCurrentHand()->getGrasp();
+  graspitCore->getMainWindow()->graspQualityMeasures();
   if (grasp->getNumQM()>0) GenerateButton->setEnabled(true);
   qmComboBox->clear();
   for (int i=0;i<grasp->getNumQM();i++)
@@ -217,7 +217,7 @@ void PlannerDlg::chooseSaveFile()
 void PlannerDlg::testGrasps()
 {
   QString planFilename,quadFilename;
-  World *world = graspItGUI->getIVmgr()->getWorld();
+  World *world = graspitCore->getWorld();
  /*  
   if (TestButton->text() == "Pause") {
 	TestButton->setText("Continue");

--- a/ui/bodyPropDlg.cpp
+++ b/ui/bodyPropDlg.cpp
@@ -30,7 +30,7 @@
 
 #include "robot.h"
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "qvalidator.h"
 #include "collisionStructures.h"
@@ -52,7 +52,7 @@
 void BodyPropDlg::init()
 {
   int i,c,l;
-  World *w=graspItGUI->getIVmgr()->getWorld();
+  World *w=graspitCore->getWorld();
   std::list<WorldElement *> elemList = w->getSelectedElementList();
   std::list<WorldElement *>::iterator ep;
   
@@ -230,7 +230,7 @@ void BodyPropDlg::setShowDynContactForces( int state )
 */
 void BodyPropDlg::setMaterial( int choice )
 {
-  World *w=graspItGUI->getIVmgr()->getWorld();
+  World *w=graspitCore->getWorld();
   
   if (choice == w->getNumMaterials()) {
     for (int i=0;i<numBodies;i++) 
@@ -274,7 +274,7 @@ void
 BodyPropDlg::showBvs()
 {
 	std::vector<BoundingBox> bvs;
-	World *w=graspItGUI->getIVmgr()->getWorld();
+	World *w=graspitCore->getWorld();
 	int depth = -1;
 	if (!boundingCheckBox->isChecked()) {
 		boundingSpinBox->setEnabled(false);

--- a/ui/contactExaminerDlg.cpp
+++ b/ui/contactExaminerDlg.cpp
@@ -33,7 +33,7 @@
 #include "contact.h"
 #include "grasp.h"
 #include "quality.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "body.h"
 #include "mainWindow.h"
@@ -42,7 +42,7 @@
 
 void ContactExaminerDlg::init()
 {
-	mWorld = graspItGUI->getIVmgr()->getWorld();
+	mWorld = graspitCore->getWorld();
 	//check the hand
 	if(mWorld->getCurrentHand()){
 		mHand = mWorld->getCurrentHand();
@@ -240,7 +240,7 @@ void ContactExaminerDlg::destroy()
 void ContactExaminerDlg::showGWSButton_clicked()
 {
 	mGrasp->update();
-	graspItGUI->getMainWindow()->graspCreateProjection(mGrasp);
+	graspitCore->getMainWindow()->graspCreateProjection(mGrasp);
 }
 
 void ContactExaminerDlg::modeSelected()

--- a/ui/gfoDlg.cpp
+++ b/ui/gfoDlg.cpp
@@ -27,7 +27,7 @@
 
 #include <QInputDialog>
 
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "robot.h"
 #include "grasp.h"
@@ -127,10 +127,10 @@ GFODlg::displayResults(int result)
     statusLabel->setText("Status: problem unfeasible");
   } else {
     statusLabel->setText("Status: optimization successful");
-    graspItGUI->getIVmgr()->drawDynamicForces();
+    graspitCore->getIVmgr()->drawDynamicForces();
     //keep in mind that World::updateGrasps() will overwrite this and use the wrenches
     //to draw the worst case disturbance instead
-    graspItGUI->getIVmgr()->drawUnbalancedForces();
+    graspitCore->getIVmgr()->drawUnbalancedForces();
     mMainWindow->updateContactsList();
   }
 }

--- a/ui/gloveCalibrationDlg.cpp
+++ b/ui/gloveCalibrationDlg.cpp
@@ -28,7 +28,7 @@
 #include <QFileDialog>
 
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "robot.h"
 #include "gloveInterface.h"
@@ -37,7 +37,7 @@ void GloveCalibrationDlg::init()
 {
 //	calibrateButton->setEnabled(false);
 
-	World *w=graspItGUI->getIVmgr()->getWorld();
+	World *w=graspitCore->getWorld();
 	mInterface = w->getCurrentHand()->getGloveInterface();
 
 	mInterface->saveRobotPose();

--- a/ui/graspCaptureDlg.cpp
+++ b/ui/graspCaptureDlg.cpp
@@ -34,7 +34,7 @@
 #include "searchState.h"
 #include "contact.h"
 #include "quality.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "mytools.h"
 
@@ -60,7 +60,7 @@ GraspCaptureDlg::init(World *w) {
 	mCurrentHand = NULL;
 	saveToDBaseButton->setEnabled(FALSE);
 
-	if (graspItGUI->getIVmgr()->getDBMgr()) {
+	if (graspitCore->getIVmgr()->getDBMgr()) {
 		saveToDBaseButton->setEnabled(TRUE);
 	} else {
 		QTWARNING("DBase connection not found; only Save to File possible.");
@@ -123,7 +123,7 @@ GraspCaptureDlg::captureButtonClicked()
 	mGrasps.push_back(newState);
 	updateNumGrasps();
 
-	if (graspItGUI->getIVmgr()->getDBMgr()) {
+	if (graspitCore->getIVmgr()->getDBMgr()) {
 		saveToDBaseButton->setEnabled(TRUE);
 	} else {
 		saveToDBaseButton->setEnabled(FALSE);
@@ -165,7 +165,7 @@ GraspCaptureDlg::saveToDBaseButtonClicked()
 #ifndef CGDB_ENABLED
 	return;
 #else
-	db_planner::DatabaseManager *dbMgr = graspItGUI->getIVmgr()->getDBMgr();
+	db_planner::DatabaseManager *dbMgr = graspitCore->getIVmgr()->getDBMgr();
 	if (!dbMgr) return;
 	std::list<GraspPlanningState*>::iterator it;
 	std::vector<db_planner::Grasp*> graspList;

--- a/ui/graspCaptureDlg.cpp
+++ b/ui/graspCaptureDlg.cpp
@@ -60,7 +60,7 @@ GraspCaptureDlg::init(World *w) {
 	mCurrentHand = NULL;
 	saveToDBaseButton->setEnabled(FALSE);
 
-	if (graspitCore->getIVmgr()->getDBMgr()) {
+    if (graspitCore->getDBMgr()) {
 		saveToDBaseButton->setEnabled(TRUE);
 	} else {
 		QTWARNING("DBase connection not found; only Save to File possible.");
@@ -123,7 +123,7 @@ GraspCaptureDlg::captureButtonClicked()
 	mGrasps.push_back(newState);
 	updateNumGrasps();
 
-	if (graspitCore->getIVmgr()->getDBMgr()) {
+    if (graspitCore->getDBMgr()) {
 		saveToDBaseButton->setEnabled(TRUE);
 	} else {
 		saveToDBaseButton->setEnabled(FALSE);
@@ -165,7 +165,7 @@ GraspCaptureDlg::saveToDBaseButtonClicked()
 #ifndef CGDB_ENABLED
 	return;
 #else
-	db_planner::DatabaseManager *dbMgr = graspitCore->getIVmgr()->getDBMgr();
+    db_planner::DatabaseManager *dbMgr = graspitCore->getDBMgr();
 	if (!dbMgr) return;
 	std::list<GraspPlanningState*>::iterator it;
 	std::vector<db_planner::Grasp*> graspList;

--- a/ui/mainWindow.cpp
+++ b/ui/mainWindow.cpp
@@ -807,7 +807,7 @@ void MainWindow::dbasePlannerAction_activated()
     QTWARNING("No object selected");
     return;
   }
-  if (!graspitCore->getIVmgr()->getDBMgr()) {
+  if (!graspitCore->getDBMgr()) {
     QTWARNING("Connection to database not established. Connect to database first.");
     return;
   }
@@ -815,7 +815,7 @@ void MainWindow::dbasePlannerAction_activated()
     QTWARNING("DBase Planner currently works only with models loaded from the database");
     return;
   }
-  DBasePlannerDlg *dlg = new DBasePlannerDlg(mWindow, graspitCore->getIVmgr()->getDBMgr(), 
+  DBasePlannerDlg *dlg = new DBasePlannerDlg(mWindow, graspitCore->getDBMgr(),
                                              world->getGB(gb)->getDBModel(), world->getCurrentHand());
   dlg->setAttribute(Qt::WA_ShowModal, false);
   dlg->setAttribute(Qt::WA_DeleteOnClose, true);

--- a/ui/qmDlg.cpp
+++ b/ui/qmDlg.cpp
@@ -25,7 +25,7 @@
 
 #include <QHBoxLayout>
 #include "qmDlg.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "grasp.h"
 #include "list"
@@ -45,7 +45,7 @@
 void QMDlg::init()
 {
   std::list<QualityMeasure *>::iterator qp;
-  Grasp *g = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp();
+  Grasp *g = graspitCore->getWorld()->getCurrentHand()->getGrasp();
   int i;
   
   qmListBox->insertItem("New quality measure");
@@ -105,7 +105,7 @@ void QMDlg::updateSettingsBox()
 */
 void QMDlg::addEditQM()
 {
-  Grasp *g = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp();
+  Grasp *g = graspitCore->getWorld()->getCurrentHand()->getGrasp();
   QualityMeasure *newQM;
   int selectedQM;
 
@@ -138,7 +138,7 @@ void QMDlg::deleteQM()
   int numItems;
   
   selectedQM = qmListBox->currentItem();
-  graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp()->
+  graspitCore->getWorld()->getCurrentHand()->getGrasp()->
     removeQM(selectedQM-1);
   qmListBox->removeItem(selectedQM);
 
@@ -166,7 +166,7 @@ void QMDlg::selectQM( int which)
   }
   else {
     DeleteButton->setEnabled(true);
-    Grasp *g = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp();
+    Grasp *g = graspitCore->getWorld()->getCurrentHand()->getGrasp();
     qmDlgData.currQM = g->getQM(which-1);
 
 	for (int i=0;QualityMeasure::TYPE_LIST[i];i++) {
@@ -183,7 +183,7 @@ void QMDlg::selectQM( int which)
 
 void QMDlg::gravityBox_clicked()
 {
-    Grasp *g = graspItGUI->getIVmgr()->getWorld()->getCurrentHand()->getGrasp();
+    Grasp *g = graspitCore->getWorld()->getCurrentHand()->getGrasp();
 	g->setGravity( gravityBox->isChecked() );
 	if ( gravityBox->isChecked() ) {
 		fprintf(stderr,"Gravity on\n");

--- a/ui/qmDlg.ui
+++ b/ui/qmDlg.ui
@@ -220,7 +220,7 @@
   </customwidget>
  </customwidgets>
  <includes>
-  <include location="local" >graspitGUI.h</include>
+  <include location="local" >graspitCore.h</include>
   <include location="local" >ivmgr.h</include>
   <include location="local" >quality.h</include>
  </includes>

--- a/ui/sensorInputDlg.cpp
+++ b/ui/sensorInputDlg.cpp
@@ -30,7 +30,7 @@
 
 #include "robot.h"
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 #include "body.h"
 #include "barrett.h"

--- a/ui/settingsDlg.cpp
+++ b/ui/settingsDlg.cpp
@@ -29,7 +29,7 @@
 
 #include "settingsDlg.h"
 #include "world.h"
-#include "graspitGUI.h"
+#include "graspitCore.h"
 #include "ivmgr.h"
 
 #include <QValidator>
@@ -48,7 +48,7 @@ void SettingsDlg::init()
 {   
   int i,j;
   QString val;
-    World *w = graspItGUI->getIVmgr()->getWorld();
+    World *w = graspitCore->getWorld();
    
     dlgUI->staticFrictionTable->horizontalHeader()->hide();
     dlgUI->staticFrictionTable->verticalHeader()->hide();


### PR DESCRIPTION
Problem:
Could not run graspit headless. ivmgr was doing way to many things, and this made it difficult to run headless. Ivmgr needed to do less, so that it is possible to run graspit without creating one.

Fix:
GraspitGUI-> GraspitCore
made it possible to run graspit without creating an ivmgr
moved dbmgr, world ownership to graspitCore rather than ivmgr. 
added arg to be able to start graspit headless

Running headless:
cd ~/graspit/plugins/openclose
qmake-qt4 openClosePlugin.pro
make -j5
cd lib
export GRASPIT_PLUGIN_DIR=$PWD
cd ~/graspit 
export GRASPIT=$PWD
mkdir build
cd build
cmake ..
make -j5
./graspit_simulator --headless 1 -r Barrett -p libopenClosePlugin

This will cause graspit to run headless, load the Barrett hand, and then the plugin will print out "in main loop " over and over again.