### PR TITLE
fixed incorrect coefficient accessor in setCrossProductMatrix()

### DIFF
--- a/src/matvec.cpp
+++ b/src/matvec.cpp
@@ -87,6 +87,6 @@ void setCrossProductMatrix(mat3 &mat, const vec3 &v)
 
   mat(6) = v.y();
   mat(7) = -v.x();
-  mat(9) = 0.0;
+  mat(8) = 0.0;
 }
 


### PR DESCRIPTION
Simple typo that attempts to access data that lies out of range of the Eigen matrix