### PR TITLE
Bullet Dynamics Set Robot Velocity

### DIFF
--- a/include/robot.h
+++ b/include/robot.h
@@ -158,9 +158,9 @@ protected:
   double defaultRotVel;
 
   //! magnitude of dynamic movement of the base of the robot
-  vec3 mDynamicImpulse;
+  vec3 linearVelocity;
   //! direction of dynamic movement of the base of the robot
-  vec3 mDynamicImpulseRelPose;
+  vec3 angularVelocity;
 
   // Input from external hardware
   //! Shows if this robot is to be controlled via a CyberGlove
@@ -240,8 +240,8 @@ protected:
 	approachTran = transf::IDENTITY;
 	// temporary
 	defaultTranslVel = 50; defaultRotVel = M_PI/4.0;
-    mDynamicImpulse = vec3(0,0,1);
-    mDynamicImpulseRelPose = vec3(0,0,1);
+    linearVelocity = vec3(0,0,0);
+    angularVelocity = vec3(1,0,0);
   }
   
   //! Deletes all kinematic chains, the base and mount piece, etc.
@@ -279,11 +279,11 @@ protected:
   void setDesiredDOFVals(double *dofVals);
 
   //! The main way to move the robot pose IN DYNAMICS mode.
-  void setRobotImpulse(vec3 dynamicImpulse){mDynamicImpulse = dynamicImpulse;}
-  void setRobotImpulseRelPose(vec3 dynamicImpulseRelPose){mDynamicImpulseRelPose = dynamicImpulseRelPose;}
+  void setRobotImpulse(vec3 dynamicImpulse){linearVelocity = dynamicImpulse;}
+  void setRobotImpulseRelPose(vec3 dynamicImpulseRelPose){angularVelocity = dynamicImpulseRelPose;}
 
-  vec3 getRobotImpulse(){return mDynamicImpulse;}
-  vec3 getRobotImpulseRelPose(){return mDynamicImpulseRelPose;}
+  vec3 getLinearVelocity(){return linearVelocity;}
+  vec3 getAngularVelocity(){return angularVelocity;}
 
   //! Returns true if any of the contacts on the fingers are slipping during dynamics
   bool contactSlip();

--- a/include/robot.h
+++ b/include/robot.h
@@ -158,9 +158,9 @@ protected:
   double defaultRotVel;
 
   //! magnitude of dynamic movement of the base of the robot
-  vec3 linearVelocity;
+  vec3 mLinearVelocity;
   //! direction of dynamic movement of the base of the robot
-  vec3 angularVelocity;
+  vec3 mAngularVelocity;
 
   // Input from external hardware
   //! Shows if this robot is to be controlled via a CyberGlove
@@ -240,8 +240,8 @@ protected:
 	approachTran = transf::IDENTITY;
 	// temporary
 	defaultTranslVel = 50; defaultRotVel = M_PI/4.0;
-    linearVelocity = vec3(0,0,0);
-    angularVelocity = vec3(0,0,0);
+    mLinearVelocity = vec3(0,0,0);
+    mAngularVelocity = vec3(0,0,0);
   }
   
   //! Deletes all kinematic chains, the base and mount piece, etc.
@@ -279,11 +279,11 @@ protected:
   void setDesiredDOFVals(double *dofVals);
 
   //! The main way to move the robot pose IN DYNAMICS mode.
-  void setRobotImpulse(vec3 dynamicImpulse){linearVelocity = dynamicImpulse;}
-  void setRobotImpulseRelPose(vec3 dynamicImpulseRelPose){angularVelocity = dynamicImpulseRelPose;}
+  void setLinearVelocity(vec3 velocity){mLinearVelocity = velocity;}
+  void setAngularVelocity(vec3 angularVelocity){mAngularVelocity = angularVelocity;}
 
-  vec3 getLinearVelocity(){return linearVelocity;}
-  vec3 getAngularVelocity(){return angularVelocity;}
+  vec3 getLinearVelocity(){return mLinearVelocity;}
+  vec3 getAngularVelocity(){return mAngularVelocity;}
 
   //! Returns true if any of the contacts on the fingers are slipping during dynamics
   bool contactSlip();

--- a/include/robot.h
+++ b/include/robot.h
@@ -157,9 +157,11 @@ protected:
   //! The default rotational velocity (rad/sec) to use when generating cartesian trajectories
   double defaultRotVel;
 
-  //! magnitude of dynamic movement of the base of the robot
+  //! linear velocity for dynamic movement of the base of the robot
+  //! this is only used when dynamics is on, and with the bullet dynamics engine
   vec3 mLinearVelocity;
-  //! direction of dynamic movement of the base of the robot
+  //! angular velocity for dynamic movement of the base of the robot
+  //! this is only used when dynamics is on, and with the bullet dynamics engine
   vec3 mAngularVelocity;
 
   // Input from external hardware

--- a/include/robot.h
+++ b/include/robot.h
@@ -157,6 +157,11 @@ protected:
   //! The default rotational velocity (rad/sec) to use when generating cartesian trajectories
   double defaultRotVel;
 
+  //! magnitude of dynamic movement of the base of the robot
+  vec3 mDynamicImpulse;
+  //! direction of dynamic movement of the base of the robot
+  vec3 mDynamicImpulseRelPose;
+
   // Input from external hardware
   //! Shows if this robot is to be controlled via a CyberGlove
   bool mUseCyberGlove;
@@ -235,6 +240,8 @@ protected:
 	approachTran = transf::IDENTITY;
 	// temporary
 	defaultTranslVel = 50; defaultRotVel = M_PI/4.0;
+    mDynamicImpulse = vec3(0,0,1);
+    mDynamicImpulseRelPose = vec3(0,0,1);
   }
   
   //! Deletes all kinematic chains, the base and mount piece, etc.
@@ -270,6 +277,13 @@ protected:
 
   //! The main way to move the robot dofs IN DYNAMICS mode. 
   void setDesiredDOFVals(double *dofVals);
+
+  //! The main way to move the robot pose IN DYNAMICS mode.
+  void setRobotImpulse(vec3 dynamicImpulse){mDynamicImpulse = dynamicImpulse;}
+  void setRobotImpulseRelPose(vec3 dynamicImpulseRelPose){mDynamicImpulseRelPose = dynamicImpulseRelPose;}
+
+  vec3 getRobotImpulse(){return mDynamicImpulse;}
+  vec3 getRobotImpulseRelPose(){return mDynamicImpulseRelPose;}
 
   //! Returns true if any of the contacts on the fingers are slipping during dynamics
   bool contactSlip();

--- a/include/robot.h
+++ b/include/robot.h
@@ -241,7 +241,7 @@ protected:
 	// temporary
 	defaultTranslVel = 50; defaultRotVel = M_PI/4.0;
     linearVelocity = vec3(0,0,0);
-    angularVelocity = vec3(1,0,0);
+    angularVelocity = vec3(0,0,0);
   }
   
   //! Deletes all kinematic chains, the base and mount piece, etc.

--- a/src/dynamics/bulletDynamics.cpp
+++ b/src/dynamics/bulletDynamics.cpp
@@ -502,7 +502,6 @@ void BulletDynamics::btApplyInternalWrench (Joint * activeJoint, double magnitud
 
         btVector3 torqueNext(magnitude*worldAxis.x(),magnitude*worldAxis.y(), magnitude*worldAxis.z());
         btNextLink->applyTorqueImpulse(torqueNext);
-
 }
 
 int BulletDynamics::stepDynamics()
@@ -602,7 +601,6 @@ double BulletDynamics::moveDynamicBodies(double timeStep) {
         btbase->setAngularVelocity(angularVelocity);
 
     }
-
     return 0;
 }
 

--- a/src/dynamics/bulletDynamics.cpp
+++ b/src/dynamics/bulletDynamics.cpp
@@ -147,7 +147,7 @@ void BulletDynamics::addRobot(Robot *robot)
     btRigidBody* btbase=NULL;
 
     if (robot->getBase()) {
-        btScalar mass(10.);
+        btScalar mass(robot->getBase()->getMass());
         btVector3 localInertia(0, 0, 0);
         if ((btbase=btBodyMap.find(robot->getBase())->second) == NULL) {
             DBGA("error, base is not in the btBodyMap\n");

--- a/src/dynamics/bulletDynamics.cpp
+++ b/src/dynamics/bulletDynamics.cpp
@@ -40,7 +40,7 @@
 #include "robot.h"
 #include "triangle.h"
 #include "world.h"
-#include "matvec3D.h"
+
 #include "debug.h"
 #include "dynamics.h"
 #include "humanHand.h"
@@ -65,7 +65,7 @@ BulletDynamics::BulletDynamics(World *world)
     mBtDynamicsWorld =
             new btDiscreteDynamicsWorld(dispatcher,overlappingPairCache,solver,collisionConfiguration);
 
-    mBtDynamicsWorld->setGravity(btVector3(0,0, 0));
+    mBtDynamicsWorld->setGravity(btVector3(0,0,0));
 }
 
 BulletDynamics::~BulletDynamics()
@@ -148,7 +148,7 @@ void BulletDynamics::addRobot(Robot *robot)
 
     if (robot->getBase()) {
         btScalar mass(10.);
-        btVector3 localInertia(0,0,0);
+        btVector3 localInertia(0, 0, 0);
         if ((btbase=btBodyMap.find(robot->getBase())->second) == NULL) {
             DBGA("error, base is not in the btBodyMap\n");
         }

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -212,7 +212,7 @@ Robot::loadFromXml(const TiXmlElement* root,QString rootPath)
         forceDefaultDOFVals();
 
 	//reset the dynamics: fix the base and set desired dof's to current values
-	getBase()->fix();
+    //getBase()->fix();
 	for (int i=0; i<getNumDOF(); i++) {
 		getDOF(i)->setDesiredPos( getDOF(i)->getVal() );
 	}
@@ -495,7 +495,7 @@ Robot::cloneFrom(Robot *original)
 
 	base->setTran(transf::IDENTITY);
 	//careful: clones robots have never been tested with the dynamics engine
-	getBase()->fix();
+    //getBase()->fix();
 	for (int i=0; i<getNumDOF(); i++) {
 		getDOF(i)->setDesiredPos( getDOF(i)->getVal() );
 	}

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -212,7 +212,7 @@ Robot::loadFromXml(const TiXmlElement* root,QString rootPath)
         forceDefaultDOFVals();
 
 	//reset the dynamics: fix the base and set desired dof's to current values
-    //getBase()->fix();
+	getBase()->fix();
 	for (int i=0; i<getNumDOF(); i++) {
 		getDOF(i)->setDesiredPos( getDOF(i)->getVal() );
 	}
@@ -495,7 +495,7 @@ Robot::cloneFrom(Robot *original)
 
 	base->setTran(transf::IDENTITY);
 	//careful: clones robots have never been tested with the dynamics engine
-    //getBase()->fix();
+	getBase()->fix();
 	for (int i=0; i<getNumDOF(); i++) {
 		getDOF(i)->setDesiredPos( getDOF(i)->getVal() );
 	}


### PR DESCRIPTION
I added two new fields to the robot class, a linear and angular vec3 for velocity.  In the Bullet Dynamics engine, I look for these values and set the robot's velocity based on these values.  The linear and angular velocity of the robot are defined in the approach frame of reference for the robot.  

This makes it possible to "execute a grasp" in dynamics mode by moving along the approach direction and then autoclosing.
