### PR TITLE
mHand was referenced in the destructor of the hand object state

### DIFF
--- a/src/EGPlanner/energy/searchEnergy.cpp
+++ b/src/EGPlanner/energy/searchEnergy.cpp
@@ -95,8 +95,8 @@ SearchEnergy::setHandAndObject(Hand *h, Body *o)
 
 SearchEnergy::~SearchEnergy()
 {
-    delete mVolQual;
-    delete mEpsQual;
+    if (mVolQual) delete mVolQual;
+    if (mEpsQual) delete mEpsQual;
 }
 
 bool

--- a/src/EGPlanner/searchState.cpp
+++ b/src/EGPlanner/searchState.cpp
@@ -36,6 +36,7 @@
 #include <Inventor/nodes/SoGroup.h>
 #include "SoArrow.h"
 
+#include "graspitCore.h"
 #include "robot.h"
 #include "body.h"
 #include "world.h"
@@ -708,11 +709,11 @@ void
 HandObjectState::hideVisualMarker()
 {
 	if (!IVRoot) return;
-	int i = mHand->getWorld()->getIVRoot()->findChild( IVRoot );
+	int i = graspitCore->getWorld()->getIVRoot()->findChild( IVRoot );
 	if ( i < 0 ) {
 		DBGP("Could not find search state marker in the world root");
 	} else {
-		mHand->getWorld()->getIVRoot()->removeChild(i);
+		graspitCore->getWorld()->getIVRoot()->removeChild(i);
 	}
 }
 


### PR DESCRIPTION
If the hand is removed from the world before this class is destroyed, when you attempt to delete it, graspit segfaults, as it tries to use an invalid hand.  The only reason it uses the hand is to get the world, in order to remove it's IVRoot.  I just had it go through graspitCore rather than the hand
