### PR TITLE
the dot product for two 3x3 matvec3s was only used once, prior to eig…

### DIFF
--- a/src/Collision/Graspit/collisionModel.cpp
+++ b/src/Collision/Graspit/collisionModel.cpp
@@ -226,7 +226,7 @@ void Leaf::computeBboxOO()
     if (halfSize[i] < 0) { halfSize[i] = -halfSize[i]; }
   }
 
-  R = rotate.affine()* R;
+  R = R * rotate.affine();
 
   mBbox.halfSize = halfSize;
   mBbox.setTran(transf(R, center));


### PR DESCRIPTION
In the old pre-eigen code, when calling m1*m2 actually returned m2*m1 opposite of what is done by eigen and numpy. 

Old pre-eigen code:

/*! Returns the product of \a m1 * \a m2. */

mat3

operator*(const mat3 &m1, const mat3 &m2)

{
  double M[9];

  M[0] = m1.mat[0] * m2.mat[0] + m1.mat[3] * m2.mat[1] + m1.mat[6] * m2.mat[2];
  M[1] = m1.mat[1] * m2.mat[0] + m1.mat[4] * m2.mat[1] + m1.mat[7] * m2.mat[2];
  M[2] = m1.mat[2] * m2.mat[0] + m1.mat[5] * m2.mat[1] + m1.mat[8] * m2.mat[2];


  M[3] = m1.mat[0] * m2.mat[3] + m1.mat[3] * m2.mat[4] + m1.mat[6] * m2.mat[5];
  M[4] = m1.mat[1] * m2.mat[3] + m1.mat[4] * m2.mat[4] + m1.mat[7] * m2.mat[5];
  M[5] = m1.mat[2] * m2.mat[3] + m1.mat[5] * m2.mat[4] + m1.mat[8] * m2.mat[5];


  M[6] = m1.mat[0] * m2.mat[6] + m1.mat[3] * m2.mat[7] + m1.mat[6] * m2.mat[8];
  M[7] = m1.mat[1] * m2.mat[6] + m1.mat[4] * m2.mat[7] + m1.mat[7] * m2.mat[8];
  M[8] = m1.mat[2] * m2.mat[6] + m1.mat[5] * m2.mat[7] + m1.mat[8] * m2.mat[8];

  return mat3(M);

}

This actually returns what eigen or numpy would consider m2*m1 rather than m1 * m2

Solution:
 I found the one location it was used and reordered m1 and m2