### PR TITLE
Disable collisions between body pairs that are in collision by default.

### DIFF
--- a/src/Collision/Graspit/graspitCollision.cpp
+++ b/src/Collision/Graspit/graspitCollision.cpp
@@ -130,7 +130,7 @@ GraspitCollision::activatePair(const Body *body1, const Body *body2, bool active
     std::swap(model1, model2);
   }
   if (!active) {
-    DBGP("Disable pair: " << model1 << " -- " << model2);
+    DBGP("Disable pair: " << getBody(model1)->getName().latin1() << " -- " << getBody(model2)->getName().latin1());
     mDisabledMap.insert(std::pair<const CollisionModel *, const CollisionModel *>(model1, model2));
   } else {
     //remove from list
@@ -391,7 +391,7 @@ GraspitCollision::allContacts(CollisionReport *report, double threshold,
       report->back().contacts = cc.getReport();
 
       //remove duplicates from the contact report
-      DBGP("Body: " << getBody(it->first)->getName().latin1());
+      DBGP("Bodies: " << getBody(it->first)->getName().latin1() << " -- " << getBody(it->second)->getName().latin1());
       DBGP("Before duplicate removal: " << report->back().contacts.size());
       removeContactDuplicates(&(report->back().contacts), CONTACT_DUPLICATE_THRESHOLD);
       DBGP("After duplicate removal: " << report->back().contacts.size());

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1076,6 +1076,15 @@ World::addRobot(Robot *robot, bool addToScene)
       }
     }
   }
+  // Disable collisions between default-colliding pairs
+  CollisionReport report;
+  const int numContacts = mCollisionInterface->allContacts(&report, Contact::THRESHOLD, NULL);
+  for (int i = 0; i < numContacts; ++i) {
+    DBGA("In collision by default, disabling: "
+    << report[i].first->getName().toStdString().c_str() << " -- " << report[i].second->getName().toStdString().c_str());
+    mCollisionInterface->activatePair(report[i].first, report[i].second, false);
+  }
+
   if (robot->inherits("Hand")) {
     handVec.push_back((Hand *)robot);
     if (numGB > 0) { ((Hand *)robot)->getGrasp()->setObject(GBVec[0]); }


### PR DESCRIPTION
I have a robot model (https://github.com/a-price/robotiq_3finger_description) that has geometries in collision in the default state that are not adjacent nodes in the kinematic tree. This PR mimics functionality in e.g. MoveIt that can filter out default collisions (http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/urdf_srdf/urdf_srdf_tutorial.html#self-collisions, http://docs.ros.org/hydro/api/moveit_setup_assistant/html/doc/tutorial.html#step-2-generate-self-collision-matrix). Possibly a better option would be to have a collision checking configuration file.