### PR TITLE
Remove body within loop

### DIFF
--- a/src/world.cpp
+++ b/src/world.cpp
@@ -457,7 +457,7 @@ World::destroyElement(WorldElement *e, bool deleteElement)
       if (*bp == e) {
         mCollisionInterface->removeBody( (Body*) e);
         bodyVec.erase(bp); numBodies--;
-        DBGP("removed body " << ((Body *)e)->getName().toStdString().c_str() <<" from world");
+        DBGP("removed body " << ((Body *)e)->getName().toStdString().c_str() << " from world");
         break;
       }
     }

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -453,11 +453,11 @@ World::destroyElement(WorldElement *e, bool deleteElement)
 
   if (e->inherits("Body")) {
     DBGP("found a body");
-    mCollisionInterface->removeBody((Body *) e);
     for (bp = bodyVec.begin(); bp != bodyVec.end(); bp++) {
       if (*bp == e) {
+        mCollisionInterface->removeBody( (Body*) e);
         bodyVec.erase(bp); numBodies--;
-        DBGP("removed body " << ((Body *)e)->getName().toStdString().c_str() << " from world");
+        DBGP("removed body " << ((Body *)e)->getName().toStdString().c_str() <<" from world");
         break;
       }
     }


### PR DESCRIPTION
This is a bug I found a while back which caused me a segmentation fault or other error - I can't remember the occasion, but it was detrimental to add this fix. I think I was adding and then removing objects from the world.

We need to remove the body from the collision interface ONLY if the body is actually still in the World.
Otherwise we get an error from the collision interface when the Body has been removed from the World earlier, but destroyElement() is still used as destructor method, e.g. from the Robot destructor. 

Basically, only objects added to the world should exist in the collision interface. If also objects which are NOT part of the world should be able to exist in the collision interface, this PR would be wrong.
But because WorldElement inherently is meant to be part of World (and also are QObject children of World, which was relevant to this bug happening), I assume that the following change is desirable.