### PR TITLE
corrected order in assignment of rotation matrix in transf::set()

### DIFF
--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -147,7 +147,7 @@ transf::set(const SoTransform *IVt)
   IVt->translation.getValue().getValue(x, y, z);
   rot.w() = (double)qw; rot.x() = (double)qx; rot.y() = (double)qy; rot.z() = (double)qz;
   t[0] = (double)x; t[1] = (double)y; t[2] = (double)z;
-  rot = R;
+  R = rot;
 }
 
 /*! Multiplies two transforms.  */


### PR DESCRIPTION
Reversed order in assignment causes quaternion of transform to be assigned non defined values and leaves rotation matrix undefined?