### PR TITLE
migrating GraspIt! from qt4 to qt5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 sudo: required
 
-dist: trusty
+dist: focal
 
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,6 +960,7 @@ set_target_properties( primative_planner_tests eigen_tests transform_tests grasp
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test"
 )
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 add_dependencies(primative_planner_tests googletest)
 add_dependencies(eigen_tests googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeMacros/")
 
 find_package(Qhull REQUIRED)
-find_package(SoQt4 REQUIRED)
+find_package(SoQt REQUIRED)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(Eigen3)
@@ -103,10 +103,7 @@ if (OPTIMIZATION_SOLVER STREQUAL GUROBI)
 
 endif (OPTIMIZATION_SOLVER STREQUAL GUROBI)
 
-SET( QT_USE_QT3SUPPORT TRUE )
-find_package(Qt4 COMPONENTS QtCore QtSql REQUIRED)
-
-include (${QT_USE_FILE})
+find_package(Qt5 COMPONENTS Core Sql Widgets Network REQUIRED)
 
 #--------------------------------------- Core sources ---------------------------------
 
@@ -712,36 +709,6 @@ set (MOC_HEADERS
 
 
 
-#-------------------------------------- images and resources -------------------------------------------------------
-
-set (GRASPIT_IMAGES
-    ${GSRC}/src/images/play.xpm 
-    ${GSRC}/src/images/pause.xpm 
-    ${GSRC}/src/images/splash.jpg 
-    ${GSRC}/src/images/logo.png 
-    ${GSRC}/src/images/nocollide.xpm 
-    ${GSRC}/src/images/collide.xpm 
-    ${GSRC}/src/images/translateTool.xpm 
-    ${GSRC}/src/images/selectTool.xpm 
-    ${GSRC}/src/images/rotateTool.xpm 
-    ${GSRC}/src/images/mark.xpm 
-    ${GSRC}/src/images/prevMark.xpm 
-    ${GSRC}/src/images/filenew.xpm 
-    ${GSRC}/src/images/fileopen.xpm 
-    ${GSRC}/src/images/filesave.xpm 
-    ${GSRC}/src/images/filenew 
-    ${GSRC}/src/images/fileopen 
-    ${GSRC}/src/images/filesave 
-    ${GSRC}/src/images/print 
-    ${GSRC}/src/images/undo 
-    ${GSRC}/src/images/redo 
-    ${GSRC}/src/images/editcut 
-    ${GSRC}/src/images/editcopy 
-    ${GSRC}/src/images/editpaste 
-    ${GSRC}/src/images/searchfind
-)
-
-
 #-------------------------------------- The TinyXML XML parser ---------------------------------------------------
 
 set (TINYXML_INCLUDES
@@ -766,15 +733,7 @@ set (GRASPIT_CORE_SOURCES
 # The qt_image_collection.cpp must then be added to the sources to compile.
 # I also tried adding images as resource (QT4_ADD_RESOURCES) but this didn't work with the 
 # current GraspIt source.
-ADD_CUSTOM_COMMAND(OUTPUT 
-    ${CMAKE_CURRENT_BINARY_DIR}/qt_image_collection.cpp 
-    COMMAND ${QT_UIC3_EXECUTABLE} 
-    ARGS -o ${CMAKE_CURRENT_BINARY_DIR}/qt_image_collection.cpp 
-        -embed graspit ${GRASPIT_IMAGES} 
-    DEPENDS ${GRASPIT_IMAGES})
-
-SET(GRASPIT_IMAGE_SOURCES 
-    ${CMAKE_CURRENT_BINARY_DIR}/qt_image_collection.cpp)
+QT5_ADD_RESOURCES(graspit_RESOURCES_RCC src/graspitResources.qrc)
 
 ################################
 ## Make Qt Moc files of GraspIT
@@ -799,11 +758,11 @@ file(MAKE_DIRECTORY ${GRASPIT_UI_INCLUDE_PATH})
 set (OLD_CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}) # backup current binary dir
 set (CMAKE_CURRENT_BINARY_DIR ${GRASPIT_UI_INCLUDE_PATH}) #artificially changing output location for UI files
 
-QT4_WRAP_UI(UI_OUTFILES ${ALL_GRASPIT_FORMS}) # generate UI outfiles (will use CMAKE_CURRENT_BINARY_DIR)
+QT5_WRAP_UI(UI_OUTFILES ${ALL_GRASPIT_FORMS}) # generate UI outfiles (will use CMAKE_CURRENT_BINARY_DIR)
 
 set (CMAKE_CURRENT_BINARY_DIR ${OLD_CMAKE_CURRENT_BINARY_DIR}) # restore current binary dir
 
-QT4_WRAP_CPP(MOC_OUTFILES ${MOC_HEADERS})
+QT5_WRAP_CPP(MOC_OUTFILES ${MOC_HEADERS})
 
 
 # add Qt stuff to the includes
@@ -813,7 +772,6 @@ set (GRASPIT_INCLUDES
      ${SOQT_INCLUDE_DIRS}
      ${QT_INCLUDES}
      ${QT_INCLUDE_DIR}
-     ${QT_QT3SUPPORT_INCLUDE_DIR}
      ${QHULL_INCLUDE_DIRS}
 )
 
@@ -853,12 +811,11 @@ add_library(graspit SHARED ${GRASPIT_LIBRARY_SOURCES})
 # sources for executable graspit_simulator
 set(SIMULATOR_SRC ${GSRC}/src/main.cpp)
 
-add_executable(graspit_simulator ${SIMULATOR_SRC})
+add_executable(graspit_simulator ${SIMULATOR_SRC} ${graspit_RESOURCES_RCC})
 
 ## System libraries which are needed for graspit
 set(GRASPIT_LINK_LIBRARIES
    ${QT_LIBRARIES}
-   ${QT_QT3SUPPORT_LIBRARY}
    ${QHULL_LIBRARIES}
    ${SOQT_LIBRARY}
    ${LAPACK_LIBRARIES}
@@ -869,8 +826,8 @@ set(GRASPIT_LINK_LIBRARIES
 )
 
 ## Link the shared library and the executable
-target_link_libraries(graspit ${GRASPIT_LINK_LIBRARIES})
-target_link_libraries(graspit_simulator graspit ${GRASPIT_LINK_LIBRARIES})
+target_link_libraries(graspit ${GRASPIT_LINK_LIBRARIES} Qt5::Widgets Qt5::Network Qt5::Sql)
+target_link_libraries(graspit_simulator graspit ${GRASPIT_LINK_LIBRARIES} Qt5::Widgets Qt5::Network Qt5::Sql)
 
 ## Set install destination paths
 set ( INCLUDE_DESTINATION ${CMAKE_INSTALL_PREFIX}/include/)

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -1,10 +1,6 @@
 APT='
 cmake
-libqt4-dev
-libqt4-opengl-dev
-libqt4-sql-psql
-libcoin80-dev
-libsoqt4-dev
+libsoqt520
 libblas-dev
 liblapack-dev
 libqhull-dev 

--- a/include/graspit/graspitServer.h
+++ b/include/graspit/graspitServer.h
@@ -28,9 +28,8 @@
  */
 
 #ifndef GRASPITSERVER_HXX
-#include <q3serversocket.h>
-#include <q3socket.h>
-#include <qstringlist.h>
+#include <QTcpSocket>
+#include <QTcpServer>
 #include <iostream>
 #include <vector>
 
@@ -68,7 +67,7 @@ class Robot;
   the input.
 
 */
-class ClientSocket : public Q3Socket
+class ClientSocket : public QTcpSocket
 {
     Q_OBJECT
 
@@ -80,11 +79,12 @@ class ClientSocket : public Q3Socket
       to use \a sock .
     */
     ClientSocket(int sock, QObject *parent = 0, const char *name = 0) :
-      Q3Socket(parent, name)
+      QTcpSocket(parent)
     {
+      this->setObjectName(name);
       connect(this, SIGNAL(readyRead()), SLOT(readClient()));
       connect(this, SIGNAL(connectionClosed()), SLOT(connectionClosed()));
-      setSocket(sock);
+      // setSocket(sock);
     }
 
     ~ClientSocket();
@@ -132,13 +132,13 @@ class ClientSocket : public Q3Socket
   port and if a connection is requested, it creates a new ClientSocket, which
   will handle all communication.
 */
-class GraspItServer : public Q3ServerSocket
+class GraspItServer : public QTcpServer
 {
     Q_OBJECT
     //  std::vector<SocketNotifier *> snVec;
 
   public:
-    GraspItServer(Q_UINT16 port, int backlog = 1, QObject *parent = 0,
+    GraspItServer(quint16 port, int backlog = 1, QObject *parent = 0,
                   const char *name = 0);
 
     /*! Stub */

--- a/include/graspit/ivmgr.h
+++ b/include/graspit/ivmgr.h
@@ -231,7 +231,7 @@ class IVmgr : public QWidget {
     void restoreCameraPos();
 
   public:
-    IVmgr(World *w, QWidget *parent = 0, const char *name = 0, Qt::WFlags f = 0);
+    IVmgr(World *w, QWidget *parent = 0, const char *name = 0, Qt::WindowFlags f = 0);
     ~IVmgr();
 
     void setWorld(World *w);

--- a/include/graspit/robots/mcGrip.h
+++ b/include/graspit/robots/mcGrip.h
@@ -110,7 +110,7 @@ class McGripGrasp : public Grasp
   public:
     //! Also check that the hand is indeed a McGrip
     McGripGrasp(Hand *h) : Grasp(h) {
-      assert(h->isA("McGrip"));
+      assert(h->metaObject()->className() == QString("McGrip"));
     }
 
     //! Optimizes contact forces tendon routes and construction parameters for one particular grasp

--- a/src/DBase/DBPlanner/database.cpp
+++ b/src/DBase/DBPlanner/database.cpp
@@ -86,7 +86,7 @@ DatabaseConnection::DatabaseConnection(const string &host_name,
   if (!db_.open()) {
     cerr << "Database " << database_name << "@" << host_name
          << ":" << port << " could not be opened.\n";
-    cerr << "Error: " << db_.lastError().text().latin1() << std::endl;
+    cerr << "Error: " << db_.lastError().text().toStdString() << std::endl;
     connected_ = false;
   } else {
     cerr << "Database successfully opened.\n";
@@ -102,7 +102,7 @@ bool DatabaseConnection::Query(const string &sql, Table *table) const {
   query.setForwardOnly(true);
   if (!query.exec(sql.c_str())) {
     std::cerr << "SQL Query failure on query: " << sql << std::endl;
-    std::cerr << "Error: " << query.lastError().text().latin1() << std::endl;
+    std::cerr << "Error: " << query.lastError().text().toStdString() << std::endl;
     return false;
   } else {
     if (table) {

--- a/src/DBase/compliantGraspCopyTask.cpp
+++ b/src/DBase/compliantGraspCopyTask.cpp
@@ -55,7 +55,7 @@ void CompliantGraspCopyTask::start()
   loadHand();
   if (mStatus == FAILED) { return; }
 
-  if (!mHand->isA("Pr2Gripper2010")) {
+  if (!mHand->metaObject()->className() == QString("Pr2Gripper2010")) {
     DBGA("Compliant copy task only works on the PR2 gripper");
     mStatus = FAILED;
     return;

--- a/src/DBase/dbase_grasp.cpp
+++ b/src/DBase/dbase_grasp.cpp
@@ -145,12 +145,12 @@ bool DBaseBatchPlanner::processArguments(int argc, char **argv)
     mScanDirectory = new char[1000];
     strcpy(mScanDirectory, argv[9]);
     QString testfile = QString(mScanDirectory) + QString("scan_log.txt");
-    FILE *tf = fopen(testfile.latin1(), "a");
+    FILE *tf = fopen(testfile.toLatin1().constData(), "a");
     if (!tf) {
-      DBGAF(mLogStream, "Failed scan directory test: " << testfile.latin1());
+      DBGAF(mLogStream, "Failed scan directory test: " << testfile.toLatin1().constData());
       return false;
     }
-    fprintf(tf, "Starting object: %s\n", mObject->getName().latin1());
+    fprintf(tf, "Starting object: %s\n", mObject->getName().toLatin1().constData());
     fclose(tf);
   }
 
@@ -204,7 +204,7 @@ bool DBaseBatchPlanner::startPlanner()
       numChildren = numCPU.toInt();
     }
     if (numChildren <= 0) {
-      DBGAF(mLogStream, "Can not understand NUMBER_OF_PROCESSORS: " << numCPU.latin1());
+      DBGAF(mLogStream, "Can not understand NUMBER_OF_PROCESSORS: " << numCPU.toLatin1().constData());
     }
 #else
     //on Linux we hard-code 2 CPU's for now
@@ -470,9 +470,9 @@ void DBaseBatchPlanner::writeCloudToFile(int i, int j, const std::vector<positio
   n.setNum(j);
   filename = filename + QString("_") + n + QString(".txt");
 
-  FILE *f = fopen(filename.latin1(), "w");
+  FILE *f = fopen(filename.toLatin1().constData(), "w");
   if (!f) {
-    DBGAF(mLogStream, "Failed to open file " << filename.latin1());
+    DBGAF(mLogStream, "Failed to open file " << filename.toLatin1().constData());
     fprintf(stderr, "Failed to open scan file\n");
     return;
   }
@@ -496,9 +496,9 @@ void DBaseBatchPlanner::writeRawToFile(int i, int j, const std::vector<RawScanPo
   n.setNum(j);
   filename = filename + QString("_") + n + QString(".txt");
 
-  FILE *f = fopen(filename.latin1(), "w");
+  FILE *f = fopen(filename.toLatin1().constData(), "w");
   if (!f) {
-    DBGAF(mLogStream, "Failed to open file " << filename.latin1());
+    DBGAF(mLogStream, "Failed to open file " << filename.toLatin1().constData());
     fprintf(stderr, "Failed to open scan file\n");
     return;
   }

--- a/src/DBase/graspClusteringTask.cpp
+++ b/src/DBase/graspClusteringTask.cpp
@@ -70,7 +70,7 @@ void GraspClusteringTask::start()
   } else {
     QString handPath = mDBMgr->getHandGraspitPath(QString(mPlanningTask.handName.c_str()));
     handPath = QString(getenv("GRASPIT")) + handPath;
-    DBGA("Grasp Planning Task: loading hand from " << handPath.latin1());
+    DBGA("Grasp Planning Task: loading hand from " << handPath.toLatin1().constData());
     hand = static_cast<Hand *>(world->importRobot(handPath));
     if (!hand) {
       DBGA("Failed to load hand");

--- a/src/DBase/graspPlanningTask.cpp
+++ b/src/DBase/graspPlanningTask.cpp
@@ -84,7 +84,7 @@ void GraspPlanningTask::start()
   } else {
     QString handPath = mDBMgr->getHandGraspitPath(QString(mPlanningTask.handName.c_str()));
     handPath = QString(getenv("GRASPIT")) + handPath;
-    DBGA("Grasp Planning Task: loading hand from " << handPath.latin1());
+    DBGA("Grasp Planning Task: loading hand from " << handPath.toLatin1().constData());
     mHand = static_cast<Hand *>(world->importRobot(handPath));
     if (!mHand) {
       DBGA("Failed to load hand");

--- a/src/DBase/graspTransferCheckTask.cpp
+++ b/src/DBase/graspTransferCheckTask.cpp
@@ -80,7 +80,7 @@ void GraspTransferCheckTask::start()
   if (!world->getNumHands()) {
     QString handPath = mDBMgr->getHandGraspitPath(QString(mPlanningTask.handName.c_str()));
     handPath = QString(getenv("GRASPIT")) + handPath;
-    DBGA("Grasp transfer task: loading hands from " << handPath.latin1());
+    DBGA("Grasp transfer task: loading hands from " << handPath.toLatin1().constData());
     mHand1 = static_cast<Hand *>(world->importRobot(handPath));
     mHand2 = static_cast<Hand *>(world->importRobot(handPath));
     if (!mHand1 || !mHand2) {

--- a/src/DBase/graspit_db_model.cpp
+++ b/src/DBase/graspit_db_model.cpp
@@ -62,7 +62,7 @@ int GraspitDBModel::loadGeometry()
     DBGA("Failed to load .ply geometry from file " << GeometryPath());
     return mGraspableBody->loadGeometryPLY(filename);
   } else {
-    DBGA("Uknown geometry file extension: " << extension.latin1());
+    DBGA("Uknown geometry file extension: " << extension.toLatin1().constData());
     return FAILURE;
   }
 }

--- a/src/DBase/preGraspCheckTask.cpp
+++ b/src/DBase/preGraspCheckTask.cpp
@@ -76,7 +76,7 @@ void PreGraspCheckTask::loadHand()
   } else {
     QString handPath = mDBMgr->getHandGraspitPath(QString(mPlanningTask.handName.c_str()));
     handPath = QString(getenv("GRASPIT")) + handPath;
-    DBGA("Grasp Planning Task: loading hand from " << handPath.latin1());
+    DBGA("Grasp Planning Task: loading hand from " << handPath.toLatin1().constData());
     mHand = static_cast<Hand *>(world->importRobot(handPath));
     if (!mHand) {
       DBGA("Failed to load hand");

--- a/src/EGPlanner/egPlanner.cpp
+++ b/src/EGPlanner/egPlanner.cpp
@@ -209,11 +209,11 @@ EGPlanner::createAndUseClone()
     mHand->getWorld()->getCollisionInterface()->newThread();
   }
   Hand *clone;
-  if (mHand->isA("Barrett")) {
+  if (mHand->metaObject()->className() == QString("Barrett")) {
     clone = new Barrett(mHand->getWorld(), "Barrett clone");
-  } else if (mHand->isA("Pr2Gripper")) {
+  } else if (mHand->metaObject()->className() == QString("Pr2Gripper")) {
     clone = new Pr2Gripper(mHand->getWorld(), "PR2 Gripper clone");
-  } else if (mHand->isA("RobotIQ")) {
+  } else if (mHand->metaObject()->className() == QString("RobotIQ")) {
     clone = new RobotIQ(mHand->getWorld(), "RobotIQ clone");
   } else {
     clone = new Hand(mHand->getWorld(), "Hand clone");

--- a/src/EGPlanner/onLineGraspInterface.cpp
+++ b/src/EGPlanner/onLineGraspInterface.cpp
@@ -46,7 +46,7 @@ void
 OnLineGraspInterface::useRealBarrettHand(bool s)
 {
   if (s) {
-    if (!mHand->isA("Barrett")) {
+    if (!mHand->metaObject()->className() == QString("Barrett")) {
       DBGA("Can't use real hand: this is not a Barrett!");
       mBarrettHand = NULL;
       return;

--- a/src/EGPlanner/searchState.cpp
+++ b/src/EGPlanner/searchState.cpp
@@ -137,7 +137,7 @@ VariableSet::getVariable(QString name)
   for (unsigned int i = 0; i < mVariables.size(); i++) {
     if (mVariables[i]->getName() == name) { return mVariables[i]; }
   }
-  DBGP("Requested variable " << name.latin1() << " not found in search state");
+  DBGP("Requested variable " << name.toLatin1().constData() << " not found in search state");
   return NULL;
 }
 
@@ -147,7 +147,7 @@ VariableSet::getConstVariable(QString name) const
   for (unsigned int i = 0; i < mVariables.size(); i++) {
     if (mVariables[i]->getName() == name) { return mVariables[i]; }
   }
-  DBGP("Requested variable " << name.latin1() << " not found in search state");
+  DBGP("Requested variable " << name.toLatin1().constData() << " not found in search state");
   return NULL;
 }
 
@@ -157,7 +157,7 @@ VariableSet::readVariable(QString name) const
   for (unsigned int i = 0; i < mVariables.size(); i++) {
     if (mVariables[i]->getName() == name) { return mVariables[i]->getValue(); }
   }
-  DBGP("Requested variable " << name.latin1() << " not found in search state");
+  DBGP("Requested variable " << name.toLatin1().constData() << " not found in search state");
   return 0;
 }
 
@@ -169,7 +169,7 @@ VariableSet::setParameter(QString name, double value)
     if (it->name() == name) { break; }
   }
   if (it == mParameters.end()) {
-    DBGA("Parameter " << name.latin1() << " not found!");
+    DBGA("Parameter " << name.toLatin1().constData() << " not found!");
     assert(0);
     return;
   }
@@ -184,7 +184,7 @@ VariableSet::getParameter(QString name) const
     if (it->name() == name) { break; }
   }
   if (it == mParameters.end()) {
-    DBGA("Parameter " << name.latin1() << " not found!");
+    DBGA("Parameter " << name.toLatin1().constData() << " not found!");
     assert(0);
     return 0;
   }
@@ -199,7 +199,7 @@ VariableSet::addParameter(QString name, double value)
     if (it->name() == name) { break; }
   }
   if (it != mParameters.end()) {
-    DBGA("Parameter " << name.latin1() << " already present!");
+    DBGA("Parameter " << name.toLatin1().constData() << " already present!");
     assert(0);
     return;
   }
@@ -214,7 +214,7 @@ VariableSet::removeParameter(QString name)
     if (it->name() == name) { break; }
   }
   if (it == mParameters.end()) {
-    DBGA("Parameter " << name.latin1() << " does not exist!");
+    DBGA("Parameter " << name.toLatin1().constData() << " does not exist!");
     assert(0);
     return;
   }
@@ -321,7 +321,7 @@ VariableSet::print() const
   fprintf(stderr, "\n");
   fprintf(stderr, "Type: %d\n", getType());
   for (int i = 0; i < getNumVariables(); i++) {
-    fprintf(stderr, "%s = %.2f; ", mVariables[i]->getName().latin1(), mVariables[i]->getValue());
+    fprintf(stderr, "%s = %.2f; ", mVariables[i]->getName().toLatin1().constData(), mVariables[i]->getValue());
   }
   fprintf(stderr, "\n");
 }
@@ -595,7 +595,7 @@ HandObjectState::distance(const HandObjectState *s) const
   vec3 dvec = t1.translation() - t2.translation();
   double d = dvec.norm();
 
-  if (mTargetObject->isA("GraspableBody")) {
+  if (mTargetObject->metaObject()->className() == QString("GraspableBody")) {
     d = d / ((GraspableBody *)mTargetObject)->getMaxRadius();
   } else {
     d = d / 200;

--- a/src/EGPlanner/searchStateImpl.cpp
+++ b/src/EGPlanner/searchStateImpl.cpp
@@ -64,10 +64,10 @@ void PostureStateEigen::createVariables()
     if (mHand->getEigenGrasps()->getGrasp(i)->mPredefinedLimits) {
       min = mHand->getEigenGrasps()->getGrasp(i)->mMin;
       max = mHand->getEigenGrasps()->getGrasp(i)->mMax;
-    } else if (mHand->isA("Pr2Gripper")) {
+    } else if (mHand->metaObject()->className() == QString("Pr2Gripper")) {
       min = -0.6f;
       max = 0.6f;
-    } else if (mHand->isA("Pr2Gripper2010")) {
+    } else if (mHand->metaObject()->className() == QString("Pr2Gripper2010")) {
       min = -0.45f;
       max = 0.45f;
     } else {

--- a/src/Planner/grasp_manager.cpp
+++ b/src/Planner/grasp_manager.cpp
@@ -57,9 +57,7 @@
 #include <Inventor/SbLinear.h>
 #include <Inventor/nodes/SoSelection.h>
 
-#ifdef Q_WS_X11
 #include <unistd.h>
-#endif
 
 /* graspit includes */
 #include "graspit/graspitCore.h"

--- a/src/Planner/grasp_manager.cpp
+++ b/src/Planner/grasp_manager.cpp
@@ -154,9 +154,9 @@ grasp_manager::loadPrimitives()
   filename = filename.section('.', -2, -2) + ".iv";
   QString path = directory + filename;
 
-  printf("Loading primitive %s.\n", path.latin1());
+  printf("Loading primitive %s.\n", path.toLatin1().constData());
 
-  if (!(myInput.openFile(path.latin1()))) {
+  if (!(myInput.openFile(path.toLatin1().constData()))) {
     pr_error("could not open primitives file!");
     primitives = my_body->getIVGeomRoot();
     printf("%s\n", prDir);

--- a/src/Planner/grasp_planner.cpp
+++ b/src/Planner/grasp_planner.cpp
@@ -60,9 +60,7 @@
 #include <Inventor/nodes/SoTransformSeparator.h>
 #include <Inventor/nodes/SoDirectionalLight.h>
 
-#ifdef Q_WS_X11
 #include <unistd.h>
-#endif
 
 /* graspit includes */
 #include "graspit/contact/contact.h"

--- a/src/Planner/grasp_presenter.cpp
+++ b/src/Planner/grasp_presenter.cpp
@@ -62,9 +62,7 @@
 #include <Inventor/nodes/SoTransform.h>
 #include <Inventor/nodes/SoDirectionalLight.h>
 
-#ifdef Q_WS_X11
 #include <unistd.h>
-#endif
 
 /* graspit includes */
 #include "graspit/graspitCore.h"

--- a/src/Planner/grasp_tester.cpp
+++ b/src/Planner/grasp_tester.cpp
@@ -60,10 +60,8 @@
 #include <Inventor/SbColor.h>
 #include <Inventor/nodes/SoTransform.h>
 
-#ifdef Q_WS_X11
 #include <unistd.h>
 #include <sys/time.h>
-#endif
 
 #include <list>
 

--- a/src/Planner/grasp_tester.cpp
+++ b/src/Planner/grasp_tester.cpp
@@ -159,7 +159,7 @@ grasp_tester::saveGraspsToFile(const QString &filename, bool append)
 {
   if (saveToFile) { graspFile.close(); }
 
-  graspFile.setName(filename);
+  graspFile.setFileName(filename);
   if (append) {
     if (graspFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
       graspOut.setDevice(&graspFile);

--- a/src/arch.cpp
+++ b/src/arch.cpp
@@ -164,7 +164,7 @@ void create_arch(World *world, double inner_radius, double outer_radius, double 
   for (int i = 0; i < n_blocks; i++) {
     QString name("Block "), id;
     name.append(id.setNum(i));
-    GraspableBody *addBlock = new GraspableBody(world, name.latin1());
+    GraspableBody *addBlock = new GraspableBody(world, name.toLatin1().constData());
     addBlock->cloneFrom(block); //this also adds it to collision detection!
     world->addBody(addBlock);
 

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -171,7 +171,7 @@ Body::Body(const Body &b) : WorldElement(b)
 Body::~Body()
 {
   breakContacts();
-  DBGP("Deleting Body: " << myName.latin1());
+  DBGP("Deleting Body: " << myName.toLatin1().toStdString());
 }
 
 /*! Clones this body from an original. This means that the two bodies have independent
@@ -310,7 +310,7 @@ Body::loadFromXml(const TiXmlElement *root, QString rootPath)
     } else if (mGeometryFileType == "ply") {
       result = loadGeometryPLY(valueStr);
     } else {
-      DBGA("Unknown geometry file type: " << mGeometryFileType.latin1());
+      DBGA("Unknown geometry file type: " << mGeometryFileType.toLatin1().toStdString());
       result = FAILURE;
     }
     if (result == FAILURE) {
@@ -367,7 +367,7 @@ Body::loadFromXml(const TiXmlElement *root, QString rootPath)
 
 int
 Body::saveToXml(QTextStream &xml) {
-  xml << "\t\t\t<material>" << myWorld->getMaterialName(material).latin1() << "</material>" << endl;
+  xml << "\t\t\t<material>" << myWorld->getMaterialName(material).toLatin1().constData() << "</material>" << endl;
   if (youngMod > 0) {
     xml << "\t\t\t<youngs>" << youngMod << "</youngs>" << endl;
   }
@@ -380,8 +380,8 @@ Body::saveToXml(QTextStream &xml) {
   if (mUsesFlock) {
     xml << "\t\t\t<useFlockOfBirds>" << mBirdNumber << "</useFlockOfBirds>" << endl;
   }
-  xml << "\t\t\t<geometryFile type = \"" << mGeometryFileType.latin1() << "\">"
-      << mGeometryFilename.latin1() << "</geometryFile>" << endl;
+  xml << "\t\t\t<geometryFile type = \"" << mGeometryFileType.toLatin1().constData() << "\">"
+      << mGeometryFilename.toLatin1().constData() << "</geometryFile>" << endl;
   return SUCCESS;
 }
 
@@ -417,7 +417,7 @@ Body::load(const QString &filename)
   }
 
   //load the graspit specific information in XML format
-  TiXmlDocument doc(xmlFilename);
+  TiXmlDocument doc(xmlFilename.toStdString());
   if (doc.LoadFile() == false) {
     QTWARNING("Could not open " + xmlFilename);
     return FAILURE;
@@ -434,7 +434,7 @@ Body::load(const QString &filename)
     } else if (fileType == "ply") {
       element->SetAttribute("type", "ply");
     }
-    TiXmlText *text = new TiXmlText(relFilename);
+    TiXmlText *text = new TiXmlText(relFilename.toStdString());
     element->LinkEndChild(text);
     doc.RootElement()->LinkEndChild(element);
   }
@@ -457,7 +457,7 @@ int
 Body::loadGeometryIV(const QString &filename)
 {
   SoInput myInput;
-  if (!myInput.openFile(filename.latin1())) {
+  if (!myInput.openFile(filename.toLatin1().constData())) {
     QTWARNING("Could not open Inventor file " + filename);
     return FAILURE;
   }
@@ -999,10 +999,10 @@ Body::breakContacts()
 int
 Body::loadContactData(QString fn)
 {
-  std::ifstream inFile(fn.latin1(), std::ios::in);
+  std::ifstream inFile(fn.toLatin1().constData(), std::ios::in);
   if (!inFile.is_open())
   {
-    fprintf(stderr, "Could not open filename %s\n", fn.latin1());
+    fprintf(stderr, "Could not open filename %s\n", fn.toLatin1().constData());
     return FAILURE;
   }
 
@@ -1010,7 +1010,7 @@ Body::loadContactData(QString fn)
   VirtualContactOnObject *newContact;
   inFile >> numContacts;
   {
-    fprintf(stderr, "Failed to read contacts from %s\n", fn.latin1());
+    fprintf(stderr, "Failed to read contacts from %s\n", fn.toLatin1().constData());
     return FAILURE;
   }
 
@@ -1019,7 +1019,7 @@ Body::loadContactData(QString fn)
     newContact = new VirtualContactOnObject();
     if (!newContact->readFromFile(inFile))
     {
-      fprintf(stderr, "Failed to a contacts from %s\n", fn.latin1());
+      fprintf(stderr, "Failed to a contacts from %s\n", fn.toLatin1().constData());
       return FAILURE;
     }
     newContact->setBody(this);
@@ -1451,9 +1451,9 @@ DynamicBody::loadFromXml(const TiXmlElement *root, QString rootPath)
   } else {
     overrideCog = true;
     valueStr = element->GetText();
-    valueStr = valueStr.simplifyWhiteSpace();
+    valueStr = valueStr.simplified();
     QStringList l;
-    l = QStringList::split(' ', valueStr.stripWhiteSpace());
+    l = valueStr.trimmed().split(' ');
     if (l.count() != 3) {
       QTWARNING("Invalid Center of Gravity Input");
       return FAILURE;
@@ -1471,9 +1471,9 @@ DynamicBody::loadFromXml(const TiXmlElement *root, QString rootPath)
   } else {
     overrideI = true;
     valueStr = element->GetText();
-    valueStr = valueStr.simplifyWhiteSpace();
+    valueStr = valueStr.simplified();
     QStringList l;
-    l = QStringList::split(' ', valueStr.stripWhiteSpace());
+    l = valueStr.trimmed().split(' ');
     if (l.count() != 9) { //error
       QTWARNING("Invalid Inertia Matrix Input");
       return FAILURE;

--- a/src/contact/contact.cpp
+++ b/src/contact/contact.cpp
@@ -351,7 +351,7 @@ Contact::localToWorldWrenchMatrix() const
   //also scale by object max radius so we get same units as force
   //and optimization does not favor torque over force
   double scale = 1.0;
-  if (getBody2()->isA("GraspableBody")) {
+  if (getBody2()->metaObject()->className() == QString("GraspableBody")) {
     scale = scale / static_cast<GraspableBody *>(getBody2())->getMaxRadius();
   }
   CR.multiply(scale);

--- a/src/contact/virtualContact.cpp
+++ b/src/contact/virtualContact.cpp
@@ -426,7 +426,7 @@ VirtualContact::loadFromXml(const TiXmlElement * root)
     {
 
      QString friction_edge = xmlElement->GetText();
-     QStringList l = QStringList::split(' ', friction_edge);
+     QStringList l = friction_edge.split(' ');
 
      for (int j=0; j<6; j++)
      {
@@ -437,8 +437,8 @@ VirtualContact::loadFromXml(const TiXmlElement * root)
 
      xmlElement = findXmlElement(root, "location");
      QString location = xmlElement->GetText();
-     location = location.simplifyWhiteSpace().stripWhiteSpace();
-     QStringList l = QStringList::split(' ', location);
+     location = location.simplified().trimmed();
+     QStringList l = location.split(' ');
      if(l.count()!=3){
        DBGA("Invalid Location");
        return FAILURE;
@@ -448,8 +448,8 @@ VirtualContact::loadFromXml(const TiXmlElement * root)
 
      xmlElement = findXmlElement(root, "rotation");
      QString rotation = xmlElement->GetText();
-     rotation = rotation.simplifyWhiteSpace().stripWhiteSpace();
-     l = QStringList::split(' ', rotation);
+     rotation = rotation.simplified().trimmed();
+     l = rotation.split(' ');
      if(l.count()!=4){
        DBGA("Invalid Rotation");
        return FAILURE;
@@ -462,8 +462,8 @@ VirtualContact::loadFromXml(const TiXmlElement * root)
 
      xmlElement = findXmlElement(root, "translation");
      QString translation = xmlElement->GetText();
-     translation = translation.simplifyWhiteSpace().stripWhiteSpace();
-     l = QStringList::split(' ', translation);
+     translation = translation.simplified().trimmed();
+     l = translation.split(' ');
      if(l.count()!=3){
        DBGA("Invalid Translation");
        return FAILURE;
@@ -476,8 +476,8 @@ VirtualContact::loadFromXml(const TiXmlElement * root)
 
      xmlElement = findXmlElement(root, "normal");
      QString normal_str = xmlElement->GetText();
-     normal_str = normal_str.simplifyWhiteSpace().stripWhiteSpace();
-     l = QStringList::split(' ', normal_str);
+     normal_str = normal_str.simplified().trimmed();
+     l = normal_str.split(' ');
      if(l.count()!=3){
        QTWARNING("Invalid Normal");
        return FAILURE;

--- a/src/dynamics/dynamics.cpp
+++ b/src/dynamics/dynamics.cpp
@@ -32,9 +32,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
-#ifdef Q_WS_X11
 #include <unistd.h>
-#endif
 #include "graspit/mytools.h"
 #include "graspit/dynamics/dynamics.h"
 #include "graspit/dynamics/dynJoint.h"

--- a/src/dynamics/dynamics.cpp
+++ b/src/dynamics/dynamics.cpp
@@ -198,10 +198,10 @@ moveBodies(int numBodies, std::vector<DynamicBody *> bodyVec, double h)
     memcpy(currv, bodyVec[bn]->getVelocity(), 6 * sizeof(double));;
 
 #ifdef GRASPITDBG
-    fprintf(stdout, "object %s old velocity: \n", bodyVec[bn]->getName().latin1());
+    fprintf(stdout, "object %s old velocity: \n", bodyVec[bn]->getName().toLatin1().constData());
     for (int i = 0; i < 6; i++) { fprintf(stdout, "%le   ", currv[i]); }
     printf("\n");
-    fprintf(stdout, "object %s old position: \n", bodyVec[bn]->getName().latin1());
+    fprintf(stdout, "object %s old position: \n", bodyVec[bn]->getName().toLatin1().constData());
     for (int i = 0; i < 7; i++) { fprintf(stdout, "%le   ", currq[i]); }
 #endif
 
@@ -242,10 +242,10 @@ moveBodies(int numBodies, std::vector<DynamicBody *> bodyVec, double h)
     dgemv("N", 7, 6, h, V, 7, currv, 1, 1.0, newPos, 1);
 
 #ifdef GRASPITDBG
-    fprintf(stdout, "object %s new velocity: \n", bodyVec[bn]->getName().latin1());
+    fprintf(stdout, "object %s new velocity: \n", bodyVec[bn]->getName().toLatin1().constData());
     for (int i = 0; i < 6; i++) { fprintf(stdout, "%le   ", currv[i]); }
     printf("\n");
-    fprintf(stdout, "object %s new position: \n", bodyVec[bn]->getName().latin1());
+    fprintf(stdout, "object %s new position: \n", bodyVec[bn]->getName().toLatin1().constData());
     disp_mat(stdout, newPos, 1, 7);
 #endif
 
@@ -423,7 +423,7 @@ iterateDynamics(std::vector<Robot *> robotVec,
     if (bodyVec[bn]->getDynJoint()) {
       int numCon = bodyVec[bn]->getDynJoint()->getNumConstraints();
       numDynJointConstraints += numCon;
-      DBGP(bodyVec[bn]->getName().latin1() << ": " << numCon << " constraints");
+      DBGP(bodyVec[bn]->getName().toLatin1().constData() << ": " << numCon << " constraints");
     }
     //count contacts
     objContactList = bodyVec[bn]->getContacts();
@@ -529,7 +529,7 @@ iterateDynamics(std::vector<Robot *> robotVec,
       fprintf(stderr, "%f %f %f\n", Jcg_B[0], Jcg_B[1], Jcg_B[2]);
       fprintf(stderr, "%f %f %f\n", Jcg_B[3], Jcg_B[4], Jcg_B[5]);
       fprintf(stderr, "%f %f %f\n", Jcg_B[6], Jcg_B[7], Jcg_B[8]);
-      fprintf(stderr, "Body is %s\n", bodyVec[bn]->getName().latin1());
+      fprintf(stderr, "Body is %s\n", bodyVec[bn]->getName().toLatin1().constData());
     }
 
     currM = M + ((6 * bn) * Mrows + bn * 6); //point to the correct block of M

--- a/src/dynamics/graspitDynamics.cpp
+++ b/src/dynamics/graspitDynamics.cpp
@@ -307,7 +307,7 @@ int GraspitDynamics::computeNewVelocities(double timeStep) {
           DynamicBody *contactedBody = (DynamicBody *)(*cp)->getBody2();
 
           // is this body is a link, add all robots connected to the link
-          if (contactedBody->isA("Link")) {
+          if (contactedBody->metaObject()->className() == QString("Link")) {
             Robot *robot = ((Robot *)((Link *)contactedBody)->getOwner())->getBaseRobot();
             robot->getAllLinks(robotLinks);
             robot->getAllAttachedRobots(islandRobots);

--- a/src/eigenGrasp.cpp
+++ b/src/eigenGrasp.cpp
@@ -124,7 +124,7 @@ EigenGrasp::writeToFile(TiXmlElement *ep)
   {
     varStr.setNum(i);
     varStr = "d" + varStr;
-    DimVals->SetDoubleAttribute(varStr, mVals[i]);
+    DimVals->SetDoubleAttribute(varStr.toLatin1().constData(), mVals[i]);
   }
   ep->LinkEndChild(DimVals);
 
@@ -199,7 +199,7 @@ EigenGrasp::readFromXml(const TiXmlElement *element)
   EVList = findAllXmlElements(element, "DimVals");
   if (!countXmlElements(element, "DimVals")) {DBGA("DimVals tag missing from file."); return 0;}
   for (int i = 0; i < mSize; i++) {
-    valueStr = (*EVList.begin())->Attribute(QString("d") + QString::number(i));
+    valueStr = (*EVList.begin())->Attribute((QString("d") + QString::number(i)).toStdString().c_str());
     if (valueStr.isNull() || valueStr.isEmpty()) { mVals[i] = 0.0; }
     else {
       mVals[i] = valueStr.toDouble(&ok);
@@ -385,9 +385,9 @@ EigenGraspInterface::readFromFile(QString filename)
   }
 
   //load the graspit specific information in XML format or fail
-  TiXmlDocument doc(xmlFilename);
+  TiXmlDocument doc(xmlFilename.toStdString());
   if (doc.LoadFile() == false) {
-    DBGA("Failed to open EG file: " << filename.latin1());
+    DBGA("Failed to open EG file: " << filename.toLatin1().toStdString());
     QTWARNING("Could not open " + xmlFilename);
     return 0;
   }

--- a/src/grasp.cpp
+++ b/src/grasp.cpp
@@ -36,7 +36,6 @@
 #include <typeinfo>
 
 #include <QString>
-#include <q3listbox.h>
 
 //#include "mainWindow.h"
 #include "graspit/grasp.h"

--- a/src/graspRecord.cpp
+++ b/src/graspRecord.cpp
@@ -44,8 +44,8 @@ GraspRecord::~GraspRecord()
 void GraspRecord::writeToFile(FILE *fp)
 {
   //write names
-  fprintf(fp, "%s\n", mObjectName.latin1());
-  fprintf(fp, "%s\n", mRobotName.latin1());
+  fprintf(fp, "%s\n", mObjectName.toLatin1().constData());
+  fprintf(fp, "%s\n", mRobotName.toLatin1().constData());
   //write transform
   Quaternion q = mTran.rotation();
   fprintf(fp, "%f %f %f %f ", q.x(), q.y(), q.z(), q.w());
@@ -67,8 +67,8 @@ void GraspRecord::readFromFile(FILE *fp)
     }
   } while (name[0] == '\n' || name[0] == '\0' || name[0] == ' ');
   mObjectName = QString(name);
-  mObjectName = mObjectName.stripWhiteSpace();
-  fprintf(stderr, "object: %s__\n", mObjectName.latin1());
+  mObjectName = mObjectName.trimmed();
+  fprintf(stderr, "object: %s__\n", mObjectName.toLatin1().constData());
   do {
     if (fgets(name, 1000, fp) == NULL) {
       DBGA("GraspRecord::readFromFile - failed to read robot name");
@@ -76,8 +76,8 @@ void GraspRecord::readFromFile(FILE *fp)
     }
   } while (name[0] == '\n' || name[0] == '\0' || name[0] == ' ');
   mRobotName = QString(name);
-  mRobotName = mRobotName.stripWhiteSpace();
-  fprintf(stderr, "robot: %s__\n", mRobotName.latin1());
+  mRobotName = mRobotName.trimmed();
+  fprintf(stderr, "robot: %s__\n", mRobotName.toLatin1().constData());
   //read transform
   if (fscanf(fp, "%f %f %f %f", &x, &y, &z, &w) <= 0) {
     DBGA("GraspRecord::readFromFile - failed to read record orientation.");

--- a/src/graspitApp.cpp
+++ b/src/graspitApp.cpp
@@ -48,30 +48,29 @@ GraspItApp::showSplash()
 {
   QRect screen = QApplication::desktop()->screenGeometry();
   QSettings config;
-  config.insertSearchPath(QSettings::Windows, "/Columbia");
+  config.setPath(QSettings::IniFormat, QSettings::UserScope, "/Columbia");
 
   QRect mainRect;
   QString keybase = "/GraspIt/0.9/";
-  bool show = config.readBoolEntry(keybase + "SplashScreen", TRUE);
-  mainRect.setX(config.readNumEntry(keybase + "Geometries/MainwindowX", 0));
-  mainRect.setY(config.readNumEntry(keybase + "Geometries/MainwindowY", 0));
-  mainRect.setWidth(config.readNumEntry(keybase + "Geometries/MainwindowWidth", 500));
-  mainRect.setHeight(config.readNumEntry(keybase + "Geometries/MainwindowHeight", 500));
+  bool show = config.value(keybase + "SplashScreen", TRUE).toBool();
+  mainRect.setX(config.value(keybase + "Geometries/MainwindowX", 0).toInt());
+  mainRect.setY(config.value(keybase + "Geometries/MainwindowY", 0).toInt());
+  mainRect.setWidth(config.value(keybase + "Geometries/MainwindowWidth", 500).toInt());
+  mainRect.setHeight(config.value(keybase + "Geometries/MainwindowHeight", 500).toInt());
   screen = QApplication::desktop()->screenGeometry(QApplication::desktop()->screenNumber(mainRect.center()));
 
   if (show) {
-    splash = new QLabel(0, "splash", Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
+    splash = new QLabel("splash", 0, Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint);
     // WStyle_Customize | WStyle_StaysOnTop
     splash->setAttribute(Qt::WA_DeleteOnClose, true);
     splash->setFrameStyle(QFrame::WinPanel | QFrame::Raised);
-    splash->setPixmap(load_pixmap("splash.jpg"));
+    splash->setPixmap(QPixmap(":/images/splash.jpg"));
     splash->adjustSize();
     splash->setFixedSize(splash->sizeHint());
-    splash->setCaption("GraspIt!");
+    splash->setWindowTitle("GraspIt!");
     splash->move(screen.center() - QPoint(splash->width() / 2, splash->height() / 2));
     splash->show();
-    splash->repaint(FALSE);
-    QApplication::flush();
+    QApplication::processEvents(QEventLoop::AllEvents, 1);
     //  set_splash_status( "Initializing..." );
   }
 }

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -40,9 +40,7 @@
 #include <Inventor/sensors/SoIdleSensor.h>
 #include <QLayout>
 
-#ifdef Q_WS_X11
 #include <unistd.h>
-#endif
 
 #include "graspit/cmdline/cmdline.h"
 #include "graspit/graspitCore.h"
@@ -204,8 +202,6 @@ GraspitCore::GraspitCore(int argc, char **argv):
 #endif
   }
 
-#ifdef Q_WS_X11
-
   if (args->exist("world"))
   {
     QString filename = graspitRoot + QString("/worlds/") + QString::fromStdString(args->get<std::string>("world")) + QString(".xml");
@@ -268,7 +264,6 @@ GraspitCore::GraspitCore(int argc, char **argv):
     return;
   }
 
-#endif // Q_WS_X11
   initResult =  SUCCESS;
   return;
 }

--- a/src/graspitCore.cpp
+++ b/src/graspitCore.cpp
@@ -34,7 +34,7 @@
   all plugins.
 */
 
-#include <Q3GroupBox>
+#include <QGroupBox>
 #include <Inventor/Qt/SoQt.h>
 #include <Inventor/Qt/viewers/SoQtExaminerViewer.h>
 #include <Inventor/sensors/SoIdleSensor.h>

--- a/src/graspitResources.qrc
+++ b/src/graspitResources.qrc
@@ -1,0 +1,28 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+        <file>images/collide.xpm</file>
+        <file>images/editcopy</file>
+        <file>images/editcut</file>
+        <file>images/editpaste</file>
+        <file>images/filenew</file>
+        <file>images/filenew.xpm</file>
+        <file>images/fileopen</file>
+        <file>images/fileopen.xpm</file>
+        <file>images/filesave</file>
+        <file>images/filesave.xpm</file>
+        <file>images/logo.png</file>
+        <file>images/mark.xpm</file>
+        <file>images/nocollide.xpm</file>
+        <file>images/pause.xpm</file>
+        <file>images/play.xpm</file>
+        <file>images/prevMark.xpm</file>
+        <file>images/print</file>
+        <file>images/redo</file>
+        <file>images/rotateTool.xpm</file>
+        <file>images/searchfind</file>
+        <file>images/selectTool.xpm</file>
+        <file>images/splash.jpg</file>
+        <file>images/translateTool.xpm</file>
+        <file>images/undo</file>
+</qresource>
+</RCC>

--- a/src/graspitServer.cpp
+++ b/src/graspitServer.cpp
@@ -64,7 +64,7 @@ ClientSocket::readBodyIndList(std::vector<Body *> &bodyVec)
   int i, numBodies, bodNum;
   bool ok;
   World *world = graspitCore->getWorld();
-  std::cout << "ReadBodyIndList Line:" << line.latin1() << std::endl;
+  std::cout << "ReadBodyIndList Line:" << line.toLatin1().constData() << std::endl;
 
   /* if the index list is empty, use every body and send
      back the count
@@ -124,7 +124,7 @@ ClientSocket::readRobotIndList(std::vector<Robot *> &robVec)
   int i, robNum, numRobots;
   bool ok;
   World *world = graspitCore->getWorld();
-  std::cout << "ReadRobotIndList Line:" << line.latin1() << std::endl;
+  std::cout << "ReadRobotIndList Line:" << line.toLatin1().constData() << std::endl;
 
   /* if the index list is empty, use every robot and send
      back the count
@@ -188,8 +188,7 @@ ClientSocket::readClient()
   while (canReadLine()) {
     line = readLine();
     line.truncate(line.length() - 1); //strip newline character
-    lineStrList =
-      QStringList::split(' ', line);
+    lineStrList = line.split(' ');
     strPtr = lineStrList.begin();
 
 #ifdef GRASPITDBG
@@ -345,8 +344,8 @@ void
 ClientSocket::sendBodyName(Body *bod)
 {
   QTextStream os(this);
-  std::cout << "sending " << bod->getName().latin1() << "\n";
-  os << bod->getName().latin1() << "\n";
+  std::cout << "sending " << bod->getName().toLatin1().constData() << "\n";
+  os << bod->getName().toLatin1().constData() << "\n";
 }
 
 /*!
@@ -357,8 +356,8 @@ void
 ClientSocket::sendRobotName(Robot *rob)
 {
   QTextStream os(this);
-  std::cout << "sending " << rob->getName().latin1() << "\n";
-  os << rob->getName().latin1() << "\n";
+  std::cout << "sending " << rob->getName().toLatin1().constData() << "\n";
+  os << rob->getName().toLatin1().constData() << "\n";
 }
 
 /*!
@@ -649,11 +648,14 @@ ClientSocket::readTorques()
   Starts a TCP server that listens on port \a port.  \a backlog specifies
   the number of pending connections the server can have.
 */
-GraspItServer::GraspItServer(Q_UINT16 port, int backlog,
+GraspItServer::GraspItServer(quint16 port, int backlog,
                              QObject *parent, const char *name) :
-  Q3ServerSocket(port, backlog, parent, name)
+  QTcpServer(parent)
 {
-  if (!ok()) {
+  this->listen(QHostAddress::Any, port);
+  this->setMaxPendingConnections(backlog);
+  this->setObjectName(name);
+  if (!isListening()) {
     qWarning("Failed to bind to port");
   }
 }

--- a/src/ivmgr.cpp
+++ b/src/ivmgr.cpp
@@ -35,7 +35,6 @@
 #include <stdexcept>
 #include <typeinfo>
 
-#include <q3listbox.h>
 #include <QApplication>
 #include <QThread>
 #include <QGLWidget>
@@ -218,9 +217,10 @@ IVmgr *IVmgr::ivmgr = 0;
   for draggers and wireframe models, which indicate when bodies are selected,
   are also created.
 */
-IVmgr::IVmgr(World *w, QWidget *parent, const char *name, Qt::WFlags f) :
-  QWidget(parent, name, f)
+IVmgr::IVmgr(World *w, QWidget *parent, const char *name, Qt::WindowFlags f) :
+  QWidget(parent, f)
 {
+  this->setObjectName(name);
   ivmgr = this;
   camerafp = NULL;
   CtrlDown = FALSE;
@@ -1356,7 +1356,7 @@ IVmgr::handleSelection(SoPath *p)
       for (b = 0; b < world->getNumBodies(); b++) {
         if (p->getTail() == world->getBody(b)->getIVRoot()) {
           //#ifdef GRASPITDBG
-          printf("body %s selected\n", world->getBody(b)->getName().latin1());
+          printf("body %s selected\n", world->getBody(b)->getName().toLatin1().constData());
           //#endif
           selectionFound = true;
           if (currTool == ROTATE_TOOL) {
@@ -1433,7 +1433,7 @@ IVmgr::handleDeselection(SoPath *p)
 
   for (b = 0; b < world->getNumBodies() && !deselectedElement; b++)
     if (p->getTail() == world->getBody(b)->getIVRoot()) {
-      DBGP("deselecting body " << world->getBody(b)->getName().latin1());
+      DBGP("deselecting body " << world->getBody(b)->getName().toLatin1().constData());
       deselectedElement = world->getBody(b);
     }
 

--- a/src/joint.cpp
+++ b/src/joint.cpp
@@ -212,7 +212,7 @@ PrismaticJoint::initJointFromXml(const TiXmlElement *root, int jnum)
   const TiXmlElement *element = findXmlElement(root, "d");
   if (element) {
     dQStr = element->GetText();
-    dQStr = dQStr.stripWhiteSpace();
+    dQStr = dQStr.trimmed();
     strcpy(dStr, dQStr.toStdString().c_str());
   } else {
     return FAILURE;
@@ -303,7 +303,7 @@ RevoluteJoint::initJointFromXml(const TiXmlElement *root, int jnum)
   const TiXmlElement *element = findXmlElement(root, "theta");
   if (element) {
     thQStr = element->GetText();
-    thQStr = thQStr.stripWhiteSpace();
+    thQStr = thQStr.trimmed();
     strcpy(thStr, thQStr.toStdString().c_str());
   }
   else {

--- a/src/kinematicChain.cpp
+++ b/src/kinematicChain.cpp
@@ -216,7 +216,7 @@ KinematicChain::initChainFromXml(const TiXmlElement *root, QString &linkDir)
       QTWARNING("No Dynamic Joint Type Specified");
       return FAILURE;
     }
-    jointType = jointType.stripWhiteSpace();
+    jointType = jointType.trimmed();
     if (jointType == "Revolute") {
       dynJointTypes.push_back(DynJoint::REVOLUTE);
       lastJointNum += 1;
@@ -237,9 +237,9 @@ KinematicChain::initChainFromXml(const TiXmlElement *root, QString &linkDir)
     }
 
     QString linkFilename = (*p)->GetText();
-    linkFilename = linkFilename.stripWhiteSpace();
-    QString linkName = QString(owner->name()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
-    linkVec[l] = new Link(owner, chainNum, l, owner->getWorld(), linkName.latin1());
+    linkFilename = linkFilename.trimmed();
+    QString linkName = QString(owner->getName()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
+    linkVec[l] = new Link(owner, chainNum, l, owner->getWorld(), linkName.toLatin1().constData());
     QString sensorType = (*p)->Attribute("sensorType");
 
     if (linkVec[l]->load(linkDir + linkFilename) == FAILURE) {
@@ -256,7 +256,7 @@ KinematicChain::initChainFromXml(const TiXmlElement *root, QString &linkDir)
     QString collisionRule = (*p)->Attribute("collisionRule");
 
     if (!collisionRule.isNull()) {
-      collisionRule = collisionRule.stripWhiteSpace();
+      collisionRule = collisionRule.trimmed();
       if (collisionRule == "Off") {
         linkVec[l]->addToIvc(true);
         linkVec[l]->myWorld->toggleCollisions(false, linkVec[l], NULL);
@@ -269,7 +269,7 @@ KinematicChain::initChainFromXml(const TiXmlElement *root, QString &linkDir)
          */
         linkVec[l]->addToIvc();
         QString targetChain = (*p)->Attribute("targetChain");
-        targetChain = targetChain.stripWhiteSpace();
+        targetChain = targetChain.trimmed();
         if (targetChain == "base") {
           linkVec[l]->myWorld->toggleCollisions(false, linkVec[l], owner->getBase());
         }
@@ -375,8 +375,8 @@ KinematicChain::cloneFrom(const KinematicChain *original)
   std::vector<int> dynJointTypes;
   for (int l = 0; l < numLinks; l++) {
     lastJoint[l] = original->getLastJoint(l);
-    QString linkName =  QString(owner->name()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
-    linkVec[l] = new Link(owner, chainNum, l, owner->getWorld(), linkName);
+    QString linkName =  QString(owner->getName()) + QString("_chain%1_link%2").arg(chainNum).arg(l);
+    linkVec[l] = new Link(owner, chainNum, l, owner->getWorld(), linkName.toLatin1().constData());
     linkVec[l]->cloneFrom(original->getLink(l));
     //linkVec[l]->setTransparency(0.5);
     IVRoot->addChild(linkVec[l]->getIVRoot());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
   if (!headless) {
     if (app.splashEnabled()) {
       app.showSplash();
-      QApplication::setOverrideCursor(Qt::waitCursor);
+      QApplication::setOverrideCursor(Qt::WaitCursor);
     }
   }
 
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
 
   if (!headless)
   {
-    app.setMainWidget(core.getMainWindow()->mWindow);
+    app.setActiveWindow(core.getMainWindow()->mWindow);
     if (app.splashEnabled()) {
       app.closeSplash();
       QApplication::restoreOverrideCursor();

--- a/src/matvecIO.cpp
+++ b/src/matvecIO.cpp
@@ -197,9 +197,10 @@ operator>>(QTextStream &is, vec3 &v)
 QTextStream &
 operator<<(QTextStream &os, const vec3 &v)
 {
-  int oldFlags = os.setf(QTextStream::showpos);
+  QTextStream::NumberFlags oldFlags = os.numberFlags();
+  os.setNumberFlags(QTextStream::ForceSign);
   os << '[' << v[0] << ' ' << v[1] << ' ' << v[2] << ']';
-  os.flags(oldFlags);
+  os.setNumberFlags(oldFlags);
   return os;
 }
 
@@ -232,11 +233,12 @@ operator>>(QTextStream &is, mat3 &m)
 QTextStream &
 operator<<(QTextStream &os, const mat3 &m)
 {
-  int oldFlags = os.setf(QTextStream::showpos);
+  QTextStream::NumberFlags oldFlags = os.numberFlags();
+  os.setNumberFlags(QTextStream::ForceSign);
   os << '[' << m(0) << ' ' << m(3) << ' ' << m(6) << ']' << endl;
   os << '[' << m(1) << ' ' << m(4) << ' ' << m(7) << ']' << endl;
   os << '[' << m(2) << ' ' << m(5) << ' ' << m(8) << ']' << endl;
-  os.flags(oldFlags);
+  os.setNumberFlags(oldFlags);
   return os;
 }
 
@@ -260,9 +262,10 @@ operator>>(QTextStream &is, Quaternion &q)
 QTextStream &
 operator<<(QTextStream &os, const Quaternion &q)
 {
-  int oldFlags = os.setf(QTextStream::showpos);
+  QTextStream::NumberFlags oldFlags = os.numberFlags();
+  os.setNumberFlags(QTextStream::ForceSign);
   os << '(' << q.w() << ' ' << q.x() << ' ' << q.y() << ' ' << q.z() << ')';
-  os.flags(oldFlags);
+  os.setNumberFlags(oldFlags);
   return os;
 }
 
@@ -331,7 +334,7 @@ readTransRotFromQTextStream(QTextStream &stream, transf &tr)
   do {
     if (!line.isNull() && (line[0] == 'r' || line[0] == 't' || line[0] == 'T' || line[0] == 'R')) {
       if (line[0] == 'r') { /* rotation */
-        strings = QStringList::split(QChar(' '), line);
+        strings = line.split(' ');
         if (strings.count() < 3) { return FAILURE; }
         theta = strings[1].toDouble(&ok); if (!ok) { return FAILURE; }
         axis = strings[2][0];
@@ -348,7 +351,7 @@ readTransRotFromQTextStream(QTextStream &stream, transf &tr)
         tmpTr = transf::AXIS_ANGLE_ROTATION(theta, tmpVec);
       }
       else if (line[0] == 't') { /* translation */
-        strings = QStringList::split(QChar(' '), line);
+        strings = line.split(' ');
         if (strings.count() < 4) { return FAILURE; }
         x = strings[1].toDouble(&ok); if (!ok) { return FAILURE; }
         y = strings[2].toDouble(&ok); if (!ok) { return FAILURE; }

--- a/src/mytools.cpp
+++ b/src/mytools.cpp
@@ -27,9 +27,6 @@
   \brief Implements the load_pixmap() function.  Other misc. functions could go here too.
 */
 
-#include <Q3MimeSourceFactory>
-#include <qmime.h>
-#include <q3dragobject.h>
 #include <QPixmap>
 
 #include "graspit/debug.h"
@@ -44,12 +41,7 @@
 */
 QPixmap load_pixmap(const QString &name)
 {
-  const QMimeSource *m = Q3MimeSourceFactory::defaultFactory()->data(name);
-  if (!m) {
-    return QPixmap();
-  }
-  QPixmap pix;
-  Q3ImageDrag::decode(m, pix);
+  QPixmap pix(name);
   return pix;
 }
 
@@ -107,8 +99,8 @@ relativePath(QString absolutePath, QString relativeToDir)
   int lastCommonRoot = -1;
   int index;
 
-  DBGP("Absolute path: " << absolutePath.latin1());
-  DBGP("Relative to  : " << relativeToDir.latin1());
+  DBGP("Absolute path: " << absolutePath.toLatin1().constData());
+  DBGP("Relative to  : " << relativeToDir.toLatin1().constData());
 
   //Find common root
   for (index = 0; index < length; index++) {
@@ -141,7 +133,7 @@ relativePath(QString absolutePath, QString relativeToDir)
   }
   relativePath.append(absoluteDirectories[absoluteDirectories.count() - 1]);
 
-  DBGP("Relative path: " << relativePath.latin1());
+  DBGP("Relative path: " << relativePath.toLatin1().constData());
   return relativePath;
 }
 
@@ -153,7 +145,7 @@ relativePath(QString absolutePath, QString relativeToDir)
 const TiXmlElement *
 findXmlElement(const TiXmlElement *root, QString defStr)
 {
-  defStr = defStr.stripWhiteSpace();
+  defStr = defStr.trimmed();
   const TiXmlElement *child = root->FirstChildElement();
   while (child != NULL) {
     if (child->Value() == defStr) { break; }
@@ -170,7 +162,7 @@ findXmlElement(const TiXmlElement *root, QString defStr)
 std::list<const TiXmlElement *>
 findAllXmlElements(const TiXmlElement *root, QString defStr)
 {
-  defStr = defStr.stripWhiteSpace();
+  defStr = defStr.trimmed();
   std::list<const TiXmlElement *> children;
   const TiXmlElement *child = root->FirstChildElement();
   while (child != NULL) {
@@ -245,15 +237,15 @@ bool getPosition(const TiXmlElement *root, vec3 &pos) {
     return false;
   }
   QString rootValue = root->Value();
-  rootValue = rootValue.stripWhiteSpace();
+  rootValue = rootValue.trimmed();
   if (!(rootValue == "position" || rootValue == "orientation")) {
     QTWARNING("The given root is not a Position Element");
     return false;
   }
   QString valueStr = root->GetText();
-  valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
+  valueStr = valueStr.simplified().trimmed();
   QStringList l;
-  l = QStringList::split(' ', valueStr);
+  l = valueStr.split(' ');
   if (l.count() != 3) {
     QTWARNING("Invalid position input");
     return false;
@@ -281,7 +273,7 @@ bool getTransform(const TiXmlElement *root, transf &totalTran)
     return false;
   }
   QString rootValue = root->Value();
-  rootValue = rootValue.stripWhiteSpace();
+  rootValue = rootValue.trimmed();
   if (rootValue != "transform") {
     QTWARNING("The given root is not a Transform Element");
     return false;
@@ -293,11 +285,11 @@ bool getTransform(const TiXmlElement *root, transf &totalTran)
   while (child != NULL) {
     transf newTran;
     QString valueStr = child->GetText();
-    valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
+    valueStr = valueStr.simplified().trimmed();
     QStringList l;
-    l = QStringList::split(' ', valueStr);
+    l = valueStr.split(' ');
     QString defString = child->Value();
-    defString = defString.stripWhiteSpace();
+    defString = defString.trimmed();
     if (defString == "translation") {
       if (l.count() != 3) {
         QTWARNING("Invalid translation transformation input");

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -114,7 +114,7 @@ PluginCreator *PluginCreator::loadFromLibrary(std::string libName)
     //filename is an absolute path
     QFile file(filename);
     if (!file.exists()) {
-      DBGA("Could not find absolute plugin file " << filename.latin1());
+      DBGA("Could not find absolute plugin file " << filename.toLatin1().toStdString());
       return NULL;
     }
   } else {
@@ -137,17 +137,17 @@ PluginCreator *PluginCreator::loadFromLibrary(std::string libName)
       }
     }
     if (!found) {
-      DBGA("Could not find relative plugin file " << filename.latin1() <<
+      DBGA("Could not find relative plugin file " << filename.toLatin1().toStdString() <<
            " in any directory specified in GRASPIT_PLUGIN_DIR");
       return NULL;
     }
   }
 
   //look for the library file and load it
-  PLUGIN_DYNLIB_HANDLE handle = PLUGIN_DYNLIB_OPEN(filename.toAscii().constData());
+  PLUGIN_DYNLIB_HANDLE handle = PLUGIN_DYNLIB_OPEN(filename.toLatin1().constData());
   char *errstr = PLUGIN_DYNLIB_ERROR();
   if (!handle) {
-    DBGA("Failed to open dynamic library " << filename.toAscii().constData());
+    DBGA("Failed to open dynamic library " << filename.toLatin1().constData());
     if (errstr) { DBGA("Error: " << errstr); }
     return NULL;
   }
@@ -160,7 +160,7 @@ PluginCreator *PluginCreator::loadFromLibrary(std::string libName)
   //maybe in the future a better solution can be found...
   PluginCreator::CreatePluginFctn _createPluginFctn = (CreatePluginFctn) PLUGIN_DYNLIB_IMPORT(handle, "createPlugin");
   if (PLUGIN_DYNLIB_ERROR()) {
-    DBGA("Could not load symbol createPlugin from library " << filename.toAscii().constData());
+    DBGA("Could not load symbol createPlugin from library " << filename.toLatin1().constData());
     return NULL;
   }
   PluginCreator::CreatePluginFctn createPluginFctn = reinterpret_cast<PluginCreator::CreatePluginFctn>(_createPluginFctn);
@@ -168,7 +168,7 @@ PluginCreator *PluginCreator::loadFromLibrary(std::string libName)
   //read the type of plugin
   PluginCreator::GetTypeFctn _getTypeFctn = (GetTypeFctn) PLUGIN_DYNLIB_IMPORT(handle, "getType");
   if (PLUGIN_DYNLIB_ERROR()) {
-    DBGA("Could not load symbol getType from library " << filename.toAscii().constData());
+    DBGA("Could not load symbol getType from library " << filename.toLatin1().constData());
     return NULL;
   }
   PluginCreator::GetTypeFctn getTypeFctn = reinterpret_cast<PluginCreator::GetTypeFctn>(_getTypeFctn);
@@ -176,7 +176,7 @@ PluginCreator *PluginCreator::loadFromLibrary(std::string libName)
   std::cout << "Function name " << (*getTypeFctn)() << std::endl;
   std::string type = (*getTypeFctn)();
   if (type.empty()) {
-    DBGA("Could not get plugin type from library " << filename.toAscii().constData());
+    DBGA("Could not get plugin type from library " << filename.toLatin1().constData());
   }
 
   //create the PluginCreator and push it back

--- a/src/quality/qualEpsilon.cpp
+++ b/src/quality/qualEpsilon.cpp
@@ -51,7 +51,7 @@ struct QualEpsilonParamT {
 QualEpsilon::QualEpsilon(qmDlgDataT *data) : QualityMeasure(data)
 {
   QualEpsilonParamT *params = (QualEpsilonParamT *)data->paramPtr;
-  gws = grasp->addGWS(params->gwsTypeComboBox->currentText().latin1());
+  gws = grasp->addGWS(params->gwsTypeComboBox->currentText().toLatin1());
 }
 
 QualEpsilon::QualEpsilon(Grasp *g, QString n, const char *gwsType) : QualityMeasure(g, n)
@@ -143,25 +143,28 @@ QualEpsilon::buildParamArea(qmDlgDataT *qmData)
   std::cout << "building qualepsilon" << std::endl;
 #endif
 
-  QLayout *l = new QGridLayout(qmData->settingsArea, 2, 2, 1);
-  l->setAutoAdd(true);
+  QGridLayout *l = new QGridLayout(qmData->settingsArea);
 
   // create the GWS type menu
-  new QLabel(QString("Limit unit GWS using:"), qmData->settingsArea);
-  params.gwsTypeComboBox = new QComboBox(qmData->settingsArea, "gwsComboBox");
+  l->addWidget(new QLabel(QString("Limit unit GWS using:"), qmData->settingsArea), 0, 0);
+  params.gwsTypeComboBox = new QComboBox(qmData->settingsArea);
+  params.gwsTypeComboBox->setObjectName("gwsComboBox");
+  l->addWidget(params.gwsTypeComboBox, 0, 1);
 
-  new QLabel(QString("Task Wrench Space (TWS):"), qmData->settingsArea);
-  params.twsTypeComboBox = new QComboBox(qmData->settingsArea, "twsComboBox");
+  l->addWidget(new QLabel(QString("Task Wrench Space (TWS):"), qmData->settingsArea), 1, 0);
+  params.twsTypeComboBox = new QComboBox(qmData->settingsArea);
+  params.twsTypeComboBox->setObjectName("twsComboBox");
+  l->addWidget(params.twsTypeComboBox, 1, 1);
 
   // count the number of possible gws types
   for (i = 0; GWS::TYPE_LIST[i]; i++) {
-    params.gwsTypeComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
+    params.gwsTypeComboBox->addItem(QString(GWS::TYPE_LIST[i]));
     if (currQM && !strcmp(currQM->gws->getType(), GWS::TYPE_LIST[i])) {
-      params.gwsTypeComboBox->setCurrentItem(i);
+      params.gwsTypeComboBox->setCurrentIndex(i);
     }
   }
 
-  params.twsTypeComboBox->insertItem(QString("Unit Ball"));
+  params.twsTypeComboBox->addItem(QString("Unit Ball"));
 
   qmData->paramPtr = &params;
 }

--- a/src/quality/qualPCR.cpp
+++ b/src/quality/qualPCR.cpp
@@ -176,47 +176,47 @@ QualPCR::buildParamArea(qmDlgDataT *qmData)
     wrenchMultiplier = qmData->grasp->getObject()->getMass() * 1.0e-3 * 9.80665 * 1.0e6;
   } 
 
-  QGridLayout *wl = new QGridLayout(qmData->settingsArea,8,2);
+  QGridLayout *wl = new QGridLayout(qmData->settingsArea);
 
-  wl->addWidget(new QLabel(QString("Multiplier:")));
+  wl->addWidget(new QLabel(QString("Multiplier:")), 0, 0);
   params.wrenchInput = new QLineEdit();
   params.wrenchInput->setText(QString::number(wrenchMultiplier));
-  wl->addWidget(params.wrenchInput);
+  wl->addWidget(params.wrenchInput, 0, 1);
 
-  wl->addWidget(new QLabel(QString("Force X:")));
+  wl->addWidget(new QLabel(QString("Force X:")), 1, 0);
   params.FxInput = new QLineEdit();
   params.FxInput->setText(QString::number(wrench[0]));
-  wl->addWidget(params.FxInput);
+  wl->addWidget(params.FxInput, 1, 1);
 
-  wl->addWidget(new QLabel(QString("Force Y:")));
+  wl->addWidget(new QLabel(QString("Force Y:")), 2, 0);
   params.FyInput = new QLineEdit();
   params.FyInput->setText(QString::number(wrench[1]));
-  wl->addWidget(params.FyInput);
+  wl->addWidget(params.FyInput, 2, 1);
 
-  wl->addWidget(new QLabel(QString("Force Z:")));
+  wl->addWidget(new QLabel(QString("Force Z:")), 3, 0);
   params.FzInput = new QLineEdit();
   params.FzInput->setText(QString::number(wrench[2]));
-  wl->addWidget(params.FzInput);
+  wl->addWidget(params.FzInput, 3, 1);
 
-  wl->addWidget(new QLabel(QString("Torque X:")));
+  wl->addWidget(new QLabel(QString("Torque X:")), 4, 0);
   params.MxInput = new QLineEdit();
   params.MxInput->setText(QString::number(wrench[3]));
-  wl->addWidget(params.MxInput);
+  wl->addWidget(params.MxInput, 4, 1);
 
-  wl->addWidget(new QLabel(QString("Torque Y:")));
+  wl->addWidget(new QLabel(QString("Torque Y:")), 5, 0);
   params.MyInput = new QLineEdit();
   params.MyInput->setText(QString::number(wrench[4]));
-  wl->addWidget(params.MyInput);
+  wl->addWidget(params.MyInput, 5, 1);
 
-  wl->addWidget(new QLabel(QString("Torque Z:")));
+  wl->addWidget(new QLabel(QString("Torque Z:")), 6, 0);
   params.MzInput = new QLineEdit();
   params.MzInput->setText(QString::number(wrench[5]));
-  wl->addWidget(params.MzInput);
+  wl->addWidget(params.MzInput, 6, 1);
 
-  wl->addWidget(new QLabel(QString("Maximum Force:")));
+  wl->addWidget(new QLabel(QString("Maximum Force:")), 7, 0);
   params.maxForceInput = new QLineEdit();
   params.maxForceInput->setText(QString::number(maxForce));
-  wl->addWidget(params.maxForceInput);
+  wl->addWidget(params.maxForceInput, 7, 1);
 
   qmData->paramPtr = &params;
 }

--- a/src/quality/qualPGR.cpp
+++ b/src/quality/qualPGR.cpp
@@ -283,52 +283,52 @@ QualPGR::buildParamArea(qmDlgDataT *qmData)
     wrenchMultiplier = qmData->grasp->getObject()->getMass() * 1.0e-3 * 9.80665 * 1.0e6;
   } 
 
-  QGridLayout *wl = new QGridLayout(qmData->settingsArea,8,2);
+  QGridLayout *wl = new QGridLayout(qmData->settingsArea);
 
-  wl->addWidget(new QLabel(QString("Multiplier:")));
+  wl->addWidget(new QLabel(QString("Multiplier:")), 0, 0);
   params.wrenchInput = new QLineEdit();
   params.wrenchInput->setText(QString::number(wrenchMultiplier));
-  wl->addWidget(params.wrenchInput);
+  wl->addWidget(params.wrenchInput, 0, 1);
 
-  wl->addWidget(new QLabel(QString("Force X:")));
+  wl->addWidget(new QLabel(QString("Force X:")), 1, 0);
   params.FxInput = new QLineEdit();
   params.FxInput->setText(QString::number(wrench[0]));
-  wl->addWidget(params.FxInput);
+  wl->addWidget(params.FxInput, 1, 1);
 
-  wl->addWidget(new QLabel(QString("Force Y:")));
+  wl->addWidget(new QLabel(QString("Force Y:")), 2, 0);
   params.FyInput = new QLineEdit();
   params.FyInput->setText(QString::number(wrench[1]));
-  wl->addWidget(params.FyInput);
+  wl->addWidget(params.FyInput, 2, 1);
 
-  wl->addWidget(new QLabel(QString("Force Z:")));
+  wl->addWidget(new QLabel(QString("Force Z:")), 3, 0);
   params.FzInput = new QLineEdit();
   params.FzInput->setText(QString::number(wrench[2]));
-  wl->addWidget(params.FzInput);
+  wl->addWidget(params.FzInput, 3, 1);
 
-  wl->addWidget(new QLabel(QString("Torque X:")));
+  wl->addWidget(new QLabel(QString("Torque X:")), 4, 0);
   params.MxInput = new QLineEdit();
   params.MxInput->setText(QString::number(wrench[3]));
-  wl->addWidget(params.MxInput);
+  wl->addWidget(params.MxInput, 4, 1);
 
-  wl->addWidget(new QLabel(QString("Torque Y:")));
+  wl->addWidget(new QLabel(QString("Torque Y:")), 5, 0);
   params.MyInput = new QLineEdit();
   params.MyInput->setText(QString::number(wrench[4]));
-  wl->addWidget(params.MyInput);
+  wl->addWidget(params.MyInput, 5, 1);
 
-  wl->addWidget(new QLabel(QString("Torque Z:")));
+  wl->addWidget(new QLabel(QString("Torque Z:")), 6, 0);
   params.MzInput = new QLineEdit();
   params.MzInput->setText(QString::number(wrench[5]));
-  wl->addWidget(params.MzInput);
+  wl->addWidget(params.MzInput, 6, 1);
 
-  wl->addWidget(new QLabel(QString("Max. Force:")));
+  wl->addWidget(new QLabel(QString("Max. Force:")), 7, 0);
   params.maxForceInput = new QLineEdit();
   params.maxForceInput->setText(QString::number(maxForce));
-  wl->addWidget(params.maxForceInput);
+  wl->addWidget(params.maxForceInput, 7, 1);
 
-  wl->addWidget(new QLabel(QString("Max. no. of contacts:")));
+  wl->addWidget(new QLabel(QString("Max. no. of contacts:")), 8, 0);
   params.maxContactsInput = new QLineEdit();
   params.maxContactsInput->setText(QString::number(maxContacts));
-  wl->addWidget(params.maxContactsInput);
+  wl->addWidget(params.maxContactsInput, 8, 1);
 
   qmData->paramPtr = &params;
 }

--- a/src/quality/qualVolume.cpp
+++ b/src/quality/qualVolume.cpp
@@ -51,7 +51,7 @@ struct QualVolumeParamT {
 QualVolume::QualVolume(qmDlgDataT *data) : QualityMeasure(data)
 {
   QComboBox *gwsType = (QComboBox *)data->paramPtr;
-  gws = grasp->addGWS(gwsType->currentText().latin1());
+  gws = grasp->addGWS(gwsType->currentText().toLatin1().constData());
 }
 
 QualVolume::QualVolume(Grasp *g, QString n, const char *gwsType) : QualityMeasure(g, n)
@@ -105,17 +105,18 @@ QualVolume::buildParamArea(qmDlgDataT *qmData)
 #endif
 
   QBoxLayout *l = new QHBoxLayout(qmData->settingsArea);
-  l->setAutoAdd(true);
 
   // create the GWS type menu
-  new QLabel(QString("Limit unit GWS using:"), qmData->settingsArea);
-  QComboBox *gwsComboBox = new QComboBox(qmData->settingsArea, "gwsComboBox");
+  l->addWidget(new QLabel(QString("Limit unit GWS using:"), qmData->settingsArea));
+  QComboBox *gwsComboBox = new QComboBox(qmData->settingsArea);
+  gwsComboBox->setObjectName("gwsComboBox");
+  l->addWidget(gwsComboBox);
 
   // count the number of possible gws types
   for (i = 0; GWS::TYPE_LIST[i]; i++) {
-    gwsComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
+    gwsComboBox->addItem(QString(GWS::TYPE_LIST[i]));
     if (currQM && !strcmp(currQM->gws->getType(), GWS::TYPE_LIST[i])) {
-      gwsComboBox->setCurrentItem(i);
+      gwsComboBox->setCurrentIndex(i);
     }
   }
 

--- a/src/quality/quality.cpp
+++ b/src/quality/quality.cpp
@@ -38,7 +38,6 @@
 #include <QBoxLayout>
 #include <QHBoxLayout>
 #include <QWidget>
-#include <q3groupbox.h>
 #include <QLayout>
 #include <QLabel>
 #include <QLineEdit>

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -85,7 +85,7 @@ Robot::~Robot()
   if (mGloveInterface) { delete mGloveInterface; }
   if (mEigenGrasps) { delete mEigenGrasps; }
 
-  std::cout << "Deleted robot: " << name() << std::endl;
+  std::cout << "Deleted robot: " << getName().toStdString() << std::endl;
 }
 
 /*! Loads the robot information from an XML node, which is asumed
@@ -115,8 +115,8 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
   QString sensorType = element->Attribute("sensorType");
   if (element) {
     valueStr = element->GetText();
-    valueStr = valueStr.stripWhiteSpace();
-    base = new Link(this, -1, -1, myWorld, (QString(name()) + "Base").latin1());
+    valueStr = valueStr.trimmed();
+    base = new Link(this, -1, -1, myWorld, (QString(getName()) + "Base").toLatin1().constData());
     if (!base  || base->load(ivdir + valueStr) == FAILURE) {
       if (base) { delete base; }
       base = NULL;
@@ -161,7 +161,7 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
       QTWARNING("DOF Type not found");
       return FAILURE;
     }
-    QString dofType = valueStr.stripWhiteSpace();
+    QString dofType = valueStr.trimmed();
     if (dofType == "r") {
       dofVec[f] = new RigidDOF();
     }
@@ -288,8 +288,8 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
       return FAILURE;
     }
     valueStr = tmp->GetText();
-    valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
-    QStringList l = QStringList::split(' ', valueStr);
+    valueStr = valueStr.simplified().trimmed();
+    QStringList l = valueStr.split(' ');
     if (l.count() != 3) {
       DBGA("Invalid approach direction input");
       return FAILURE;
@@ -311,8 +311,8 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
       return FAILURE;
     }
     valueStr = tmp->GetText();
-    valueStr = valueStr.simplifyWhiteSpace().stripWhiteSpace();
-    l = QStringList::split(' ', valueStr);
+    valueStr = valueStr.simplified().trimmed();
+    l = valueStr.split(' ');
     if (l.count() != 3) {
       DBGA("Invalid approach direction input");
       return FAILURE;
@@ -347,10 +347,10 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
   element = findXmlElement(root, "eigenGrasps");
   if (element) {
     valueStr = element->GetText();
-    valueStr = valueStr.stripWhiteSpace();
+    valueStr = valueStr.trimmed();
     QString eigenFile = rootPath + valueStr;
     if (loadEigenData(eigenFile) == SUCCESS) {
-      DBGA("Using eigengrasps from file: " << valueStr.latin1());
+      DBGA("Using eigengrasps from file: " << valueStr.toLatin1().constData());
       eigenLoaded = true;
     }
   }
@@ -363,13 +363,13 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
   element = findXmlElement(root, "virtualContacts");
   if (element) {
     valueStr = element->GetText();
-    valueStr = valueStr.stripWhiteSpace();
+    valueStr = valueStr.trimmed();
     QString contactFile = rootPath + valueStr;
     if (loadContactData(contactFile) == SUCCESS) {
-      DBGA("Loaded virtual contacts from file " << valueStr.latin1());
+      DBGA("Loaded virtual contacts from file " << valueStr.toLatin1().constData());
       showVirtualContacts(true);
     } else {
-      DBGA("Failed to load virtual contacts from file " << valueStr.latin1());
+      DBGA("Failed to load virtual contacts from file " << valueStr.toLatin1().constData());
     }
   }
 
@@ -378,15 +378,15 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
   element = findXmlElement(root, "cyberGlove");
   if (element) {
     valueStr = element->GetText();
-    valueStr = valueStr.stripWhiteSpace();
+    valueStr = valueStr.trimmed();
     mGloveInterface = new GloveInterface(this);
     QString calibFile = rootPath + valueStr;
-    if (!mGloveInterface->loadCalibration(calibFile.latin1())) {
-      DBGA("Failed to load glove calibration file " << calibFile.latin1());
+    if (!mGloveInterface->loadCalibration(calibFile.toLatin1().constData())) {
+      DBGA("Failed to load glove calibration file " << calibFile.toLatin1().constData());
       delete mGloveInterface; mGloveInterface = NULL;
       mUseCyberGlove = false;
     } else {
-      DBGA("Cyberglove calibration loaded from " << calibFile.latin1());
+      DBGA("Cyberglove calibration loaded from " << calibFile.toLatin1().constData());
       mUseCyberGlove = true;
     }
   }
@@ -399,7 +399,7 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
       DBGA("There was a problem reading the Flock of Birds data in the configuration file");
       return FAILURE;
     }
-    birdNumber = birdNumber.stripWhiteSpace();
+    birdNumber = birdNumber.trimmed();
     mBirdNumber = birdNumber.toInt();
     transf sensorTrans;
     const TiXmlElement *tmp = findXmlElement(element, "transform");
@@ -422,8 +422,8 @@ Robot::loadFromXml(const TiXmlElement *root, QString rootPath)
 int
 Robot::loadEigenData(QString filename)
 {
-  if (!mEigenGrasps->readFromFile(filename.latin1())) {
-    DBGA("Unable to load eigenGrasp file " << filename.latin1());
+  if (!mEigenGrasps->readFromFile(filename.toLatin1().constData())) {
+    DBGA("Unable to load eigenGrasp file " << filename.toLatin1().constData());
     return FAILURE;
   }
   QString name = filename.section('/', -1, -1);
@@ -436,7 +436,7 @@ int
 Robot::loadContactData(QString filename)
 {
 
-  TiXmlDocument doc(filename);
+  TiXmlDocument doc(filename.toLatin1().constData());
   if (doc.LoadFile() == false) {
     QTWARNING("Could not open " + filename);
     return FAILURE;
@@ -480,10 +480,10 @@ Robot::loadContactData(QString filename)
 int
 Robot::loadContactData(QString filename)
 {
-  std::ifstream inFile(filename.latin1(), std::ios::in);
+  std::ifstream inFile(filename.toLatin1().constData(), std::ios::in);
   if (!inFile.is_open())
   {
-    fprintf(stderr, "Could not open filename %s\n", filename.latin1());
+    fprintf(stderr, "Could not open filename %s\n", filename.toLatin1().constData());
     return FAILURE;
   }
 
@@ -550,7 +550,7 @@ Robot::cloneFrom(Robot *original)
 
   //new robots have contact indicators disabled by default
   if (base) { delete base; }
-  base = new Link(this, -1, -1, myWorld, (QString(name()) + "Base").latin1());
+  base = new Link(this, -1, -1, myWorld, (QString(getName()) + "Base").toLatin1().constData());
   base->cloneFrom(original->getBase());
   //base->initDynamics();
   IVRoot = new SoSeparator;
@@ -769,8 +769,8 @@ world and connect it to the base of this robot.
 Link *
 Robot::importMountPiece(QString filename)
 {
-  QString mountName = QString(name()) + "_mount";
-  mountPiece = new Link(this, -1, -1, myWorld, mountName.latin1());
+  QString mountName = QString(getName()) + "_mount";
+  mountPiece = new Link(this, -1, -1, myWorld, mountName.toLatin1().constData());
   if (mountPiece->load(filename) == FAILURE) {
     delete mountPiece; mountPiece = NULL; return NULL;
   }
@@ -871,7 +871,7 @@ move independently.
 void
 Robot::detachRobot(Robot *r)
 {
-  DBGA("Detaching Robot " << r->getName().latin1() << " from " << getName().latin1());
+  DBGA("Detaching Robot " << r->getName().toLatin1().constData() << " from " << getName().toLatin1().constData());
   r->parent = NULL;
   chainVec[r->parentChainNum]->detachRobot(r);
 }
@@ -1448,10 +1448,10 @@ Robot::interpolateJoints(double *initialVals, double *finalVals,
   if (deltat < 1.0e-20 || t < 0) {
 #ifdef GRASPITDBG
     std::cerr << "t: " << t << "  d: " << deltat << std::endl;
-    std::cerr << "I am " << getName().latin1() << std::endl;
+    std::cerr << "I am " << getName().toLatin1().constData() << std::endl;
     for (int i = 0; i < (int)colReport->size(); i++) {
-      std::cerr << (*colReport)[i].first->getName().latin1() << " -- "
-                << (*colReport)[i].second->getName().latin1() << std::endl;
+      std::cerr << (*colReport)[i].first->getName().toLatin1().constData() << " -- "
+                << (*colReport)[i].second->getName().toLatin1().constData() << std::endl;
     }
     std::cerr << "min dist: " << minDist << std::endl << std::endl;
 #endif
@@ -1643,8 +1643,8 @@ Robot::jumpDOFToContact(double *desiredVals, int *stoppedJoints, int *numCols)
     lateContacts.clear();
     for (int i = 0; i < (int)colReport.size(); i++) {
       lateContacts.push_back(colReport[i]);
-      DBGP("Contact: " << colReport[i].first->getName().latin1() << "--" <<
-           colReport[i].second->getName().latin1());
+      DBGP("Contact: " << colReport[i].first->getName().toLatin1().constData() << "--" <<
+           colReport[i].second->getName().toLatin1().constData());
     }
     for (int d = 0; d < numDOF; d++) {
       DBGP("Dof " << d << "initial " << initialDofVals[d] << " new " << newDofVals[d]);
@@ -2503,7 +2503,7 @@ Hand::quickOpen(double speedFactor)
       success = true;
     }
   }
-  if (loops > 20) { DBGA("Open finger loops: " << loops << " Hand: " << myName.latin1()); }
+  if (loops > 20) { DBGA("Open finger loops: " << loops << " Hand: " << myName.toLatin1().constData()); }
   delete [] desiredVals;
   delete [] desiredSteps;
   return success;

--- a/src/robots/humanHand.cpp
+++ b/src/robots/humanHand.cpp
@@ -332,9 +332,9 @@ inline bool wrapperIntersection(TendonWrapper *wrapper, QString tendonName,
     vec3 dPrevLink = Pa_link - Pb_link;
     double length = dPrevLink.norm();
     dPrevLink = normalise(dPrevLink);
-    //DBGA("Tendon " << tendonName.latin1() << " has wrapping side; direction is " << dPrevLink);
+    //DBGA("Tendon " << tendonName.toLatin1().toStdString() << " has wrapping side; direction is " << dPrevLink);
     if ( dPrevLink % wrapping_direction < 0 ) {
-      DBGA("Tendon " << tendonName.latin1() << " on the wrong side of a wrapper at mua " << mua);
+      DBGA("Tendon " << tendonName.toLatin1().toStdString() << " on the wrong side of a wrapper at mua " << mua);
       //new insertion point is in opposite direction
       vec3 dRes = vec3(Pb_link.toSbVec3f() ) - ( wrapper->radius) * dPrevLink;
       newInsPtPos = position ( dRes.toSbVec3f() );
@@ -1182,7 +1182,7 @@ int HumanHand::loadFromXml(const TiXmlElement *root, QString rootPath)
   for (size_t t = 0; t < mTendonVec.size(); t++)
   {
     IVRoot->addChild(mTendonVec[t]->getIVRoot());
-    DBGA("Tendon " << mTendonVec[t]->getName().ascii() << " read and added");
+    DBGA("Tendon " << mTendonVec[t]->getName().toLatin1().toStdString() << " read and added");
   }
 
   elementList = findAllXmlElements(root, "tendonWrapper");

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -33,7 +33,7 @@
 #include <QStringList>
 #include <QSettings>
 #include <QPushButton>
-#include <Q3GroupBox>
+#include <QGroupBox>
 #include <QFile>
 #include <QDateTime>
 #include <QTextStream>
@@ -110,9 +110,10 @@ that will handle all user interaction. Also initialized collision detection
 system and reads in global settings such as friction coefficients
 */
 World::World(QObject *parent, const char *name) :
-  QObject(parent, name),
+  QObject(parent),
   myIVmgr(NULL)
 {
+  this->setObjectName(name);
   numBodies = numGB = numRobots = numHands = 0;
   numSelectedBodyElements = numSelectedRobotElements = 0;
   numSelectedElements = 0;
@@ -179,7 +180,7 @@ World::~World()
   }
 
   for (i = numBodies - 1; i >= 0; i--) {
-    DBGP("Deleting body: " << i << " " << bodyVec[i]->getName().latin1());
+    DBGP("Deleting body: " << i << " " << bodyVec[i]->getName().toLatin1().constData());
     destroyElement(bodyVec[i]);
   }
 
@@ -360,9 +361,9 @@ World::readSettings()
 
   setDefaults();
 
-  dynamicsTimeStep = settings.readDoubleEntry(QString("/GraspIt/") + QString("World/dynamicsTimeStep"), dynamicsTimeStep);
+  dynamicsTimeStep = settings.value(QString("/GraspIt/") + QString("World/dynamicsTimeStep"), dynamicsTimeStep).toDouble();
 
-  newNumMaterials = settings.readNumEntry(QString("/GraspIt/") + QString("World/numMaterials"), numMaterials);
+  newNumMaterials = settings.value(QString("/GraspIt/") + QString("World/numMaterials"), numMaterials).toInt();
 
   newcofTable = (double **)malloc(newNumMaterials * sizeof(double *));
   newkcofTable = (double **)malloc(newNumMaterials * sizeof(double *));
@@ -374,33 +375,33 @@ World::readSettings()
   }
 
   for (i = 0; i < numMaterials; i++) {
-    newMaterialNames[i] = settings.readEntry(QString("/GraspIt/") + QString("World/material%1").arg(i), materialNames[i]);
+    newMaterialNames[i] = settings.value(QString("/GraspIt/") + QString("World/material%1").arg(i), materialNames[i]).toString();
 
     for (j = i; j < numMaterials; j++) {
       newcofTable[i][j] = newcofTable[j][i] =
-                            settings.readDoubleEntry(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j), cofTable[i][j]);
+                            settings.value(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j), cofTable[i][j]).toDouble();
 
       newkcofTable[i][j] = newkcofTable[j][i] =
-                             settings.readDoubleEntry(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j), kcofTable[i][j]);
+                             settings.value(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j), kcofTable[i][j]).toDouble();
     }
 
     for (; j < newNumMaterials; j++) {
       newcofTable[i][j] = newcofTable[j][i] =
-                            settings.readDoubleEntry(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j));
+                            settings.value(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j)).toDouble();
 
       newkcofTable[i][j] = newkcofTable[j][i] =
-                             settings.readDoubleEntry(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j));
+                             settings.value(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j)).toDouble();
     }
   }
   for (; i < newNumMaterials; i++) {
-    newMaterialNames.push_back(settings.readEntry(QString("/GraspIt/") + QString("World/material%1").arg(i)));
+    newMaterialNames.push_back(settings.value(QString("/GraspIt/") + QString("World/material%1").arg(i)).toString());
 
     for (j = i; j < newNumMaterials; j++) {
       newcofTable[i][j] = newcofTable[j][i] =
-                            settings.readDoubleEntry(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j));
+                            settings.value(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j)).toDouble();
 
       newkcofTable[i][j] = newkcofTable[j][i] =
-                             settings.readDoubleEntry(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j));
+                             settings.value(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j)).toDouble();
     }
   }
 
@@ -426,12 +427,12 @@ World::saveSettings()
   QSettings settings(organization, application);
 
   int i, j;
-  settings.writeEntry(QString("/GraspIt/") + QString("World/numMaterials"), numMaterials);
+  settings.setValue(QString("/GraspIt/") + QString("World/numMaterials"), numMaterials);
   for (i = 0; i < numMaterials; i++) {
-    settings.writeEntry(QString("/GraspIt/") + QString("World/material%1").arg(i), materialNames[i]);
+    settings.setValue(QString("/GraspIt/") + QString("World/material%1").arg(i), materialNames[i]);
     for (j = i; j < numMaterials; j++) {
-      settings.writeEntry(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j), cofTable[i][j]);
-      settings.writeEntry(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j), kcofTable[i][j]);
+      settings.setValue(QString("/GraspIt/") + QString("World/cof%1%2").arg(i).arg(j), cofTable[i][j]);
+      settings.setValue(QString("/GraspIt/") + QString("World/kcof%1%2").arg(i).arg(j), kcofTable[i][j]);
     }
   }
 }
@@ -529,7 +530,7 @@ World::load(const QString &filename)
     graspitRoot += "/";
   }
   //load the graspit specific information in XML format
-  TiXmlDocument doc(filename);
+  TiXmlDocument doc(filename.toLatin1().constData());
   if (doc.LoadFile() == false) {
     QTWARNING("Could not open file " + filename);
     return FAILURE;
@@ -568,8 +569,8 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
       if (xmlElement) {
         elementName = xmlElement->GetText();
         elementPath = rootPath + elementName;
-        elementPath = elementPath.stripWhiteSpace();
-        DBGP("importing " << elementPath.latin1());
+        elementPath = elementPath.trimmed();
+        DBGP("importing " << elementPath.toLatin1().constData());
         element = importBody("Body", elementPath);
         if (!element) {
           QTWARNING("Could not open " + elementPath);
@@ -609,8 +610,8 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
       if (xmlElement) {
         elementName = xmlElement->GetText();
         elementPath = rootPath + elementName;
-        elementPath = elementPath.stripWhiteSpace();
-        DBGP("importing " << elementPath.latin1());
+        elementPath = elementPath.trimmed();
+        DBGP("importing " << elementPath.toLatin1().constData());
         element = importBody("GraspableBody", elementPath);
         if (!element) {
           QTWARNING("Could not open " + elementPath);
@@ -654,7 +655,7 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
       }
       elementName = xmlElement->GetText();
       elementPath = rootPath + elementName;
-      DBGP("importing " << elementPath.latin1());
+      DBGP("importing " << elementPath.toLatin1().constData());
       if ((robot = importRobot(elementPath)) == NULL) {
         QTWARNING("Could not open " + elementPath);
         return FAILURE;
@@ -663,7 +664,7 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
       xmlElement = findXmlElement(child, "dofValues");
       if (xmlElement) {
         QString dofValues =  xmlElement->GetText();
-        dofValues = dofValues.stripWhiteSpace().simplifyWhiteSpace();
+        dofValues = dofValues.trimmed().simplified();
         QTextStream lineStream(&dofValues, QIODevice::ReadOnly);
         robot->readDOFVals(lineStream);
       }
@@ -705,10 +706,10 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
       if (xmlElement) {
         mountFilename = xmlElement->GetText();
         if (!mountFilename.isEmpty()) {
-          mountFilename = mountFilename.stripWhiteSpace();
+          mountFilename = mountFilename.trimmed();
           KinematicChain *prevChain = robotVec[prevRobNum]->getChain(chainNum);
           mountFilename = rootPath + mountFilename;
-          DBGA("Mount filename: " << mountFilename.latin1());
+          DBGA("Mount filename: " << mountFilename.toLatin1().constData());
           if ((mountPiece = robotVec[nextRobNum]->importMountPiece(mountFilename))) {
             addLink(mountPiece);
             toggleCollisions(false, prevChain->getLink(prevChain->getNumLinks() - 1), mountPiece);
@@ -728,8 +729,8 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
         return FAILURE;
       }
       QString position = xmlElement->GetText();
-      position = position.simplifyWhiteSpace().stripWhiteSpace();
-      l = QStringList::split(' ', position);
+      position = position.simplified().trimmed();
+      l = position.split(' ');
       if (l.count() != 3) {
         QTWARNING("Invalid camera position input");
         return FAILURE;
@@ -748,8 +749,8 @@ World::loadFromXml(const TiXmlElement *root, QString rootPath)
         return FAILURE;
       }
       QString orientation = xmlElement->GetText();
-      position = orientation.simplifyWhiteSpace().stripWhiteSpace();
-      l = QStringList::split(' ', orientation);
+      position = orientation.simplified().trimmed();
+      l = orientation.split(' ');
       if (l.count() != 4) {
         QTWARNING("Invalid camera orientation input");
         return FAILURE;
@@ -809,7 +810,7 @@ World::save(const QString &filename)
   stream << "<?xml version=\"1.0\" ?>" << endl;
   stream << "<world>" << endl;
   for (i = 0; i < numBodies; i++) {
-    if (bodyVec[i]->isA("Body")) {
+    if (bodyVec[i]->metaObject()->className() == QString("Body")) {
       stream << "\t<obstacle>" << endl;
       if (bodyVec[i]->getFilename() == "unspecified") {
         stream << "\t\t<body>" << endl;
@@ -820,7 +821,7 @@ World::save(const QString &filename)
         stream << "\t\t</body>" << endl;
       }
       else {
-        stream << "\t\t<filename>" << bodyVec[i]->getFilename().latin1() << "</filename>" << endl;
+        stream << "\t\t<filename>" << bodyVec[i]->getFilename().toLatin1().constData() << "</filename>" << endl;
       }
       stream << "\t\t<transform>" << endl;
       stream << "\t\t\t<fullTransform>" << bodyVec[i]->getTran() << "</fullTransform>" << endl;
@@ -838,7 +839,7 @@ World::save(const QString &filename)
         stream << "\t\t</body>" << endl;
       }
       else {
-        stream << "\t\t<filename>" << bodyVec[i]->getFilename().latin1() << "</filename>" << endl;
+        stream << "\t\t<filename>" << bodyVec[i]->getFilename().toLatin1().constData() << "</filename>" << endl;
       }
       stream << "\t\t<transform>" << endl;
       stream << "\t\t\t<fullTransform>" << bodyVec[i]->getTran() << "</fullTransform>" << endl;
@@ -849,7 +850,7 @@ World::save(const QString &filename)
 
   for (i = 0; i < numRobots; i++) {
     stream << "\t<robot>" << endl;
-    stream << "\t\t<filename>" << robotVec[i]->getFilename().latin1() << "</filename>" << endl;
+    stream << "\t\t<filename>" << robotVec[i]->getFilename().toLatin1().constData() << "</filename>" << endl;
     stream << "\t\t<dofValues>";
     robotVec[i]->writeDOFVals(stream);
     stream << "</dofValues>" << endl;
@@ -1002,7 +1003,7 @@ World::addLink(Link *newLink)
 Robot *
 World::importRobot(QString filename)
 {
-  TiXmlDocument doc(filename);
+  TiXmlDocument doc(filename.toLatin1().constData());
   if (doc.LoadFile() == false) {
     QTWARNING("Could not open " + filename);
     return NULL;
@@ -1019,7 +1020,7 @@ World::importRobot(QString filename)
     QTWARNING("Class Type not found");
     return NULL;
   }
-  line = line.stripWhiteSpace();
+  line = line.trimmed();
 
   Robot *robot = (Robot *) getWorldElementFactory().createElement(line.toStdString(), this, NULL);
 

--- a/src/worldElement.cpp
+++ b/src/worldElement.cpp
@@ -50,7 +50,7 @@ const double WorldElement::ONE_STEP = 1.0e6;
   Protected constructor should only be called by subclasses.
   It initializes an empty worldElement.
 */
-WorldElement::WorldElement(World *w, const char *name) : QObject((QObject *)w, name)
+WorldElement::WorldElement(World *w, const char *name) : QObject((QObject *)w)
 {
   myWorld = w; IVRoot = NULL;
   if (!name) { myName = "unnamed"; }
@@ -63,7 +63,7 @@ WorldElement::WorldElement(World *w, const char *name) : QObject((QObject *)w, n
 /*!
   Protected copy constructor (should not be called by user)
 */
-WorldElement::WorldElement(const WorldElement &e) : QObject((QObject *)e.myWorld, e.name())
+WorldElement::WorldElement(const WorldElement &e) : QObject((QObject *)e.myWorld)
 {
   myWorld = e.myWorld;
   myName = e.myName;
@@ -140,8 +140,8 @@ WorldElement::interpolateTo(transf lastTran, transf newTran, const CollisionRepo
     if (deltat <= 1.0e-20 || t < 0) {
       for (int i = 0; i < numCols; i++) {
         double dist = myWorld->getDist(colReport[i].first, colReport[i].second);
-        DBGA(colReport[i].first->getName().latin1() << " -- " <<
-             colReport[i].second->getName().latin1() << " is " << dist);
+        DBGA(colReport[i].first->getName().toLatin1().constData() << " -- " <<
+             colReport[i].second->getName().toLatin1().constData() << " is " << dist);
       }
     }
 
@@ -181,10 +181,10 @@ bool WorldElement::jumpTo(transf newTran, CollisionReport *contactReport)
 
 #ifdef GRASPITDBG
     for (i = 0; i < numCols; i++) {
-      std::cerr << colReport[i].first->getName().latin1() << " -- "
-                << colReport[i].second->getName().latin1() << std::endl;
+      std::cerr << colReport[i].first->getName().toLatin1().constData() << " -- "
+                << colReport[i].second->getName().toLatin1().constData() << std::endl;
     }
-    DBGP("I am " << myName.latin1());
+    DBGP("I am " << myName.toLatin1().constData());
 #endif
 
     success = interpolateTo(lastTran, getTran(), colReport);
@@ -302,7 +302,7 @@ WorldElement::moveTo(transf &newTran, double translStepSize, double rotStepSize)
   }
 
   if (!success) {
-    DBGA("JumpTo error, stopping execution. Object " << myName.latin1() << " in thread "
+    DBGA("JumpTo error, stopping execution. Object " << myName.toLatin1().constData() << " in thread "
          << getWorld()->getCollisionInterface()->getThreadId());
   } else {
     myWorld->findContacts(contactReport);

--- a/test/graspit_collision_tests.cpp
+++ b/test/graspit_collision_tests.cpp
@@ -11,14 +11,14 @@
 #include "ivmgr.h"
 #include "world.h"
 #include "plannerdlg.h"
-#include "quality.h"
+#include "quality/quality.h"
 #include "robot.h"
 #include "qmDlg.h"
 #include "grasp.h"
-#include "collisionInterface.h"
-#include "collisionStructures.h"
+#include "Collision/collisionInterface.h"
+#include "Collision/collisionStructures.h"
 #include "collisionModel.h"
-#include "Graspit/collisionAlgorithms.h"
+#include "Collision/Graspit/collisionAlgorithms.h"
 #include "bBox.h"
 
 #define SLOP 0.001
@@ -142,8 +142,6 @@ int main(int argc, char **argv)
 {
   GraspItApp app(argc, NULL);
   GraspitCore core(argc, NULL);
-
-  app.setMainWidget(core.getMainWindow()->mWindow);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/primative_planner_tests.cpp
+++ b/test/primative_planner_tests.cpp
@@ -11,7 +11,7 @@
 #include "ivmgr.h"
 #include "world.h"
 #include "plannerdlg.h"
-#include "quality.h"
+#include "quality/quality.h"
 #include "robot.h"
 #include "qmDlg.h"
 #include "grasp.h"
@@ -72,8 +72,6 @@ TEST(TEST_PLANNER, TEST_VALID_GRASP_FOUND) {
   GraspItApp app(argc, NULL);
   GraspitCore core(argc, NULL);
 
-  app.setMainWidget(core.getMainWindow()->mWindow);
-
   QString fileName = QString(QString(getenv("GRASPIT"))+QString("/worlds/") + QString("plannerMug.xml"));
 
   graspitCore->getMainWindow()->mUI->worldBox->setTitle(fileName);
@@ -113,11 +111,6 @@ TEST(TEST_PLANNER, TEST_VALID_GRASP_FOUND) {
 
 int main(int argc, char **argv)
 {
-  GraspItApp app(argc, NULL);
-  GraspitCore core(argc, NULL);
-
-  app.setMainWidget(core.getMainWindow()->mWindow);
-
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tinyxml/tinyxml.h
+++ b/tinyxml/tinyxml.h
@@ -22,7 +22,7 @@ must not be misrepresented as being the original software.
 distribution.
 */
 
-//#define TIXML_USE_STL
+#define TIXML_USE_STL
 
 #ifndef TINYXML_INCLUDED
 #define TINYXML_INCLUDED

--- a/ui/DBase/dbaseDlg.cpp
+++ b/ui/DBase/dbaseDlg.cpp
@@ -77,9 +77,9 @@ void DBaseDlg::init()
   if (mDBMgr) {
     getModelList();
   }
-  sortBox->insertItem("Epsilon");
-  sortBox->insertItem("Volume");
-  sortBox->insertItem("Energy");
+  sortBox->addItem("Epsilon");
+  sortBox->addItem("Volume");
+  sortBox->addItem("Energy");
 }
 
 void DBaseDlg::destroy()
@@ -150,7 +150,7 @@ void DBaseDlg::connectButton_clicked()
 
 #ifndef ROS_DATABASE_MANAGER
   mDBMgr = new db_planner::SqlDatabaseManager(hostLineEdit->text().toStdString(),
-                                              atoi(portLineEdit->text().latin1()),
+                                              atoi(portLineEdit->text().toLatin1()),
                                               usernameLineEdit->text().toStdString(),
                                               passwordLineEdit->text().toStdString(),
                                               databaseLineEdit->text().toStdString(),
@@ -465,22 +465,22 @@ void DBaseDlg::displayModelList() {
   std::set<string> tags;
   mModelMap.clear();
   for (int i = 0; i < (int)mModelList.size(); ++i) {
-    modelsComboBox->insertItem(QString(mModelList[i]->ModelName().c_str()));
+    modelsComboBox->addItem(QString(mModelList[i]->ModelName().c_str()));
     tags.insert(mModelList[i]->Tags().begin(), mModelList[i]->Tags().end());
     mModelMap.insert(std::make_pair(mModelList[i]->ModelName(), i));
   }
   classesComboBox->clear();
-  classesComboBox->insertItem("ALL");
+  classesComboBox->addItem("ALL");
   for (std::set<string>::iterator i = tags.begin(); i != tags.end(); ++i) {
-    classesComboBox->insertItem(QString((*i).c_str()));
+    classesComboBox->addItem(QString((*i).c_str()));
   }
 }
 
 void DBaseDlg::displayGraspTypeList(std::vector<std::string> list) {
   typesComboBox->clear();
-  typesComboBox->insertItem("ALL");
+  typesComboBox->addItem("ALL");
   for (size_t i = 0; i < list.size(); ++i) {
-    typesComboBox->insertItem(QString(list[i].c_str()));
+    typesComboBox->addItem(QString(list[i].c_str()));
   }
 }
 
@@ -503,7 +503,7 @@ void DBaseDlg::showGrasp(int i)
       return;
     }
     static_cast<GraspitDBGrasp *>(mGraspList[i])->getFinalGraspPlanningState()->execute();
-    if (graspitCore->getWorld()->getCurrentHand()->isA("Barrett")) {
+    if (graspitCore->getWorld()->getCurrentHand()->metaObject()->className() == QString("Barrett")) {
       graspitCore->getWorld()->getCurrentHand()->autoGrasp(true);
     }
   }

--- a/ui/DBase/dbasePlannerDlg.cpp
+++ b/ui/DBase/dbasePlannerDlg.cpp
@@ -222,7 +222,7 @@ void DBasePlannerDlg::createGWSButton_clicked() {
 // put the entries into the distance function combo box
 void DBasePlannerDlg::initializeDistanceComboBox(std::vector<string> entries) {
   for (int i = 0; i < (int)entries.size(); ++i) {
-    distanceFunctionComboBox->insertItem(QString(entries[i].c_str()));
+    distanceFunctionComboBox->addItem(QString(entries[i].c_str()));
   }
 }
 
@@ -304,7 +304,7 @@ void DBasePlannerDlg::showGrasp(db_planner::Grasp *grasp) {
   }
   static_cast<GraspitDBModel *>(mPlanningModel)->getGraspableBody()->setTran(transf::IDENTITY);
   g->getPreGraspPlanningState()->execute();
-  if (mHand->isA("Barrett") && testedGraspRadioButton->isChecked()) {
+  if (mHand->metaObject()->className() == QString("Barrett") && testedGraspRadioButton->isChecked()) {
     graspitCore->getWorld()->getCurrentHand()->autoGrasp(true);
   }
   mHand->getWorld()->findAllContacts();
@@ -316,7 +316,7 @@ void DBasePlannerDlg::updateNeighborList() {
   neighborComboBoxInReconstruction = true;
   neighborComboBox->clear();
   for (int i = 0; i < (int)mNeighbors.size(); ++i) {
-    neighborComboBox->insertItem(mNeighbors[i].first->ModelName().c_str());
+    neighborComboBox->addItem(mNeighbors[i].first->ModelName().c_str());
   }
   neighborComboBoxInReconstruction = false;
 }

--- a/ui/EGPlanner/compliantPlannerDlg.cpp
+++ b/ui/EGPlanner/compliantPlannerDlg.cpp
@@ -56,8 +56,8 @@ void
 CompliantPlannerDlg::init()
 {
   mPlanner = new ListPlanner(mHand);
-  energyTypeBox->insertItem("COMPLIANT_ENERGY");
-  energyTypeBox->insertItem("DYNAMIC_AUTO_GRASP_ENERGY");
+  energyTypeBox->addItem("COMPLIANT_ENERGY");
+  energyTypeBox->addItem("DYNAMIC_AUTO_GRASP_ENERGY");
   mPlanner->setRenderType(RENDER_ALWAYS);
   mPlanner->setStatStream(&std::cerr);
   mOut = NULL;
@@ -73,8 +73,8 @@ CompliantPlannerDlg::init()
   QIntValidator *val2 = new QIntValidator(this);
   testOneEdit->setValidator(val2);
   testOneEdit->setText("0");
-  resultsBox->insertItem("console");
-  resultsBox->insertItem("file:");
+  resultsBox->addItem("console");
+  resultsBox->addItem("file:");
   resultsFileEdit->setText("comp_plan.txt");
 
   QDoubleValidator *dVal = new QDoubleValidator(0.5, 1.5, 3, this);
@@ -448,13 +448,13 @@ CompliantPlannerDlg::updateOut()
     return;
   }
   QString filename("data\\" + resultsFileEdit->text());
-  mOut = new std::fstream(filename.latin1(), std::fstream::out | std::fstream::app);
+  mOut = new std::fstream(filename.toLatin1().constData(), std::fstream::out | std::fstream::app);
   if (mOut->fail()) {
-    DBGA("Failed to open file " << filename.latin1());
+    DBGA("Failed to open file " << filename.toLatin1().constData());
     delete mOut; mOut = NULL;
-    resultsBox->setCurrentItem(0);
+    resultsBox->setCurrentIndex(0);
   } else {
-    DBGA("Output file opened: " << filename.latin1());
+    DBGA("Output file opened: " << filename.toLatin1().constData());
   }
 }
 

--- a/ui/EGPlanner/egPlannerDlg.cpp
+++ b/ui/EGPlanner/egPlannerDlg.cpp
@@ -68,16 +68,16 @@ void EigenGraspPlannerDlg::init()
   std::vector<std::string> registeredEnergies = SearchEnergyFactory::getInstance()->getAllRegisteredEnergy();
   for(std::vector<std::string>::const_iterator it = registeredEnergies.begin(); it != registeredEnergies.end(); it++)
   {
-      energyBox->insertItem(QString::fromStdString(*it));
+      energyBox->addItem(QString::fromStdString(*it));
   }
-  energyBox->setCurrentItem(5);
+  energyBox->setCurrentIndex(5);
 
-  plannerTypeBox->insertItem("Sim. Ann.");
-  plannerTypeBox->insertItem("Loop");
-  plannerTypeBox->insertItem("Multi-Threaded");
-  plannerTypeBox->insertItem("Online");
-  plannerTypeBox->insertItem("Time Test");
-  plannerTypeBox->setCurrentItem(0);
+  plannerTypeBox->addItem("Sim. Ann.");
+  plannerTypeBox->addItem("Loop");
+  plannerTypeBox->addItem("Multi-Threaded");
+  plannerTypeBox->addItem("Online");
+  plannerTypeBox->addItem("Time Test");
+  plannerTypeBox->setCurrentIndex(0);
 
   plannerInitButton->setEnabled(TRUE);
   plannerResetButton->setEnabled(FALSE);
@@ -93,23 +93,22 @@ void EigenGraspPlannerDlg::init()
   n.setNum(70000);
   annStepsEdit->setText(n);
 
-  spaceSearchBox->insertItem("Complete");
-  spaceSearchBox->insertItem("Axis-angle");
-  spaceSearchBox->insertItem("Ellipsoid");
-  spaceSearchBox->insertItem("Approach");
-  spaceSearchBox->setCurrentItem(1);
+  spaceSearchBox->addItem("Complete");
+  spaceSearchBox->addItem("Axis-angle");
+  spaceSearchBox->addItem("Ellipsoid");
+  spaceSearchBox->addItem("Approach");
+  spaceSearchBox->setCurrentIndex(1);
 
   prevGraspButton->setEnabled(FALSE);
   nextGraspButton->setEnabled(FALSE);
   bestGraspButton->setEnabled(FALSE);
 
-  variableBox->setColumnLayout(0, Qt::Vertical);
-
-  varGridLayout = new QGridLayout(variableBox->layout(), 1, 5);
+  varGridLayout = new QGridLayout(variableBox);
+  varGridLayout->addLayout(variableBox->layout(), 1, 5);
   varGridLayout->setSpacing(5);
   varGridLayout->setAlignment(Qt::AlignTop);
-  varGridLayout->addMultiCellWidget(spaceSearchLabel, 0, 0, 0, 1);
-  varGridLayout->addMultiCellWidget(spaceSearchBox, 0, 0, 2, 4);
+  varGridLayout->addWidget(spaceSearchLabel, 0, 0, 1, 1);
+  varGridLayout->addWidget(spaceSearchBox, 0, 2, 1, 4);
 
   varGridLayout->addWidget(new QLabel("On", variableBox), 1, 0);
   varGridLayout->addWidget(new QLabel("Name", variableBox), 1, 1);
@@ -132,11 +131,11 @@ void EigenGraspPlannerDlg::destroy()
   for (unsigned int i = 0; i < varNames.size(); i++) {
     //  varMainLayout->removeItem(varLayouts[i]);
 
-    varGridLayout->remove(varNames[i]);
-    varGridLayout->remove(varCheck[i]);
-    varGridLayout->remove(varInput[i]);
-    varGridLayout->remove(varTarget[i]);
-    varGridLayout->remove(varConfidence[i]);
+    varGridLayout->removeWidget(varNames[i]);
+    varGridLayout->removeWidget(varCheck[i]);
+    varGridLayout->removeWidget(varInput[i]);
+    varGridLayout->removeWidget(varTarget[i]);
+    varGridLayout->removeWidget(varConfidence[i]);
 
     delete varNames[i];
     delete varCheck[i];
@@ -183,11 +182,11 @@ void EigenGraspPlannerDlg::setVariableLayout()
 {
   //cleanup
   for (unsigned int i = 0; i < varNames.size(); i++) {
-    varGridLayout->remove(varNames[i]);
-    varGridLayout->remove(varCheck[i]);
-    varGridLayout->remove(varInput[i]);
-    varGridLayout->remove(varTarget[i]);
-    varGridLayout->remove(varConfidence[i]);
+    varGridLayout->removeWidget(varNames[i]);
+    varGridLayout->removeWidget(varCheck[i]);
+    varGridLayout->removeWidget(varInput[i]);
+    varGridLayout->removeWidget(varTarget[i]);
+    varGridLayout->removeWidget(varConfidence[i]);
     delete varNames[i];
     delete varCheck[i];
     delete varInput[i];
@@ -210,10 +209,12 @@ void EigenGraspPlannerDlg::setVariableLayout()
     QCheckBox *inputCheck = new QCheckBox(variableBox);
     connect(inputCheck, SIGNAL(clicked()), this, SLOT(variableInputChanged()));
     QLabel *target = new QLabel("N/A", variableBox);
-    QSlider *slider = new QSlider(0, 100, 10, 0, Qt::Horizontal, variableBox);
+    QSlider *slider = new QSlider(Qt::Horizontal, variableBox);
+    slider->setRange(0, 100);
+    slider->setPageStep(10);
     connect(slider, SIGNAL(sliderReleased()), this, SLOT(variableInputChanged()));
 
-    slider->setLineStep(1);
+    slider->setSingleStep(1);
     slider->setMaximumWidth(50);
     varGridLayout->addWidget(check, 2 + i, 0);
     varGridLayout->addWidget(name, 2 + i, 1);
@@ -578,14 +579,14 @@ void EigenGraspPlannerDlg::plannerInit_clicked()
     if (mPlanner) { delete mPlanner; }
     mPlanner = new GuidedPlanner(mHand);
     ((GuidedPlanner *)mPlanner)->setModelState(mHandObjectState);
-    energyBox->setCurrentItem(2);
+    energyBox->setCurrentIndex(2);
     energyBox->setEnabled(FALSE);
   } else if (s == QString("Online")) {
     if (mPlanner) { delete mPlanner; }
     mPlanner = new OnLinePlanner(mHand);
     ((OnLinePlanner *)mPlanner)->setModelState(mHandObjectState);
     energyBox->setEnabled(TRUE);
-    energyBox->setCurrentItem(5);
+    energyBox->setCurrentIndex(5);
     QString n;
     n.setNum(2000);
     annStepsEdit->setText(n);
@@ -669,16 +670,16 @@ void EigenGraspPlannerDlg::onlinePlannerUpdate()
   ActionType s = op->getAction();
   switch (s) {
     case ACTION_PLAN:
-      num.setAscii("PLANNING");
+      num = QString("PLANNING");
       break;
     case ACTION_GRASP:
-      num.setAscii("GRASPING");
+      num = QString("GRASPING");
       break;
     case ACTION_OPEN:
-      num.setAscii("OPEN");
+      num = QString("OPEN");
       break;
     default:
-      num.setAscii("N/A");
+      num = QString("N/A");
       break;
   }
   onlineStatusLabel->setText("Status: " + num);
@@ -773,7 +774,7 @@ void EigenGraspPlannerDlg::inputLoadButton_clicked()
     return;
   }
 
-  FILE *fp = fopen(fn.latin1(), "r");
+  FILE *fp = fopen(fn.toLatin1().constData(), "r");
   bool success = true;
   if (!fp) {
     DBGA("Failed to open input file!");

--- a/ui/EGPlanner/egPlannerDlg.ui
+++ b/ui/EGPlanner/egPlannerDlg.ui
@@ -26,7 +26,7 @@
     <string>Exit</string>
    </property>
   </widget>
-  <widget class="Q3GroupBox" name="groupBox3">
+  <widget class="QGroupBox" name="groupBox3">
    <property name="geometry">
     <rect>
      <x>300</x>
@@ -37,9 +37,6 @@
    </property>
    <property name="title">
     <string>Planner</string>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QLabel" name="textLabel1">
     <property name="geometry">
@@ -120,7 +117,7 @@
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="groupBox8">
+  <widget class="QGroupBox" name="groupBox8">
    <property name="geometry">
     <rect>
      <x>300</x>
@@ -131,9 +128,6 @@
    </property>
    <property name="title">
     <string>Settings and results</string>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QPushButton" name="nextGraspButton">
     <property name="geometry">
@@ -390,7 +384,7 @@
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="onlineDetailsGroup">
+  <widget class="QGroupBox" name="onlineDetailsGroup">
    <property name="geometry">
     <rect>
      <x>300</x>
@@ -401,9 +395,6 @@
    </property>
    <property name="title">
     <string>OnLine Planning Details</string>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QLabel" name="objDistLabel">
     <property name="geometry">
@@ -628,7 +619,7 @@
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="inputBox">
+  <widget class="QGroupBox" name="inputBox">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -639,9 +630,6 @@
    </property>
    <property name="title">
     <string>Input</string>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QPushButton" name="inputLoadButton">
     <property name="geometry">
@@ -670,7 +658,7 @@
     </property>
    </widget>
   </widget>
-  <widget class="Q3GroupBox" name="variableBox">
+  <widget class="QGroupBox" name="variableBox">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -681,9 +669,6 @@
    </property>
    <property name="title">
     <string>Space Search</string>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QComboBox" name="spaceSearchBox">
     <property name="geometry">
@@ -715,14 +700,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
- <customwidgets>
-  <customwidget>
-   <class>Q3GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>Qt3Support/Q3GroupBox</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <includes>
   <include location="global">vector</include>
  </includes>

--- a/ui/Planner/plannerdlg.cpp
+++ b/ui/Planner/plannerdlg.cpp
@@ -89,7 +89,7 @@ void PlannerDlg::init()
   if (grasp->getNumQM() == 0) { GenerateButton->setEnabled(false); }
   else {
     for (i = 0; i < grasp->getNumQM(); i++) {
-      qmComboBox->insertItem(grasp->getQM(i)->getName());
+      qmComboBox->addItem(grasp->getQM(i)->getName());
     }
   }
 }
@@ -134,7 +134,7 @@ void PlannerDlg::generateGrasps()
 
   myGraspManager->get_graspTester()->set_testingParameters(e, f);
   myGraspManager->get_graspTester()->
-  useQM(qmComboBox->currentItem());
+  useQM(qmComboBox->currentIndex());
   myGraspManager->set_render(visualizeBox->isChecked());
 
   if (automaticCheckBox->isChecked() || filenameLineEdit->text().isEmpty()) {
@@ -144,7 +144,7 @@ void PlannerDlg::generateGrasps()
   }
   else {
     if (filenameLineEdit->text().contains("master.txt")) {
-      masterFile.setName(filenameLineEdit->text());
+      masterFile.setFileName(filenameLineEdit->text());
       if (!masterFile.open(QIODevice::ReadOnly)) {
         QTWARNING("Could not open master grasp file");
         return;
@@ -186,7 +186,7 @@ void PlannerDlg::newQM()
   if (grasp->getNumQM() > 0) { GenerateButton->setEnabled(true); }
   qmComboBox->clear();
   for (int i = 0; i < grasp->getNumQM(); i++) {
-    qmComboBox->insertItem(grasp->getQM(i)->getName());
+    qmComboBox->addItem(grasp->getQM(i)->getName());
   }
 }
 

--- a/ui/Planner/plannerdlg.ui
+++ b/ui/Planner/plannerdlg.ui
@@ -31,12 +31,9 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="Q3GroupBox" name="plannerBox" >
+      <widget class="QGroupBox" name="plannerBox" >
        <property name="title" >
         <string>Generator</string>
-       </property>
-       <property name="orientation" >
-        <enum>Qt::Vertical</enum>
        </property>
        <layout class="QVBoxLayout" >
         <property name="margin" >
@@ -56,12 +53,9 @@
          </widget>
         </item>
         <item>
-         <widget class="Q3GroupBox" name="automaticBox" >
+         <widget class="QGroupBox" name="automaticBox" >
           <property name="title" >
            <string>Automatic</string>
-          </property>
-          <property name="orientation" >
-           <enum>Qt::Vertical</enum>
           </property>
           <layout class="QGridLayout" >
            <property name="margin" >
@@ -94,15 +88,12 @@
          </widget>
         </item>
         <item>
-         <widget class="Q3GroupBox" name="manualBox" >
+         <widget class="QGroupBox" name="manualBox" >
           <property name="enabled" >
            <bool>false</bool>
           </property>
           <property name="title" >
            <string>Manual</string>
-          </property>
-          <property name="orientation" >
-           <enum>Qt::Vertical</enum>
           </property>
           <layout class="QGridLayout" >
            <property name="margin" >
@@ -263,12 +254,9 @@
       </widget>
      </item>
      <item>
-      <widget class="Q3GroupBox" name="testerBox" >
+      <widget class="QGroupBox" name="testerBox" >
        <property name="title" >
         <string>Tester</string>
-       </property>
-       <property name="orientation" >
-        <enum>Qt::Vertical</enum>
        </property>
        <layout class="QGridLayout" >
         <property name="margin" >
@@ -474,15 +462,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11" />
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
- <customwidgets>
-  <customwidget>
-   <class>Q3GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>Qt3Support/Q3GroupBox</header>
-   <container>1</container>
-   <pixmap></pixmap>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>automaticCheckBox</tabstop>
   <tabstop>densityFactorLine</tabstop>
@@ -501,7 +480,6 @@
  </tabstops>
  <includes>
   <include location="global" >qfile.h</include>
-  <include location="global" >q3textstream.h</include>
  </includes>
  <resources/>
  <connections>

--- a/ui/about.ui
+++ b/ui/about.ui
@@ -45,7 +45,7 @@
           <item>
             <widget class="QLabel" name="pixmapLabel1" >
               <property name="pixmap" >
-                <pixmap>logo.png</pixmap>
+                <pixmap>:/images/logo.png</pixmap>
               </property>
               <property name="scaledContents" >
                 <bool>true</bool>

--- a/ui/barrettHandDlg.cpp
+++ b/ui/barrettHandDlg.cpp
@@ -21,7 +21,8 @@
 //
 // $Id: barrettHandDlg.cpp,v 1.5 2009/04/21 16:21:57 cmatei Exp $
 //
-//#######################################################################include "barrettHandDlg.h"
+//######################################################################
+#include "barrettHandDlg.h"
 
 #include <QValidator>
 #include <QPushButton>
@@ -38,7 +39,7 @@
 
 void BarrettHandDlg::init()
 {
-  QLineEdit *stepSize = (QLineEdit *) this->child("stepSize", "QLineEdit");
+  QLineEdit *stepSize = (QLineEdit *) this->findChild<QLineEdit*>("stepSize");
   stepSize->setValidator(new QIntValidator(0, 180, stepSize));
   withinSimulationUpdate = false;
   simulatedHandForContinuousOperation = NULL;
@@ -58,7 +59,7 @@ bool BarrettHandDlg::setWorld(World *w)
 #endif
   world = w;
   if (!world->getCurrentHand()) { return false; }
-  if (!world->getCurrentHand()->isA("Barrett")) { return false; }
+  if (!world->getCurrentHand()->metaObject()->className() == QString("Barrett")) { return false; }
   mSimBarrett = (Barrett *)world->getCurrentHand();
   mRealBarrett = mSimBarrett->getRealHand();
   if (!mRealBarrett) { return false; }
@@ -158,7 +159,7 @@ void BarrettHandDlg::toggleContinuousOperation()
     text = new QString("Begin continuous operation");
   }
 
-  QPushButton *button = (QPushButton *) this->child("continuousOperationButton", "QPushButton");
+  QPushButton *button = (QPushButton *) this->findChild<QPushButton *>("continuousOperationButton");
   button->setText(*text);
   delete text;
 }

--- a/ui/bodyPropDlg.cpp
+++ b/ui/bodyPropDlg.cpp
@@ -110,15 +110,15 @@ void BodyPropDlg::init()
   else { origIsDynamic = false; }
 
   for (i = 0; i < w->getNumMaterials(); i++) {
-    materialComboBox->insertItem(w->getMaterialName(i));
+    materialComboBox->addItem(w->getMaterialName(i));
   }
   int firstMat = bodyVec[0]->getMaterial();
   for (i = 1; i < numBodies; i++)
     if (bodyVec[i]->getMaterial() != firstMat) { break; }
-  if (i == numBodies) { materialComboBox->setCurrentItem(firstMat); }
+  if (i == numBodies) { materialComboBox->setCurrentIndex(firstMat); }
   else {
-    materialComboBox->insertItem(QString("Keep Original"));
-    materialComboBox->setCurrentItem(w->getNumMaterials());
+    materialComboBox->addItem(QString("Keep Original"));
+    materialComboBox->setCurrentIndex(w->getNumMaterials());
   }
 
   bool showFC = bodyVec[0]->frictionConesShown();
@@ -127,13 +127,13 @@ void BodyPropDlg::init()
   if (i == numBodies) { fcCheckBox->setChecked(showFC); }
   else {
     fcCheckBox->setTristate(true);
-    fcCheckBox->setNoChange();
+    fcCheckBox->setCheckState(Qt::PartiallyChecked);
   }
 
   float transp = bodyVec[0]->getTransparency();
   for (i = 1; i < numBodies; i++)
     if (bodyVec[i]->getTransparency() != transp) { break; }
-  if (i == numBodies) { transparencySlider->setValue((int)(transp * transparencySlider->maxValue())); }
+  if (i == numBodies) { transparencySlider->setValue((int)(transp * transparencySlider->maximum())); }
 
   boundingCheckBox->setChecked(false);
   boundingSpinBox->setEnabled(false);
@@ -148,7 +148,7 @@ void BodyPropDlg::init()
 */
 void BodyPropDlg::setTransparency(int val)
 {
-  float ratio = (float)val / (float)transparencySlider->maxValue();
+  float ratio = (float)val / (float)transparencySlider->maximum();
   for (int i = 0; i < numBodies; i++) {
     bodyVec[i]->setTransparency(ratio);
   }
@@ -161,8 +161,8 @@ void BodyPropDlg::setTransparency(int val)
 void BodyPropDlg::setShowAxes(int state)
 {
   if (!dynBod) { return; }
-  if (state == QCheckBox::On) { dynBod->showAxes(true); }
-  else if (state == QCheckBox::Off) { dynBod->showAxes(false); }
+  if (state == Qt::Checked) { dynBod->showAxes(true); }
+  else if (state == Qt::Unchecked) { dynBod->showAxes(false); }
 }
 
 /*!
@@ -172,9 +172,9 @@ void BodyPropDlg::setShowAxes(int state)
 void BodyPropDlg::setShowFC(int state)
 {
   for (int i = 0; i < numBodies; i++)
-    if (state == QCheckBox::On) { bodyVec[i]->showFrictionCones(true); }
-    else if (state == QCheckBox::Off) { bodyVec[i]->showFrictionCones(false); }
-    else if (state == QCheckBox::NoChange) { bodyVec[i]->showFrictionCones(origShowFC[i]); }
+    if (state == Qt::Checked) { bodyVec[i]->showFrictionCones(true); }
+    else if (state == Qt::Unchecked) { bodyVec[i]->showFrictionCones(false); }
+    else if (state == Qt::PartiallyChecked) { bodyVec[i]->showFrictionCones(origShowFC[i]); }
 }
 
 /*!
@@ -189,15 +189,15 @@ void BodyPropDlg::setShowFC(int state)
 void BodyPropDlg::setDynamic(int state)
 {
   if (dynBod) {
-    if (state == QCheckBox::On) { dynBod->setUseDynamics(true); }
-    else if (state == QCheckBox::Off) {
+    if (state == Qt::Checked) { dynBod->setUseDynamics(true); }
+    else if (state == Qt::Unchecked) {
       dynBod->setUseDynamics(false);
       axesCheckBox->setEnabled(false);
       dynamicForcesCheckBox->setEnabled(false);
       massLineEdit->setEnabled(false);
     }
   }
-  else if (state == QCheckBox::On) {
+  else if (state == Qt::Checked) {
     bodyVec[0]->getWorld()->deselectElement(bodyVec[0]);
     dynBod = bodyVec[0]->getWorld()->makeBodyDynamic(bodyVec[0], DynamicBody::defaultMass);
     dynBod->getWorld()->selectElement(dynBod);
@@ -205,7 +205,7 @@ void BodyPropDlg::setDynamic(int state)
     origAxesShown = dynBod->axesShown();
     origDynContactForcesShown = dynBod->dynContactForcesShown();
   }
-  if (state == QCheckBox::On) {
+  if (state == Qt::Checked) {
     axesCheckBox->setEnabled(true);
     dynamicForcesCheckBox->setEnabled(true);
     massLineEdit->setEnabled(true);
@@ -221,8 +221,8 @@ void BodyPropDlg::setDynamic(int state)
 void BodyPropDlg::setShowDynContactForces(int state)
 {
   if (!dynBod) { return; }
-  if (state == QCheckBox::On) { dynBod->showDynContactForces(true); }
-  else if (state == QCheckBox::Off) { dynBod->showDynContactForces(false); }
+  if (state == Qt::Checked) { dynBod->showDynContactForces(true); }
+  else if (state == Qt::Unchecked) { dynBod->showDynContactForces(false); }
 }
 
 /*!

--- a/ui/contactExaminerDlg.cpp
+++ b/ui/contactExaminerDlg.cpp
@@ -157,7 +157,7 @@ void ContactExaminerDlg::saveButton_clicked()
   }
 
   std::ofstream outFile;
-  outFile.open(fn.latin1(), std::ios::out | std::ios::trunc);
+  outFile.open(fn.toLatin1().constData(), std::ios::out | std::ios::trunc);
   if (!outFile.is_open())
   {
     fprintf(stderr, "Failed to open file for writing\n");
@@ -168,7 +168,7 @@ void ContactExaminerDlg::saveButton_clicked()
 
   outFile << "<?xml version=\"1.0\" ?>\n";
   outFile << "<virtual_contacts>\n";
-  outFile << "<robot_name>" << mHand->getName().latin1() << "</robot_name>" << std::endl;
+  outFile << "<robot_name>" << mHand->getName().toLatin1().constData() << "</robot_name>" << std::endl;
   outFile << "<num_contacts>" << (int)mMarkedContacts.size()<< "</num_contacts>" << std::endl;
 
   if (handRadioButton->isChecked()) {

--- a/ui/contactExaminerDlg.ui
+++ b/ui/contactExaminerDlg.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Virtual Grasp</string>
   </property>
-  <widget class="Q3GroupBox" name="graspQualityAnalysisGroupBox">
+  <widget class="QGroupBox" name="graspQualityAnalysisGroupBox">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -255,14 +255,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
- <customwidgets>
-  <customwidget>
-   <class>Q3GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>Qt3Support/Q3GroupBox</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <includes>
   <include location="global">vector</include>
  </includes>

--- a/ui/eigenGraspDlg.cpp
+++ b/ui/eigenGraspDlg.cpp
@@ -178,16 +178,21 @@ void EigenGraspDlg::resetSlave()
 
 void EigenGraspDlg::setSlaveLayout(int nGrasps)
 {
-  mainLayout = new QVBoxLayout(mSlave, 5);
+  mainLayout = new QVBoxLayout(mSlave);
+  mainLayout->setSpacing(5);
 
   QLabel *valueLabel = new QLabel(QString("Value:"), mSlave);
   QLabel *amplLabel = new QLabel(QString("Amplitude:"), mSlave);
   QLabel *fixedLabel = new QLabel(QString("Fixed"), mSlave);
 
-  QHBoxLayout *fakeRow = new QHBoxLayout(mainLayout, -1);
+  QHBoxLayout *fakeRow = new QHBoxLayout();
+  mainLayout->addLayout(fakeRow);
+  fakeRow->setSpacing(-1);
   fakeRow->addSpacing(400);
 
-  QHBoxLayout *labelRow = new QHBoxLayout(mainLayout, -1);
+  QHBoxLayout *labelRow = new QHBoxLayout();
+  mainLayout->addLayout(labelRow);
+  labelRow->setSpacing(-1);
   labelRow->addSpacing(5);
   labelRow->addWidget(valueLabel, 0);
   labelRow->addWidget(amplLabel, 1, Qt::AlignHCenter);
@@ -196,13 +201,15 @@ void EigenGraspDlg::setSlaveLayout(int nGrasps)
   mainLayout->addLayout(labelRow);
 
   for (int i = 0; i < nGrasps; i++) {
-    QHBoxLayout *graspRow = new QHBoxLayout(mainLayout, 10);
+    QHBoxLayout *graspRow = new QHBoxLayout();
+    mainLayout->addLayout(graspRow);
+    graspRow->setSpacing(10);
 
     QLabel *eigenValue = new QLabel(QString("0.0"), mSlave);
     QScrollBar *bar = new QScrollBar(Qt::Horizontal, mSlave);
     bar->setRange(-SLIDER_STEPS, SLIDER_STEPS);
     bar->setPageStep(5000);
-    bar->setLineStep(1000);
+    bar->setSingleStep(1000);
     bar->setValue(0);
     QCheckBox *box = new QCheckBox(mSlave);
 
@@ -237,7 +244,7 @@ void EigenGraspDlg::saveButton_clicked()
     if (fn.section('.', 1).isEmpty()) {
       fn.append(".xml");
     }
-    mEigenGrasps->writeToFile(fn.latin1());
+    mEigenGrasps->writeToFile(fn.toLatin1().constData());
   }
 }
 

--- a/ui/eigenGraspDlg.ui
+++ b/ui/eigenGraspDlg.ui
@@ -28,7 +28,7 @@
     <string>Exit</string>
    </property>
   </widget>
-  <widget class="Q3GroupBox" name="groupBox3" >
+  <widget class="QGroupBox" name="groupBox3" >
    <property name="geometry" >
     <rect>
      <x>10</x>
@@ -39,9 +39,6 @@
    </property>
    <property name="title" >
     <string>Properties and control</string>
-   </property>
-   <property name="orientation" >
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QPushButton" name="closeHandButton" >
     <property name="geometry" >
@@ -173,15 +170,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11" />
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
- <customwidgets>
-  <customwidget>
-   <class>Q3GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>Qt3Support/Q3GroupBox</header>
-   <container>1</container>
-   <pixmap></pixmap>
-  </customwidget>
- </customwidgets>
  <includes>
   <include location="global" >vector</include>
  </includes>

--- a/ui/gfoDlg.cpp
+++ b/ui/gfoDlg.cpp
@@ -48,15 +48,15 @@ GFODlg::GFODlg(MainWindow *mw, Hand *h, QWidget *parent) : QDialog(parent), mMai
 {
   setupUi(this);
   statusLabel->setText("Status: optimization off");
-  optimizationTypeBox->insertItem("Contact force existence");
-  optimizationTypeBox->insertItem("Contact force optimization");
-  optimizationTypeBox->insertItem("Grasp force existence");
-  optimizationTypeBox->insertItem("Grasp force optimization");
-  optimizationTypeBox->insertItem("Compliant joint equilibrium");
-  optimizationTypeBox->insertItem("DOF force equilibrium");
-  if (mHand->isA("McGrip")) {
-    optimizationTypeBox->insertItem("McGrip tendon route");
-    optimizationTypeBox->insertItem("McGrip joint equilibrium");
+  optimizationTypeBox->addItem("Contact force existence");
+  optimizationTypeBox->addItem("Contact force optimization");
+  optimizationTypeBox->addItem("Grasp force existence");
+  optimizationTypeBox->addItem("Grasp force optimization");
+  optimizationTypeBox->addItem("Compliant joint equilibrium");
+  optimizationTypeBox->addItem("DOF force equilibrium");
+  if (mHand->metaObject()->className() == QString("McGrip")) {
+    optimizationTypeBox->addItem("McGrip tendon route");
+    optimizationTypeBox->addItem("McGrip joint equilibrium");
   }
   QObject::connect(exitButton, SIGNAL(clicked()), this, SLOT(exitButtonClicked()));
   QObject::connect(mHand, SIGNAL(configurationChanged()), this, SLOT(handConfigurationChanged()));
@@ -138,7 +138,7 @@ GFODlg::displayResults(int result)
 void
 GFODlg::mcgripEquilibrium()
 {
-  if (!mHand->isA("McGrip")) {
+  if (!mHand->metaObject()->className() == QString("McGrip")) {
     DBGA("Hand is not a McGrip!");
     return;
   }
@@ -148,7 +148,7 @@ GFODlg::mcgripEquilibrium()
 
 void GFODlg::tendonRouteOptimization()
 {
-  if (!mHand->isA("McGrip")) {
+  if (!mHand->metaObject()->className() == QString("McGrip")) {
     DBGA("Hand is not a McGrip!");
     return;
   }

--- a/ui/gloveCalibrationDlg.cpp
+++ b/ui/gloveCalibrationDlg.cpp
@@ -42,19 +42,19 @@ void GloveCalibrationDlg::init()
 
   mInterface->saveRobotPose();
 
-  calibrationTypeBox->insertItem("Fist");
-  calibrationTypeBox->insertItem("Simple thumb");
-  calibrationTypeBox->insertItem("Complex thumb");
-  calibrationTypeBox->insertItem("Abd. - Add.");
-  calibrationTypeBox->insertItem("Mean Pose");
-  calibrationTypeBox->setCurrentItem(2);
+  calibrationTypeBox->addItem("Fist");
+  calibrationTypeBox->addItem("Simple thumb");
+  calibrationTypeBox->addItem("Complex thumb");
+  calibrationTypeBox->addItem("Abd. - Add.");
+  calibrationTypeBox->addItem("Mean Pose");
+  calibrationTypeBox->setCurrentIndex(2);
   mInterface->initCalibration(GloveInterface::COMPLEX_THUMB);
 
-  poseDistanceBox->insertItem("0");
-  poseDistanceBox->insertItem("17");
-  poseDistanceBox->insertItem("61");
-  poseDistanceBox->insertItem("82");
-  poseDistanceBox->setCurrentItem(0);
+  poseDistanceBox->addItem("0");
+  poseDistanceBox->addItem("17");
+  poseDistanceBox->addItem("61");
+  poseDistanceBox->addItem("82");
+  poseDistanceBox->setCurrentIndex(0);
 
   update();
 }
@@ -116,7 +116,7 @@ void GloveCalibrationDlg::save()
     if (fn.section('.', 1).isEmpty()) {
       fn.append(".txt");
     }
-    mInterface->saveCalibration(fn.latin1());
+    mInterface->saveCalibration(fn.toLatin1().constData());
   }
 }
 
@@ -136,7 +136,7 @@ void GloveCalibrationDlg::savePoses()
     if (fn.section('.', 1).isEmpty()) {
       fn.append(".pos");
     }
-    mInterface->saveCalibrationPoses(fn.latin1());
+    mInterface->saveCalibrationPoses(fn.toLatin1().constData());
   }
 }
 
@@ -146,7 +146,7 @@ void GloveCalibrationDlg::loadPoses()
   QString fn(QFileDialog::getOpenFileName(this, QString(), QString(getenv("GRASPIT")) + QString("/models/CyberGlove"),
                                           "Glove Pose Files (*.pos)"));
   if (!fn.isEmpty()) {
-    mInterface->loadCalibrationPoses(fn.latin1());
+    mInterface->loadCalibrationPoses(fn.toLatin1().constData());
   }
   update();
 }
@@ -156,14 +156,14 @@ void GloveCalibrationDlg::loadCalibration()
   QString fn(QFileDialog::getOpenFileName(this, QString(), QString(getenv("GRASPIT")) + QString("/models/CyberGlove"),
                                           "Glove Pose Files (*.txt)"));
   if (!fn.isEmpty()) {
-    mInterface->loadCalibration(fn.latin1());
+    mInterface->loadCalibration(fn.toLatin1().constData());
   }
 }
 
 
 void GloveCalibrationDlg::initCalibration()
 {
-  switch (calibrationTypeBox->currentItem()) {
+  switch (calibrationTypeBox->currentIndex()) {
     case 0:
       mInterface->initCalibration(GloveInterface::FIST);
       break;

--- a/ui/gloveCalibrationDlg.ui
+++ b/ui/gloveCalibrationDlg.ui
@@ -15,7 +15,7 @@
     <property name="windowTitle" >
       <string>Glove Calibration</string>
     </property>
-    <widget class="Q3GroupBox" name="groupBox5" >
+    <widget class="QGroupBox" name="groupBox5" >
       <property name="geometry" >
         <rect>
           <x>10</x>
@@ -212,7 +212,7 @@
         </property>
       </widget>
     </widget>
-    <widget class="Q3GroupBox" name="groupBox3" >
+    <widget class="QGroupBox" name="groupBox3" >
       <property name="geometry" >
         <rect>
           <x>10</x>

--- a/ui/graspCaptureDlg.cpp
+++ b/ui/graspCaptureDlg.cpp
@@ -143,9 +143,9 @@ GraspCaptureDlg::saveToFileButtonClicked()
                                           QString(getenv("GRASPIT")), "Text Files (*.txt)"));
   if (fn.isEmpty()) { return; }
   if (fn.section('.', 1).isEmpty()) { fn.append(".txt"); }
-  FILE *fp = fopen(fn.ascii(), "a");
+  FILE *fp = fopen(fn.toUtf8().constData(), "a");
   if (!fp) {
-    DBGA("Failed to open save file " << fn.ascii());
+    DBGA("Failed to open save file " << fn.toUtf8().constData());
     return;
   }
   std::list<GraspPlanningState *>::iterator it;

--- a/ui/graspCaptureDlg.h
+++ b/ui/graspCaptureDlg.h
@@ -54,9 +54,9 @@ class QualityIndicator : public QDialog, public Ui::QualityIndicatorUI
     void setBar(double value) {
       qualityBar->setValue((value / 0.25) * 100);
       if (value > 0.0) {
-        fcLabel->setEnabled(TRUE);
+        fcLabel->setEnabled(true);
       } else {
-        fcLabel->setEnabled(FALSE);
+        fcLabel->setEnabled(false);
       }
     }
 };

--- a/ui/gsaDlg.ui
+++ b/ui/gsaDlg.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Grasp Stability Analysis</string>
   </property>
-  <widget class="Q3GroupBox" name="gsaGroupBox">
+  <widget class="QGroupBox" name="gsaGroupBox">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -120,14 +120,6 @@
    </property>
   </widget>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>Q3GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>Qt3Support/Q3GroupBox</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/ui/gwsProjDlg.cpp
+++ b/ui/gwsProjDlg.cpp
@@ -85,7 +85,7 @@ GWSProjDlg::GWSProjDlg(QWidget *parent) : QDialog(parent)
   coordButtonGroup->setId(tzCheckBox, 5);
   //coordButtonGroup->hide();
   for (int i = 0; GWS::TYPE_LIST[i]; i++) {
-    gwsTypeComboBox->insertItem(QString(GWS::TYPE_LIST[i]));
+    gwsTypeComboBox->addItem(QString(GWS::TYPE_LIST[i]));
   }
   OKButton->setEnabled(false);
 }

--- a/ui/mainWindow.cpp
+++ b/ui/mainWindow.cpp
@@ -27,6 +27,7 @@
 
 #include <QDialog>
 #include <QStatusBar>
+#include <QPixmap>
 
 #include <QLineEdit>
 #include <QMessageBox>
@@ -82,8 +83,7 @@
 
 MainWindow::MainWindow(QWidget *parent)
 {
-  mWindow = new Q3MainWindow(parent);
-  //mWindow = new QMainWindow(parent);
+  mWindow = new QMainWindow(parent);
   mUI = new Ui::MainWindowUI;
   mUI->setupUi(mWindow);
   init();
@@ -103,12 +103,12 @@ MainWindow::MainWindow(QWidget *parent)
   QObject::connect(mUI->helpAboutAction, SIGNAL(triggered()), this, SLOT(helpAbout()));
   QObject::connect(mUI->helpAboutQTAction, SIGNAL(triggered()), this, SLOT(helpAboutQT()));
   // -- body meny
-  QObject::connect(mUI->elementGroup, SIGNAL(selected(QAction *)), this, SLOT(setTool(QAction *)));
-  QObject::connect(mUI->elementCollisionToggleAction, SIGNAL(activated()),
+  QObject::connect(mUI->elementGroup, SIGNAL(triggered(QAction *)), this, SLOT(setTool(QAction *)));
+  QObject::connect(mUI->elementCollisionToggleAction, SIGNAL(triggered()),
                    this, SLOT(elementTurnOffCollisions()));
   QObject::connect(mUI->elementCollisionToggleAction, SIGNAL(toggled(bool)),
                    this, SLOT(updateCollisionAction(bool)));
-  QObject::connect(mUI->elementBodyPropertiesAction, SIGNAL(activated()),
+  QObject::connect(mUI->elementBodyPropertiesAction, SIGNAL(triggered()),
                    this, SLOT(elementBodyProperties()));
   // -- grasp menu, part I
   QObject::connect(mUI->graspAutoGraspAction, SIGNAL(triggered()), this, SLOT(graspAutoGrasp()));
@@ -144,11 +144,11 @@ MainWindow::MainWindow(QWidget *parent)
   // -- misc menu
   QObject::connect(mUI->dynamicsArch_BuilderAction, SIGNAL(triggered()), this, SLOT(archBuilder()));
   // -- contacts
-  QObject::connect(mUI->contactsListBox, SIGNAL(highlighted(int)), this, SLOT(contactSelected(int)));
+  QObject::connect(mUI->contactsListBox, SIGNAL(currentRowChanged(int)), this, SLOT(contactSelected(int)));
   // -- dynamics
-  QObject::connect(mUI->dynamicsPlayAction, SIGNAL(activated()), this, SLOT(toggleDynamics()));
-  QObject::connect(mUI->dynamicsPopAction, SIGNAL(activated()), this, SLOT(dynamicsPopState()));
-  QObject::connect(mUI->dynamicsPushAction, SIGNAL(activated()), this, SLOT(dynamicsPushState()));
+  QObject::connect(mUI->dynamicsPlayAction, SIGNAL(triggered()), this, SLOT(toggleDynamics()));
+  QObject::connect(mUI->dynamicsPopAction, SIGNAL(triggered()), this, SLOT(dynamicsPopState()));
+  QObject::connect(mUI->dynamicsPushAction, SIGNAL(triggered()), this, SLOT(dynamicsPushState()));
   // -- toolbars
   QObject::connect(mUI->materialComboBox, SIGNAL(activated(int)), this, SLOT(materialSelected(int)));
   QObject::connect(mUI->graspedBodyBox, SIGNAL(activated(int)), this, SLOT(selectGraspedBody(int)));
@@ -168,14 +168,14 @@ void MainWindow::init()
 {
   world = NULL;
   mUI->timeReadout->display("00:00.000");
-  mWindow->statusBar()->message("Ready", 2000);
-  QIcon playIconSet = mUI->dynamicsPlayAction->iconSet();
-  playIconSet.setPixmap(load_pixmap("pause.xpm"), QIcon::Automatic, QIcon::Normal, QIcon::On);
-  mUI->dynamicsPlayAction->setIconSet(playIconSet);
+  mWindow->statusBar()->showMessage("Ready", 2000);
+  QIcon playIconSet = mUI->dynamicsPlayAction->icon();
+  playIconSet.addPixmap(QPixmap(":/images/pause.xpm"), QIcon::Normal, QIcon::On);
+  mUI->dynamicsPlayAction->setIcon(playIconSet);
 
-  QIcon collisionIconSet = mUI->elementCollisionToggleAction->iconSet();
-  collisionIconSet.setPixmap(load_pixmap("nocollide.xpm"), QIcon::Automatic, QIcon::Normal, QIcon::On);
-  mUI->elementCollisionToggleAction->setIconSet(collisionIconSet);
+  QIcon collisionIconSet = mUI->elementCollisionToggleAction->icon();
+  collisionIconSet.addPixmap(QPixmap(":/images/nocollide.xpm"), QIcon::Normal, QIcon::On);
+  mUI->elementCollisionToggleAction->setIcon(collisionIconSet);
 }
 
 /*!
@@ -409,12 +409,12 @@ void MainWindow::fileEditSettings()
 
   if (dlg->exec() == QDialog::Accepted) {
     //Process the changes to the COFs
-    for (i = 0; i < dlg->dlgUI->staticFrictionTable->numRows() - 1; i++) {
-      world->materialNames[i] = dlg->dlgUI->staticFrictionTable->text(i + 1, 0);
+    for (i = 0; i < dlg->dlgUI->staticFrictionTable->rowCount() - 1; i++) {
+      world->materialNames[i] = dlg->dlgUI->staticFrictionTable->item(i + 1, 0)->text();
 
-      for (j = 0; j < dlg->dlgUI->staticFrictionTable->numCols() - 1; j++) {
-        world->cofTable[i][j] = dlg->dlgUI->staticFrictionTable->text(i + 1, j + 1).toDouble();
-        world->kcofTable[i][j] = dlg->dlgUI->kineticFrictionTable->text(i + 1, j + 1).toDouble();
+      for (j = 0; j < dlg->dlgUI->staticFrictionTable->columnCount() - 1; j++) {
+        world->cofTable[i][j] = dlg->dlgUI->staticFrictionTable->item(i + 1, j + 1)->text().toDouble();
+        world->kcofTable[i][j] = dlg->dlgUI->kineticFrictionTable->item(i + 1, j + 1)->text().toDouble();
       }
     }
     world->dynamicsTimeStep = dlg->dlgUI->timeStepLine->text().toDouble() * 1.0e-3;
@@ -494,7 +494,7 @@ void MainWindow::setTool(QAction *a)
 */
 void MainWindow::elementTurnOffCollisions()
 {
-  world->toggleAllCollisions(!mUI->elementCollisionToggleAction->isOn());
+  world->toggleAllCollisions(!mUI->elementCollisionToggleAction->isEnabled());
 }
 
 /*!
@@ -568,7 +568,7 @@ void MainWindow::updateElementMenu()
         break;
       }
   }
-  mUI->elementCollisionToggleAction->setOn(collisionsOFF);
+  mUI->elementCollisionToggleAction->setChecked(collisionsOFF);
 
 }
 
@@ -621,7 +621,7 @@ void MainWindow::graspCreateProjection(Grasp *g)
     else {
       grasp = g;
     }
-    GWS *gws = grasp->addGWS(dlg->gwsTypeComboBox->currentText().latin1());
+    GWS *gws = grasp->addGWS(dlg->gwsTypeComboBox->currentText().toLatin1().constData());
 
     double w[6];
     w[0] = dlg->fxCoord->text().toDouble();
@@ -711,7 +711,7 @@ MainWindow::graspStabilityAnalysis()
 */
 void MainWindow::graspCompliantPlanner()
 {
-  int gb = mUI->graspedBodyBox->currentItem();
+  int gb = mUI->graspedBodyBox->currentIndex();
   if (gb < 0 || world->getNumGB() < gb + 1) {
     fprintf(stderr, "No object selected\n");
     return;
@@ -770,7 +770,7 @@ void MainWindow::eigenGraspPlannerActivated()
     fprintf(stderr, "Current hand has no EigenGrasp information!\n");
     return;
   }
-  int gb = mUI->graspedBodyBox->currentItem();
+  int gb = mUI->graspedBodyBox->currentIndex();
   if (gb < 0 || world->getNumGB() < gb + 1) {
     fprintf(stderr, "No object selected\n");
     return;
@@ -800,7 +800,7 @@ void MainWindow::dbasePlannerAction_activated()
     QTWARNING("No hand selected");
     return;
   }
-  int gb = mUI->graspedBodyBox->currentItem();
+  int gb = mUI->graspedBodyBox->currentIndex();
   if (gb < 0 || world->getNumGB() < gb + 1) {
     QTWARNING("No object selected");
     return;
@@ -955,7 +955,7 @@ void MainWindow::updateContactsList()
 
     for (cp = contactList.begin(); cp != contactList.end(); cp++, contactNum++) {
       contactForce = (*cp)->getDynamicContactWrench();
-      mUI->contactsListBox->insertItem(QString("Contact %1:  force %2 %3 %4 torque %5 %6 %7").
+      mUI->contactsListBox->addItem(QString("Contact %1:  force %2 %3 %4 torque %5 %6 %7").
                                        arg(contactNum + 1).
                                        arg(contactForce[0], 5, 'f', 2).arg(contactForce[1], 5, 'f', 2).arg(contactForce[2], 5, 'f', 2).
                                        arg(contactForce[3], 5, 'f', 4).arg(contactForce[4], 5, 'f', 4).arg(contactForce[5], 5, 'f', 4));
@@ -997,7 +997,7 @@ void MainWindow::clearContactsList()
 */
 void MainWindow::updateTimeReadout()
 {
-  QTime simTime;
+  QTime simTime(0, 0, 0, 0);
   double seconds = world->getWorldTime();
   simTime = simTime.addMSecs(ROUND(seconds * 1000));
   mUI->timeReadout->display(simTime.toString("mm:ss.zzz"));
@@ -1040,12 +1040,12 @@ void MainWindow::updateQualityList()
     h = world->getHand(i);
     g = h->getGrasp();
 
-    mUI->qualityListBox->insertItem(h->getName());
+    mUI->qualityListBox->addItem(h->getName());
 
     for (int j = 0; j < g->getNumQM(); j++) {
       valStr = "  " + g->getQM(j)->getName() +
                QString(": %1").arg(g->getQM(j)->evaluate(), 6, 'g', 3);
-      mUI->qualityListBox->insertItem(valStr);
+      mUI->qualityListBox->addItem(valStr);
     }
   }
 }
@@ -1056,7 +1056,7 @@ void MainWindow::updateQualityList()
 */
 void MainWindow::showDynamicsError(const char *errMsg)
 {
-  mUI->dynamicsPlayAction->setOn(false);
+  mUI->dynamicsPlayAction->setEnabled(false);
   QTWARNING(errMsg);
 }
 
@@ -1085,7 +1085,7 @@ void MainWindow::updateMaterialBoxList()
 {
   mUI->materialComboBox->clear();
   for (int i = 0; i < world->getNumMaterials(); i++) {
-    mUI->materialComboBox->insertItem(world->getMaterialName(i));
+    mUI->materialComboBox->addItem(world->getMaterialName(i));
   }
 }
 
@@ -1115,16 +1115,16 @@ void MainWindow::updateMaterialBox()
     for (i = 1; i < world->getNumSelectedBodies(); i++)
       if (world->getSelectedBody(i)->getMaterial() != firstMat) { break; }
     if (i == world->getNumSelectedBodies()) {
-      mUI->materialComboBox->setCurrentItem(firstMat);
+      mUI->materialComboBox->setCurrentIndex(firstMat);
       if (mUI->materialComboBox->count() > world->getNumMaterials()) {
         mUI->materialComboBox->removeItem(world->getNumMaterials());
       }
     }
     else {
       if (mUI->materialComboBox->count() == world->getNumMaterials()) {
-        mUI->materialComboBox->insertItem(QString(" "));
+        mUI->materialComboBox->addItem(QString(" "));
       }
-      mUI->materialComboBox->setCurrentItem(world->getNumMaterials());
+      mUI->materialComboBox->setCurrentIndex(world->getNumMaterials());
     }
   }
 }
@@ -1137,9 +1137,9 @@ void MainWindow::updateGraspBoxes()
 {
   mUI->handSelectionBox->clear();
   for (int i = 0; i < world->getNumHands(); i++) {
-    mUI->handSelectionBox->insertItem(world->getHand(i)->getName());
+    mUI->handSelectionBox->addItem(world->getHand(i)->getName());
     if (world->getCurrentHand() == world->getHand(i)) {
-      mUI->handSelectionBox->setCurrentItem(i);
+      mUI->handSelectionBox->setCurrentIndex(i);
     }
     updateTendonNamesBox();
     world->deselectTendon();
@@ -1147,9 +1147,9 @@ void MainWindow::updateGraspBoxes()
   mUI->graspedBodyBox->clear();
   if (world->getCurrentHand()) {
     for (int i = 0; i < world->getNumGB(); i++) {
-      mUI->graspedBodyBox->insertItem(world->getGB(i)->getName());
+      mUI->graspedBodyBox->addItem(world->getGB(i)->getName());
       if (world->getCurrentHand()->getGrasp()->getObject() == world->getGB(i)) {
-        mUI->graspedBodyBox->setCurrentItem(i);
+        mUI->graspedBodyBox->setCurrentIndex(i);
       }
     }
   }
@@ -1161,7 +1161,7 @@ void MainWindow::handleHandSelectionChange()
   int i;
   for (i = 0; i < world->getNumHands(); i++) {
     if (world->getCurrentHand() == world->getHand(i)) {
-      mUI->handSelectionBox->setCurrentItem(i);
+      mUI->handSelectionBox->setCurrentIndex(i);
     }
   }
   updateTendonNamesBox();
@@ -1175,7 +1175,7 @@ void MainWindow::handleHandSelectionChange()
 void MainWindow::selectGraspedBody(int sb)
 {
   GraspableBody *b = world->getGB(sb);
-  world->getHand(mUI->handSelectionBox->currentItem())->getGrasp()->setObject(b);
+  world->getHand(mUI->handSelectionBox->currentIndex())->getGrasp()->setObject(b);
   updateQualityList();
 }
 
@@ -1220,7 +1220,7 @@ void MainWindow::handleTendonSelectionArea()
     mUI->forcesVisibleLabel->setEnabled(false);
     mUI->forcesVisibleCheckBox->setEnabled(false);
     if (mUI->tendonNamesBox->isEnabled()) {
-      mUI->tendonNamesBox->setCurrentItem(mUI->tendonNamesBox->count() - 1);    /* "none selected" */
+      mUI->tendonNamesBox->setCurrentIndex(mUI->tendonNamesBox->count() - 1);    /* "none selected" */
     }
   } else {
     mUI->tendonActiveForceLabel->setEnabled(true);
@@ -1240,8 +1240,8 @@ void MainWindow::handleTendonSelectionArea()
     }
     //there's got to be a better way to do this...
     for (int i = 0; i < mUI->tendonNamesBox->count(); i++) {
-      if (mUI->tendonNamesBox->text(i) == world->getSelectedTendon()->getName()) {
-        mUI->tendonNamesBox->setCurrentItem(i);
+      if (mUI->tendonNamesBox->itemText(i) == world->getSelectedTendon()->getName()) {
+        mUI->tendonNamesBox->setCurrentIndex(i);
         break;
       }
     }
@@ -1327,7 +1327,7 @@ void MainWindow::updateTendonNamesBox()
   mUI->tendonNamesBox->setEnabled(true);
   mUI->tendonNamesBox->clear();
   for (i = 0; i < nrTendons; i++) {
-    mUI->tendonNamesBox->insertItem(world->getSelectedHandTendonName(i));
+    mUI->tendonNamesBox->addItem(world->getSelectedHandTendonName(i));
   }
-  mUI->tendonNamesBox->insertItem(QString("--none selected--"));
+  mUI->tendonNamesBox->addItem(QString("--none selected--"));
 }

--- a/ui/mainWindow.h
+++ b/ui/mainWindow.h
@@ -43,8 +43,7 @@
 
 #include "ui_mainWindow.h"
 
-#include <Q3MainWindow>
-//#include <QMainWindow>
+#include <QMainWindow>
 #include <QString>
 #include <QObject>
 
@@ -65,7 +64,7 @@ class MainWindow : public QObject
     void destroyChildren();
   public:
     Ui::MainWindowUI *mUI;
-    Q3MainWindow *mWindow;
+    QMainWindow *mWindow;
 
     MainWindow(QWidget *parent = 0);
     virtual ~MainWindow() {

--- a/ui/mainWindow.ui
+++ b/ui/mainWindow.ui
@@ -3,7 +3,7 @@
   <comment></comment>
   <exportmacro></exportmacro>
   <class>MainWindowUI</class>
-  <widget class="Q3MainWindow" name="MainWindowUI" >
+  <widget class="QMainWindow" name="MainWindowUI" >
     <property name="geometry" >
       <rect>
         <x>0</x>
@@ -24,7 +24,7 @@
           <number>0</number>
         </property>
         <item>
-          <widget class="Q3GroupBox" name="worldBox" >
+          <widget class="QGroupBox" name="worldBox" >
             <property name="sizePolicy" >
               <sizepolicy>
                 <hsizetype>7</hsizetype>
@@ -73,7 +73,7 @@
               <number>6</number>
             </property>
             <item>
-              <widget class="Q3GroupBox" name="qualityGroupBox" >
+              <widget class="QGroupBox" name="qualityGroupBox" >
                 <property name="sizePolicy" >
                   <sizepolicy>
                     <hsizetype>5</hsizetype>
@@ -99,12 +99,12 @@
                     <number>6</number>
                   </property>
                   <item>
-                    <widget class="Q3ListBox" name="qualityListBox" >
+                    <widget class="QListWidget" name="qualityListBox" >
                       <property name="focusPolicy" >
                         <enum>Qt::NoFocus</enum>
                       </property>
                       <property name="selectionMode" >
-                        <enum>Q3ListBox::NoSelection</enum>
+                        <enum>QListWidget::NoSelection</enum>
                       </property>
                       <item>
                         <property name="text" >
@@ -117,7 +117,7 @@
               </widget>
             </item>
             <item>
-              <widget class="Q3GroupBox" name="contactsGroupBox" >
+              <widget class="QGroupBox" name="contactsGroupBox" >
                 <property name="sizePolicy" >
                   <sizepolicy>
                     <hsizetype>5</hsizetype>
@@ -143,7 +143,7 @@
                     <number>6</number>
                   </property>
                   <item>
-                    <widget class="Q3ListBox" name="contactsListBox" >
+                    <widget class="QListWidget" name="contactsListBox" >
                       <property name="focusPolicy" >
                         <enum>Qt::NoFocus</enum>
                       </property>
@@ -156,11 +156,8 @@
         </item>
       </layout>
     </widget>
-    <widget class="Q3ToolBar" name="toolBar" >
-      <property name="resizeEnabled" >
-        <bool>false</bool>
-      </property>
-      <property name="label" >
+    <widget class="QToolBar" name="toolBar" >
+      <property name="windowTitle" >
         <string>File</string>
       </property>
       <addaction name="fileNewAction" />
@@ -168,11 +165,8 @@
       <addaction name="fileSaveAction" />
       <addaction name="separator" />
     </widget>
-    <widget class="Q3ToolBar" name="Toolbar_2" >
-      <property name="resizeEnabled" >
-        <bool>false</bool>
-      </property>
-      <property name="label" >
+    <widget class="QToolBar" name="Toolbar_2" >
+      <property name="windowTitle" >
         <string>Body Tools</string>
       </property>
       <widget class="QComboBox" name="materialComboBox" >
@@ -188,17 +182,13 @@
       <addaction name="selectToolAction" />
       <addaction name="separator" />
       <addaction name="elementCollisionToggleAction" />
-      <addaction name="materialComboBox" />
     </widget>
-    <widget class="Q3ToolBar" name="ToolbarDynamics" >
-      <property name="resizeEnabled" >
-        <bool>false</bool>
-      </property>
-      <property name="label" >
+    <widget class="QToolBar" name="ToolbarDynamics" >
+      <property name="windowTitle" >
         <string>Dynamics</string>
       </property>
       <widget class="QLCDNumber" name="timeReadout" >
-        <property name="numDigits" >
+        <property name="digitCount" >
           <number>9</number>
         </property>
         <property name="toolTip" stdset="0" >
@@ -208,13 +198,9 @@
       <addaction name="dynamicsPopAction" />
       <addaction name="dynamicsPushAction" />
       <addaction name="dynamicsPlayAction" />
-      <addaction name="timeReadout" />
     </widget>
-    <widget class="Q3ToolBar" name="graspToolbar" >
-      <property name="resizeEnabled" >
-        <bool>false</bool>
-      </property>
-      <property name="label" >
+    <widget class="QToolBar" name="graspToolbar" >
+      <property name="windowTitle" >
         <string>Grasp</string>
       </property>
       <widget class="QComboBox" name="handSelectionBox" >
@@ -233,14 +219,9 @@
           <string>Body to grasp</string>
         </property>
       </widget>
-      <addaction name="handSelectionBox" />
-      <addaction name="graspedBodyBox" />
     </widget>
-    <widget class="Q3ToolBar" name="tendonToolbar" >
-      <property name="resizeEnabled" >
-        <bool>false</bool>
-      </property>
-      <property name="label" >
+    <widget class="QToolBar" name="tendonToolbar" >
+      <property name="windowTitle" >
         <string>Tendon forces</string>
       </property>
       <widget class="QLabel" name="Tendon_force_label" >
@@ -376,18 +357,6 @@
           <string/>
         </property>
       </widget>
-      <addaction name="Tendon_force_label" />
-      <addaction name="tendonNamesBox" />
-      <addaction name="tendonActiveForceLabel" />
-      <addaction name="TendonForceInput" />
-      <addaction name="tendonPassiveForceLabel" />
-      <addaction name="tendonPassiveForceEdit" />
-      <addaction name="tendonExcursionLabel" />
-      <addaction name="tendonExcursionEdit" />
-      <addaction name="tendonVisibleLabel" />
-      <addaction name="tendonVisibleCheckBox" />
-      <addaction name="forcesVisibleLabel" />
-      <addaction name="forcesVisibleCheckBox" />
     </widget>
     <widget class="QMenuBar" name="menubar" >
       <widget class="QMenu" name="fileMenu" >
@@ -485,11 +454,11 @@
       <addaction name="helpMenu" />
     </widget>
     <action name="fileNewAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileNewAction</cstring>
       </property>
       <property name="icon" >
-        <iconset>filenew.xpm</iconset>
+        <iconset>:/images/filenew.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>New</string>
@@ -502,11 +471,11 @@
       </property>
     </action>
     <action name="fileOpenAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileOpenAction</cstring>
       </property>
       <property name="icon" >
-        <iconset>fileopen.xpm</iconset>
+        <iconset>:/images/fileopen.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>Open</string>
@@ -519,11 +488,11 @@
       </property>
     </action>
     <action name="fileSaveAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileSaveAction</cstring>
       </property>
       <property name="icon" >
-        <iconset>filesave.xpm</iconset>
+        <iconset>:/images/filesave.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>Save</string>
@@ -536,7 +505,7 @@
       </property>
     </action>
     <action name="fileSaveAsAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileSaveAsAction</cstring>
       </property>
       <property name="iconText" >
@@ -550,7 +519,7 @@
       </property>
     </action>
     <action name="fileExitAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileExitAction</cstring>
       </property>
       <property name="iconText" >
@@ -564,7 +533,7 @@
       </property>
     </action>
     <action name="helpManualAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>helpManualAction</cstring>
       </property>
       <property name="iconText" >
@@ -581,7 +550,7 @@
       </property>
     </action>
     <action name="helpIndexAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>helpIndexAction</cstring>
       </property>
       <property name="iconText" >
@@ -595,7 +564,7 @@
       </property>
     </action>
     <action name="helpAboutAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>helpAboutAction</cstring>
       </property>
       <property name="iconText" >
@@ -609,7 +578,7 @@
       </property>
     </action>
     <action name="fileImportRobotAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileImportRobotAction</cstring>
       </property>
       <property name="iconText" >
@@ -620,7 +589,7 @@
       </property>
     </action>
     <action name="fileImportObjectAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileImportObjectAction</cstring>
       </property>
       <property name="iconText" >
@@ -631,7 +600,7 @@
       </property>
     </action>
     <action name="fileImportObstacleAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileImportObstacleAction</cstring>
       </property>
       <property name="iconText" >
@@ -642,7 +611,7 @@
       </property>
     </action>
     <action name="fileSaveImageAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileSaveImageAction</cstring>
       </property>
       <property name="iconText" >
@@ -653,7 +622,7 @@
       </property>
     </action>
     <action name="graspCreateProjectionAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspCreateProjectionAction</cstring>
       </property>
       <property name="iconText" >
@@ -664,7 +633,7 @@
       </property>
     </action>
     <action name="graspQualityMeasuresAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspQualityMeasuresAction</cstring>
       </property>
       <property name="iconText" >
@@ -675,7 +644,7 @@
       </property>
     </action>
     <action name="fileEditSettingsAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileEditSettingsAction</cstring>
       </property>
       <property name="iconText" >
@@ -686,7 +655,7 @@
       </property>
     </action>
     <action name="graspPlannerAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspPlannerAction</cstring>
       </property>
       <property name="iconText" >
@@ -697,7 +666,7 @@
       </property>
     </action>
     <action name="graspGFOAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspGFOAction</cstring>
       </property>
       <property name="iconText" >
@@ -708,7 +677,7 @@
       </property>
     </action>
     <action name="graspStabilityAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspStabilityAction</cstring>
       </property>
       <property name="iconText" >
@@ -719,7 +688,7 @@
       </property>
     </action>
     <action name="graspCompliantPlannerAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspCompliantPlannerAction</cstring>
       </property>
       <property name="iconText" >
@@ -730,14 +699,14 @@
       </property>
     </action>
     <action name="dynamicsPlayAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dynamicsPlayAction</cstring>
       </property>
       <property name="checkable" >
         <bool>true</bool>
       </property>
       <property name="icon" >
-        <iconset>play.xpm</iconset>
+        <iconset>:/images/play.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>Start Simulation</string>
@@ -747,11 +716,11 @@
       </property>
     </action>
     <action name="dynamicsPopAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dynamicsPopAction</cstring>
       </property>
       <property name="icon" >
-        <iconset>prevMark.xpm</iconset>
+        <iconset>:/images/prevMark.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>Pop State</string>
@@ -761,11 +730,11 @@
       </property>
     </action>
     <action name="dynamicsPushAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dynamicsPushAction</cstring>
       </property>
       <property name="icon" >
-        <iconset>mark.xpm</iconset>
+        <iconset>:/images/mark.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>Push State</string>
@@ -775,14 +744,14 @@
       </property>
     </action>
     <action name="elementCollisionToggleAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>elementCollisionToggleAction</cstring>
       </property>
       <property name="checkable" >
         <bool>true</bool>
       </property>
       <property name="icon" >
-        <iconset>collide.xpm</iconset>
+        <iconset>:/images/collide.xpm</iconset>
       </property>
       <property name="iconText" >
         <string>Collisions ON</string>
@@ -792,7 +761,7 @@
       </property>
     </action>
     <action name="elementBodyPropertiesAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>elementBodyPropertiesAction</cstring>
       </property>
       <property name="enabled" >
@@ -806,7 +775,7 @@
       </property>
     </action>
     <action name="graspAutoGraspAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspAutoGraspAction</cstring>
       </property>
       <property name="iconText" >
@@ -820,7 +789,7 @@
       </property>
     </action>
     <action name="helpAboutQTAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>helpAboutQTAction</cstring>
       </property>
       <property name="iconText" >
@@ -831,7 +800,7 @@
       </property>
     </action>
     <action name="fileImport_Human_HandAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>fileImport_Human_HandAction</cstring>
       </property>
       <property name="iconText" >
@@ -842,7 +811,7 @@
       </property>
     </action>
     <action name="dynamicsArch_BuilderAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dynamicsArch_BuilderAction</cstring>
       </property>
       <property name="iconText" >
@@ -853,7 +822,7 @@
       </property>
     </action>
     <action name="sensorsSensor_InputAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>sensorsSensor_InputAction</cstring>
       </property>
       <property name="iconText" >
@@ -864,7 +833,7 @@
       </property>
     </action>
     <action name="stereoOnAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>stereoOnAction</cstring>
       </property>
       <property name="iconText" >
@@ -875,7 +844,7 @@
       </property>
     </action>
     <action name="stereoOffAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>stereoOffAction</cstring>
       </property>
       <property name="iconText" >
@@ -886,7 +855,7 @@
       </property>
     </action>
     <action name="stereoFlip_leftrightAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>stereoFlip_leftrightAction</cstring>
       </property>
       <property name="iconText" >
@@ -897,7 +866,7 @@
       </property>
     </action>
     <action name="dbaseGraspCaptureAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dbaseGraspCaptureAction</cstring>
       </property>
       <property name="iconText" >
@@ -908,7 +877,7 @@
       </property>
     </action>
     <action name="graspEigenGrasp_InterfaceAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspEigenGrasp_InterfaceAction</cstring>
       </property>
       <property name="iconText" >
@@ -919,7 +888,7 @@
       </property>
     </action>
     <action name="graspContact_ExaminerAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspContact_ExaminerAction</cstring>
       </property>
       <property name="iconText" >
@@ -930,7 +899,7 @@
       </property>
     </action>
     <action name="graspEigenGrasp_PlannerAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspEigenGrasp_PlannerAction</cstring>
       </property>
       <property name="iconText" >
@@ -941,7 +910,7 @@
       </property>
     </action>
     <action name="sensorsBarrett_HandAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>sensorsBarrett_HandAction</cstring>
       </property>
       <property name="iconText" >
@@ -952,7 +921,7 @@
       </property>
     </action>
     <action name="graspAuto_OpenAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>graspAuto_OpenAction</cstring>
       </property>
       <property name="iconText" >
@@ -963,7 +932,7 @@
       </property>
     </action>
     <action name="elementPrimitivesAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>elementPrimitivesAction</cstring>
       </property>
       <property name="enabled" >
@@ -977,7 +946,7 @@
       </property>
     </action>
     <action name="dbaseGUIAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dbaseGUIAction</cstring>
       </property>
       <property name="iconText" >
@@ -988,7 +957,7 @@
       </property>
     </action>
     <action name="dbasePlannerAction" >
-      <property name="name" >
+      <property name="objectName" >
         <cstring>dbasePlannerAction</cstring>
       </property>
       <property name="iconText" >
@@ -1000,7 +969,7 @@
     </action>
     <actiongroup name="elementGroup" >
       <action name="translateToolAction" >
-        <property name="name" >
+        <property name="objectName" >
           <cstring>translateToolAction</cstring>
         </property>
         <property name="checkable" >
@@ -1010,7 +979,7 @@
           <bool>true</bool>
         </property>
         <property name="icon" >
-          <iconset>translateTool.xpm</iconset>
+          <iconset>:/images/translateTool.xpm</iconset>
         </property>
         <property name="iconText" >
           <string>Translate</string>
@@ -1026,14 +995,14 @@
         </property>
       </action>
       <action name="rotateToolAction" >
-        <property name="name" >
+        <property name="objectName" >
           <cstring>rotateToolAction</cstring>
         </property>
         <property name="checkable" >
           <bool>true</bool>
         </property>
         <property name="icon" >
-          <iconset>rotateTool.xpm</iconset>
+          <iconset>:/images/rotateTool.xpm</iconset>
         </property>
         <property name="iconText" >
           <string>Rotate</string>
@@ -1049,14 +1018,14 @@
         </property>
       </action>
       <action name="selectToolAction" >
-        <property name="name" >
+        <property name="objectName" >
           <cstring>selectToolAction</cstring>
         </property>
         <property name="checkable" >
           <bool>true</bool>
         </property>
         <property name="icon" >
-          <iconset>selectTool.xpm</iconset>
+          <iconset>:/images/selectTool.xpm</iconset>
         </property>
         <property name="iconText" >
           <string>Select</string>
@@ -1071,7 +1040,7 @@
           <string>F4</string>
         </property>
       </action>
-      <property name="name" >
+      <property name="objectName" >
         <cstring>elementGroup</cstring>
       </property>
     </actiongroup>

--- a/ui/qmDlg.cpp
+++ b/ui/qmDlg.cpp
@@ -125,7 +125,7 @@ void QMDlg::addEditQM()
     qmListBox->insertItem(selectedQM, qmName->text());
   }
 
-  qmListBox->setCurrentItem(0);
+  qmListBox->setCurrentRow(0);
   qmListBox->update();
   qmListBox->show();
 

--- a/ui/qmDlg.cpp
+++ b/ui/qmDlg.cpp
@@ -48,17 +48,16 @@ void QMDlg::init()
   Grasp *g = graspitCore->getWorld()->getCurrentHand()->getGrasp();
   int i;
 
-  qmListBox->insertItem("New quality measure");
+  qmListBox->addItem("New quality measure");
   for (qp = g->qmList.begin(), i = 1; qp != g->qmList.end(); qp++, i++) {
-    qmListBox->insertItem((*qp)->getName());
+    qmListBox->addItem((*qp)->getName());
   }
 
   for (i = 0; QualityMeasure::TYPE_LIST[i]; i++) {
-    qmTypeComboBox->insertItem(QString(QualityMeasure::TYPE_LIST[i]));
+    qmTypeComboBox->addItem(QString(QualityMeasure::TYPE_LIST[i]));
   }
 
-  qmSettingsBox->setColumnLayout(0, Qt::Vertical);
-  QHBoxLayout *settingsBoxLayout = new QHBoxLayout(qmSettingsBox->layout());
+  QHBoxLayout *settingsBoxLayout = new QHBoxLayout(qmSettingsBox);
   settingsBoxLayout->setAlignment(Qt::AlignTop);
 
   qmDlgData.settingsArea = new QWidget(qmSettingsBox);
@@ -70,6 +69,7 @@ void QMDlg::init()
   gravityBox->setChecked(g->isGravitySet());
 
   qmListBox->setCurrentItem(0);
+  qmListBox->setFocus();
 }
 
 
@@ -78,7 +78,7 @@ void QMDlg::init()
 */
 void QMDlg::selectQMType(const QString &typeStr)
 {
-  qmDlgData.qmType = typeStr.latin1();
+  qmDlgData.qmType = typeStr.toStdString().c_str();
   updateSettingsBox();
 }
 
@@ -93,7 +93,7 @@ void QMDlg::updateSettingsBox()
 
   qmDlgData.settingsArea = new QWidget(qmSettingsBox);
   qmSettingsBox->layout()->setAlignment(Qt::AlignTop);
-  qmSettingsBox->layout()->add(qmDlgData.settingsArea);
+  qmSettingsBox->layout()->addWidget(qmDlgData.settingsArea);
   QualityMeasure::buildParamArea(&qmDlgData);
 
   qmDlgData.settingsArea->show();
@@ -113,15 +113,16 @@ void QMDlg::addEditQM()
 
   newQM = QualityMeasure::createInstance(&qmDlgData);
 
-  selectedQM = qmListBox->currentItem();
+  selectedQM = qmListBox->currentRow();
   if (selectedQM == 0) { // create a new quality measure
     g->addQM(newQM);
 
-    qmListBox->insertItem(qmName->text());
+    qmListBox->addItem(qmName->text());
   }
   else { // replace an old quality measure with a new one
     g->replaceQM(selectedQM - 1, newQM);
-    qmListBox->changeItem(qmName->text(), selectedQM);
+    qmListBox->takeItem(selectedQM);
+    qmListBox->insertItem(selectedQM, qmName->text());
   }
 
   qmListBox->setCurrentItem(0);
@@ -139,14 +140,14 @@ void QMDlg::deleteQM()
   int selectedQM;
   int numItems;
 
-  selectedQM = qmListBox->currentItem();
+  selectedQM = qmListBox->currentRow();
   graspitCore->getWorld()->getCurrentHand()->getGrasp()->
   removeQM(selectedQM - 1);
-  qmListBox->removeItem(selectedQM);
+  qmListBox->takeItem(selectedQM);
 
   // select the next item in the list
   numItems = qmListBox->count();
-  qmListBox->setCurrentItem(selectedQM < numItems ? selectedQM : 0);
+  qmListBox->setCurrentRow(selectedQM < numItems ? selectedQM : 0);
   qmListBox->update();
 }
 
@@ -162,7 +163,7 @@ void QMDlg::selectQM(int which)
   if (which == 0) { // "New quality measure" selected
     qmDlgData.currQM = NULL;
     qmDlgData.qmType = QualityMeasure::TYPE_LIST[0];
-    qmTypeComboBox->setCurrentItem(0);
+    qmTypeComboBox->setCurrentIndex(0);
     DeleteButton->setEnabled(false);
     qmName->setText(QString("New Quality Measure"));
   }
@@ -173,12 +174,12 @@ void QMDlg::selectQM(int which)
 
     for (int i = 0; QualityMeasure::TYPE_LIST[i]; i++) {
       if (!strcmp(QualityMeasure::TYPE_LIST[i], qmDlgData.currQM->getType())) {
-        qmTypeComboBox->setCurrentItem(i);
+        qmTypeComboBox->setCurrentIndex(i);
         qmDlgData.qmType = QualityMeasure::TYPE_LIST[i];
         break;
       }
     }
-    qmName->setText(qmListBox->text(which));
+    qmName->setText(qmListBox->item(which)->text());
   }
   updateSettingsBox();
 }

--- a/ui/qmDlg.ui
+++ b/ui/qmDlg.ui
@@ -53,7 +53,7 @@
      </widget>
     </item>
     <item rowspan="2" row="0" column="0" >
-     <widget class="Q3ListBox" name="qmListBox" >
+     <widget class="QListWidget" name="qmListBox" >
       <property name="sizePolicy" >
        <sizepolicy>
         <hsizetype>0</hsizetype>
@@ -89,7 +89,7 @@
      </widget>
     </item>
     <item rowspan="3" row="1" column="1" colspan="2" >
-     <widget class="Q3GroupBox" name="qmSettingsBox" >
+     <widget class="QGroupBox" name="qmSettingsBox" >
       <property name="sizePolicy" >
        <sizepolicy>
         <hsizetype>7</hsizetype>
@@ -100,9 +100,6 @@
       </property>
       <property name="title" >
        <string>Settings</string>
-      </property>
-      <property name="orientation" >
-       <enum>Qt::Vertical</enum>
       </property>
      </widget>
     </item>
@@ -129,7 +126,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="Q3GroupBox" name="groupBox8" >
+  <widget class="QGroupBox" name="groupBox8" >
    <property name="geometry" >
     <rect>
      <x>10</x>
@@ -140,9 +137,6 @@
    </property>
    <property name="title" >
     <string/>
-   </property>
-   <property name="orientation" >
-    <enum>Qt::Vertical</enum>
    </property>
    <widget class="QPushButton" name="OKButton" >
     <property name="geometry" >
@@ -203,22 +197,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11" />
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
- <customwidgets>
-  <customwidget>
-   <class>Q3GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>Qt3Support/Q3GroupBox</header>
-   <container>1</container>
-   <pixmap></pixmap>
-  </customwidget>
-  <customwidget>
-   <class>Q3ListBox</class>
-   <extends>Q3Frame</extends>
-   <header>q3listbox.h</header>
-   <container>0</container>
-   <pixmap></pixmap>
-  </customwidget>
- </customwidgets>
  <includes>
   <include location="local" >graspit/graspitCore.h</include>
   <include location="local" >graspit/ivmgr.h</include>
@@ -292,7 +270,7 @@
   </connection>
   <connection>
    <sender>qmListBox</sender>
-   <signal>highlighted(int)</signal>
+   <signal>currentRowChanged(int)</signal>
    <receiver>QMDlgUI</receiver>
    <slot>selectQM(int)</slot>
    <hints>

--- a/ui/sensorInputDlg.cpp
+++ b/ui/sensorInputDlg.cpp
@@ -96,7 +96,7 @@ SensorInputDlg::timerInternalCB()
     bool process = true;
     // If the Flock is attached to a real Barrett, we ignore readings
     // while the motors of the Barrett are active, as they corrupt the bird.
-    if (mWorld->getCurrentHand() && mWorld->getCurrentHand()->isA("Barrett")) {
+    if (mWorld->getCurrentHand() && mWorld->getCurrentHand()->metaObject()->className() == QString("Barrett")) {
       if (((Barrett *)mWorld->getCurrentHand())->isBusy()) { process = false; }
     }
     if (process) {

--- a/ui/settingsDlg.cpp
+++ b/ui/settingsDlg.cpp
@@ -54,45 +54,42 @@ void SettingsDlg::init()
   dlgUI->staticFrictionTable->verticalHeader()->hide();
   dlgUI->kineticFrictionTable->horizontalHeader()->hide();
   dlgUI->kineticFrictionTable->verticalHeader()->hide();
-  dlgUI->staticFrictionTable->setTopMargin(0);
-  dlgUI->staticFrictionTable->setLeftMargin(0);
-  dlgUI->kineticFrictionTable->setTopMargin(0);
-  dlgUI->kineticFrictionTable->setLeftMargin(0);
+  dlgUI->kineticFrictionTable->setContentsMargins(0, 0, 0, 0);
 
 
-  dlgUI->staticFrictionTable->setNumRows(w->getNumMaterials() + 1);
-  dlgUI->staticFrictionTable->setNumCols(w->getNumMaterials() + 1);
-  dlgUI->kineticFrictionTable->setNumRows(w->getNumMaterials() + 1);
-  dlgUI->kineticFrictionTable->setNumCols(w->getNumMaterials() + 1);
+  dlgUI->staticFrictionTable->setRowCount(w->getNumMaterials() + 1);
+  dlgUI->staticFrictionTable->setColumnCount(w->getNumMaterials() + 1);
+  dlgUI->kineticFrictionTable->setRowCount(w->getNumMaterials() + 1);
+  dlgUI->kineticFrictionTable->setColumnCount(w->getNumMaterials() + 1);
 
-  dlgUI->staticFrictionTable->setItem(0, 0, new Q3TableItem(dlgUI->staticFrictionTable, Q3TableItem::Never, ""));
-  dlgUI->kineticFrictionTable->setItem(0, 0, new Q3TableItem(dlgUI->kineticFrictionTable, Q3TableItem::Never, ""));
+  dlgUI->staticFrictionTable->setItem(0, 0, new QTableWidgetItem(""));
+  dlgUI->kineticFrictionTable->setItem(0, 0, new QTableWidgetItem(""));
 
   for (i = 0; i < w->getNumMaterials(); i++) {
-    dlgUI->staticFrictionTable->setText(0, i + 1, w->getMaterialName(i));
-    dlgUI->staticFrictionTable->setText(i + 1, 0, w->getMaterialName(i));
-    dlgUI->kineticFrictionTable->setText(0, i + 1, w->getMaterialName(i));
-    dlgUI->kineticFrictionTable->setText(i + 1, 0, w->getMaterialName(i));
+    dlgUI->staticFrictionTable->setItem(0, i + 1, new QTableWidgetItem(QString(w->getMaterialName(i))));
+    dlgUI->staticFrictionTable->setItem(i + 1, 0, new QTableWidgetItem(QString(w->getMaterialName(i))));
+    dlgUI->kineticFrictionTable->setItem(0, i + 1, new QTableWidgetItem(QString(w->getMaterialName(i))));
+    dlgUI->kineticFrictionTable->setItem(i + 1, 0, new QTableWidgetItem(QString(w->getMaterialName(i))));
   }
 
   for (i = 0; i < w->getNumMaterials(); i++) {
     for (j = 0; j < w->getNumMaterials(); j++) {
-      dlgUI->staticFrictionTable->setText(i + 1, j + 1, val.setNum(w->getCOF(i, j)));
-      dlgUI->kineticFrictionTable->setText(i + 1, j + 1, val.setNum(w->getKCOF(i, j)));
+      dlgUI->staticFrictionTable->setItem(i + 1, j + 1, new QTableWidgetItem(val.setNum(w->getCOF(i, j))));
+      dlgUI->kineticFrictionTable->setItem(i + 1, j + 1, new QTableWidgetItem(val.setNum(w->getKCOF(i, j))));
     }
   }
 
   dlgUI->timeStepLine->setText(QString::number(w->getTimeStep() * 1.0e+3));
   dlgUI->timeStepLine->setValidator(new QDoubleValidator(1.0e-2, 1.0e+4, 10, dlgImpl));
 
-  QObject::connect(dlgUI->staticFrictionTable, SIGNAL(currentChanged(int, int)),
-                   this, SLOT(saveCurrentCOF(int, int)));
-  QObject::connect(dlgUI->kineticFrictionTable, SIGNAL(currentChanged(int, int)),
-                   this, SLOT(saveCurrentKCOF(int, int)));
+  QObject::connect(dlgUI->staticFrictionTable, SIGNAL(currentCellChanged(int, int, int, int)),
+                   this, SLOT(saveCurrentCOF(int, int, int, int)));
+  QObject::connect(dlgUI->kineticFrictionTable, SIGNAL(currentCellChanged(int, int, int, int)),
+                   this, SLOT(saveCurrentKCOF(int, int, int, int)));
 
-  QObject::connect(dlgUI->staticFrictionTable, SIGNAL(valueChanged(int, int)),
+  QObject::connect(dlgUI->staticFrictionTable, SIGNAL(cellChanged(int, int)),
                    this, SLOT(checkCOFEntry(int, int)));
-  QObject::connect(dlgUI->kineticFrictionTable, SIGNAL(valueChanged(int, int)),
+  QObject::connect(dlgUI->kineticFrictionTable, SIGNAL(cellChanged(int, int)),
                    this, SLOT(checkKCOFEntry(int, int)));
 
   QObject::connect(dlgUI->okButton, SIGNAL(clicked()), this, SLOT(validateDlg()));
@@ -118,17 +115,17 @@ void SettingsDlg::checkCOFEntry(int row, int col)
   bool ok;
 
   if (row > 0 && col > 0) {
-    val = dlgUI->staticFrictionTable->text(row, col).toDouble(&ok);
+    val = dlgUI->staticFrictionTable->item(row, col)->text().toDouble(&ok);
     if (!ok || val < 0) {
-      dlgUI->staticFrictionTable->setText(row, col, QString::number(currCOFVal));
+      dlgUI->staticFrictionTable->setItem(row, col, new QTableWidgetItem(QString::number(currCOFVal)));
       return;
     }
   }
   else {
-    dlgUI->kineticFrictionTable->setText(row, col, dlgUI->staticFrictionTable->text(row, col));
-    dlgUI->kineticFrictionTable->setText(col, row, dlgUI->staticFrictionTable->text(row, col));
+    dlgUI->kineticFrictionTable->setItem(row, col, new QTableWidgetItem(dlgUI->staticFrictionTable->item(row, col)->text()));
+    dlgUI->kineticFrictionTable->setItem(col, row, new QTableWidgetItem(dlgUI->staticFrictionTable->item(row, col)->text()));
   }
-  dlgUI->staticFrictionTable->setText(col, row, dlgUI->staticFrictionTable->text(row, col));
+  dlgUI->staticFrictionTable->setItem(col, row, new QTableWidgetItem(dlgUI->staticFrictionTable->item(row, col)->text()));
 }
 
 
@@ -137,9 +134,9 @@ void SettingsDlg::checkCOFEntry(int row, int col)
   current value there in case it needs to be reset when the user tries
   to enter an invalid number.
 */
-void SettingsDlg::saveCurrentCOF(int row, int col)
+void SettingsDlg::saveCurrentCOF(int row, int col, int prevRow, int prevCol)
 {
-  currCOFVal = dlgUI->staticFrictionTable->text(row, col).toDouble();
+  currCOFVal = dlgUI->staticFrictionTable->item(row, col)->text().toDouble();
 }
 
 /*!
@@ -147,9 +144,9 @@ void SettingsDlg::saveCurrentCOF(int row, int col)
   current value there in case it needs to be reset when the user tries
   to enter an invalid number.
 */
-void SettingsDlg::saveCurrentKCOF(int row, int col)
+void SettingsDlg::saveCurrentKCOF(int row, int col, int prevRow, int prevCol)
 {
-  currKCOFVal = dlgUI->kineticFrictionTable->text(row, col).toDouble();
+  currKCOFVal = dlgUI->kineticFrictionTable->item(row, col)->text().toDouble();
 }
 
 
@@ -165,17 +162,17 @@ void SettingsDlg::checkKCOFEntry(int row, int col)
   double val;
   bool ok;
   if (row > 0 && col > 0) {
-    val = dlgUI->kineticFrictionTable->text(row, col).toDouble(&ok);
+    val = dlgUI->kineticFrictionTable->item(row, col)->text().toDouble(&ok);
     if (!ok || val < 0) {
-      dlgUI->kineticFrictionTable->setText(row, col, QString::number(currKCOFVal));
+      dlgUI->kineticFrictionTable->setItem(row, col, new QTableWidgetItem(QString::number(currKCOFVal)));
       return;
     }
   }
   else {
-    dlgUI->staticFrictionTable->setText(row, col, dlgUI->kineticFrictionTable->text(row, col));
-    dlgUI->staticFrictionTable->setText(col, row, dlgUI->kineticFrictionTable->text(row, col));
+    dlgUI->staticFrictionTable->setItem(row, col, new QTableWidgetItem(dlgUI->kineticFrictionTable->item(row, col)->text()));
+    dlgUI->staticFrictionTable->setItem(col, row, new QTableWidgetItem(dlgUI->kineticFrictionTable->item(row, col)->text()));
   }
-  dlgUI->kineticFrictionTable->setText(col, row, dlgUI->kineticFrictionTable->text(row, col));
+  dlgUI->kineticFrictionTable->setItem(col, row, new QTableWidgetItem(dlgUI->kineticFrictionTable->item(row, col)->text()));
 }
 
 

--- a/ui/settingsDlg.h
+++ b/ui/settingsDlg.h
@@ -57,14 +57,14 @@ class SettingsDlg : public QObject
 
   private Q_SLOTS:
     void checkCOFEntry(int row, int col);
-    void saveCurrentCOF(int row, int col);
-    void saveCurrentKCOF(int row, int col);
+    void saveCurrentCOF(int row, int col, int prevRow, int prevCol);
+    void saveCurrentKCOF(int row, int col, int prevRow, int prevCol);
     void checkKCOFEntry(int row, int col);
     void validateDlg();
 
   public:
     Ui::SettingsDlgUI *dlgUI;
-    SettingsDlg(QWidget *parent = 0, Qt::WFlags f = 0) {
+    SettingsDlg(QWidget *parent = 0, Qt::WindowFlags f = 0) {
       dlgImpl = new QDialog(parent, f);
       dlgUI = new Ui::SettingsDlgUI;
       dlgUI->setupUi(dlgImpl);

--- a/ui/settingsDlg.ui
+++ b/ui/settingsDlg.ui
@@ -100,7 +100,7 @@
       </widget>
      </item>
      <item>
-      <widget class="Q3Table" name="staticFrictionTable" >
+      <widget class="QTableWidget" name="staticFrictionTable" >
        <property name="sizePolicy" >
         <sizepolicy>
          <hsizetype>7</hsizetype>
@@ -108,12 +108,6 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="numRows" >
-        <number>0</number>
-       </property>
-       <property name="numCols" >
-        <number>0</number>
        </property>
       </widget>
      </item>
@@ -128,7 +122,7 @@
       </widget>
      </item>
      <item>
-      <widget class="Q3Table" name="kineticFrictionTable" >
+      <widget class="QTableWidget" name="kineticFrictionTable" >
        <property name="sizePolicy" >
         <sizepolicy>
          <hsizetype>7</hsizetype>
@@ -136,12 +130,6 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="numRows" >
-        <number>0</number>
-       </property>
-       <property name="numCols" >
-        <number>0</number>
        </property>
       </widget>
      </item>
@@ -228,15 +216,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11" />
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
- <customwidgets>
-  <customwidget>
-   <class>Q3Table</class>
-   <extends>Q3Frame</extends>
-   <header>q3table.h</header>
-   <container>0</container>
-   <pixmap></pixmap>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>settingsTabs</tabstop>
   <tabstop>staticFrictionTable</tabstop>
@@ -265,9 +244,9 @@
   </connection>
   <connection>
    <sender>staticFrictionTable</sender>
-   <signal>currentChanged(int,int)</signal>
-   <receiver>SettingsDlgUI</receiver>
-   <slot>saveCurrentCOF(int,int)</slot>
+   <signal>currentCellChanged(int,int,int,int)</signal>
+   <receiver>SettingsDlg</receiver>
+   <slot>saveCurrentCOF(int,int,int,int)</slot>
    <hints>
     <hint type="sourcelabel" >
      <x>20</x>
@@ -281,8 +260,8 @@
   </connection>
   <connection>
    <sender>staticFrictionTable</sender>
-   <signal>valueChanged(int,int)</signal>
-   <receiver>SettingsDlgUI</receiver>
+   <signal>cellChanged(int,int)</signal>
+   <receiver>SettingsDlg</receiver>
    <slot>checkCOFEntry(int,int)</slot>
    <hints>
     <hint type="sourcelabel" >
@@ -297,9 +276,9 @@
   </connection>
   <connection>
    <sender>kineticFrictionTable</sender>
-   <signal>currentChanged(int,int)</signal>
-   <receiver>SettingsDlgUI</receiver>
-   <slot>saveCurrentKCOF(int,int)</slot>
+   <signal>currentCellChanged(int,int,int,int)</signal>
+   <receiver>SettingsDlg</receiver>
+   <slot>saveCurrentKCOF(int,int,int,int)</slot>
    <hints>
     <hint type="sourcelabel" >
      <x>20</x>
@@ -313,8 +292,8 @@
   </connection>
   <connection>
    <sender>kineticFrictionTable</sender>
-   <signal>valueChanged(int,int)</signal>
-   <receiver>SettingsDlgUI</receiver>
+   <signal>cellChanged(int,int)</signal>
+   <receiver>SettingsDlg</receiver>
    <slot>checkKCOFEntry(int,int)</slot>
    <hints>
     <hint type="sourcelabel" >
@@ -330,7 +309,7 @@
   <connection>
    <sender>okButton</sender>
    <signal>clicked()</signal>
-   <receiver>SettingsDlgUI</receiver>
+   <receiver>SettingsDlg</receiver>
    <slot>validateDlg()</slot>
    <hints>
     <hint type="sourcelabel" >


### PR DESCRIPTION
qt5 is the minimum qt requirement for Ubuntu 20.04.

This migration borrows some ideas from a previous effort [here](https://github.com/iocroblab/graspit/tree/Qt5)

This PR has been tested on Ubuntu 20.04 to confirm that the behavior matched the working Qt4 version on Ubuntu 18.04 and below.

The only known issue is with the "Save Image" functionality which breaks on this [line](https://github.com/iretiayo/graspit/blob/qt5/src/ivmgr.cpp#L1561) with the same error message described [here](https://stackoverflow.com/questions/30953210/program-with-graphics-being-aborted-even-though-xinitthreads-was-called).

Other functionalities of GraspIt! backend and UI seem to be working fine.