### PR TITLE
modified searchState to use initialization list rather than init()

### DIFF
--- a/include/EGPlanner/searchState.h
+++ b/include/EGPlanner/searchState.h
@@ -246,7 +246,6 @@ public:
 class HandObjectState
 {
 private:
-	void init();
 	//! The variables that define the hand posture
 	PostureState *mPosture;
 	//! The variables that define the hand position relative to mRefTran
@@ -276,7 +275,7 @@ private:
 	
 public:
 	HandObjectState(Hand *h);
-	HandObjectState(const HandObjectState *s){init();copyFrom(s);}
+	HandObjectState(const HandObjectState *s);
 	virtual ~HandObjectState();
 	inline void copyFrom(const HandObjectState *s);
 	//! Resets both posture and position (currently sets all variables to 0)

--- a/src/EGPlanner/searchState.cpp
+++ b/src/EGPlanner/searchState.cpp
@@ -354,26 +354,30 @@ PositionState* PositionState::createInstance(StateType type, const Hand *h)
 }
 
 //----------------------------------------------------------------------------------
-HandObjectState::HandObjectState(Hand *h)
+HandObjectState::HandObjectState(Hand *h):
+    mRefTran(transf::IDENTITY),
+    mTargetObject(NULL),
+    mPosture(PostureState::createInstance(POSE_EIGEN,h)),
+    mPosition(PositionState::createInstance(SPACE_COMPLETE,h)),
+    mAttributes(new AttributeSet(h)),
+    IVRoot(NULL),
+    IVMat(NULL),
+    IVTran(NULL),
+    mHand(h)
 {
-	init();
-	mPosture = PostureState::createInstance(POSE_EIGEN,h);
-	mPosition = PositionState::createInstance(SPACE_COMPLETE,h);
-	mAttributes = new AttributeSet(h);
-	mHand = h;
 }
 
-void
-HandObjectState::init()
+HandObjectState::HandObjectState(const HandObjectState *s):
+    mRefTran(transf::IDENTITY),
+    mTargetObject(NULL),
+    mPosture(NULL),
+    mPosition(NULL),
+    mAttributes(NULL),
+    IVRoot(NULL),
+    IVMat(NULL),
+    IVTran(NULL)
 {
-	mRefTran = transf::IDENTITY;
-	mTargetObject = NULL;
-	mPosture = NULL;
-	mPosition = NULL;
-	mAttributes = NULL;
-	IVRoot = NULL;
-	IVMat = NULL;
-	IVTran = NULL;
+    copyFrom(s);
 }
 
 HandObjectState::~HandObjectState()


### PR DESCRIPTION
modified searchState to use initialization list rather than init() as it was easy to miss a call to init() and then the SearchState would enter an invalid state.  For example, this happened in the GraspPlanningState copy constructor. init was never called, and the searchState had non-NULL invalid pointers