### PR TITLE
Print warnings/errors on inconsistent robot xml files

### DIFF
--- a/src/dof.cpp
+++ b/src/dof.cpp
@@ -91,6 +91,11 @@ DOF::initDOF(Robot *myRobot, const std::vector<Joint *> &jList)
   limits. Also forces defaultValue to be inside those limits.*/
 void DOF::updateMinMax()
 {
+  if (jointList.empty())
+  {
+    DBGA("Error: joint list is empty, cannot update min/max in DOF.");
+    return;
+  }
   maxq = (*jointList.begin())->getMax() / getStaticRatio(*jointList.begin());
   minq = (*jointList.begin())->getMin() / getStaticRatio(*jointList.begin());
   DBGP("Joint 0 min "  << minq << " max " << maxq);

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -221,7 +221,15 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
         }
       }
     }
-    dofVec[d]->initDOF(this, jointList);
+    if (!jointList.empty())
+    {
+      dofVec[d]->initDOF(this, jointList);
+    }
+    else
+    {
+      DBGA("WARNING: DOF " << d << " is not present in any chain and won't be "
+           << "initialized. Check your robot XML file.");
+    }
   }
   //with DOF initialized with joints, we can set default values
   forceDefaultDOFVals();
@@ -551,7 +559,15 @@ Robot::cloneFrom(Robot *original)
         }
       }
     }
-    dofVec[d]->initDOF(this, jointList);
+    if (!jointList.empty())
+    {
+      dofVec[d]->initDOF(this, jointList);
+    }
+    else
+    {
+      DBGA("WARNING: DOF " << d << " is not present in any chain and won't be "
+           << "initialized. Check your robot XML file.");
+    }
   }
   //with DOF initialized with joints, we can set default values
   forceDefaultDOFVals();


### PR DESCRIPTION
I have repeatedly come across this issue when trying robot files which weren't set up properly.
This PR just adds some print messages and avoids segfaults in such cases. It should be easier to find the source of an issue with this.