### PR TITLE
Added missing addSensor calls

### DIFF
--- a/include/graspit/robot.h
+++ b/include/graspit/robot.h
@@ -210,8 +210,6 @@ class Robot : public WorldElement {
     virtual void setJointValues(const double *jointVals);
     //! Asks all chains to set the given joint values, then update the position of all links
     virtual void setJointValuesAndUpdate(const double *jointVals);
-    //! Gets the current joint values from the chains
-    inline void getJointValues(double *jointVals) const;
     //! Informs the dof's that certain values have been set.
     inline void updateDofVals(double *dofVals);
     //! Main function for obtaining joint values from the dofs given desired dof values
@@ -331,6 +329,9 @@ class Robot : public WorldElement {
 
     //! Returns the values of the DOFs that can be used to save the current state
     inline void storeDOFVals(double *dofVals) const;
+
+    //! Gets the current joint values from the chains
+    inline void getJointValues(double *jointVals) const;
 
     //------------------------- static checks and range of motion
 

--- a/models/objects/default.xml
+++ b/models/objects/default.xml
@@ -10,4 +10,5 @@
      value here, GraspIt wil lprobably use some default value that's
      hard-coded in the file loader.
 -->
+<geometryScaling>1000</geometryScaling>
 </root>

--- a/src/kinematicChain.cpp
+++ b/src/kinematicChain.cpp
@@ -324,6 +324,7 @@ KinematicChain::initChainFromXml(const TiXmlElement *root, QString &linkDir)
     QString params = (*p)->Attribute("params");
     TactileSensor *bd = new TactileSensor(linkVec[linkVecIndex]);
     bd->setFilterParams(&params);
+    owner->addSensor(bd);
 
   }
 

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -136,6 +136,7 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
       QString params = (*p)->Attribute("params");
       TactileSensor *bd = new TactileSensor(base);
       bd->setFilterParams(&params);
+      addSensor(bd);
     }
   }
   else {


### PR DESCRIPTION
The robot in the scene was not reporting the tactile information collected from its own sensors. The robot is now aware of its own sensors from the robot specification file. 
Also exposed the getJointValues interface publicly as it is often useful to know the current state of the hand. 